### PR TITLE
Remove generics

### DIFF
--- a/api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.util;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.Properties;
 
 import org.apache.logging.log4j.Logger;

--- a/core/src/main/java/org/apache/logging/log4j/core/Appender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/Appender.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
  *
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
-public interface Appender<T extends Serializable> extends LifeCycle {
+public interface Appender extends LifeCycle {
 
     /**
      * Log in <code>Appender</code> specific way. When appropriate,
@@ -47,7 +47,7 @@ public interface Appender<T extends Serializable> extends LifeCycle {
      *
      * @return the Layout for the Appender or null if none is configured.
      */
-    Layout<T> getLayout();
+    Layout<? extends Serializable> getLayout();
 
     /**
      * Some appenders need to propagate exceptions back to the application. When {@code ignoreExceptions} is

--- a/core/src/main/java/org/apache/logging/log4j/core/Logger.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/Logger.java
@@ -139,7 +139,7 @@ public class Logger extends AbstractLogger {
      * This method is not exposed through the public API and is used primarily for unit testing.
      * @param appender The Appender to add to the Logger.
      */
-    public void addAppender(final Appender<?> appender) {
+    public void addAppender(final Appender appender) {
         config.config.addLoggerAppender(this, appender);
     }
 
@@ -147,7 +147,7 @@ public class Logger extends AbstractLogger {
      * This method is not exposed through the public API and is used primarily for unit testing.
      * @param appender The Appender to remove from the Logger.
      */
-    public void removeAppender(final Appender<?> appender) {
+    public void removeAppender(final Appender appender) {
         config.loggerConfig.removeAppender(appender.getName());
     }
 
@@ -155,7 +155,7 @@ public class Logger extends AbstractLogger {
      * This method is not exposed through the public API and is used primarily for unit testing.
      * @return A Map containing the Appender's name as the key and the Appender as the value.
      */
-    public Map<String, Appender<?>> getAppenders() {
+    public Map<String, Appender> getAppenders() {
          return config.loggerConfig.getAppenders();
     }
 

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/AbstractAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/AbstractAppender.java
@@ -34,8 +34,8 @@ import org.apache.logging.log4j.status.StatusLogger;
  *
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
-public abstract class AbstractAppender<T extends Serializable> extends AbstractFilterable
-    implements Appender<T> {
+public abstract class AbstractAppender extends AbstractFilterable
+    implements Appender {
     /**
      * Allow subclasses access to the status logger without creating another instance.
      */
@@ -45,7 +45,7 @@ public abstract class AbstractAppender<T extends Serializable> extends AbstractF
 
     private ErrorHandler handler = new DefaultErrorHandler(this);
 
-    private final Layout<T> layout;
+    private final Layout<? extends Serializable> layout;
 
     private final String name;
 
@@ -69,7 +69,7 @@ public abstract class AbstractAppender<T extends Serializable> extends AbstractF
      * @param filter The Filter to associate with the Appender.
      * @param layout The layout to use to format the event.
      */
-    protected AbstractAppender(final String name, final Filter filter, final Layout<T> layout) {
+    protected AbstractAppender(final String name, final Filter filter, final Layout<? extends Serializable> layout) {
         this(name, filter, layout, true);
     }
 
@@ -81,7 +81,7 @@ public abstract class AbstractAppender<T extends Serializable> extends AbstractF
      * @param ignoreExceptions If true, exceptions will be logged and suppressed. If false errors will be
      * logged and then passed to the application.
      */
-    protected AbstractAppender(final String name, final Filter filter, final Layout<T> layout,
+    protected AbstractAppender(final String name, final Filter filter, final Layout<? extends Serializable> layout,
                                final boolean ignoreExceptions) {
         super(filter);
         this.name = name;
@@ -130,7 +130,7 @@ public abstract class AbstractAppender<T extends Serializable> extends AbstractF
      * @return The Layout used to format the event.
      */
     @Override
-    public Layout<T> getLayout() {
+    public Layout<? extends Serializable> getLayout() {
         return layout;
     }
 

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/AbstractOutputStreamAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/AbstractOutputStreamAppender.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.core.LogEvent;
  *
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
-public abstract class AbstractOutputStreamAppender<T extends Serializable> extends AbstractAppender<T> {
+public abstract class AbstractOutputStreamAppender extends AbstractAppender {
 
     /**
      * Immediate flush means that the underlying writer or output stream
@@ -57,7 +57,7 @@ public abstract class AbstractOutputStreamAppender<T extends Serializable> exten
      * @param layout The layout to format the message.
      * @param manager The OutputStreamManager.
      */
-    protected AbstractOutputStreamAppender(final String name, final Layout<T> layout, final Filter filter,
+    protected AbstractOutputStreamAppender(final String name, final Layout<? extends Serializable> layout, final Filter filter,
                                            final boolean ignoreExceptions, final boolean immediateFlush,
                                            final OutputStreamManager manager) {
         super(name, filter, layout, ignoreExceptions);

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
@@ -48,7 +48,7 @@ import org.apache.logging.log4j.util.PropertiesUtil;
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
 @Plugin(name = "Console", category = "Core", elementType = "appender", printObject = true)
-public final class ConsoleAppender<T extends Serializable> extends AbstractOutputStreamAppender<T> {
+public final class ConsoleAppender extends AbstractOutputStreamAppender {
 
     private static ConsoleManagerFactory factory = new ConsoleManagerFactory();
 
@@ -62,7 +62,7 @@ public final class ConsoleAppender<T extends Serializable> extends AbstractOutpu
         SYSTEM_ERR
     }
 
-    private ConsoleAppender(final String name, final Layout<T> layout, final Filter filter,
+    private ConsoleAppender(final String name, final Layout<? extends Serializable> layout, final Filter filter,
                             final OutputStreamManager manager,
                             final boolean ignoreExceptions) {
         super(name, layout, filter, ignoreExceptions, true, manager);
@@ -81,7 +81,7 @@ public final class ConsoleAppender<T extends Serializable> extends AbstractOutpu
      * @return The ConsoleAppender.
      */
     @PluginFactory
-    public static <S extends Serializable> ConsoleAppender<S> createAppender(@PluginElement("layout") Layout<S> layout,
+    public static ConsoleAppender createAppender(@PluginElement("layout") Layout<? extends Serializable> layout,
                                                  @PluginElement("filters") final Filter filter,
                                                  @PluginAttr("target") final String t,
                                                  @PluginAttr("name") final String name,
@@ -92,18 +92,15 @@ public final class ConsoleAppender<T extends Serializable> extends AbstractOutpu
             return null;
         }
         if (layout == null) {
-            @SuppressWarnings({ "unchecked", "UnnecessaryLocalVariable" })
-            final
-            Layout<S> l = (Layout<S>) PatternLayout.createLayout(null, null, null, null, null);
-            layout = l;
+            layout = PatternLayout.createLayout(null, null, null, null, null);
         }
         final boolean isFollow = Boolean.parseBoolean(follow);
         final boolean ignoreExceptions = Booleans.parseBoolean(ignore, true);
         final Target target = t == null ? Target.SYSTEM_OUT : Target.valueOf(t);
-        return new ConsoleAppender<S>(name, layout, filter, getManager(isFollow, target, layout), ignoreExceptions);
+        return new ConsoleAppender(name, layout, filter, getManager(isFollow, target, layout), ignoreExceptions);
     }
 
-    private static OutputStreamManager getManager(final boolean follow, final Target target, final Layout layout) {
+    private static OutputStreamManager getManager(final boolean follow, final Target target, final Layout<? extends Serializable> layout) {
         final String type = target.name();
         final OutputStream os = getOutputStream(follow, target);
         return OutputStreamManager.getManager(target.name() + "." + follow, new FactoryData(os, type, layout), factory);
@@ -217,14 +214,14 @@ public final class ConsoleAppender<T extends Serializable> extends AbstractOutpu
     private static class FactoryData {
         private final OutputStream os;
         private final String type;
-        private final Layout layout;
+        private final Layout<? extends Serializable> layout;
 
         /**
          * Constructor.
          * @param os The OutputStream.
          * @param type The name of the target.
          */
-        public FactoryData(final OutputStream os, final String type, final Layout layout) {
+        public FactoryData(final OutputStream os, final String type, final Layout<? extends Serializable> layout) {
             this.os = os;
             this.type = type;
             this.layout = layout;

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/FailoverAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/FailoverAppender.java
@@ -43,7 +43,7 @@ import org.apache.logging.log4j.core.helpers.Constants;
  * @param <T> The {@link org.apache.logging.log4j.core.Layout}'s {@link Serializable} type.
  */
 @Plugin(name = "Failover", category = "Core", elementType = "appender", printObject = true)
-public final class FailoverAppender<T extends Serializable> extends AbstractAppender<T> {
+public final class FailoverAppender extends AbstractAppender {
 
     private static final int DEFAULT_INTERVAL_SECONDS = 60;
 
@@ -53,9 +53,9 @@ public final class FailoverAppender<T extends Serializable> extends AbstractAppe
 
     private final Configuration config;
 
-    private AppenderControl<?> primary;
+    private AppenderControl primary;
 
-    private final List<AppenderControl<?>> failoverAppenders = new ArrayList<AppenderControl<?>>();
+    private final List<AppenderControl> failoverAppenders = new ArrayList<AppenderControl>();
 
     private final long intervalMillis;
 
@@ -74,9 +74,8 @@ public final class FailoverAppender<T extends Serializable> extends AbstractAppe
 
 
     @Override
-    @SuppressWarnings("unchecked")
     public void start() {
-        final Map<String, Appender<?>> map = config.getAppenders();
+        final Map<String, Appender> map = config.getAppenders();
         int errors = 0;
         if (map.containsKey(primaryRef)) {
             primary = new AppenderControl(map.get(primaryRef), null, null);
@@ -187,7 +186,7 @@ public final class FailoverAppender<T extends Serializable> extends AbstractAppe
      * @return The FailoverAppender that was created.
      */
     @PluginFactory
-    public static <S extends Serializable> FailoverAppender<S> createAppender(@PluginAttr("name") final String name,
+    public static FailoverAppender createAppender(@PluginAttr("name") final String name,
                                                   @PluginAttr("primary") final String primary,
                                                   @PluginElement("failovers") final String[] failovers,
                                                   @PluginAttr("retryInterval") final String retryIntervalString,
@@ -218,6 +217,6 @@ public final class FailoverAppender<T extends Serializable> extends AbstractAppe
 
         final boolean ignoreExceptions = Booleans.parseBoolean(ignore, true);
 
-        return new FailoverAppender<S>(name, filter, primary, failovers, retryIntervalMillis, config, ignoreExceptions);
+        return new FailoverAppender(name, filter, primary, failovers, retryIntervalMillis, config, ignoreExceptions);
     }
 }

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/FileAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/FileAppender.java
@@ -38,13 +38,13 @@ import org.apache.logging.log4j.core.net.Advertiser;
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
 @Plugin(name = "File", category = "Core", elementType = "appender", printObject = true)
-public final class FileAppender<T extends Serializable> extends AbstractOutputStreamAppender<T> {
+public final class FileAppender extends AbstractOutputStreamAppender {
 
     private final String fileName;
     private final Advertiser advertiser;
     private Object advertisement;
 
-    private FileAppender(final String name, final Layout<T> layout, final Filter filter, final FileManager manager,
+    private FileAppender(final String name, final Layout<? extends Serializable> layout, final Filter filter, final FileManager manager,
                          final String filename, final boolean ignoreExceptions, final boolean immediateFlush,
                          final Advertiser advertiser) {
         super(name, layout, filter, ignoreExceptions, immediateFlush, manager);
@@ -97,14 +97,14 @@ public final class FileAppender<T extends Serializable> extends AbstractOutputSt
      * @return The FileAppender.
      */
     @PluginFactory
-    public static <S extends Serializable> FileAppender<S> createAppender(@PluginAttr("fileName") final String fileName,
+    public static FileAppender createAppender(@PluginAttr("fileName") final String fileName,
                                               @PluginAttr("append") final String append,
                                               @PluginAttr("locking") final String locking,
                                               @PluginAttr("name") final String name,
                                               @PluginAttr("immediateFlush") final String immediateFlush,
                                               @PluginAttr("ignoreExceptions") final String ignore,
                                               @PluginAttr("bufferedIO") final String bufferedIO,
-                                              @PluginElement("layout") Layout<S> layout,
+                                              @PluginElement("layout") Layout<? extends Serializable> layout,
                                               @PluginElement("filters") final Filter filter,
                                               @PluginAttr("advertise") final String advertise,
                                               @PluginAttr("advertiseURI") final String advertiseURI,
@@ -133,10 +133,7 @@ public final class FileAppender<T extends Serializable> extends AbstractOutputSt
             return null;
         }
         if (layout == null) {
-            @SuppressWarnings({ "unchecked", "UnnecessaryLocalVariable" })
-            final
-            Layout<S> l = (Layout<S>) PatternLayout.createLayout(null, null, null, null, null);
-            layout = l;
+            layout = PatternLayout.createLayout(null, null, null, null, null);
         }
 
         final FileManager manager = FileManager.getFileManager(fileName, isAppend, isLocking, isBuffered, advertiseURI,
@@ -146,7 +143,7 @@ public final class FileAppender<T extends Serializable> extends AbstractOutputSt
         }
 
 
-        return new FileAppender<S>(name, layout, filter, manager, fileName, ignoreExceptions, isFlush,
+        return new FileAppender(name, layout, filter, manager, fileName, ignoreExceptions, isFlush,
                 isAdvertise ? config.getAdvertiser() : null);
     }
 }

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/FileManager.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/FileManager.java
@@ -22,6 +22,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.util.HashMap;
@@ -42,7 +43,7 @@ public class FileManager extends OutputStreamManager {
     private final String advertiseURI;
 
     protected FileManager(final String fileName, final OutputStream os, final boolean append, final boolean locking,
-                          final String advertiseURI, final Layout layout) {
+                          final String advertiseURI, final Layout<? extends Serializable> layout) {
         super(os, fileName, layout);
         this.isAppend = append;
         this.isLocking = locking;
@@ -61,7 +62,7 @@ public class FileManager extends OutputStreamManager {
      */
     public static FileManager getFileManager(final String fileName, final boolean append, boolean locking,
                                              final boolean bufferedIO, final String advertiseURI,
-                                             final Layout layout) {
+                                             final Layout<? extends Serializable> layout) {
 
         if (locking && bufferedIO) {
             locking = false;
@@ -142,7 +143,7 @@ public class FileManager extends OutputStreamManager {
         private final boolean locking;
         private final boolean bufferedIO;
         private final String advertiseURI;
-        private final Layout layout;
+        private final Layout<? extends Serializable> layout;
 
         /**
          * Constructor.
@@ -152,7 +153,7 @@ public class FileManager extends OutputStreamManager {
          * @param advertiseURI the URI to use when advertising the file
          */
         public FactoryData(final boolean append, final boolean locking, final boolean bufferedIO,
-                           final String advertiseURI, final Layout layout) {
+                           final String advertiseURI, final Layout<? extends Serializable> layout) {
             this.append = append;
             this.locking = locking;
             this.bufferedIO = bufferedIO;

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/JMSQueueAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/JMSQueueAppender.java
@@ -35,11 +35,11 @@ import org.apache.logging.log4j.core.net.JMSQueueManager;
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
 @Plugin(name = "JMSQueue", category = "Core", elementType = "appender", printObject = true)
-public final class JMSQueueAppender<T extends Serializable> extends AbstractAppender<T> {
+public final class JMSQueueAppender extends AbstractAppender {
 
     private final JMSQueueManager manager;
 
-    private JMSQueueAppender(final String name, final Filter filter, final Layout<T> layout,
+    private JMSQueueAppender(final String name, final Filter filter, final Layout<? extends Serializable> layout,
                              final JMSQueueManager manager, final boolean ignoreExceptions) {
         super(name, filter, layout, ignoreExceptions);
         this.manager = manager;
@@ -80,7 +80,7 @@ public final class JMSQueueAppender<T extends Serializable> extends AbstractAppe
      * @return The JMSQueueAppender.
      */
     @PluginFactory
-    public static <S extends Serializable> JMSQueueAppender<S> createAppender(
+    public static JMSQueueAppender createAppender(
                                                 @PluginAttr("name") final String name,
                                                 @PluginAttr("factoryName") final String factoryName,
                                                 @PluginAttr("providerURL") final String providerURL,
@@ -91,7 +91,7 @@ public final class JMSQueueAppender<T extends Serializable> extends AbstractAppe
                                                 @PluginAttr("queueBindingName") final String queueBindingName,
                                                 @PluginAttr("userName") final String userName,
                                                 @PluginAttr("password") final String password,
-                                                @PluginElement("layout") Layout<S> layout,
+                                                @PluginElement("layout") Layout<? extends Serializable> layout,
                                                 @PluginElement("filter") final Filter filter,
                                                 @PluginAttr("ignoreExceptions") final String ignore) {
         if (name == null) {
@@ -105,11 +105,8 @@ public final class JMSQueueAppender<T extends Serializable> extends AbstractAppe
             return null;
         }
         if (layout == null) {
-            @SuppressWarnings({ "unchecked", "UnnecessaryLocalVariable" })
-            final
-            Layout<S> l = (Layout<S>) SerializedLayout.createLayout();
-            layout = l;
+            layout = SerializedLayout.createLayout();
         }
-        return new JMSQueueAppender<S>(name, filter, layout, manager, ignoreExceptions);
+        return new JMSQueueAppender(name, filter, layout, manager, ignoreExceptions);
     }
 }

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/JMSTopicAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/JMSTopicAppender.java
@@ -35,11 +35,11 @@ import org.apache.logging.log4j.core.net.JMSTopicManager;
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
 @Plugin(name = "JMSTopic", category = "Core", elementType = "appender", printObject = true)
-public final class JMSTopicAppender<T extends Serializable> extends AbstractAppender<T> {
+public final class JMSTopicAppender extends AbstractAppender {
 
     private final JMSTopicManager manager;
 
-    private JMSTopicAppender(final String name, final Filter filter, final Layout<T> layout,
+    private JMSTopicAppender(final String name, final Filter filter, final Layout<? extends Serializable> layout,
                              final JMSTopicManager manager, final boolean ignoreExceptions) {
         super(name, filter, layout, ignoreExceptions);
         this.manager = manager;
@@ -80,7 +80,7 @@ public final class JMSTopicAppender<T extends Serializable> extends AbstractAppe
      * @return The JMSTopicAppender.
      */
     @PluginFactory
-    public static <S extends Serializable> JMSTopicAppender<S> createAppender(
+    public static JMSTopicAppender createAppender(
                                                 @PluginAttr("name") final String name,
                                                 @PluginAttr("factoryName") final String factoryName,
                                                 @PluginAttr("providerURL") final String providerURL,
@@ -91,7 +91,7 @@ public final class JMSTopicAppender<T extends Serializable> extends AbstractAppe
                                                 @PluginAttr("topicBindingName") final String topicBindingName,
                                                 @PluginAttr("userName") final String userName,
                                                 @PluginAttr("password") final String password,
-                                                @PluginElement("layout") Layout<S> layout,
+                                                @PluginElement("layout") Layout<? extends Serializable> layout,
                                                 @PluginElement("filters") final Filter filter,
                                                 @PluginAttr("ignoreExceptions") final String ignore) {
 
@@ -106,11 +106,8 @@ public final class JMSTopicAppender<T extends Serializable> extends AbstractAppe
             return null;
         }
         if (layout == null) {
-            @SuppressWarnings({ "unchecked", "UnnecessaryLocalVariable" })
-            final
-            Layout<S> l = (Layout<S>) SerializedLayout.createLayout();
-            layout = l;
+            layout = SerializedLayout.createLayout();
         }
-        return new JMSTopicAppender<S>(name, filter, layout, manager, ignoreExceptions);
+        return new JMSTopicAppender(name, filter, layout, manager, ignoreExceptions);
     }
 }

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/OutputStreamManager.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/OutputStreamManager.java
@@ -32,7 +32,7 @@ public class OutputStreamManager extends AbstractManager {
     private final byte[] footer;
     private final byte[] header;
 
-    protected OutputStreamManager(final OutputStream os, final String streamName, final Layout layout) {
+    protected OutputStreamManager(final OutputStream os, final String streamName, final Layout<?> layout) {
         super(streamName);
         this.os = os;
         if (layout != null) {

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/RandomAccessFileAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/RandomAccessFileAppender.java
@@ -39,13 +39,13 @@ import org.apache.logging.log4j.core.net.Advertiser;
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
 @Plugin(name = "RandomAccessFile", category = "Core", elementType = "appender", printObject = true)
-public final class RandomAccessFileAppender<T extends Serializable> extends AbstractOutputStreamAppender<T> {
+public final class RandomAccessFileAppender extends AbstractOutputStreamAppender {
 
     private final String fileName;
     private Object advertisement;
     private final Advertiser advertiser;
 
-    private RandomAccessFileAppender(final String name, final Layout<T> layout, final Filter filter,
+    private RandomAccessFileAppender(final String name, final Layout<? extends Serializable> layout, final Filter filter,
             final RandomAccessFileManager manager, final String filename, final boolean ignoreExceptions,
             final boolean immediateFlush, final Advertiser advertiser) {
         super(name, layout, filter, ignoreExceptions, immediateFlush, manager);
@@ -121,13 +121,13 @@ public final class RandomAccessFileAppender<T extends Serializable> extends Abst
      * @return The FileAppender.
      */
     @PluginFactory
-    public static <S extends Serializable> RandomAccessFileAppender<S> createAppender(
+    public static RandomAccessFileAppender createAppender(
             @PluginAttr("fileName") final String fileName,
             @PluginAttr("append") final String append,
             @PluginAttr("name") final String name,
             @PluginAttr("immediateFlush") final String immediateFlush,
             @PluginAttr("ignoreExceptions") final String ignore,
-            @PluginElement("layout") Layout<S> layout,
+            @PluginElement("layout") Layout<? extends Serializable> layout,
             @PluginElement("filters") final Filter filter,
             @PluginAttr("advertise") final String advertise,
             @PluginAttr("advertiseURI") final String advertiseURI,
@@ -149,10 +149,7 @@ public final class RandomAccessFileAppender<T extends Serializable> extends Abst
             return null;
         }
         if (layout == null) {
-            @SuppressWarnings({ "unchecked", "UnnecessaryLocalVariable" })
-            final
-            Layout<S> l = (Layout<S>) PatternLayout.createLayout(null, null, null, null, null);
-            layout = l;
+            layout = PatternLayout.createLayout(null, null, null, null, null);
         }
         final RandomAccessFileManager manager = RandomAccessFileManager.getFileManager(
                 fileName, isAppend, isFlush, advertiseURI, layout
@@ -161,7 +158,7 @@ public final class RandomAccessFileAppender<T extends Serializable> extends Abst
             return null;
         }
 
-        return new RandomAccessFileAppender<S>(
+        return new RandomAccessFileAppender(
                 name, layout, filter, manager, fileName, ignoreExceptions, isFlush,
                 isAdvertise ? config.getAdvertiser() : null
         );

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/RandomAccessFileManager.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/RandomAccessFileManager.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +46,7 @@ public class RandomAccessFileManager extends OutputStreamManager {
     protected RandomAccessFileManager(final RandomAccessFile file,
             final String fileName, final OutputStream os,
             final boolean immediateFlush, final String advertiseURI,
-            final Layout layout) {
+            final Layout<? extends Serializable> layout) {
         super(os, fileName, layout);
         this.isImmediateFlush = immediateFlush;
         this.randomAccessFile = file;
@@ -70,7 +71,7 @@ public class RandomAccessFileManager extends OutputStreamManager {
      */
     public static RandomAccessFileManager getFileManager(final String fileName,
             final boolean append, final boolean isFlush,
-            final String advertiseURI, final Layout layout) {
+            final String advertiseURI, final Layout<? extends Serializable> layout) {
         return (RandomAccessFileManager) getManager(fileName, new FactoryData(append,
                 isFlush, advertiseURI, layout), FACTORY);
     }
@@ -168,7 +169,7 @@ public class RandomAccessFileManager extends OutputStreamManager {
         private final boolean append;
         private final boolean immediateFlush;
         private final String advertiseURI;
-        private final Layout layout;
+        private final Layout<? extends Serializable> layout;
 
         /**
          * Constructor.
@@ -176,7 +177,7 @@ public class RandomAccessFileManager extends OutputStreamManager {
          * @param append Append status.
          */
         public FactoryData(final boolean append, final boolean immediateFlush,
-                final String advertiseURI, final Layout layout) {
+                final String advertiseURI, final Layout<? extends Serializable> layout) {
             this.append = append;
             this.immediateFlush = immediateFlush;
             this.advertiseURI = advertiseURI;

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/RollingFileAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/RollingFileAppender.java
@@ -43,7 +43,7 @@ import org.apache.logging.log4j.core.net.Advertiser;
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
 @Plugin(name = "RollingFile", category = "Core", elementType = "appender", printObject = true)
-public final class RollingFileAppender<T extends Serializable> extends AbstractOutputStreamAppender<T> {
+public final class RollingFileAppender extends AbstractOutputStreamAppender {
 
     private final String fileName;
     private final String filePattern;
@@ -51,7 +51,7 @@ public final class RollingFileAppender<T extends Serializable> extends AbstractO
     private final Advertiser advertiser;
 
 
-    private RollingFileAppender(final String name, final Layout<T> layout, final Filter filter,
+    private RollingFileAppender(final String name, final Layout<? extends Serializable> layout, final Filter filter,
                                 final RollingFileManager manager, final String fileName,
                                 final String filePattern, final boolean ignoreExceptions, final boolean immediateFlush,
                                 final Advertiser advertiser) {
@@ -124,7 +124,7 @@ public final class RollingFileAppender<T extends Serializable> extends AbstractO
      * @return A RollingFileAppender.
      */
     @PluginFactory
-    public static <S extends Serializable> RollingFileAppender<S> createAppender(
+    public static <S extends Serializable> RollingFileAppender createAppender(
                                               @PluginAttr("fileName") final String fileName,
                                               @PluginAttr("filePattern") final String filePattern,
                                               @PluginAttr("append") final String append,
@@ -133,7 +133,7 @@ public final class RollingFileAppender<T extends Serializable> extends AbstractO
                                               @PluginAttr("immediateFlush") final String immediateFlush,
                                               @PluginElement("policy") final TriggeringPolicy policy,
                                               @PluginElement("strategy") RolloverStrategy strategy,
-                                              @PluginElement("layout") Layout<S> layout,
+                                              @PluginElement("layout") Layout<? extends Serializable> layout,
                                               @PluginElement("filter") final Filter filter,
                                               @PluginAttr("ignoreExceptions") final String ignore,
                                               @PluginAttr("advertise") final String advertise,
@@ -170,10 +170,7 @@ public final class RollingFileAppender<T extends Serializable> extends AbstractO
         }
 
         if (layout == null) {
-            @SuppressWarnings({ "unchecked", "UnnecessaryLocalVariable" })
-            final
-            Layout<S> l = (Layout<S>) PatternLayout.createLayout(null, null, null, null, null);
-            layout = l;
+            layout = PatternLayout.createLayout(null, null, null, null, null);
         }
 
         final RollingFileManager manager = RollingFileManager.getFileManager(fileName, filePattern, isAppend,
@@ -182,7 +179,7 @@ public final class RollingFileAppender<T extends Serializable> extends AbstractO
             return null;
         }
 
-        return new RollingFileAppender<S>(name, layout, filter, manager, fileName, filePattern,
+        return new RollingFileAppender(name, layout, filter, manager, fileName, filePattern,
                 ignoreExceptions, isFlush, isAdvertise ? config.getAdvertiser() : null);
     }
 }

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/RollingRandomAccessFileAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/RollingRandomAccessFileAppender.java
@@ -45,14 +45,14 @@ import org.apache.logging.log4j.core.net.Advertiser;
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
 @Plugin(name = "RollingRandomAccessFile", category = "Core", elementType = "appender", printObject = true)
-public final class RollingRandomAccessFileAppender<T extends Serializable> extends AbstractOutputStreamAppender<T> {
+public final class RollingRandomAccessFileAppender extends AbstractOutputStreamAppender {
 
     private final String fileName;
     private final String filePattern;
     private Object advertisement;
     private final Advertiser advertiser;
 
-    private RollingRandomAccessFileAppender(final String name, final Layout<T> layout,
+    private RollingRandomAccessFileAppender(final String name, final Layout<? extends Serializable> layout,
             final Filter filter, final RollingFileManager manager, final String fileName,
             final String filePattern, final boolean ignoreExceptions,
             final boolean immediateFlush, final Advertiser advertiser) {
@@ -143,7 +143,7 @@ public final class RollingRandomAccessFileAppender<T extends Serializable> exten
      * @return A RollingRandomAccessFileAppender.
      */
     @PluginFactory
-    public static <S extends Serializable> RollingRandomAccessFileAppender<S> createAppender(
+    public static <S extends Serializable> RollingRandomAccessFileAppender createAppender(
             @PluginAttr("fileName") final String fileName,
             @PluginAttr("filePattern") final String filePattern,
             @PluginAttr("append") final String append,
@@ -151,7 +151,7 @@ public final class RollingRandomAccessFileAppender<T extends Serializable> exten
             @PluginAttr("immediateFlush") final String immediateFlush,
             @PluginElement("policy") final TriggeringPolicy policy,
             @PluginElement("strategy") RolloverStrategy strategy,
-            @PluginElement("layout") Layout<S> layout,
+            @PluginElement("layout") Layout<? extends Serializable> layout,
             @PluginElement("filter") final Filter filter,
             @PluginAttr("ignoreExceptions") final String ignore,
             @PluginAttr("advertise") final String advertise,
@@ -191,10 +191,7 @@ public final class RollingRandomAccessFileAppender<T extends Serializable> exten
         }
 
         if (layout == null) {
-            @SuppressWarnings({ "unchecked", "UnnecessaryLocalVariable" })
-            final
-            Layout<S> l = (Layout<S>) PatternLayout.createLayout(null, null, null, null, null);
-            layout = l;
+            layout = PatternLayout.createLayout(null, null, null, null, null);
         }
 
 
@@ -204,7 +201,7 @@ public final class RollingRandomAccessFileAppender<T extends Serializable> exten
             return null;
         }
 
-        return new RollingRandomAccessFileAppender<S>(name, layout, filter, manager,
+        return new RollingRandomAccessFileAppender(name, layout, filter, manager,
                 fileName, filePattern, ignoreExceptions, isFlush,
                 isAdvertise ? config.getAdvertiser() : null);
     }

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/SMTPAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/SMTPAppender.java
@@ -52,14 +52,14 @@ import org.apache.logging.log4j.core.net.SMTPManager;
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
 @Plugin(name = "SMTP", category = "Core", elementType = "appender", printObject = true)
-public final class SMTPAppender<T extends Serializable> extends AbstractAppender<T> {
+public final class SMTPAppender extends AbstractAppender {
 
     private static final int DEFAULT_BUFFER_SIZE = 512;
 
     /** The SMTP Manager */
     protected final SMTPManager manager;
 
-    private SMTPAppender(final String name, final Filter filter, final Layout<T> layout, final SMTPManager manager,
+    private SMTPAppender(final String name, final Filter filter, final Layout<? extends Serializable> layout, final SMTPManager manager,
                          final boolean ignoreExceptions) {
         super(name, filter, layout, ignoreExceptions);
         this.manager = manager;
@@ -106,7 +106,7 @@ public final class SMTPAppender<T extends Serializable> extends AbstractAppender
      * @return The SMTPAppender.
      */
     @PluginFactory
-    public static <S extends Serializable> SMTPAppender<S> createAppender(@PluginAttr("name") final String name,
+    public static SMTPAppender createAppender(@PluginAttr("name") final String name,
                                               @PluginAttr("to") final String to,
                                               @PluginAttr("cc") final String cc,
                                               @PluginAttr("bcc") final String bcc,
@@ -120,7 +120,7 @@ public final class SMTPAppender<T extends Serializable> extends AbstractAppender
                                               @PluginAttr("smtpPassword") final String smtpPassword,
                                               @PluginAttr("smtpDebug") final String smtpDebug,
                                               @PluginAttr("bufferSize") final String bufferSizeNum,
-                                              @PluginElement("layout") Layout<S> layout,
+                                              @PluginElement("layout") Layout<? extends Serializable> layout,
                                               @PluginElement("filter") Filter filter,
                                               @PluginAttr("ignoreExceptions") final String ignore) {
         if (name == null) {
@@ -134,10 +134,7 @@ public final class SMTPAppender<T extends Serializable> extends AbstractAppender
         final int bufferSize = bufferSizeNum == null ? DEFAULT_BUFFER_SIZE : Integer.valueOf(bufferSizeNum);
 
         if (layout == null) {
-            @SuppressWarnings({ "unchecked", "UnnecessaryLocalVariable" })
-            final
-            Layout<S> l = (Layout<S>) HTMLLayout.createLayout(null, null, null, null, null, null);
-            layout = l;
+            layout = HTMLLayout.createLayout(null, null, null, null, null, null);
         }
         if (filter == null) {
             filter = ThresholdFilter.createFilter(null, null, null);
@@ -149,7 +146,7 @@ public final class SMTPAppender<T extends Serializable> extends AbstractAppender
             return null;
         }
 
-        return new SMTPAppender<S>(name, filter, layout, manager, ignoreExceptions);
+        return new SMTPAppender(name, filter, layout, manager, ignoreExceptions);
     }
 
     /**

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/SocketAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/SocketAppender.java
@@ -43,11 +43,11 @@ import org.apache.logging.log4j.util.EnglishEnums;
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
 @Plugin(name = "Socket", category = "Core", elementType = "appender", printObject = true)
-public class SocketAppender<T extends Serializable> extends AbstractOutputStreamAppender<T> {
+public class SocketAppender extends AbstractOutputStreamAppender {
     private Object advertisement;
     private final Advertiser advertiser;
 
-    protected SocketAppender(final String name, final Layout<T> layout, final Filter filter,
+    protected SocketAppender(final String name, final Layout<? extends Serializable> layout, final Filter filter,
                              final AbstractSocketManager manager, final boolean ignoreExceptions,
                              final boolean immediateFlush, final Advertiser advertiser) {
         super(name, layout, filter, ignoreExceptions, immediateFlush, manager);
@@ -88,7 +88,7 @@ public class SocketAppender<T extends Serializable> extends AbstractOutputStream
      * @return A SocketAppender.
      */
     @PluginFactory
-    public static <S extends Serializable> SocketAppender<S> createAppender(@PluginAttr("host") final String host,
+    public static <S extends Serializable> SocketAppender createAppender(@PluginAttr("host") final String host,
                                                 @PluginAttr("port") final String portNum,
                                                 @PluginAttr("protocol") final String protocol,
                                                 @PluginAttr("reconnectionDelay") final String delay,
@@ -96,7 +96,7 @@ public class SocketAppender<T extends Serializable> extends AbstractOutputStream
                                                 @PluginAttr("name") final String name,
                                                 @PluginAttr("immediateFlush") final String immediateFlush,
                                                 @PluginAttr("ignoreExceptions") final String ignore,
-                                                @PluginElement("layout") Layout<S> layout,
+                                                @PluginElement("layout") Layout<? extends Serializable> layout,
                                                 @PluginElement("filters") final Filter filter,
                                                 @PluginAttr("advertise") final String advertise,
                                                 @PluginConfiguration final Configuration config) {
@@ -108,10 +108,7 @@ public class SocketAppender<T extends Serializable> extends AbstractOutputStream
         final int reconnectDelay = AbstractAppender.parseInt(delay, 0);
         final int port = AbstractAppender.parseInt(portNum, 0);
         if (layout == null) {
-            @SuppressWarnings({ "unchecked", "UnnecessaryLocalVariable" })
-            final
-            Layout<S> l = (Layout<S>) SerializedLayout.createLayout();
-            layout = l;
+            layout = SerializedLayout.createLayout();
         }
 
         if (name == null) {
@@ -129,13 +126,13 @@ public class SocketAppender<T extends Serializable> extends AbstractOutputStream
             return null;
         }
 
-        return new SocketAppender<S>(name, layout, filter, manager, ignoreExceptions, isFlush,
+        return new SocketAppender(name, layout, filter, manager, ignoreExceptions, isFlush,
                 isAdvertise ? config.getAdvertiser() : null);
     }
 
     protected static AbstractSocketManager createSocketManager(final Protocol p, final String host, final int port,
                                                                final int delay, final boolean immediateFail,
-                                                               final Layout layout) {
+                                                               final Layout<? extends Serializable> layout) {
         switch (p) {
             case TCP:
                 return TCPSocketManager.getSocketManager(host, port, delay, immediateFail, layout);

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/SyslogAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/SyslogAppender.java
@@ -41,11 +41,11 @@ import org.apache.logging.log4j.util.EnglishEnums;
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
 @Plugin(name = "Syslog", category = "Core", elementType = "appender", printObject = true)
-public class SyslogAppender<T extends Serializable> extends SocketAppender<T> {
+public class SyslogAppender extends SocketAppender {
 
     private static final String RFC5424 = "RFC5424";
 
-    protected SyslogAppender(final String name, final Layout<T> layout, final Filter filter,
+    protected SyslogAppender(final String name, final Layout<? extends Serializable> layout, final Filter filter,
                              final boolean ignoreExceptions, final boolean immediateFlush,
                              final AbstractSocketManager manager, final Advertiser advertiser) {
         super(name, layout, filter, manager, ignoreExceptions, immediateFlush, advertiser);
@@ -90,7 +90,7 @@ public class SyslogAppender<T extends Serializable> extends SocketAppender<T> {
      * @return A SyslogAppender.
      */
     @PluginFactory
-    public static <S extends Serializable> SyslogAppender<S> createAppender(@PluginAttr("host") final String host,
+    public static <S extends Serializable> SyslogAppender createAppender(@PluginAttr("host") final String host,
                                                 @PluginAttr("port") final String portNum,
                                                 @PluginAttr("protocol") final String protocol,
                                                 @PluginAttr("reconnectionDelay") final String delay,
@@ -126,8 +126,7 @@ public class SyslogAppender<T extends Serializable> extends SocketAppender<T> {
         final boolean fail = Booleans.parseBoolean(immediateFail, true);
         final int port = AbstractAppender.parseInt(portNum, 0);
         final boolean isAdvertise = Boolean.parseBoolean(advertise);
-        @SuppressWarnings("unchecked")
-        final Layout<S> layout = (Layout<S>) (RFC5424.equalsIgnoreCase(format) ?
+        final Layout<? extends Serializable> layout = (RFC5424.equalsIgnoreCase(format) ?
             RFC5424Layout.createLayout(facility, id, ein, includeMDC, mdcId, mdcPrefix, eventPrefix, includeNL,
                 escapeNL, appName, msgId, excludes, includes, required, exceptionPattern, loggerFields, config) :
             SyslogLayout.createLayout(facility, includeNL, escapeNL, charsetName));
@@ -142,7 +141,7 @@ public class SyslogAppender<T extends Serializable> extends SocketAppender<T> {
             return null;
         }
 
-        return new SyslogAppender<S>(name, layout, filter, ignoreExceptions, isFlush, manager,
+        return new SyslogAppender(name, layout, filter, ignoreExceptions, isFlush, manager,
                 isAdvertise ? config.getAdvertiser() : null);
     }
 }

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/db/AbstractDatabaseAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/db/AbstractDatabaseAppender.java
@@ -35,12 +35,12 @@ import org.apache.logging.log4j.core.appender.AppenderLoggingException;
  *
  * @param <T> Specifies which type of {@link AbstractDatabaseManager} this Appender requires.
  */
-public abstract class AbstractDatabaseAppender<T extends AbstractDatabaseManager> extends AbstractAppender<LogEvent> {
+public abstract class AbstractDatabaseAppender extends AbstractAppender {
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
     private final Lock readLock = lock.readLock();
     private final Lock writeLock = lock.writeLock();
 
-    private T manager;
+    private AbstractDatabaseManager manager;
 
     /**
      * Instantiates the base appender.
@@ -52,7 +52,7 @@ public abstract class AbstractDatabaseAppender<T extends AbstractDatabaseManager
      * @param manager The matching {@link AbstractDatabaseManager} implementation.
      */
     protected AbstractDatabaseAppender(final String name, final Filter filter, final boolean ignoreExceptions,
-                                       final T manager) {
+                                       final AbstractDatabaseManager manager) {
         super(name, filter, null, ignoreExceptions);
         this.manager = manager;
     }
@@ -73,7 +73,7 @@ public abstract class AbstractDatabaseAppender<T extends AbstractDatabaseManager
      *
      * @return the manager.
      */
-    public final T getManager() {
+    public final AbstractDatabaseManager getManager() {
         return this.manager;
     }
 
@@ -121,10 +121,10 @@ public abstract class AbstractDatabaseAppender<T extends AbstractDatabaseManager
      *
      * @param manager The new manager to install.
      */
-    protected final void replaceManager(final T manager) {
+    protected final void replaceManager(final AbstractDatabaseManager manager) {
         this.writeLock.lock();
         try {
-            final T old = this.getManager();
+            final AbstractDatabaseManager old = this.getManager();
             if (!manager.isConnected()) {
                 manager.connect();
             }

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/db/jdbc/JDBCAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/db/jdbc/JDBCAppender.java
@@ -35,7 +35,7 @@ import org.apache.logging.log4j.core.helpers.Booleans;
  * @see ConnectionSource
  */
 @Plugin(name = "Jdbc", category = "Core", elementType = "appender", printObject = true)
-public final class JDBCAppender extends AbstractDatabaseAppender<JDBCDatabaseManager> {
+public final class JDBCAppender extends AbstractDatabaseAppender {
     private final String description;
 
     private JDBCAppender(final String name, final Filter filter, final boolean ignoreExceptions,

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/db/jpa/AbstractLogEventWrapperEntity.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/db/jpa/AbstractLogEventWrapperEntity.java
@@ -68,7 +68,6 @@ public abstract class AbstractLogEventWrapperEntity implements LogEvent {
      * signature. The no-argument constructor is required for a standards-compliant JPA provider to accept this as an
      * entity.
      */
-    @SuppressWarnings("unused")
     protected AbstractLogEventWrapperEntity() {
         this(new NullLogEvent());
     }
@@ -102,7 +101,6 @@ public abstract class AbstractLogEventWrapperEntity implements LogEvent {
      *
      * @param level Ignored.
      */
-    @SuppressWarnings("unused")
     public void setLevel(final Level level) {
         // this entity is write-only
     }
@@ -112,7 +110,6 @@ public abstract class AbstractLogEventWrapperEntity implements LogEvent {
      *
      * @param loggerName Ignored.
      */
-    @SuppressWarnings("unused")
     public void setLoggerName(final String loggerName) {
         // this entity is write-only
     }
@@ -122,7 +119,6 @@ public abstract class AbstractLogEventWrapperEntity implements LogEvent {
      *
      * @param source Ignored.
      */
-    @SuppressWarnings("unused")
     public void setSource(final StackTraceElement source) {
         // this entity is write-only
     }
@@ -132,7 +128,6 @@ public abstract class AbstractLogEventWrapperEntity implements LogEvent {
      *
      * @param message Ignored.
      */
-    @SuppressWarnings("unused")
     public void setMessage(final Message message) {
         // this entity is write-only
     }
@@ -142,7 +137,6 @@ public abstract class AbstractLogEventWrapperEntity implements LogEvent {
      *
      * @param marker Ignored.
      */
-    @SuppressWarnings("unused")
     public void setMarker(final Marker marker) {
         // this entity is write-only
     }
@@ -152,7 +146,6 @@ public abstract class AbstractLogEventWrapperEntity implements LogEvent {
      *
      * @param threadName Ignored.
      */
-    @SuppressWarnings("unused")
     public void setThreadName(final String threadName) {
         // this entity is write-only
     }
@@ -162,7 +155,6 @@ public abstract class AbstractLogEventWrapperEntity implements LogEvent {
      *
      * @param millis Ignored.
      */
-    @SuppressWarnings("unused")
     public void setMillis(final long millis) {
         // this entity is write-only
     }
@@ -172,7 +164,6 @@ public abstract class AbstractLogEventWrapperEntity implements LogEvent {
      *
      * @param throwable Ignored.
      */
-    @SuppressWarnings("unused")
     public void setThrown(final Throwable throwable) {
         // this entity is write-only
     }
@@ -182,7 +173,6 @@ public abstract class AbstractLogEventWrapperEntity implements LogEvent {
      *
      * @param contextMap Ignored.
      */
-    @SuppressWarnings("unused")
     public void setContextMap(final Map<String, String> contextMap) {
         // this entity is write-only
     }
@@ -192,7 +182,6 @@ public abstract class AbstractLogEventWrapperEntity implements LogEvent {
      *
      * @param contextStack Ignored.
      */
-    @SuppressWarnings("unused")
     public void setContextStack(final ThreadContext.ContextStack contextStack) {
         // this entity is write-only
     }
@@ -202,7 +191,6 @@ public abstract class AbstractLogEventWrapperEntity implements LogEvent {
      *
      * @param fqcn Ignored.
      */
-    @SuppressWarnings("unused")
     public void setFQCN(final String fqcn) {
         // this entity is write-only
     }

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/db/jpa/BasicLogEventEntity.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/db/jpa/BasicLogEventEntity.java
@@ -71,7 +71,6 @@ public abstract class BasicLogEventEntity extends AbstractLogEventWrapperEntity 
      * signature. The no-argument constructor is required for a standards-compliant JPA provider to accept this as an
      * entity.
      */
-    @SuppressWarnings("unused")
     public BasicLogEventEntity() {
         super();
     }

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/db/jpa/JPAAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/db/jpa/JPAAppender.java
@@ -37,7 +37,7 @@ import org.apache.logging.log4j.core.helpers.Strings;
  * @see AbstractLogEventWrapperEntity
  */
 @Plugin(name = "Jpa", category = "Core", elementType = "appender", printObject = true)
-public final class JPAAppender extends AbstractDatabaseAppender<JPADatabaseManager> {
+public final class JPAAppender extends AbstractDatabaseAppender {
     private final String description;
 
     private JPAAppender(final String name, final Filter filter, final boolean ignoreExceptions,

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/db/nosql/NoSQLAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/db/nosql/NoSQLAppender.java
@@ -38,7 +38,7 @@ import org.apache.logging.log4j.core.helpers.Booleans;
  * @see NoSQLProvider
  */
 @Plugin(name = "NoSql", category = "Core", elementType = "appender", printObject = true)
-public final class NoSQLAppender extends AbstractDatabaseAppender<NoSQLDatabaseManager<?>> {
+public final class NoSQLAppender extends AbstractDatabaseAppender {
     private final String description;
 
     private NoSQLAppender(final String name, final Filter filter, final boolean ignoreExceptions,

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/RewriteAppender.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/RewriteAppender.java
@@ -41,7 +41,7 @@ import org.apache.logging.log4j.core.helpers.Booleans;
  * @param <T> The {@link org.apache.logging.log4j.core.Layout}'s {@link Serializable} type.
  */
 @Plugin(name = "Rewrite", category = "Core", elementType = "appender", printObject = true)
-public final class RewriteAppender<T extends Serializable> extends AbstractAppender<T> {
+public final class RewriteAppender extends AbstractAppender {
     private final Configuration config;
     private final ConcurrentMap<String, AppenderControl> appenders = new ConcurrentHashMap<String, AppenderControl>();
     private final RewritePolicy rewritePolicy;
@@ -57,15 +57,14 @@ public final class RewriteAppender<T extends Serializable> extends AbstractAppen
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void start() {
-        final Map<String, Appender<?>> map = config.getAppenders();
+        final Map<String, Appender> map = config.getAppenders();
         for (final AppenderRef ref : appenderRefs) {
             final String name = ref.getRef();
             final Appender appender = map.get(name);
             if (appender != null) {
-                final Filter filter = appender instanceof AbstractAppender<?> ?
-                    ((AbstractAppender<?>) appender).getFilter() : null;
+                final Filter filter = appender instanceof AbstractAppender ?
+                    ((AbstractAppender) appender).getFilter() : null;
                 appenders.put(name, new AppenderControl(appender, ref.getLevel(), filter));
             } else {
                 LOGGER.error("Appender " + ref + " cannot be located. Reference ignored");
@@ -106,7 +105,7 @@ public final class RewriteAppender<T extends Serializable> extends AbstractAppen
      * @return The created RewriteAppender.
      */
     @PluginFactory
-    public static <S extends Serializable> RewriteAppender<S> createAppender(@PluginAttr("name") final String name,
+    public static RewriteAppender createAppender(@PluginAttr("name") final String name,
                                           @PluginAttr("ignoreExceptions") final String ignore,
                                           @PluginElement("appender-ref") final AppenderRef[] appenderRefs,
                                           @PluginConfiguration final Configuration config,
@@ -122,6 +121,6 @@ public final class RewriteAppender<T extends Serializable> extends AbstractAppen
             LOGGER.error("No appender references defined for RewriteAppender");
             return null;
         }
-        return new RewriteAppender<S>(name, filter, ignoreExceptions, appenderRefs, rewritePolicy, config);
+        return new RewriteAppender(name, filter, ignoreExceptions, appenderRefs, rewritePolicy, config);
     }
 }

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
@@ -22,6 +22,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.util.concurrent.Semaphore;
 
 import org.apache.logging.log4j.core.Layout;
@@ -47,7 +48,7 @@ public class RollingFileManager extends FileManager {
 
     protected RollingFileManager(final String fileName, final String pattern, final OutputStream os,
                                  final boolean append, final long size, final long time, final TriggeringPolicy policy,
-                                 final RolloverStrategy strategy, final String advertiseURI, final Layout layout) {
+                                 final RolloverStrategy strategy, final String advertiseURI, final Layout<? extends Serializable> layout) {
         super(fileName, os, append, false, advertiseURI, layout);
         this.size = size;
         this.initialTime = time;
@@ -72,7 +73,7 @@ public class RollingFileManager extends FileManager {
     public static RollingFileManager getFileManager(final String fileName, final String pattern, final boolean append,
                                                     final boolean bufferedIO, final TriggeringPolicy policy,
                                                     final RolloverStrategy strategy, final String advertiseURI,
-                                                    final Layout layout) {
+                                                    final Layout<? extends Serializable> layout) {
 
         return (RollingFileManager) getManager(fileName, new FactoryData(pattern, append,
             bufferedIO, policy, strategy, advertiseURI, layout), factory);
@@ -237,7 +238,7 @@ public class RollingFileManager extends FileManager {
         private final TriggeringPolicy policy;
         private final RolloverStrategy strategy;
         private final String advertiseURI;
-        private final Layout layout;
+        private final Layout<? extends Serializable> layout;
 
         /**
          * Create the data for the factory.
@@ -249,7 +250,7 @@ public class RollingFileManager extends FileManager {
          */
         public FactoryData(final String pattern, final boolean append, final boolean bufferedIO,
                            final TriggeringPolicy policy, final RolloverStrategy strategy, final String advertiseURI,
-                           final Layout layout) {
+                           final Layout<? extends Serializable> layout) {
             this.pattern = pattern;
             this.append = append;
             this.bufferedIO = bufferedIO;

--- a/core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 
 import org.apache.logging.log4j.core.Layout;
@@ -45,7 +46,7 @@ public class RollingRandomAccessFileManager extends RollingFileManager {
             final String pattern, final OutputStream os, final boolean append,
             final boolean immediateFlush, final long size, final long time,
             final TriggeringPolicy policy, final RolloverStrategy strategy,
-            final String advertiseURI, final Layout layout) {
+            final String advertiseURI, final Layout<? extends Serializable> layout) {
         super(fileName, pattern, os, append, size, time, policy, strategy, advertiseURI, layout);
         this.isImmediateFlush = immediateFlush;
         this.randomAccessFile = raf;
@@ -57,7 +58,7 @@ public class RollingRandomAccessFileManager extends RollingFileManager {
 
     public static RollingRandomAccessFileManager getRollingRandomAccessFileManager(final String fileName, final String filePattern,
             final boolean isAppend, final boolean immediateFlush, final TriggeringPolicy policy,
-            final RolloverStrategy strategy, final String advertiseURI, final Layout layout) {
+            final RolloverStrategy strategy, final String advertiseURI, final Layout<? extends Serializable> layout) {
         return (RollingRandomAccessFileManager) getManager(fileName, new FactoryData(filePattern, isAppend, immediateFlush,
             policy, strategy, advertiseURI, layout), FACTORY);
     }
@@ -185,7 +186,7 @@ public class RollingRandomAccessFileManager extends RollingFileManager {
         private final TriggeringPolicy policy;
         private final RolloverStrategy strategy;
         private final String advertiseURI;
-        private final Layout layout;
+        private final Layout<? extends Serializable> layout;
 
         /**
          * Create the data for the factory.
@@ -196,7 +197,7 @@ public class RollingRandomAccessFileManager extends RollingFileManager {
          */
         public FactoryData(final String pattern, final boolean append, final boolean immediateFlush,
                            final TriggeringPolicy policy, final RolloverStrategy strategy, final String advertiseURI,
-                           final Layout layout) {
+                           final Layout<? extends Serializable> layout) {
             this.pattern = pattern;
             this.append = append;
             this.immediateFlush = immediateFlush;

--- a/core/src/main/java/org/apache/logging/log4j/core/config/AppenderControl.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/config/AppenderControl.java
@@ -16,8 +16,6 @@
  */
 package org.apache.logging.log4j.core.config;
 
-import java.io.Serializable;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Filter;
@@ -30,11 +28,11 @@ import org.apache.logging.log4j.core.filter.Filterable;
  * Wraps an {@link Appender} with details an appender implementation shouldn't need to know about.
  * @param <T> The appender's Serializable type.
  */
-public class AppenderControl<T extends Serializable> extends AbstractFilterable {
+public class AppenderControl extends AbstractFilterable {
 
-    private final ThreadLocal<AppenderControl<T>> recursive = new ThreadLocal<AppenderControl<T>>();
+    private final ThreadLocal<AppenderControl> recursive = new ThreadLocal<AppenderControl>();
 
-    private final Appender<T> appender;
+    private final Appender appender;
 
     private final Level level;
 
@@ -46,7 +44,7 @@ public class AppenderControl<T extends Serializable> extends AbstractFilterable 
      * @param level the Level to filter on.
      * @param filter the Filter(s) to apply.
      */
-    public AppenderControl(final Appender<T> appender, final Level level, final Filter filter) {
+    public AppenderControl(final Appender appender, final Level level, final Filter filter) {
         super(filter);
         this.appender = appender;
         this.level = level;
@@ -58,7 +56,7 @@ public class AppenderControl<T extends Serializable> extends AbstractFilterable 
      * Returns the Appender.
      * @return the Appender.
      */
-    public Appender<T> getAppender() {
+    public Appender getAppender() {
         return appender;
     }
 

--- a/core/src/main/java/org/apache/logging/log4j/core/config/Configuration.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/config/Configuration.java
@@ -52,11 +52,11 @@ public interface Configuration extends Filterable {
      * Returns a Map containing all the Appenders and their name.
      * @return A Map containing each Appender's name and the Appender object.
      */
-    Map<String, Appender<?>> getAppenders();
+    Map<String, Appender> getAppenders();
 
     Map<String, LoggerConfig> getLoggers();
 
-    void addLoggerAppender(Logger logger, Appender<?> appender);
+    void addLoggerAppender(Logger logger, Appender appender);
 
     void addLoggerFilter(Logger logger, Filter filter);
 

--- a/core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
@@ -107,9 +107,9 @@ public abstract class ConfigurationFactory {
                     }
                     final PluginManager manager = new PluginManager("ConfigurationFactory");
                     manager.collectPlugins();
-                    final Map<String, PluginType> plugins = manager.getPlugins();
+                    final Map<String, PluginType<?>> plugins = manager.getPlugins();
                     final Set<WeightedFactory> ordered = new TreeSet<WeightedFactory>();
-                    for (final PluginType type : plugins.values()) {
+                    for (final PluginType<?> type : plugins.values()) {
                         try {
                             @SuppressWarnings("unchecked")
                             final Class<ConfigurationFactory> clazz = (Class<ConfigurationFactory>)type.getPluginClass();

--- a/core/src/main/java/org/apache/logging/log4j/core/config/DefaultConfiguration.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/config/DefaultConfiguration.java
@@ -50,7 +50,7 @@ public class DefaultConfiguration extends BaseConfiguration {
         setName(DEFAULT_NAME);
         final Layout<? extends Serializable> layout =
                 PatternLayout.createLayout("%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n", null, null, null, null);
-        final Appender<? extends Serializable> appender =
+        final Appender appender =
                 ConsoleAppender.createAppender(layout, null, "SYSTEM_OUT", "Console", "false", "true");
         appender.start();
         addAppender(appender);

--- a/core/src/main/java/org/apache/logging/log4j/core/config/JSONConfiguration.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/config/JSONConfiguration.java
@@ -132,7 +132,7 @@ public class JSONConfiguration extends BaseConfiguration implements Reconfigurab
                     if (advertiserString != null)
                     {
                         @SuppressWarnings("unchecked")
-                        final PluginType<Advertiser> type = getPluginManager().getPluginType(advertiserString);
+                        final PluginType<Advertiser> type = (PluginType<Advertiser>) getPluginManager().getPluginType(advertiserString);
                         if (type != null)
                         {
                             final Class<Advertiser> clazz = type.getPluginClass();

--- a/core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -16,18 +16,6 @@
  */
 package org.apache.logging.log4j.core.config;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -54,6 +42,17 @@ import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.PropertiesUtil;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * Logger object that is created via configuration.
  */
@@ -66,7 +65,7 @@ public class LoggerConfig extends AbstractFilterable {
     private static LogEventFactory LOG_EVENT_FACTORY = null;
 
     private List<AppenderRef> appenderRefs = new ArrayList<AppenderRef>();
-    private final Map<String, AppenderControl<?>> appenders = new ConcurrentHashMap<String, AppenderControl<?>>();
+    private final Map<String, AppenderControl> appenders = new ConcurrentHashMap<String, AppenderControl>();
     private final String name;
     private LogEventFactory logEventFactory;
     private Level level;
@@ -186,9 +185,9 @@ public class LoggerConfig extends AbstractFilterable {
      * @param level The Level to use.
      * @param filter A Filter for the Appender reference.
      */
-    public <T extends Serializable> void addAppender(final Appender<T> appender, final Level level,
+    public void addAppender(final Appender appender, final Level level,
             final Filter filter) {
-        appenders.put(appender.getName(), new AppenderControl<T>(appender, level,
+        appenders.put(appender.getName(), new AppenderControl(appender, level,
                 filter));
     }
 
@@ -210,9 +209,9 @@ public class LoggerConfig extends AbstractFilterable {
      * @return a Map with the Appender name as the key and the Appender as the
      *         value.
      */
-    public Map<String, Appender<?>> getAppenders() {
-        final Map<String, Appender<?>> map = new HashMap<String, Appender<?>>();
-        for (final Map.Entry<String, AppenderControl<?>> entry : appenders
+    public Map<String, Appender> getAppenders() {
+        final Map<String, Appender> map = new HashMap<String, Appender>();
+        for (final Map.Entry<String, AppenderControl> entry : appenders
                 .entrySet()) {
             map.put(entry.getKey(), entry.getValue().getAppender());
         }
@@ -224,10 +223,10 @@ public class LoggerConfig extends AbstractFilterable {
      */
     protected void clearAppenders() {
         waitForCompletion();
-        final Collection<AppenderControl<?>> controls = appenders.values();
-        final Iterator<AppenderControl<?>> iterator = controls.iterator();
+        final Collection<AppenderControl> controls = appenders.values();
+        final Iterator<AppenderControl> iterator = controls.iterator();
         while (iterator.hasNext()) {
-            final AppenderControl<?> ctl = iterator.next();
+            final AppenderControl ctl = iterator.next();
             iterator.remove();
             cleanupFilter(ctl);
         }

--- a/core/src/main/java/org/apache/logging/log4j/core/config/Node.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/config/Node.java
@@ -31,7 +31,7 @@ public class Node {
     private final Node parent;
     private final String name;
     private String value;
-    private final PluginType type;
+    private final PluginType<?> type;
     private final Map<String, String> attributes = new HashMap<String, String>();
     private final List<Node> children = new ArrayList<Node>();
     private Object object;
@@ -45,7 +45,7 @@ public class Node {
      * @param name the node's name.
      * @param type The Plugin Type associated with the node.
      */
-    public Node(final Node parent, final String name, final PluginType type) {
+    public Node(final Node parent, final String name, final PluginType<?> type) {
         this.parent = parent;
         this.name = name;
         this.type = type;
@@ -109,7 +109,7 @@ public class Node {
         return object;
     }
 
-    public PluginType getType() {
+    public PluginType<?> getType() {
         return type;
     }
 

--- a/core/src/main/java/org/apache/logging/log4j/core/config/XMLConfiguration.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/config/XMLConfiguration.java
@@ -164,7 +164,7 @@ public class XMLConfiguration extends BaseConfiguration implements Reconfigurabl
                     if (advertiserString != null)
                     {
                         @SuppressWarnings("unchecked")
-                        final PluginType<Advertiser> type = getPluginManager().getPluginType(advertiserString);
+                        final PluginType<Advertiser> type = (PluginType<Advertiser>) getPluginManager().getPluginType(advertiserString);
                         if (type != null)
                         {
                             final Class<Advertiser> clazz = type.getPluginClass();

--- a/core/src/main/java/org/apache/logging/log4j/core/config/plugins/AppendersPlugin.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/config/plugins/AppendersPlugin.java
@@ -16,11 +16,10 @@
  */
 package org.apache.logging.log4j.core.config.plugins;
 
-import java.io.Serializable;
+import org.apache.logging.log4j.core.Appender;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
-import org.apache.logging.log4j.core.Appender;
 
 /**
  * An Appender container.
@@ -37,12 +36,12 @@ public final class AppendersPlugin {
      * @return The Appender Map.
      */
     @PluginFactory
-    public static ConcurrentMap<String, Appender<? extends Serializable>> createAppenders(
-                                             @PluginElement("appenders") final Appender<?>[] appenders) {
-        final ConcurrentMap<String, Appender<? extends Serializable>> map =
-            new ConcurrentHashMap<String, Appender<? extends Serializable>>();
+    public static ConcurrentMap<String, Appender> createAppenders(
+                                             @PluginElement("appenders") final Appender[] appenders) {
+        final ConcurrentMap<String, Appender> map =
+            new ConcurrentHashMap<String, Appender>();
 
-        for (final Appender<?> appender : appenders) {
+        for (final Appender appender : appenders) {
                 map.put(appender.getName(), appender);
         }
 

--- a/core/src/main/java/org/apache/logging/log4j/core/config/plugins/PluginManager.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/config/plugins/PluginManager.java
@@ -44,8 +44,8 @@ public class PluginManager {
 
     private static final long NANOS_PER_SECOND = 1000000000L;
 
-    private static ConcurrentMap<String, ConcurrentMap<String, PluginType>> pluginTypeMap =
-        new ConcurrentHashMap<String, ConcurrentMap<String, PluginType>>();
+    private static ConcurrentMap<String, ConcurrentMap<String, PluginType<?>>> pluginTypeMap =
+        new ConcurrentHashMap<String, ConcurrentMap<String, PluginType<?>>>();
 
     private static final CopyOnWriteArrayList<String> PACKAGES = new CopyOnWriteArrayList<String>();
     private static final String PATH = "org/apache/logging/log4j/core/config/plugins/";
@@ -56,7 +56,7 @@ public class PluginManager {
 
     private static String rootDir;
 
-    private Map<String, PluginType> plugins = new HashMap<String, PluginType>();
+    private Map<String, PluginType<?>> plugins = new HashMap<String, PluginType<?>>();
     private final String type;
     private final Class<?> clazz;
 
@@ -110,7 +110,7 @@ public class PluginManager {
      * @param name The name of the plugin.
      * @return The plugin's type.
      */
-    public PluginType getPluginType(final String name) {
+    public PluginType<?> getPluginType(final String name) {
         return plugins.get(name.toLowerCase());
     }
 
@@ -118,7 +118,7 @@ public class PluginManager {
      * Returns all the matching plugins.
      * @return A Map containing the name of the plugin and its type.
      */
-    public Map<String, PluginType> getPlugins() {
+    public Map<String, PluginType<?>> getPlugins() {
         return plugins;
     }
 
@@ -135,7 +135,7 @@ public class PluginManager {
      * @param pkgs A comma separated list of package names to scan for plugins. If
      * null the default Log4j package name will be used.
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public void collectPlugins(boolean preLoad, final String pkgs) {
         if (pluginTypeMap.containsKey(type)) {
             plugins = pluginTypeMap.get(type);
@@ -148,7 +148,7 @@ public class PluginManager {
             resolver.setClassLoader(loader);
         }
         if (preLoad) {
-            final ConcurrentMap<String, ConcurrentMap<String, PluginType>> map = decode(loader);
+            final ConcurrentMap<String, ConcurrentMap<String, PluginType<?>>> map = decode(loader);
             if (map != null) {
                 pluginTypeMap = map;
                 plugins = map.get(type);
@@ -176,9 +176,9 @@ public class PluginManager {
             final Plugin plugin = clazz.getAnnotation(Plugin.class);
             final String pluginType = plugin.category();
             if (!pluginTypeMap.containsKey(pluginType)) {
-                pluginTypeMap.putIfAbsent(pluginType, new ConcurrentHashMap<String, PluginType>());
+                pluginTypeMap.putIfAbsent(pluginType, new ConcurrentHashMap<String, PluginType<?>>());
             }
-            final Map<String, PluginType> map = pluginTypeMap.get(pluginType);
+            final Map<String, PluginType<?>> map = pluginTypeMap.get(pluginType);
             final String type = plugin.elementType().equals(Plugin.EMPTY) ? plugin.name() : plugin.elementType();
             map.put(plugin.name().toLowerCase(), new PluginType(clazz, type, plugin.printObject(),
                 plugin.deferChildren()));
@@ -196,8 +196,8 @@ public class PluginManager {
         LOGGER.debug(sb.toString());
     }
 
-    @SuppressWarnings("unchecked")
-    private static ConcurrentMap<String, ConcurrentMap<String, PluginType>> decode(final ClassLoader loader) {
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static ConcurrentMap<String, ConcurrentMap<String, PluginType<?>>> decode(final ClassLoader loader) {
         Enumeration<URL> resources;
         try {
             resources = loader.getResources(PATH + FILENAME);
@@ -205,8 +205,8 @@ public class PluginManager {
             LOGGER.warn("Unable to preload plugins", ioe);
             return null;
         }
-        final ConcurrentMap<String, ConcurrentMap<String, PluginType>> map =
-            new ConcurrentHashMap<String, ConcurrentMap<String, PluginType>>();
+        final ConcurrentMap<String, ConcurrentMap<String, PluginType<?>>> map =
+            new ConcurrentHashMap<String, ConcurrentMap<String, PluginType<?>>>();
         while (resources.hasMoreElements()) {
             DataInputStream dis = null;
             try {
@@ -219,9 +219,9 @@ public class PluginManager {
                 for (int j = 0; j < count; ++j) {
                     final String type = dis.readUTF();
                     final int entries = dis.readInt();
-                    ConcurrentMap<String, PluginType> types = map.get(type);
+                    ConcurrentMap<String, PluginType<?>> types = map.get(type);
                     if (types == null) {
-                        types = new ConcurrentHashMap<String, PluginType>(count);
+                        types = new ConcurrentHashMap<String, PluginType<?>>(count);
                     }
                     for (int i = 0; i < entries; ++i) {
                         final String key = dis.readUTF();
@@ -248,7 +248,7 @@ public class PluginManager {
         return map.size() == 0 ? null : map;
     }
 
-    private static void encode(final ConcurrentMap<String, ConcurrentMap<String, PluginType>> map) {
+    private static void encode(final ConcurrentMap<String, ConcurrentMap<String, PluginType<?>>> map) {
         final String fileName = rootDir + PATH + FILENAME;
         DataOutputStream dos = null;
         try {
@@ -258,12 +258,12 @@ public class PluginManager {
             final BufferedOutputStream bos = new BufferedOutputStream(fos);
             dos = new DataOutputStream(bos);
             dos.writeInt(map.size());
-            for (final Map.Entry<String, ConcurrentMap<String, PluginType>> outer : map.entrySet()) {
+            for (final Map.Entry<String, ConcurrentMap<String, PluginType<?>>> outer : map.entrySet()) {
                 dos.writeUTF(outer.getKey());
                 dos.writeInt(outer.getValue().size());
-                for (final Map.Entry<String, PluginType> entry : outer.getValue().entrySet()) {
+                for (final Map.Entry<String, PluginType<?>> entry : outer.getValue().entrySet()) {
                     dos.writeUTF(entry.getKey());
-                    final PluginType pt = entry.getValue();
+                    final PluginType<?> pt = entry.getValue();
                     dos.writeUTF(pt.getPluginClass().getName());
                     dos.writeUTF(pt.getElementName());
                     dos.writeBoolean(pt.isObjectPrintable());

--- a/core/src/main/java/org/apache/logging/log4j/core/jmx/AppenderAdmin.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/jmx/AppenderAdmin.java
@@ -27,7 +27,7 @@ import org.apache.logging.log4j.core.helpers.Assert;
 public class AppenderAdmin implements AppenderAdminMBean {
 
     private final String contextName;
-    private final Appender<?> appender;
+    private final Appender appender;
     private final ObjectName objectName;
 
     /**
@@ -37,7 +37,7 @@ public class AppenderAdmin implements AppenderAdminMBean {
      * @param contextName used in the {@code ObjectName} for this mbean
      * @param appender the instrumented object
      */
-    public AppenderAdmin(final String contextName, final Appender<?> appender) {
+    public AppenderAdmin(final String contextName, final Appender appender) {
         // super(executor); // no notifications for now
         this.contextName = Assert.isNotNull(contextName, "contextName");
         this.appender = Assert.isNotNull(appender, "appender");

--- a/core/src/main/java/org/apache/logging/log4j/core/jmx/Server.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/jmx/Server.java
@@ -240,9 +240,9 @@ public final class Server {
             InstanceAlreadyExistsException, MBeanRegistrationException,
             NotCompliantMBeanException {
 
-        final Map<String, Appender<?>> map = ctx.getConfiguration().getAppenders();
+        final Map<String, Appender> map = ctx.getConfiguration().getAppenders();
         for (final String name : map.keySet()) {
-            final Appender<?> appender = map.get(name);
+            final Appender appender = map.get(name);
             final AppenderAdmin mbean = new AppenderAdmin(ctx.getName(), appender);
             mbs.registerMBean(mbean, mbean.getObjectName());
         }

--- a/core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
@@ -43,11 +43,11 @@ public class Interpolator implements StrLookup {
         this.defaultLookup = defaultLookup == null ? new MapLookup(new HashMap<String, String>()) : defaultLookup;
         final PluginManager manager = new PluginManager("Lookup");
         manager.collectPlugins();
-        final Map<String, PluginType> plugins = manager.getPlugins();
+        final Map<String, PluginType<?>> plugins = manager.getPlugins();
 
-        for (final Map.Entry<String, PluginType> entry : plugins.entrySet()) {
+        for (final Map.Entry<String, PluginType<?>> entry : plugins.entrySet()) {
             @SuppressWarnings("unchecked")
-            final Class<StrLookup> clazz = entry.getValue().getPluginClass();
+            final Class<? extends StrLookup> clazz = (Class<? extends StrLookup>) entry.getValue().getPluginClass();
             try {
                 lookups.put(entry.getKey(), clazz.newInstance());
             } catch (final Exception ex) {

--- a/core/src/main/java/org/apache/logging/log4j/core/net/AbstractSocketManager.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/net/AbstractSocketManager.java
@@ -16,13 +16,14 @@
  */
 package org.apache.logging.log4j.core.net;
 
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.appender.OutputStreamManager;
+
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.apache.logging.log4j.core.Layout;
-import org.apache.logging.log4j.core.appender.OutputStreamManager;
 
 /**
  * Abstract base class for managing sockets.
@@ -51,7 +52,7 @@ public abstract class AbstractSocketManager extends OutputStreamManager {
      * @param port The target port number.
      */
     public AbstractSocketManager(final String name, final OutputStream os, final InetAddress addr, final String host,
-                                 final int port, final Layout layout) {
+                                 final int port, final Layout<? extends Serializable> layout) {
         super(os, name, layout);
         this.address = addr;
         this.host = host;

--- a/core/src/main/java/org/apache/logging/log4j/core/net/DatagramSocketManager.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/net/DatagramSocketManager.java
@@ -16,15 +16,16 @@
  */
 package org.apache.logging.log4j.core.net;
 
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.appender.ManagerFactory;
+import org.apache.logging.log4j.core.helpers.Strings;
+
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
-
-import org.apache.logging.log4j.core.Layout;
-import org.apache.logging.log4j.core.appender.ManagerFactory;
-import org.apache.logging.log4j.core.helpers.Strings;
 
 /**
  * Socket Manager for UDP connections.
@@ -43,7 +44,7 @@ public class DatagramSocketManager extends AbstractSocketManager {
      * @param layout The layout
      */
     protected DatagramSocketManager(final String name, final OutputStream os, final InetAddress address, final String host,
-                                    final int port, final Layout layout) {
+                                    final int port, final Layout<? extends Serializable> layout) {
         super(name, os, address, host, port, layout);
     }
 
@@ -54,7 +55,7 @@ public class DatagramSocketManager extends AbstractSocketManager {
      * @param layout The layout.
      * @return A DatagramSocketManager.
      */
-    public static DatagramSocketManager getSocketManager(final String host, final int port, final Layout layout) {
+    public static DatagramSocketManager getSocketManager(final String host, final int port, final Layout<? extends Serializable> layout) {
         if (Strings.isEmpty(host)) {
             throw new IllegalArgumentException("A host name is required");
         }
@@ -87,9 +88,9 @@ public class DatagramSocketManager extends AbstractSocketManager {
     private static class FactoryData {
         private final String host;
         private final int port;
-        private final Layout layout;
+        private final Layout<? extends Serializable> layout;
 
-        public FactoryData(final String host, final int port, final Layout layout) {
+        public FactoryData(final String host, final int port, final Layout<? extends Serializable> layout) {
             this.host = host;
             this.port = port;
             this.layout = layout;

--- a/core/src/main/java/org/apache/logging/log4j/core/net/MulticastDNSAdvertiser.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/net/MulticastDNSAdvertiser.java
@@ -167,7 +167,7 @@ public class MulticastDNSAdvertiser implements Advertiser {
         //version 1 uses a hashtable
         final Hashtable<String, String> hashtableProperties = new Hashtable<String, String>(properties);
         try {
-            final Class[] args = new Class[6];
+            final Class<?>[] args = new Class<?>[6];
             args[0] = String.class;
             args[1] = String.class;
             args[2] = int.class;
@@ -197,7 +197,7 @@ public class MulticastDNSAdvertiser implements Advertiser {
 
     private Object buildServiceInfoVersion3(final String zone, final int port, final String name, final Map<String, String> properties) {
         try {
-            final Class[] args = new Class[6];
+            final Class<?>[] args = new Class<?>[6];
             args[0] = String.class; //zone/type
             args[1] = String.class; //display name
             args[2] = int.class; //port

--- a/core/src/main/java/org/apache/logging/log4j/core/net/TCPSocketManager.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/net/TCPSocketManager.java
@@ -16,9 +16,16 @@
  */
 package org.apache.logging.log4j.core.net;
 
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.appender.AppenderLoggingException;
+import org.apache.logging.log4j.core.appender.ManagerFactory;
+import org.apache.logging.log4j.core.appender.OutputStreamManager;
+import org.apache.logging.log4j.core.helpers.Strings;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.Socket;
@@ -26,12 +33,6 @@ import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-
-import org.apache.logging.log4j.core.Layout;
-import org.apache.logging.log4j.core.appender.AppenderLoggingException;
-import org.apache.logging.log4j.core.appender.ManagerFactory;
-import org.apache.logging.log4j.core.appender.OutputStreamManager;
-import org.apache.logging.log4j.core.helpers.Strings;
 
 /**
  * Manager of TCP Socket connections.
@@ -72,7 +73,7 @@ public class TCPSocketManager extends AbstractSocketManager {
      */
     public TCPSocketManager(final String name, final OutputStream os, final Socket sock, final InetAddress addr,
                             final String host, final int port, final int delay, final boolean immediateFail,
-                            final Layout layout) {
+                            final Layout<? extends Serializable> layout) {
         super(name, os, addr, host, port, layout);
         this.reconnectionDelay = delay;
         this.socket = sock;
@@ -94,7 +95,7 @@ public class TCPSocketManager extends AbstractSocketManager {
      * @return A TCPSocketManager.
      */
     public static TCPSocketManager getSocketManager(final String host, int port, int delay,
-                                                    final boolean immediateFail, final Layout layout ) {
+                                                    final boolean immediateFail, final Layout<? extends Serializable> layout ) {
         if (Strings.isEmpty(host)) {
             throw new IllegalArgumentException("A host name is required");
         }
@@ -228,10 +229,10 @@ public class TCPSocketManager extends AbstractSocketManager {
         private final int port;
         private final int delay;
         private final boolean immediateFail;
-        private final Layout layout;
+        private final Layout<? extends Serializable> layout;
 
         public FactoryData(final String host, final int port, final int delay, final boolean immediateFail,
-                           final Layout layout) {
+                           final Layout<? extends Serializable> layout) {
             this.host = host;
             this.port = port;
             this.delay = delay;

--- a/core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
@@ -114,10 +114,10 @@ public final class PatternParser {
         this.config = config;
         final PluginManager manager = new PluginManager(converterKey, expectedClass);
         manager.collectPlugins();
-        final Map<String, PluginType> plugins = manager.getPlugins();
+        final Map<String, PluginType<?>> plugins = manager.getPlugins();
         final Map<String, Class<PatternConverter>> converters = new HashMap<String, Class<PatternConverter>>();
 
-        for (final PluginType type : plugins.values()) {
+        for (final PluginType<?> type : plugins.values()) {
             try {
                 @SuppressWarnings("unchecked")
                 final Class<PatternConverter> clazz = (Class<PatternConverter>)type.getPluginClass();

--- a/core/src/main/java/org/apache/logging/log4j/core/selector/ClassLoaderContextSelector.java
+++ b/core/src/main/java/org/apache/logging/log4j/core/selector/ClassLoaderContextSelector.java
@@ -81,11 +81,11 @@ public class ClassLoaderContextSelector implements ContextSelector {
         } else {
             if (getCallerClass != null) {
                 try {
-                    Class clazz = Class.class;
+                    Class<?> clazz = (Class<?>) Class.class;
                     boolean next = false;
                     for (int index = 2; clazz != null; ++index) {
                         final Object[] params = new Object[] {index};
-                        clazz = (Class) getCallerClass.invoke(null, params);
+                        clazz = (Class<?>) getCallerClass.invoke(null, params);
                         if (clazz == null) {
                             break;
                         }
@@ -106,7 +106,7 @@ public class ClassLoaderContextSelector implements ContextSelector {
             }
 
             if (securityManager != null) {
-                final Class clazz = securityManager.getCaller(fqcn);
+                final Class<?> clazz = securityManager.getCaller(fqcn);
                 if (clazz != null) {
                     final ClassLoader ldr = clazz.getClassLoader() != null ? clazz.getClassLoader() :
                         ClassLoader.getSystemClassLoader();
@@ -222,7 +222,7 @@ public class ClassLoaderContextSelector implements ContextSelector {
     private static void setupCallerCheck() {
         try {
             final ClassLoader loader = Loader.getClassLoader();
-            final Class clazz = loader.loadClass("sun.reflect.Reflection");
+            final Class<?> clazz = loader.loadClass("sun.reflect.Reflection");
             final Method[] methods = clazz.getMethods();
             for (final Method method : methods) {
                 final int modifier = method.getModifiers();
@@ -256,10 +256,10 @@ public class ClassLoaderContextSelector implements ContextSelector {
      */
     private static class PrivateSecurityManager extends SecurityManager {
 
-        public Class getCaller(final String fqcn) {
-            final Class[] classes = getClassContext();
+        public Class<?> getCaller(final String fqcn) {
+            final Class<?>[] classes = getClassContext();
             boolean next = false;
-            for (final Class clazz : classes) {
+            for (final Class<?> clazz : classes) {
                 if (clazz.getName().equals(fqcn)) {
                     next = true;
                     continue;

--- a/core/src/test/java/org/apache/logging/dumbster/smtp/SimpleSmtpServer.java
+++ b/core/src/test/java/org/apache/logging/dumbster/smtp/SimpleSmtpServer.java
@@ -229,7 +229,7 @@ public class SimpleSmtpServer implements Runnable {
      *
      * @return List of String
      */
-    public synchronized Iterator getReceivedEmail() {
+    public synchronized Iterator<SmtpMessage> getReceivedEmail() {
         return receivedMail.iterator();
     }
 

--- a/core/src/test/java/org/apache/logging/dumbster/smtp/SmtpMessage.java
+++ b/core/src/test/java/org/apache/logging/dumbster/smtp/SmtpMessage.java
@@ -70,8 +70,8 @@ public class SmtpMessage {
      *
      * @return an Iterator over the set of header names (String)
      */
-    public Iterator getHeaderNames() {
-        final Set nameSet = headers.keySet();
+    public Iterator<String> getHeaderNames() {
+        final Set<String> nameSet = headers.keySet();
         return nameSet.iterator();
     }
 

--- a/core/src/test/java/org/apache/logging/log4j/ReflectionComparison.java
+++ b/core/src/test/java/org/apache/logging/log4j/ReflectionComparison.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.StringFormattedMessage;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import sun.reflect.Reflection;
 
 import java.lang.reflect.Constructor;
@@ -39,13 +40,13 @@ public class ReflectionComparison {
 
     private static final int COUNT = 1000000;
 
-    private static Class[] paramTypes = new Class[] {String.class, Object[].class};
+    private static Class<?>[] paramTypes = new Class<?>[] {String.class, Object[].class};
 
     @BeforeClass
     public static void setupCallerCheck() {
         try {
             final ClassLoader loader = Loader.getClassLoader();
-            final Class clazz = loader.loadClass("sun.reflect.Reflection");
+            final Class<?> clazz = loader.loadClass("sun.reflect.Reflection");
             final Method[] methods = clazz.getMethods();
             for (final Method method : methods) {
                 final int modifier = method.getModifiers();
@@ -109,11 +110,11 @@ public class ReflectionComparison {
         System.out.println(timer.toString());
     }
 
-    private Class getCallerClass(final Object[] array) {
+    private Class<?> getCallerClass(final Object[] array) {
         if (getCallerClass != null) {
             try {
                 /*Object[] params = new Object[]{index}; */
-                return (Class) getCallerClass.invoke(null, array);
+                return (Class<?>) getCallerClass.invoke(null, array);
             } catch (final Exception ex) {
                 fail(ex.getMessage());
                 // logger.debug("Unable to determine caller class via Sun Reflection", ex);

--- a/core/src/test/java/org/apache/logging/log4j/core/AppenderRefLevelTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/AppenderRefLevelTest.java
@@ -40,21 +40,20 @@ public class AppenderRefLevelTest {
 
     private static final String CONFIG = "log4j-reference-level.xml";
     private static Configuration config;
-    private static ListAppender<LogEvent> app1;
-    private static ListAppender<LogEvent> app2;
+    private static ListAppender app1;
+    private static ListAppender app2;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("LIST1")) {
-                app1 = (ListAppender<LogEvent>) entry.getValue();
+                app1 = (ListAppender) entry.getValue();
             } else if (entry.getKey().equals("LIST2")) {
-                app2 = (ListAppender<LogEvent>) entry.getValue();
+                app2 = (ListAppender) entry.getValue();
             }
         }
     }

--- a/core/src/test/java/org/apache/logging/log4j/core/FileConfigTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/FileConfigTest.java
@@ -60,7 +60,7 @@ public class FileConfigTest {
     @Before
     public void before() {
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
                 app = (ListAppender) entry.getValue();
                 break;

--- a/core/src/test/java/org/apache/logging/log4j/core/LogEventFactoryTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/LogEventFactoryTest.java
@@ -47,19 +47,18 @@ public class LogEventFactoryTest {
 
     private static final String CONFIG = "log4j2-config.xml";
     private static Configuration config;
-    private static ListAppender<LogEvent> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(Constants.LOG4J_LOG_EVENT_FACTORY, TestLogEventFactory.class.getName());
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<LogEvent>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/LoggerTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/LoggerTest.java
@@ -49,9 +49,9 @@ public class LoggerTest {
 
     private static final String CONFIG = "log4j-test2.xml";
     private static Configuration config;
-    private static ListAppender<LogEvent> app;
-    private static ListAppender<String> host;
-    private static ListAppender<String> noThrown;
+    private static ListAppender app;
+    private static ListAppender host;
+    private static ListAppender noThrown;
     private static LoggerContext ctx;
 
     @BeforeClass
@@ -68,16 +68,15 @@ public class LoggerTest {
     }
 
     @Before
-    @SuppressWarnings("unchecked")
     public void before() {
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<LogEvent>) entry.getValue();
+                app = (ListAppender) entry.getValue();
             } else if (entry.getKey().equals("HostTest")) {
-                host = (ListAppender<String>) entry.getValue();
+                host = (ListAppender) entry.getValue();
             } else if (entry.getKey().equals("NoThrowable")) {
-                noThrown = (ListAppender<String>) entry.getValue();
+                noThrown = (ListAppender) entry.getValue();
             }
         }
         assertNotNull("No Appender", app);

--- a/core/src/test/java/org/apache/logging/log4j/core/LoggerUpdateTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/LoggerUpdateTest.java
@@ -40,9 +40,9 @@ public class LoggerUpdateTest {
 
     private static final String CONFIG = "log4j-test2.xml";
     private static Configuration config;
-    private static ListAppender<LogEvent> app;
-    private static ListAppender<String> host;
-    private static ListAppender<String> noThrown;
+    private static ListAppender app;
+    private static ListAppender host;
+    private static ListAppender noThrown;
     private static LoggerContext ctx;
 
     @BeforeClass
@@ -59,16 +59,15 @@ public class LoggerUpdateTest {
     }
 
     @Before
-    @SuppressWarnings("unchecked")
     public void before() {
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<LogEvent>) entry.getValue();
+                app = (ListAppender) entry.getValue();
             } else if (entry.getKey().equals("HostTest")) {
-                host = (ListAppender<String>) entry.getValue();
+                host = (ListAppender) entry.getValue();
             } else if (entry.getKey().equals("NoThrowable")) {
-                noThrown = (ListAppender<String>) entry.getValue();
+                noThrown = (ListAppender) entry.getValue();
             }
         }
         assertNotNull("No Appender", app);

--- a/core/src/test/java/org/apache/logging/log4j/core/ShutdownDisabledTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/ShutdownDisabledTest.java
@@ -35,7 +35,7 @@ public class ShutdownDisabledTest {
 
     private static final String CONFIG = "log4j-test3.xml";
     private static Configuration config;
-    private static ListAppender<LogEvent> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
@@ -52,7 +52,6 @@ public class ShutdownDisabledTest {
     }
 
     @Before
-    @SuppressWarnings("unchecked")
     public void before() {
         config = ctx.getConfiguration();
     }

--- a/core/src/test/java/org/apache/logging/log4j/core/StrictXMLConfigTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/StrictXMLConfigTest.java
@@ -42,18 +42,17 @@ public class StrictXMLConfigTest {
 
     private static final String CONFIG = "log4j-strict1.xml";
     private static Configuration config;
-    private static ListAppender<LogEvent> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<LogEvent>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/AsyncAppenderNoLocationTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/AsyncAppenderNoLocationTest.java
@@ -41,18 +41,17 @@ import static org.junit.Assert.assertTrue;
 public class AsyncAppenderNoLocationTest {
     private static final String CONFIG = "log4j-asynch-no-location.xml";
     private static Configuration config;
-    private static ListAppender<String> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<String>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/AsyncAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/AsyncAppenderTest.java
@@ -41,18 +41,17 @@ import static org.junit.Assert.*;
 public class AsyncAppenderTest {
     private static final String CONFIG = "log4j-asynch.xml";
     private static Configuration config;
-    private static ListAppender<String> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<String>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/ConsoleAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/ConsoleAppenderTest.java
@@ -52,7 +52,7 @@ public class ConsoleAppenderTest {
     public void testFollow() {
         final PrintStream ps = System.out;
         final Layout<String> layout = PatternLayout.createLayout(null, null, null, null, null);
-        final ConsoleAppender<String> app = ConsoleAppender.createAppender(layout, null, "SYSTEM_OUT", "Console", "true", "false");
+        final ConsoleAppender app = ConsoleAppender.createAppender(layout, null, "SYSTEM_OUT", "Console", "true", "false");
         app.start();
         final LogEvent event = new Log4jLogEvent("TestLogger", null, ConsoleAppenderTest.class.getName(), Level.INFO,
             new SimpleMessage("Test"), null);

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/FailoverAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/FailoverAppenderTest.java
@@ -41,19 +41,18 @@ import static org.junit.Assert.assertNotNull;
 public class FailoverAppenderTest {
     private static final String CONFIG = "log4j-failover.xml";
     private static Configuration config;
-    private static ListAppender<LogEvent> app;
-    private static FailOnceAppender<LogEvent> foApp;
+    private static ListAppender app;
+    private static FailOnceAppender foApp;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<LogEvent>) entry.getValue();
+                app = (ListAppender) entry.getValue();
             } else if (entry.getKey().equals("Once")) {
                 foApp = (FailOnceAppender) entry.getValue();
             }

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/FileAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/FileAppenderTest.java
@@ -138,7 +138,7 @@ public class FileAppenderTest {
 
     private static void writer(final boolean lock, final int count, final String name) throws Exception {
         final Layout<String> layout = PatternLayout.createLayout(PatternLayout.SIMPLE_CONVERSION_PATTERN, null, null, null, null);
-        final FileAppender<String> app = FileAppender.createAppender(FILENAME, "true", Boolean.toString(lock), "test", "false",
+        final FileAppender app = FileAppender.createAppender(FILENAME, "true", Boolean.toString(lock), "test", "false",
             "false", "false", layout, null, "false", null, null);
         final Thread t = Thread.currentThread();
         app.start();

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/OutputStreamAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/OutputStreamAppenderTest.java
@@ -38,7 +38,7 @@ public class OutputStreamAppenderTest {
     @Test
     public void testAppender() {
         final Layout<String> layout = PatternLayout.createLayout(null, null, null, null, null);
-        final InMemoryAppender<String> app = new InMemoryAppender<String>("test", layout, null, false);
+        final InMemoryAppender app = new InMemoryAppender("test", layout, null, false);
         final LogEvent event = new Log4jLogEvent("TestLogger", null, OutputStreamAppenderTest.class.getName(), Level.INFO,
             new SimpleMessage("Test"), null);
         app.start();

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/SMTPAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/SMTPAppenderTest.java
@@ -149,7 +149,7 @@ public class SMTPAppenderTest {
 
         server.stop();
         assertTrue(server.getReceivedEmailSize() == 1);
-        final SmtpMessage email = (SmtpMessage) server.getReceivedEmail().next();
+        final SmtpMessage email = server.getReceivedEmail().next();
 
         assertEquals("to@example.com", email.getHeaderValue("To"));
         assertEquals("cc@example.com", email.getHeaderValue("Cc"));

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/SocketAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/SocketAppenderTest.java
@@ -85,9 +85,9 @@ public class SocketAppenderTest {
 
     @After
     public void teardown() {
-        final Map<String,Appender<?>> map = root.getAppenders();
-        for (final Map.Entry<String, Appender<?>> entry : map.entrySet()) {
-            final Appender<?> app = entry.getValue();
+        final Map<String,Appender> map = root.getAppenders();
+        for (final Map.Entry<String, Appender> entry : map.entrySet()) {
+            final Appender app = entry.getValue();
             root.removeAppender(app);
             app.stop();
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTest.java
@@ -84,9 +84,9 @@ public class SyslogAppenderTest {
 
     @After
     public void teardown() {
-        final Map<String,Appender<?>> map = root.getAppenders();
-        for (final Map.Entry<String, Appender<?>> entry : map.entrySet()) {
-            final Appender<?> app = entry.getValue();
+        final Map<String,Appender> map = root.getAppenders();
+        for (final Map.Entry<String, Appender> entry : map.entrySet()) {
+            final Appender app = entry.getValue();
             root.removeAppender(app);
             app.stop();
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/db/AbstractDatabaseAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/db/AbstractDatabaseAppenderTest.java
@@ -91,7 +91,7 @@ public class AbstractDatabaseAppenderTest {
 
         replay(this.manager, this.appender);
 
-        final LocalAbstractDatabaseManager manager = this.appender.getManager();
+        final LocalAbstractDatabaseManager manager = (LocalAbstractDatabaseManager) this.appender.getManager();
 
         assertSame("The manager should be the same.", this.manager, manager);
 
@@ -148,7 +148,7 @@ public class AbstractDatabaseAppenderTest {
     }
 
     private static abstract class LocalAbstractDatabaseAppender extends
-            AbstractDatabaseAppender<LocalAbstractDatabaseManager> {
+            AbstractDatabaseAppender {
         public LocalAbstractDatabaseAppender(final String name, final Filter filter, final boolean exceptionSuppressed,
                                              final LocalAbstractDatabaseManager manager) {
             super(name, filter, exceptionSuppressed, manager);

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/AbstractJdbcAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/AbstractJdbcAppenderTest.java
@@ -75,8 +75,8 @@ public abstract class AbstractJdbcAppenderTest {
     public void tearDown() throws SQLException {
         final LoggerContext context = (LoggerContext) LogManager.getContext(false);
         try {
-            final Map<String, Appender<?>> list = context.getConfiguration().getAppenders();
-            final Appender<?> appender = list.get("databaseAppender");
+            final Map<String, Appender> list = context.getConfiguration().getAppenders();
+            final Appender appender = list.get("databaseAppender");
             assertNotNull("The appender should not be null.", appender);
             assertTrue("The appender should be a JDBCAppender.", appender instanceof JDBCAppender);
             ((JDBCAppender) appender).getManager().release();

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/FactoryMethodConnectionSourceTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/FactoryMethodConnectionSourceTest.java
@@ -134,21 +134,18 @@ public class FactoryMethodConnectionSourceTest {
         verify(connection);
     }
 
-    @SuppressWarnings("unused")
     protected static final class BadReturnTypeFactory {
         public static String factoryMethod01() {
             return "hello";
         }
     }
 
-    @SuppressWarnings("unused")
     protected static final class DataSourceFactory {
         public static DataSource factoryMethod02() {
             return (DataSource) holder.get();
         }
     }
 
-    @SuppressWarnings("unused")
     protected static final class ConnectionFactory {
         public static Connection anotherMethod03() {
             return (Connection) holder.get();

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/JdbcH2AppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/JdbcH2AppenderTest.java
@@ -34,7 +34,6 @@ public class JdbcH2AppenderTest extends AbstractJdbcAppenderTest {
     /**
      * Referred from log4j2-h2-factory-method.xml.
      */
-    @SuppressWarnings("unused")
     public static Connection getConfigConnection() throws SQLException {
         return DriverManager.getConnection("jdbc:h2:mem:Log4j", USER_ID, PASSWORD);
     }

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/JdbcHyperSqlAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/db/jdbc/JdbcHyperSqlAppenderTest.java
@@ -34,7 +34,6 @@ public class JdbcHyperSqlAppenderTest extends AbstractJdbcAppenderTest {
     /**
      * Referred from log4j2-hsqldb-factory-method.xml.
      */
-    @SuppressWarnings("unused")
     public static Connection getConfigConnection() throws SQLException {
         return DriverManager.getConnection("jdbc:hsqldb:mem:Log4j;ifexists=true", USER_ID, PASSWORD);
     }

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/AbstractJpaAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/AbstractJpaAppenderTest.java
@@ -60,8 +60,8 @@ public abstract class AbstractJpaAppenderTest {
     public void tearDown() throws SQLException {
         final LoggerContext context = (LoggerContext) LogManager.getContext(false);
         try {
-            final Map<String, Appender<?>> list = context.getConfiguration().getAppenders();
-            final Appender<?> appender = list.get("databaseAppender");
+            final Map<String, Appender> list = context.getConfiguration().getAppenders();
+            final Appender appender = list.get("databaseAppender");
             assertNotNull("The appender should not be null.", appender);
             assertTrue("The appender should be a JPAAppender.", appender instanceof JPAAppender);
             ((JPAAppender) appender).getManager().release();

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/JpaHyperSqlAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/JpaHyperSqlAppenderTest.java
@@ -88,7 +88,6 @@ public class JpaHyperSqlAppenderTest extends AbstractJpaAppenderTest {
         assertNull("The appender should be null.", appender);
     }
 
-    @SuppressWarnings("unused")
     public static class BadConstructorEntity1 extends TestBaseEntity {
         private static final long serialVersionUID = 1L;
 
@@ -97,7 +96,6 @@ public class JpaHyperSqlAppenderTest extends AbstractJpaAppenderTest {
         }
     }
 
-    @SuppressWarnings("unused")
     public static class BadConstructorEntity2 extends TestBaseEntity {
         private static final long serialVersionUID = 1L;
 

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/TestBaseEntity.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/TestBaseEntity.java
@@ -42,7 +42,6 @@ import org.apache.logging.log4j.message.Message;
 
 @Entity
 @Table(name = "jpaBaseLogEntry")
-@SuppressWarnings("unused")
 public class TestBaseEntity extends AbstractLogEventWrapperEntity {
     private static final long serialVersionUID = 1L;
 

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/TestBasicEntity.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/TestBasicEntity.java
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.core.appender.db.jpa.converter.ContextMapJsonAtt
 
 @Entity
 @Table(name = "jpaBasicLogEntry")
-@SuppressWarnings("unused")
 public class TestBasicEntity extends BasicLogEventEntity {
     private static final long serialVersionUID = 1L;
 

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/db/nosql/NoSQLAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/db/nosql/NoSQLAppenderTest.java
@@ -43,7 +43,6 @@ public class NoSQLAppenderTest {
 
     @Test
     public void testProvider() {
-        @SuppressWarnings("unchecked")
         final NoSQLProvider<?> provider = createStrictMock(NoSQLProvider.class);
 
         replay(provider);
@@ -62,7 +61,6 @@ public class NoSQLAppenderTest {
 
     @Test
     public void testProviderBuffer() {
-        @SuppressWarnings("unchecked")
         final NoSQLProvider<?> provider = createStrictMock(NoSQLProvider.class);
 
         replay(provider);

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/rewrite/RewriteAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/rewrite/RewriteAppenderTest.java
@@ -47,21 +47,20 @@ import static org.junit.Assert.assertEquals;
 public class RewriteAppenderTest {
     private static final String CONFIG = "log4j-rewrite.xml";
     private static Configuration config;
-    private static ListAppender<LogEvent> app;
-    private static ListAppender<String> app2;
+    private static ListAppender app;
+    private static ListAppender app2;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<LogEvent>) entry.getValue();
+                app = (ListAppender) entry.getValue();
             } else if (entry.getKey().equals("List2")) {
-                app2 = (ListAppender<String>) entry.getValue();
+                app2 = (ListAppender) entry.getValue();
             }
         }
     }

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/routing/JSONRoutingAppender2Test.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/routing/JSONRoutingAppender2Test.java
@@ -43,18 +43,17 @@ import static org.junit.Assert.assertTrue;
 public class JSONRoutingAppender2Test {
     private static final String CONFIG = "log4j-routing2.json";
     private static Configuration config;
-    private static ListAppender<LogEvent> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<LogEvent>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/routing/JSONRoutingAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/routing/JSONRoutingAppenderTest.java
@@ -43,18 +43,17 @@ import static org.junit.Assert.assertTrue;
 public class JSONRoutingAppenderTest {
     private static final String CONFIG = "log4j-routing.json";
     private static Configuration config;
-    private static ListAppender<LogEvent> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<LogEvent>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderTest.java
@@ -43,18 +43,17 @@ import static org.junit.Assert.assertTrue;
 public class RoutingAppenderTest {
     private static final String CONFIG = "log4j-routing.xml";
     private static Configuration config;
-    private static ListAppender<LogEvent> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<LogEvent>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderWithJndiTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderWithJndiTest.java
@@ -16,20 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.util.Map;
-
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-
 import org.apache.logging.log4j.EventLogger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.XMLConfigurationFactory;
@@ -43,6 +32,16 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockejb.jndi.MockContextFactory;
 
+import java.io.File;
+import java.util.Map;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 /**
  * RoutingAppenderWithJndiTest
  */
@@ -50,22 +49,21 @@ public class RoutingAppenderWithJndiTest {
 
     private static final String CONFIG = "log4j-routing-by-jndi.xml";
     private static Configuration config;
-    private static ListAppender<LogEvent> listAppender1;
-    private static ListAppender<LogEvent> listAppender2;
+    private static ListAppender listAppender1;
+    private static ListAppender listAppender2;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List1")) {
-                listAppender1 = (ListAppender<LogEvent>) entry.getValue();
+                listAppender1 = (ListAppender) entry.getValue();
             }
             if (entry.getKey().equals("List2")) {
-                listAppender2 = (ListAppender<LogEvent>) entry.getValue();
+                listAppender2 = (ListAppender) entry.getValue();
             }
         }
     }

--- a/core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingDefaultAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingDefaultAppenderTest.java
@@ -43,18 +43,17 @@ import static org.junit.Assert.assertTrue;
 public class RoutingDefaultAppenderTest {
     private static final String CONFIG = "log4j-routing3.xml";
     private static Configuration config;
-    private static ListAppender<LogEvent> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<LogEvent>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/config/BaseConfigurationTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/config/BaseConfigurationTest.java
@@ -41,7 +41,7 @@ public class BaseConfigurationTest {
 //        final String MISSINGROOT = "MissingRootTest";
 //        assertTrue("Incorrect Configuration. Expected " + MISSINGROOT + " but found " + config.getName(),
 //                MISSINGROOT.equals(config.getName()));
-        final Map<String, Appender<?>> map = config.getAppenders();
+        final Map<String, Appender> map = config.getAppenders();
         assertNotNull("Appenders not null", map);
         assertEquals("Appenders Size", 2, map.size());
         assertTrue("Contains List", map.containsKey("List"));
@@ -54,14 +54,14 @@ public class BaseConfigurationTest {
         assertTrue("contains key=sample", loggerMap.containsKey("sample"));
 
         final LoggerConfig sample = loggerMap.get("sample");
-        final Map<String, Appender<?>> sampleAppenders = sample.getAppenders();
+        final Map<String, Appender> sampleAppenders = sample.getAppenders();
         assertEquals("sampleAppenders Size", 1, sampleAppenders.size());
         // sample only has List appender, not Console!
         assertTrue("sample has appender List", sampleAppenders.containsKey("List"));
 
         final BaseConfiguration baseConfig = (BaseConfiguration) config;
         final LoggerConfig root = baseConfig.getRootLogger();
-        final Map<String, Appender<?>> rootAppenders = root.getAppenders();
+        final Map<String, Appender> rootAppenders = root.getAppenders();
         assertEquals("rootAppenders Size", 1, rootAppenders.size());
         // root only has Console appender!
         assertTrue("root has appender Console", rootAppenders.containsKey("Console"));

--- a/core/src/test/java/org/apache/logging/log4j/core/config/TestConfigurator.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/config/TestConfigurator.java
@@ -24,19 +24,19 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.filter.CompositeFilter;
-
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.Map;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -73,7 +73,7 @@ public class TestConfigurator {
         assertNotNull("No configuration", config);
         assertTrue("Incorrect Configuration. Expected " + CONFIG_NAME + " but found " + config.getName(),
             CONFIG_NAME.equals(config.getName()));
-        final Map<String, Appender<?>> map = config.getAppenders();
+        final Map<String, Appender> map = config.getAppenders();
         assertNotNull("No Appenders", map != null && map.size() > 0);
         assertTrue("Wrong configuration", map.containsKey("List"));
         Configurator.shutdown(ctx);
@@ -93,7 +93,7 @@ public class TestConfigurator {
         assertNotNull("No configuration", config);
         assertTrue("Incorrect Configuration. Expected " + CONFIG_NAME + " but found " + config.getName(),
             CONFIG_NAME.equals(config.getName()));
-        final Map<String, Appender<?>> map = config.getAppenders();
+        final Map<String, Appender> map = config.getAppenders();
         assertNotNull("No Appenders", map != null && map.size() > 0);
         assertTrue("Wrong configuration", map.containsKey("List"));
         Configurator.shutdown(ctx);
@@ -113,7 +113,7 @@ public class TestConfigurator {
         assertNotNull("No configuration", config);
         assertTrue("Incorrect Configuration. Expected " + CONFIG_NAME + " but found " + config.getName(),
             CONFIG_NAME.equals(config.getName()));
-        final Map<String, Appender<?>> map = config.getAppenders();
+        final Map<String, Appender> map = config.getAppenders();
         assertNotNull("No Appenders", map != null && map.size() > 0);
         assertTrue("Wrong configuration", map.containsKey("List"));
         Configurator.shutdown(ctx);
@@ -130,7 +130,7 @@ public class TestConfigurator {
         assertNotNull("No configuration", config);
         assertTrue("Incorrect Configuration. Expected " + CONFIG_NAME + " but found " + config.getName(),
             CONFIG_NAME.equals(config.getName()));
-        final Map<String, Appender<?>> map = config.getAppenders();
+        final Map<String, Appender> map = config.getAppenders();
         assertNotNull("No Appenders", map != null && map.size() > 0);
         assertTrue("Wrong configuration", map.containsKey("List"));
         Configurator.shutdown(ctx);
@@ -147,7 +147,7 @@ public class TestConfigurator {
         assertNotNull("No configuration", config);
         assertTrue("Incorrect Configuration. Expected " + CONFIG_NAME + " but found " + config.getName(),
             CONFIG_NAME.equals(config.getName()));
-        final Map<String, Appender<?>> map = config.getAppenders();
+        final Map<String, Appender> map = config.getAppenders();
         assertNotNull("No Appenders", map != null && map.size() > 0);
         assertTrue("Wrong configuration", map.containsKey("List"));
         Configurator.shutdown(ctx);
@@ -166,7 +166,7 @@ public class TestConfigurator {
         assertNotNull("No configuration", config);
         assertTrue("Incorrect Configuration. Expected " + CONFIG_NAME + " but found " + config.getName(),
             CONFIG_NAME.equals(config.getName()));
-        final Map<String, Appender<?>> map = config.getAppenders();
+        final Map<String, Appender> map = config.getAppenders();
         assertNotNull("No Appenders", map != null && map.size() > 0);
         assertTrue("Wrong configuration", map.containsKey("List"));
 
@@ -192,17 +192,17 @@ public class TestConfigurator {
         assertNotNull("No configuration", config);
         assertTrue("Incorrect Configuration. Expected " + CONFIG_NAME + " but found " + config.getName(),
             CONFIG_NAME.equals(config.getName()));
-        final Map<String, Appender<?>> map = config.getAppenders();
+        final Map<String, Appender> map = config.getAppenders();
         assertNotNull("No Appenders", map != null && map.size() > 0);
-        Appender<?> app = null;
-        for (final Map.Entry<String, Appender<?>> entry: map.entrySet()) {
+        Appender app = null;
+        for (final Map.Entry<String, Appender> entry: map.entrySet()) {
             if (entry.getKey().equals("List2")) {
                 app = entry.getValue();
                 break;
             }
         }
         assertNotNull("No ListAppender named List2", app);
-        final Layout layout = app.getLayout();
+        final Layout<? extends Serializable> layout = app.getLayout();
         assertNotNull("Appender List2 does not have a Layout", layout);
         assertTrue("Appender List2 is not configured with a PatternLayout", layout instanceof PatternLayout);
         final String pattern = ((PatternLayout) layout).getConversionPattern();

--- a/core/src/test/java/org/apache/logging/log4j/core/config/XMLConfigurationTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/config/XMLConfigurationTest.java
@@ -126,9 +126,9 @@ public class XMLConfigurationTest {
     public void testConfiguredAppenders() {
         final LoggerContext ctx = (LoggerContext) LogManager.getContext();
         final Configuration c = ctx.getConfiguration();
-        final Map<String, Appender<?>> apps = c.getAppenders();
+        final Map<String, Appender> apps = c.getAppenders();
         assertNotNull(apps);
-        assertEquals(3, apps.size());
+        assertEquals(apps.size(), 3);
     }
 
     @Test
@@ -142,10 +142,10 @@ public class XMLConfigurationTest {
         final Iterator<Filter> iter = l.getFilters();
         final Filter filter = iter.next();
         assertTrue(filter instanceof ThreadContextMapFilter);
-        final Map<String, Appender<?>> appenders = l.getAppenders();
+        final Map<String, Appender> appenders = l.getAppenders();
         assertNotNull(appenders);
         assertTrue("number of appenders = " + appenders.size(), appenders.size() == 1);
-        final Appender<?> a = appenders.get("STDOUT");
+        final Appender a = appenders.get("STDOUT");
         assertNotNull(a);
         assertEquals(a.getName(), "STDOUT");
     }

--- a/core/src/test/java/org/apache/logging/log4j/core/config/XMLLoggerPropsTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/config/XMLLoggerPropsTest.java
@@ -39,19 +39,18 @@ public class XMLLoggerPropsTest {
 
     private static final String CONFIG = "log4j-loggerprops.xml";
     private static Configuration config;
-    private static ListAppender<String> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         System.setProperty("test", "test");
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<String>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/filter/BurstFilterTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/filter/BurstFilterTest.java
@@ -40,19 +40,18 @@ public class BurstFilterTest {
     private static final String CONFIG = "log4j-burst.xml";
 
     private static Configuration config;
-    private static ListAppender<String> app;
+    private static ListAppender app;
     private static BurstFilter filter;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("ListAppender")) {
-                app = (ListAppender<String>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 filter = (BurstFilter) app.getFilter();
                 break;
             }

--- a/core/src/test/java/org/apache/logging/log4j/core/filter/MapFilterTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/filter/MapFilterTest.java
@@ -96,11 +96,10 @@ public class MapFilterTest {
         final Map<String, String> eventMap = new HashMap<String, String>();
         eventMap.put("eventId", "Login");
         logger.debug(new MapMessage(eventMap));
-        final Map<String,Appender<?>> appenders = config.getAppenders();
+        final Map<String,Appender> appenders = config.getAppenders();
         final Appender app = appenders.get("LIST");
         assertNotNull("No List appender", app);
-        @SuppressWarnings("unchecked")
-        final List<String> msgs = ((ListAppender<String>) app).getMessages();
+        final List<String> msgs = ((ListAppender) app).getMessages();
         assertNotNull("No messages", msgs);
         assertTrue("No messages", msgs.size() > 0);
 

--- a/core/src/test/java/org/apache/logging/log4j/core/layout/HTMLLayoutTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/layout/HTMLLayoutTest.java
@@ -87,7 +87,7 @@ public class HTMLLayoutTest {
 
         // set up appender
         final HTMLLayout layout = HTMLLayout.createLayout("true", null, null, null, "small", null);
-        final ListAppender<String> appender = new ListAppender<String>("List", null, layout, true, false);
+        final ListAppender appender = new ListAppender("List", null, layout, true, false);
         appender.start();
 
         // set appender on root and set level to debug

--- a/core/src/test/java/org/apache/logging/log4j/core/layout/RFC5424LayoutTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/layout/RFC5424LayoutTest.java
@@ -83,7 +83,7 @@ public class RFC5424LayoutTest {
         // set up appender
         final AbstractStringLayout layout = RFC5424Layout.createLayout("Local0", "Event", "3692", "true", "RequestContext",
             null, null, "true", null, "ATM", null, "key1, key2, locale", null, "loginId", null, null, null);
-        final ListAppender<String> appender = new ListAppender<String>("List", null, layout, true, false);
+        final ListAppender appender = new ListAppender("List", null, layout, true, false);
 
         appender.start();
 
@@ -147,7 +147,7 @@ public class RFC5424LayoutTest {
         // set up layout/appender
         final AbstractStringLayout layout = RFC5424Layout.createLayout("Local0", "Event", "3692", "true", "RequestContext",
             null, null, "true", "#012", "ATM", null, "key1, key2, locale", null, "loginId", null, null, null);
-        final ListAppender<String> appender = new ListAppender<String>("List", null, layout, true, false);
+        final ListAppender appender = new ListAppender("List", null, layout, true, false);
 
         appender.start();
 
@@ -210,7 +210,7 @@ public class RFC5424LayoutTest {
         // set up layout/appender
         final AbstractStringLayout layout = RFC5424Layout.createLayout("Local0", "Event", "3692", "true", "RequestContext",
             null, null, "true", null, "ATM", null, "key1, key2, locale", null, "loginId", "%xEx", null, null);
-        final ListAppender<String> appender = new ListAppender<String>("List", null, layout, true, false);
+        final ListAppender appender = new ListAppender("List", null, layout, true, false);
         appender.start();
 
         // set appender on root and set level to debug
@@ -254,7 +254,7 @@ public class RFC5424LayoutTest {
         // set up layout/appender
         final AbstractStringLayout layout = RFC5424Layout.createLayout("Local0", "Event", "3692", "true", "RequestContext",
             null, null, "true", null, "ATM", null, "key1, key2, locale", null, null, null, loggerFields, null);
-        final ListAppender<String> appender = new ListAppender<String>("List", null, layout, true, false);
+        final ListAppender appender = new ListAppender("List", null, layout, true, false);
         appender.start();
 
         // set appender on root and set level to debug

--- a/core/src/test/java/org/apache/logging/log4j/core/layout/SerializedLayoutTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/layout/SerializedLayoutTest.java
@@ -78,7 +78,7 @@ public class SerializedLayoutTest {
 
         // set up appender
         final SerializedLayout layout = SerializedLayout.createLayout();
-        final ListAppender<LogEvent> appender = new ListAppender<LogEvent>("List", null, layout, false, true);
+        final ListAppender appender = new ListAppender("List", null, layout, false, true);
         appender.start();
 
         // set appender on root and set level to debug

--- a/core/src/test/java/org/apache/logging/log4j/core/layout/SyslogLayoutTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/layout/SyslogLayoutTest.java
@@ -78,7 +78,7 @@ public class SyslogLayoutTest {
         // set up appender
         final SyslogLayout layout = SyslogLayout.createLayout("Local0", "true", null, null);
         //ConsoleAppender appender = new ConsoleAppender("Console", layout);
-        final ListAppender<String> appender = new ListAppender<String>("List", null, layout, true, false);
+        final ListAppender appender = new ListAppender("List", null, layout, true, false);
         appender.start();
 
         // set appender on root and set level to debug

--- a/core/src/test/java/org/apache/logging/log4j/core/layout/XMLLayoutTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/layout/XMLLayoutTest.java
@@ -78,7 +78,7 @@ public class XMLLayoutTest {
 
         // set up appender
         final XMLLayout layout = XMLLayout.createLayout("true", "true", "true", null, null, null);
-        final ListAppender<String> appender = new ListAppender<String>("List", null, layout, true, false);
+        final ListAppender appender = new ListAppender("List", null, layout, true, false);
         appender.start();
 
         // set appender on root and set level to debug

--- a/core/src/test/java/org/apache/logging/log4j/core/net/AbstractSocketServerTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/net/AbstractSocketServerTest.java
@@ -16,12 +16,6 @@
  */
 package org.apache.logging.log4j.core.net;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
@@ -38,7 +32,13 @@ import org.apache.logging.log4j.test.appender.ListAppender;
 import org.junit.After;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -76,9 +76,9 @@ public abstract class AbstractSocketServerTest {
 
     @After
     public void tearDown() {
-        final Map<String, Appender<?>> map = root.getAppenders();
-        for (final Map.Entry<String, Appender<?>> entry : map.entrySet()) {
-            final Appender<?> app = entry.getValue();
+        final Map<String, Appender> map = root.getAppenders();
+        for (final Map.Entry<String, Appender> entry : map.entrySet()) {
+            final Appender app = entry.getValue();
             root.removeAppender(app);
             app.stop();
         }
@@ -106,13 +106,13 @@ public abstract class AbstractSocketServerTest {
     protected void testServer(final String message1, final String message2) throws Exception {
         final Filter socketFilter = new ThreadFilter(Filter.Result.NEUTRAL, Filter.Result.DENY);
         final Filter serverFilter = new ThreadFilter(Filter.Result.DENY, Filter.Result.NEUTRAL);
-        final SocketAppender<Serializable> appender = SocketAppender.createAppender("localhost", this.port, this.protocol, "-1", null, "Test", null,
+        final SocketAppender appender = SocketAppender.createAppender("localhost", this.port, this.protocol, "-1", null, "Test", null,
                 "false", null, socketFilter, null, null);
         appender.start();
-        final ListAppender<LogEvent> listApp = new ListAppender<LogEvent>("Events", serverFilter, null, false, false);
+        final ListAppender listApp = new ListAppender("Events", serverFilter, null, false, false);
         listApp.start();
         final PatternLayout layout = PatternLayout.createLayout("%m %ex%n", null, null, null, null);
-        final ConsoleAppender<String> console = ConsoleAppender.createAppender(layout, null, "SYSTEM_OUT", "Console", "false", "true");
+        final ConsoleAppender console = ConsoleAppender.createAppender(layout, null, "SYSTEM_OUT", "Console", "false", "true");
         final Logger serverLogger = ctx.getLogger(this.getClass().getName());
         serverLogger.addAppender(console);
         serverLogger.setAdditive(false);

--- a/core/src/test/java/org/apache/logging/log4j/core/net/JMSQueueAppenderTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/net/JMSQueueAppenderTest.java
@@ -78,7 +78,7 @@ public class JMSQueueAppenderTest {
     public void testConfiguration() throws Exception {
         final LoggerContext ctx = (LoggerContext) LogManager.getContext();
         final Configuration config = ctx.getConfiguration();
-        final Map<String, Appender<?>> appenders = config.getAppenders();
+        final Map<String, Appender> appenders = config.getAppenders();
         assertTrue(appenders.containsKey("JMSQueue"));
     }
 }

--- a/core/src/test/java/org/apache/logging/log4j/core/net/JMSQueueFailoverTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/net/JMSQueueFailoverTest.java
@@ -58,7 +58,7 @@ public class JMSQueueFailoverTest {
     private static final String CONFIG = "log4j-jmsqueue-failover.xml";
 
     private static Configuration config;
-    private static ListAppender<LogEvent> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
@@ -76,12 +76,11 @@ public class JMSQueueFailoverTest {
     }
 
     @Before
-    @SuppressWarnings("unchecked")
     public void before() {
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<LogEvent>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/net/JMSQueueTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/net/JMSQueueTest.java
@@ -83,9 +83,9 @@ public class JMSQueueTest {
 
     @After
     public void teardown() {
-        final Map<String,Appender<?>> map = root.getAppenders();
-        for (final Map.Entry<String, Appender<?>> entry : map.entrySet()) {
-            final Appender<?> app = entry.getValue();
+        final Map<String,Appender> map = root.getAppenders();
+        for (final Map.Entry<String, Appender> entry : map.entrySet()) {
+            final Appender app = entry.getValue();
             root.removeAppender(app);
             app.stop();
         }
@@ -100,7 +100,7 @@ public class JMSQueueTest {
                 QUEUE_NAME, null, null, null, clientFilters, "true");
         appender.start();
         final CompositeFilter serverFilters = CompositeFilter.createFilters(new Filter[]{serverFilter});
-        final ListAppender<LogEvent> listApp = new ListAppender<LogEvent>("Events", serverFilters, null, false, false);
+        final ListAppender listApp = new ListAppender("Events", serverFilters, null, false, false);
         listApp.start();
         final PatternLayout layout = PatternLayout.createLayout("%m %ex%n", null, null, null, null);
         final ConsoleAppender console = ConsoleAppender.createAppender(layout, null, "SYSTEM_OUT", "Console", "false", "true");

--- a/core/src/test/java/org/apache/logging/log4j/core/net/JMSTopicFailoverTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/net/JMSTopicFailoverTest.java
@@ -57,7 +57,7 @@ public class JMSTopicFailoverTest {
     private static final String CONFIG = "log4j-jmstopic-failover.xml";
 
     private static Configuration config;
-    private static ListAppender<LogEvent> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
@@ -75,12 +75,11 @@ public class JMSTopicFailoverTest {
     }
 
     @Before
-    @SuppressWarnings("unchecked")
     public void before() {
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<LogEvent>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/net/JMSTopicTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/net/JMSTopicTest.java
@@ -25,27 +25,25 @@ import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.JMSTopicAppender;
-import org.apache.logging.log4j.test.appender.ListAppender;
-import org.apache.logging.log4j.core.filter.CompositeFilter;
 import org.apache.logging.log4j.core.filter.AbstractFilter;
+import org.apache.logging.log4j.core.filter.CompositeFilter;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.status.StatusConsoleListener;
 import org.apache.logging.log4j.status.StatusLogger;
-
+import org.apache.logging.log4j.test.appender.ListAppender;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import org.mockejb.jms.MockTopic;
 import org.mockejb.jms.TopicConnectionFactoryImpl;
 import org.mockejb.jndi.MockContextFactory;
 
-import javax.naming.Context;
-import javax.naming.InitialContext;
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -84,9 +82,9 @@ public class JMSTopicTest {
 
     @After
     public void teardown() {
-        final Map<String,Appender<?>> map = root.getAppenders();
-        for (final Map.Entry<String, Appender<?>> entry : map.entrySet()) {
-            final Appender<?> app = entry.getValue();
+        final Map<String,Appender> map = root.getAppenders();
+        for (final Map.Entry<String, Appender> entry : map.entrySet()) {
+            final Appender app = entry.getValue();
             root.removeAppender(app);
             app.stop();
         }
@@ -101,10 +99,10 @@ public class JMSTopicTest {
                 TOPIC_NAME, null, null, null, clientFilters, "true");
         appender.start();
         final CompositeFilter serverFilters = CompositeFilter.createFilters(new Filter[]{serverFilter});
-        final ListAppender<Serializable> listApp = new ListAppender<Serializable>("Events", serverFilters, null, false, false);
+        final ListAppender listApp = new ListAppender("Events", serverFilters, null, false, false);
         listApp.start();
         final PatternLayout layout = PatternLayout.createLayout("%m %ex%n", null, null, null, null);
-        final ConsoleAppender<? extends Serializable> console =
+        final ConsoleAppender console =
                 ConsoleAppender.createAppender(layout, null, "SYSTEM_OUT", "Console", "false", "true");
         console.start();
         final Logger serverLogger = ctx.getLogger(JMSTopicReceiver.class.getName());

--- a/core/src/test/java/org/apache/logging/log4j/core/pattern/ExtendedThrowableTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/pattern/ExtendedThrowableTest.java
@@ -30,7 +30,8 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  *
@@ -38,18 +39,17 @@ import static org.junit.Assert.*;
 public class ExtendedThrowableTest {
     private static final String CONFIG = "log4j-throwablefilter.xml";
     private static Configuration config;
-    private static ListAppender<String> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<String>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/pattern/RegexReplacementTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/pattern/RegexReplacementTest.java
@@ -42,24 +42,23 @@ import static org.junit.Assert.assertTrue;
 public class RegexReplacementTest {
     private static final String CONFIG = "log4j-replace.xml";
     private static Configuration config;
-    private static ListAppender<String> app;
-    private static ListAppender<String> app2;
+    private static ListAppender app;
+    private static ListAppender app2;
     private static LoggerContext ctx;
 
     private static final String EXPECTED = "/RegexReplacementTest" + Constants.LINE_SEP;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<String>) entry.getValue();
+                app = (ListAppender) entry.getValue();
             }
             if (entry.getKey().equals("List2")) {
-                app2 = (ListAppender<String>) entry.getValue();
+                app2 = (ListAppender) entry.getValue();
             }
         }
     }

--- a/core/src/test/java/org/apache/logging/log4j/core/pattern/RootThrowableTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/pattern/RootThrowableTest.java
@@ -39,18 +39,17 @@ import static org.junit.Assert.assertTrue;
 public class RootThrowableTest {
     private static final String CONFIG = "log4j-rootthrowablefilter.xml";
     private static Configuration config;
-    private static ListAppender<String> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<String>) entry.getValue();
+                app = (ListAppender) entry.getValue();
             }
         }
     }

--- a/core/src/test/java/org/apache/logging/log4j/core/pattern/StyleConverterTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/pattern/StyleConverterTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertTrue;
 public class StyleConverterTest {
     private static final String CONFIG = "log4j-style.xml";
     private static Configuration config;
-    private static ListAppender<String> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     private static final String EXPECTED =
@@ -49,14 +49,13 @@ public class StyleConverterTest {
         + Constants.LINE_SEP;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<String>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/pattern/ThrowableTest.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/pattern/ThrowableTest.java
@@ -38,18 +38,17 @@ import static org.junit.Assert.*;
 public class ThrowableTest {
     private static final String CONFIG = "log4j-throwable.xml";
     private static Configuration config;
-    private static ListAppender<String> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
-    @SuppressWarnings("unchecked")
     public static void setupClass() {
         System.setProperty(XMLConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
         ctx = (LoggerContext) LogManager.getContext(false);
         config = ctx.getConfiguration();
-        for (final Map.Entry<String, Appender<?>> entry : config.getAppenders().entrySet()) {
+        for (final Map.Entry<String, Appender> entry : config.getAppenders().entrySet()) {
             if (entry.getKey().equals("List")) {
-                app = (ListAppender<String>) entry.getValue();
+                app = (ListAppender) entry.getValue();
                 break;
             }
         }

--- a/core/src/test/java/org/apache/logging/log4j/core/util/Compare.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/util/Compare.java
@@ -31,7 +31,7 @@ public class Compare {
     static final int B2_NULL = -2;
 
     private static final InputStream open(
-        final Class testClass,
+        final Class<?> testClass,
         final String fileName) throws IOException {
         final String resourceName = fileName;
         /* if (fileName.startsWith("witness/")) {
@@ -53,7 +53,7 @@ public class Compare {
         return is;
     }
 
-    public static boolean compare(final Class testClass,
+    public static boolean compare(final Class<?> testClass,
                                   final String file1,
                                   final String file2)
         throws IOException {
@@ -69,7 +69,7 @@ public class Compare {
     }
 
     public static boolean compare(
-        final Class testClass, final String file1, final String file2, final BufferedReader in1, final BufferedReader in2) throws IOException {
+        final Class<?> testClass, final String file1, final String file2, final BufferedReader in1, final BufferedReader in2) throws IOException {
 
         String s1;
         int lineCounter = 0;
@@ -108,7 +108,7 @@ public class Compare {
     /**
      * Prints file on the console.
      */
-    private static void outputFile(final Class testClass, final String file)
+    private static void outputFile(final Class<?> testClass, final String file)
         throws IOException {
         final InputStream is = open(testClass, file);
         final BufferedReader in1 = new BufferedReader(new InputStreamReader(is));

--- a/core/src/test/java/org/apache/logging/log4j/core/util/Profiler.java
+++ b/core/src/test/java/org/apache/logging/log4j/core/util/Profiler.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Field;
  */
 public class Profiler {
     private static Object profiler;
-    private static Class profilingModes;
+    private static Class<?> profilingModes;
     private static Class<?> controllerClazz;
 
     static {
@@ -55,7 +55,7 @@ public class Profiler {
                 final Object[] args = new Object[2];
                 args[0] = f.getLong(profilingModes);
                 args[1] = "";
-                final Class[] parms = new Class[] {long.class, String.class};
+                final Class<?>[] parms = new Class<?>[] {long.class, String.class};
                 controllerClazz.getMethod("startCPUProfiling", parms).invoke(profiler, args);
             }
             catch (final Exception e) {
@@ -71,7 +71,7 @@ public class Profiler {
                 final Field f = profilingModes.getDeclaredField("SNAPSHOT_WITHOUT_HEAP");
                 final Object[] args = new Object[1];
                 args[0] = f.getLong(profilingModes);
-                final Class[] parms = new Class[] {long.class};
+                final Class<?>[] parms = new Class<?>[] {long.class};
                 profiler.getClass().getMethod("captureSnapshot", parms).invoke(profiler, args);
                 profiler.getClass().getMethod("stopCPUProfiling").invoke(profiler);
             }

--- a/core/src/test/java/org/apache/logging/log4j/test/appender/AlwaysFailAppender.java
+++ b/core/src/test/java/org/apache/logging/log4j/test/appender/AlwaysFailAppender.java
@@ -23,13 +23,11 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttr;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 
-import java.io.Serializable;
-
 /**
  *
  */
 @Plugin(name="AlwaysFail", category ="Core",elementType="appender",printObject=true)
-public class AlwaysFailAppender<T extends Serializable> extends AbstractAppender<T> {
+public class AlwaysFailAppender extends AbstractAppender {
 
     private AlwaysFailAppender(final String name) {
         super(name, null, null, false);
@@ -41,13 +39,13 @@ public class AlwaysFailAppender<T extends Serializable> extends AbstractAppender
     }
 
     @PluginFactory
-    public static <S extends Serializable> AlwaysFailAppender<S> createAppender(@PluginAttr("name") final String name) {
+    public static AlwaysFailAppender createAppender(@PluginAttr("name") final String name) {
         if (name == null) {
             LOGGER.error("A name for the Appender must be specified");
             return null;
         }
 
-        return new AlwaysFailAppender<S>(name);
+        return new AlwaysFailAppender(name);
     }
 
 }

--- a/core/src/test/java/org/apache/logging/log4j/test/appender/FailOnceAppender.java
+++ b/core/src/test/java/org/apache/logging/log4j/test/appender/FailOnceAppender.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttr;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,7 +30,7 @@ import java.util.List;
  *
  */
 @Plugin(name="FailOnce", category ="Core",elementType="appender",printObject=true)
-public class FailOnceAppender<T extends Serializable> extends AbstractAppender<T> {
+public class FailOnceAppender extends AbstractAppender {
 
     boolean fail = true;
 
@@ -58,13 +57,13 @@ public class FailOnceAppender<T extends Serializable> extends AbstractAppender<T
     }
 
     @PluginFactory
-    public static <S extends Serializable> FailOnceAppender<S> createAppender(@PluginAttr("name") final String name) {
+    public static FailOnceAppender createAppender(@PluginAttr("name") final String name) {
         if (name == null) {
             LOGGER.error("A name for the Appender must be specified");
             return null;
         }
 
-        return new FailOnceAppender<S>(name);
+        return new FailOnceAppender(name);
     }
 
 }

--- a/core/src/test/java/org/apache/logging/log4j/test/appender/InMemoryAppender.java
+++ b/core/src/test/java/org/apache/logging/log4j/test/appender/InMemoryAppender.java
@@ -27,9 +27,9 @@ import org.apache.logging.log4j.core.filter.CompositeFilter;
 /**
  *
  */
-public class InMemoryAppender<T extends Serializable> extends AbstractOutputStreamAppender<T> {
+public class InMemoryAppender extends AbstractOutputStreamAppender {
 
-    public InMemoryAppender(final String name, final Layout<T> layout, final CompositeFilter filters,
+    public InMemoryAppender(final String name, final Layout<? extends Serializable> layout, final CompositeFilter filters,
                             final boolean ignoreExceptions) {
         super(name, layout, filters, ignoreExceptions, true, new InMemoryManager(name, layout));
     }
@@ -41,7 +41,7 @@ public class InMemoryAppender<T extends Serializable> extends AbstractOutputStre
 
     private static class InMemoryManager extends OutputStreamManager {
 
-        public InMemoryManager(final String name, final Layout layout) {
+        public InMemoryManager(final String name, final Layout<? extends Serializable> layout) {
             super(new ByteArrayOutputStream(), name, layout);
         }
 

--- a/core/src/test/java/org/apache/logging/log4j/test/appender/ListAppender.java
+++ b/core/src/test/java/org/apache/logging/log4j/test/appender/ListAppender.java
@@ -36,7 +36,7 @@ import java.util.List;
  * List could eventually grow to cause an OutOfMemoryError.
  */
 @Plugin(name = "List", category = "Core", elementType = "appender", printObject = true)
-public class ListAppender<T extends Serializable> extends AbstractAppender<T> {
+public class ListAppender extends AbstractAppender {
 
     private final List<LogEvent> events = new ArrayList<LogEvent>();
 
@@ -56,7 +56,7 @@ public class ListAppender<T extends Serializable> extends AbstractAppender<T> {
         raw = false;
     }
 
-    public ListAppender(final String name, final Filter filter, final Layout<T> layout, final boolean newline,
+    public ListAppender(final String name, final Filter filter, final Layout<? extends Serializable> layout, final boolean newline,
                         final boolean raw) {
         super(name, filter, layout);
         this.newLine = newline;
@@ -71,7 +71,7 @@ public class ListAppender<T extends Serializable> extends AbstractAppender<T> {
 
     @Override
     public synchronized void append(final LogEvent event) {
-        final Layout layout = getLayout();
+        final Layout<? extends Serializable> layout = getLayout();
         if (layout == null) {
             events.add(event);
         } else if (layout instanceof SerializedLayout) {
@@ -126,7 +126,7 @@ public class ListAppender<T extends Serializable> extends AbstractAppender<T> {
     @Override
     public void stop() {
         super.stop();
-        final Layout layout = getLayout();
+        final Layout<? extends Serializable> layout = getLayout();
         if (layout != null) {
             final byte[] bytes = layout.getFooter();
             if (bytes != null) {
@@ -154,10 +154,10 @@ public class ListAppender<T extends Serializable> extends AbstractAppender<T> {
     }
 
     @PluginFactory
-    public static <S extends Serializable> ListAppender<S> createAppender(@PluginAttr("name") final String name,
+    public static ListAppender createAppender(@PluginAttr("name") final String name,
                                               @PluginAttr("entryPerNewLine") final String newLine,
                                               @PluginAttr("raw") final String raw,
-                                              @PluginElement("layout") final Layout<S> layout,
+                                              @PluginElement("layout") final Layout<? extends Serializable> layout,
                                               @PluginElement("filters") final Filter filter) {
 
         if (name == null) {
@@ -168,6 +168,6 @@ public class ListAppender<T extends Serializable> extends AbstractAppender<T> {
         final boolean nl = Boolean.parseBoolean(newLine);
         final boolean r = Boolean.parseBoolean(raw);
 
-        return new ListAppender<S>(name, filter, layout, nl, r);
+        return new ListAppender(name, filter, layout, nl, r);
     }
 }

--- a/flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAppender.java
+++ b/flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAppender.java
@@ -37,7 +37,7 @@ import org.apache.logging.log4j.core.layout.RFC5424Layout;
  * @param <T> The {@link Layout}'s {@link Serializable} type.
  */
 @Plugin(name = "Flume", category = "Core", elementType = "appender", printObject = true)
-public final class FlumeAppender<T extends Serializable> extends AbstractAppender<T> implements FlumeEventFactory {
+public final class FlumeAppender extends AbstractAppender implements FlumeEventFactory {
 
     private static final String[] EXCLUDED_PACKAGES = {"org.apache.flume", "org.apache.avro"};
     private static final int DEFAULT_MAX_DELAY = 60000;
@@ -67,7 +67,7 @@ public final class FlumeAppender<T extends Serializable> extends AbstractAppende
         }
     }
 
-    private FlumeAppender(final String name, final Filter filter, final Layout<T> layout,
+    private FlumeAppender(final String name, final Filter filter, final Layout<? extends Serializable> layout,
                           final boolean ignoreExceptions, final String includes, final String excludes,
                           final String required, final String mdcPrefix, final String eventPrefix,
                           final boolean compress, final FlumeEventFactory factory, final AbstractFlumeManager manager) {
@@ -158,7 +158,7 @@ public final class FlumeAppender<T extends Serializable> extends AbstractAppende
      * @return A Flume Avro Appender.
      */
     @PluginFactory
-    public static <S extends Serializable> FlumeAppender<S> createAppender(@PluginElement("agents") Agent[] agents,
+    public static FlumeAppender createAppender(@PluginElement("agents") Agent[] agents,
                                                    @PluginElement("properties") final Property[] properties,
                                                    @PluginAttr("embedded") final String embedded,
                                                    @PluginAttr("type") final String type,
@@ -177,7 +177,7 @@ public final class FlumeAppender<T extends Serializable> extends AbstractAppende
                                                    @PluginAttr("compress") final String compressBody,
                                                    @PluginAttr("batchSize") final String batchSize,
                                                    @PluginElement("flumeEventFactory") final FlumeEventFactory factory,
-                                                   @PluginElement("layout") Layout<S> layout,
+                                                   @PluginElement("layout") Layout<? extends Serializable> layout,
                                                    @PluginElement("filters") final Filter filter) {
 
         final boolean embed = embedded != null ? Boolean.parseBoolean(embedded) :
@@ -216,11 +216,8 @@ public final class FlumeAppender<T extends Serializable> extends AbstractAppende
         final int delay = Integers.parseInt(maxDelay, DEFAULT_MAX_DELAY );
 
         if (layout == null) {
-            @SuppressWarnings({ "unchecked", "UnnecessaryLocalVariable" })
-			final
-            Layout<S> l = (Layout<S>) RFC5424Layout.createLayout(null, null, null, "True", null, mdcPrefix, eventPrefix,
+            layout = RFC5424Layout.createLayout(null, null, null, "True", null, mdcPrefix, eventPrefix,
                     null, null, null, excludes, includes, required, null, null, null, null);
-            layout = l;
         }
 
         if (name == null) {
@@ -262,7 +259,7 @@ public final class FlumeAppender<T extends Serializable> extends AbstractAppende
             return null;
         }
 
-        return new FlumeAppender<S>(name, filter, layout,  ignoreExceptions, includes,
+        return new FlumeAppender(name, filter, layout,  ignoreExceptions, includes,
             excludes, required, mdcPrefix, eventPrefix, compress, factory, manager);
     }
 }

--- a/flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumePersistentManager.java
+++ b/flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumePersistentManager.java
@@ -382,13 +382,13 @@ public class FlumePersistentManager extends FlumeAvroManager {
                 if (key != null) {
                     final PluginManager manager = new PluginManager("KeyProvider", SecretKeyProvider.class);
                     manager.collectPlugins();
-                    final Map<String, PluginType> plugins = manager.getPlugins();
+                    final Map<String, PluginType<?>> plugins = manager.getPlugins();
                     if (plugins != null) {
                         boolean found = false;
-                        for (final Map.Entry<String, PluginType> entry : plugins.entrySet()) {
+                        for (final Map.Entry<String, PluginType<?>> entry : plugins.entrySet()) {
                             if (entry.getKey().equalsIgnoreCase(key)) {
                                 found = true;
-                                final Class cl = entry.getValue().getPluginClass();
+                                final Class<?> cl = entry.getValue().getPluginClass();
                                 try {
                                     final SecretKeyProvider provider = (SecretKeyProvider) cl.newInstance();
                                     secretKey = provider.getSecretKey();

--- a/flume-ng/src/test/java/org/apache/logging/log4j/flume/appender/FlumeAppenderTest.java
+++ b/flume-ng/src/test/java/org/apache/logging/log4j/flume/appender/FlumeAppenderTest.java
@@ -372,15 +372,15 @@ public class FlumeAppenderTest {
 
 
     private void removeAppenders(final Logger logger) {
-        final Map<String,Appender<?>> map = logger.getAppenders();
-        for (final Map.Entry<String, Appender<?>> entry : map.entrySet()) {
-            final Appender<?> app = entry.getValue();
+        final Map<String,Appender> map = logger.getAppenders();
+        for (final Map.Entry<String, Appender> entry : map.entrySet()) {
+            final Appender app = entry.getValue();
             avroLogger.removeAppender(app);
             app.stop();
         }
     }
 
-    private Appender<?> getAppender(final Logger logger, final String name) {
+    private Appender getAppender(final Logger logger, final String name) {
         return logger.getAppenders().get(name);
     }
 

--- a/jcl-bridge/src/main/java/org/apache/logging/log4j/jcl/LogFactoryImpl.java
+++ b/jcl-bridge/src/main/java/org/apache/logging/log4j/jcl/LogFactoryImpl.java
@@ -77,7 +77,7 @@ public class LogFactoryImpl extends LogFactory {
     }
 
     @Override
-    public Log getInstance(final Class clazz) throws LogConfigurationException {
+    public Log getInstance(@SuppressWarnings("rawtypes") final Class clazz) throws LogConfigurationException {
         return getInstance(clazz.getName());
     }
 

--- a/jcl-bridge/src/test/java/org/apache/logging/log4j/jcl/LoggerTest.java
+++ b/jcl-bridge/src/test/java/org/apache/logging/log4j/jcl/LoggerTest.java
@@ -70,14 +70,13 @@ public class LoggerTest {
         verify("List", "o.a.l.l.j.LoggerTest Info Message {} MDC{}" + Constants.LINE_SEP);
     }
 
-    @SuppressWarnings("unchecked")
     private void verify(final String name, final String expected) {
         final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        final Map<String, Appender<?>> list = ctx.getConfiguration().getAppenders();
-        final Appender<?> listApp = list.get(name);
+        final Map<String, Appender> list = ctx.getConfiguration().getAppenders();
+        final Appender listApp = list.get(name);
         assertNotNull("Missing Appender", listApp);
         assertTrue("Not a ListAppender", listApp instanceof ListAppender);
-        final List<String> events = ((ListAppender<String>) listApp).getMessages();
+        final List<String> events = ((ListAppender) listApp).getMessages();
         assertTrue("Incorrect number of messages. Expected 1 Actual " + events.size(), events.size()== 1);
         final String actual = events.get(0);
         assertEquals("Incorrect message. Expected " + expected + ". Actual " + actual, expected, actual);

--- a/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/LoggerTest.java
+++ b/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/LoggerTest.java
@@ -27,14 +27,17 @@ import java.util.List;
 import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.joran.spi.JoranException;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.message.ParameterizedMessageFactory;
 import org.apache.logging.log4j.message.StringFormatterMessageFactory;
+
 import ch.qos.logback.core.testUtil.StringListAppender;
 import ch.qos.logback.classic.LoggerContext;
+
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/log4j12-api/src/main/java/org/apache/log4j/Category.java
+++ b/log4j12-api/src/main/java/org/apache/log4j/Category.java
@@ -92,11 +92,11 @@ public class Category {
         return prev == null ? logger : prev;
     }
 
-    public static Category getInstance(final Class clazz) {
+    public static Category getInstance(@SuppressWarnings("rawtypes") final Class clazz) {
         return getInstance(clazz.getName());
     }
 
-    static Category getInstance(final LoggerContext context, final Class clazz) {
+    static Category getInstance(final LoggerContext context, @SuppressWarnings("rawtypes") final Class clazz) {
         return getInstance(context, clazz.getName());
     }
 
@@ -148,6 +148,7 @@ public class Category {
 
      @deprecated Please use {@link LogManager#getCurrentLoggers()} instead.
      */
+    @SuppressWarnings("rawtypes")
     @Deprecated
     public static Enumeration getCurrentCategories() {
         return LogManager.getCurrentLoggers();
@@ -281,6 +282,7 @@ public class Category {
     public void callAppenders(final LoggingEvent event) {
     }
 
+    @SuppressWarnings("rawtypes")
     public Enumeration getAllAppenders() {
         return NullEnumeration.getInstance();
     }

--- a/log4j12-api/src/main/java/org/apache/log4j/LogManager.java
+++ b/log4j12-api/src/main/java/org/apache/log4j/LogManager.java
@@ -73,7 +73,7 @@ public final class LogManager {
         return (Logger) Category.getInstance((LoggerContext) PrivateManager.getContext(), name);
     }
 
-    public static Logger getLogger(final Class clazz) {
+    public static Logger getLogger(@SuppressWarnings("rawtypes") final Class clazz) {
         return (Logger) Category.getInstance((LoggerContext) PrivateManager.getContext(), clazz.getName());
     }
 
@@ -89,6 +89,7 @@ public final class LogManager {
         return Logger.getLogger(name);
     }
 
+    @SuppressWarnings("rawtypes")
     public static Enumeration getCurrentLoggers() {
         return NullEnumeration.getInstance();
     }
@@ -183,11 +184,13 @@ public final class LogManager {
         }
 
         @Override
+        @SuppressWarnings("rawtypes")
         public Enumeration getCurrentLoggers() {
             return NullEnumeration.getInstance();
         }
 
         @Override
+        @SuppressWarnings("rawtypes")
         public Enumeration getCurrentCategories() {
             return NullEnumeration.getInstance();
         }

--- a/log4j12-api/src/main/java/org/apache/log4j/NDC.java
+++ b/log4j12-api/src/main/java/org/apache/log4j/NDC.java
@@ -52,6 +52,7 @@ public final class NDC {
      *
      * @return Stack A clone of the current thread's  diagnostic context.
      */
+    @SuppressWarnings("rawtypes")
     public static Stack cloneStack() {
         final Stack<String> stack = new Stack<String>();
         for (final String element : org.apache.logging.log4j.ThreadContext.cloneStack().asList()) {

--- a/log4j12-api/src/main/java/org/apache/log4j/helpers/NullEnumeration.java
+++ b/log4j12-api/src/main/java/org/apache/log4j/helpers/NullEnumeration.java
@@ -24,6 +24,7 @@ import java.util.NoSuchElementException;
  *
  * @since version 1.0
  */
+@SuppressWarnings("rawtypes")
 public final class NullEnumeration implements Enumeration {
     private static final NullEnumeration INSTANCE = new NullEnumeration();
 

--- a/log4j12-api/src/main/java/org/apache/log4j/spi/LoggerRepository.java
+++ b/log4j12-api/src/main/java/org/apache/log4j/spi/LoggerRepository.java
@@ -91,6 +91,7 @@ public interface LoggerRepository {
 
     void shutdown();
 
+    @SuppressWarnings("rawtypes")
     Enumeration getCurrentLoggers();
 
     /**
@@ -98,6 +99,7 @@ public interface LoggerRepository {
      *
      * @return an enumeration of loggers.
      */
+    @SuppressWarnings("rawtypes")
     Enumeration getCurrentCategories();
 
     void fireAddAppenderEvent(Category logger, Appender appender);

--- a/log4j12-api/src/main/java/org/apache/log4j/xml/DOMConfigurator.java
+++ b/log4j12-api/src/main/java/org/apache/log4j/xml/DOMConfigurator.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
 import java.util.Properties;
+
 import javax.xml.parsers.FactoryConfigurationError;
 
 import org.apache.log4j.config.PropertySetter;
@@ -71,7 +72,7 @@ public class DOMConfigurator {
 
     }
 
-    public static Object parseElement(final Element element, final Properties props, final Class expectedClass)
+    public static Object parseElement(final Element element, final Properties props, @SuppressWarnings("rawtypes") final Class expectedClass)
         throws Exception {
         return null;
     }

--- a/log4j12-api/src/test/java/org/apache/log4j/CategoryTest.java
+++ b/log4j12-api/src/test/java/org/apache/log4j/CategoryTest.java
@@ -43,7 +43,7 @@ public class CategoryTest {
 
     static ConfigurationFactory cf = new BasicConfigurationFactory();
 
-    private static ListAppender<LogEvent> appender = new ListAppender<LogEvent>("List");
+    private static ListAppender appender = new ListAppender("List");
 
     @BeforeClass
     public static void setupClass() {
@@ -162,7 +162,7 @@ public class CategoryTest {
     public void testClassName() {
         final Category category = Category.getInstance("TestCategory");
         final Layout<String> layout = PatternLayout.createLayout("%d %p %C{1.} [%t] %m%n", null, null, null, null);
-        final ListAppender<String> appender = new ListAppender<String>("List2", null, layout, false, false);
+        final ListAppender appender = new ListAppender("List2", null, layout, false, false);
         appender.start();
         category.setAdditivity(false);
         category.getLogger().addAppender(appender);

--- a/log4j12-api/src/test/java/org/apache/log4j/LoggerTest.java
+++ b/log4j12-api/src/test/java/org/apache/log4j/LoggerTest.java
@@ -17,7 +17,13 @@
 
 package org.apache.log4j;
 
-import java.io.Serializable;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -33,8 +39,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 /**
  * Used for internal unit testing the Logger class.
@@ -119,7 +123,7 @@ public class LoggerTest {
     public void testAdditivity1() {
         final Logger a = Logger.getLogger("a");
         final Logger ab = Logger.getLogger("a.b");
-        final CountingAppender<LogEvent> ca = new CountingAppender<LogEvent>();
+        final CountingAppender ca = new CountingAppender();
         ca.start();
         a.getLogger().addAppender(ca);
 
@@ -147,9 +151,9 @@ public class LoggerTest {
         final Logger abc = Logger.getLogger("a.b.c");
         final Logger x = Logger.getLogger("x");
 
-        final CountingAppender<LogEvent> ca1 = new CountingAppender<LogEvent>();
+        final CountingAppender ca1 = new CountingAppender();
         ca1.start();
-        final CountingAppender<LogEvent> ca2 = new CountingAppender<LogEvent>();
+        final CountingAppender ca2 = new CountingAppender();
         ca2.start();
 
         a.getLogger().addAppender(ca1);
@@ -187,11 +191,11 @@ public class LoggerTest {
         final Logger abc = Logger.getLogger("a.b.c");
         Logger.getLogger("x");
 
-        final CountingAppender<LogEvent> caRoot = new CountingAppender<LogEvent>();
+        final CountingAppender caRoot = new CountingAppender();
         caRoot.start();
-        final CountingAppender<LogEvent> caA = new CountingAppender<LogEvent>();
+        final CountingAppender caA = new CountingAppender();
         caA.start();
-        final CountingAppender<LogEvent> caABC = new CountingAppender<LogEvent>();
+        final CountingAppender caABC = new CountingAppender();
         caABC.start();
 
         root.getLogger().addAppender(caRoot);
@@ -384,7 +388,7 @@ public class LoggerTest {
      */
     @Test
     public void testTrace() {
-        final ListAppender<LogEvent> appender = new ListAppender<LogEvent>("List");
+        final ListAppender appender = new ListAppender("List");
         appender.start();
         final Logger root = Logger.getRootLogger();
         root.getLogger().addAppender(appender);
@@ -411,7 +415,7 @@ public class LoggerTest {
      */
     @Test
     public void testTraceWithException() {
-        final ListAppender<LogEvent> appender = new ListAppender<LogEvent>("List");
+        final ListAppender appender = new ListAppender("List");
         appender.start();
         final Logger root = Logger.getRootLogger();
         root.getLogger().addAppender(appender);
@@ -439,7 +443,7 @@ public class LoggerTest {
      */
     @Test
     public void testIsTraceEnabled() {
-        final ListAppender<LogEvent> appender = new ListAppender<LogEvent>("List");
+        final ListAppender appender = new ListAppender("List");
         appender.start();
         final Logger root = Logger.getRootLogger();
         root.getLogger().addAppender(appender);
@@ -458,7 +462,7 @@ public class LoggerTest {
     @SuppressWarnings("deprecation")
     public void testLog() {
         final PatternLayout layout = PatternLayout.createLayout("%d %C %L %m", null, null, null, null);
-        final ListAppender<String> appender = new ListAppender<String>("List", null, layout, false, false);
+        final ListAppender appender = new ListAppender("List", null, layout, false, false);
         appender.start();
         final Logger root = Logger.getRootLogger();
         root.getLogger().addAppender(appender);
@@ -489,7 +493,7 @@ public class LoggerTest {
         }
     }
 
-    private static class CountingAppender<T extends Serializable> extends AbstractAppender<T> {
+    private static class CountingAppender extends AbstractAppender {
 
         int counter;
 

--- a/log4j12-api/src/test/java/org/apache/log4j/LoggingTest.java
+++ b/log4j12-api/src/test/java/org/apache/log4j/LoggingTest.java
@@ -36,7 +36,7 @@ public class LoggingTest {
 
     private static final String CONFIG = "log4j2-config.xml";
     private static Configuration config;
-    private static ListAppender<String> app;
+    private static ListAppender app;
     private static LoggerContext ctx;
 
     @BeforeClass
@@ -51,7 +51,6 @@ public class LoggingTest {
     }
 
     @Before
-    @SuppressWarnings("unchecked")
     public void before() {
         config = ctx.getConfiguration();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
         <version>0.6-beta2</version>
         <scope>test</scope>
       </dependency>
- 	    <dependency>
+        <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>servlet-api</artifactId>
         <version>2.5</version>
@@ -482,6 +482,52 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
           <version>${pmd.plugin.version}</version>
+        </plugin>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>
+                      maven-bundle-plugin
+                    </artifactId>
+                    <versionRange>
+                      [0.0.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>cleanVersions</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>
+                      exec-maven-plugin
+                    </artifactId>
+                    <versionRange>
+                      [0.0.0,)
+                    </versionRange>
+                    <goals>
+                      <goal>java</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/samples/flume-common/src/main/java/org/apache/logging/log4j/samples/app/LogEventFactory.java
+++ b/samples/flume-common/src/main/java/org/apache/logging/log4j/samples/app/LogEventFactory.java
@@ -44,9 +44,9 @@ public class LogEventFactory {
     private static class AuditProxy implements InvocationHandler {
 
         private final StructuredDataMessage msg;
-        private final Class intrface;
+        private final Class<?> intrface;
 
-        public AuditProxy(final StructuredDataMessage msg, final Class intrface) {
+        public AuditProxy(final StructuredDataMessage msg, final Class<?> intrface) {
             this.msg = msg;
             this.intrface = intrface;
         }

--- a/slf4j-impl/src/main/java/org/slf4j/helpers/EventDataConverter.java
+++ b/slf4j-impl/src/main/java/org/slf4j/helpers/EventDataConverter.java
@@ -18,13 +18,13 @@ public class EventDataConverter {
             final EventData data = (objects != null && objects[0] instanceof EventData) ? (EventData) objects[0] :
                 new EventData(s1);
             msg = new StructuredDataMessage(data.getEventId(), data.getMessage(), data.getEventType());
-            for (final Map.Entry entry : data.getEventMap().entrySet()) {
-                final String key = entry.getKey().toString();
+            for (final Map.Entry<String, Object> entry : data.getEventMap().entrySet()) {
+                final String key = entry.getKey();
                 if (EventData.EVENT_TYPE.equals(key) || EventData.EVENT_ID.equals(key) ||
                     EventData.EVENT_MESSAGE.equals(key)) {
                     continue;
                 }
-                ((StructuredDataMessage) msg).put(entry.getKey().toString(), entry.getValue().toString());
+                ((StructuredDataMessage) msg).put(entry.getKey(), String.valueOf(entry.getValue()));
             }
         } catch (final Exception ex) {
             msg = new ParameterizedMessage(s1, objects, throwable);

--- a/slf4j-impl/src/main/java/org/slf4j/helpers/Log4jMDCAdapter.java
+++ b/slf4j-impl/src/main/java/org/slf4j/helpers/Log4jMDCAdapter.java
@@ -53,7 +53,7 @@ public class Log4jMDCAdapter implements MDCAdapter {
 
     @Override
     @SuppressWarnings("unchecked") // nothing we can do about this, restricted by SLF4J API
-    public void setContextMap(final Map map) {
+    public void setContextMap(@SuppressWarnings("rawtypes") final Map map) {
         ThreadContext.clear();
         for (final Map.Entry<String, String> entry : ((Map<String, String>) map).entrySet()) {
             ThreadContext.put(entry.getKey(), entry.getValue());

--- a/slf4j-impl/src/test/java/org/apache/logging/slf4j/LoggerTest.java
+++ b/slf4j-impl/src/test/java/org/apache/logging/slf4j/LoggerTest.java
@@ -167,14 +167,13 @@ public class LoggerTest {
         verify("EventLogger", "o.a.l.s.LoggerTest Transfer [Audit@18060 Amount=\"200.00\" FromAccount=\"123457\" ToAccount=\"123456\"] Transfer Complete" + Constants.LINE_SEP);
     }
 
-    @SuppressWarnings("unchecked")
     private void verify(final String name, final String expected) {
         //LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        final Map<String, Appender<?>> list = ctx.getConfiguration().getAppenders();
-        final Appender<?> listApp = list.get(name);
+        final Map<String, Appender> list = ctx.getConfiguration().getAppenders();
+        final Appender listApp = list.get(name);
         assertNotNull("Missing Appender", listApp);
         assertTrue("Not a ListAppender", listApp instanceof ListAppender);
-        final List<String> events = ((ListAppender<String>) listApp).getMessages();
+        final List<String> events = ((ListAppender) listApp).getMessages();
         assertTrue("Incorrect number of messages. Expected 1 Actual " + events.size(), events.size()== 1);
         final String actual = events.get(0);
         assertEquals("Incorrect message. Expected " + expected + ". Actual " + actual, expected, actual);
@@ -184,10 +183,10 @@ public class LoggerTest {
     @Before
     public void cleanup()
     {
-        final Map<String, Appender<?>> list = ctx.getConfiguration().getAppenders();
-        final Appender<?> listApp = list.get("List");
+        final Map<String, Appender> list = ctx.getConfiguration().getAppenders();
+        final Appender listApp = list.get("List");
         ((ListAppender) listApp).clear();
-        final Appender<?> eventApp = list.get("EventLogger");
+        final Appender eventApp = list.get("EventLogger");
         ((ListAppender) eventApp).clear();
     }
 }

--- a/slf4j-impl/src/test/java/org/apache/logging/slf4j/OptionalTest.java
+++ b/slf4j-impl/src/test/java/org/apache/logging/slf4j/OptionalTest.java
@@ -70,14 +70,13 @@ public class OptionalTest {
         verify("EventLogger", "o.a.l.s.OptionalTest This is a test" + Constants.LINE_SEP);
     }
 
-    @SuppressWarnings("unchecked")
     private void verify(final String name, final String expected) {
         //LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        final Map<String, Appender<?>> list = ctx.getConfiguration().getAppenders();
-        final Appender<?> listApp = list.get(name);
+        final Map<String, Appender> list = ctx.getConfiguration().getAppenders();
+        final Appender listApp = list.get(name);
         assertNotNull("Missing Appender", listApp);
         assertTrue("Not a ListAppender", listApp instanceof ListAppender);
-        final List<String> events = ((ListAppender<String>) listApp).getMessages();
+        final List<String> events = ((ListAppender) listApp).getMessages();
         assertTrue("Incorrect number of messages. Expected 1 Actual " + events.size(), events.size()== 1);
         final String actual = events.get(0);
         assertEquals("Incorrect message. Expected " + expected + ". Actual " + actual, expected, actual);
@@ -87,10 +86,10 @@ public class OptionalTest {
     @Before
     public void cleanup()
     {
-        final Map<String, Appender<?>> list = ctx.getConfiguration().getAppenders();
-        final Appender<?> listApp = list.get("List");
+        final Map<String, Appender> list = ctx.getConfiguration().getAppenders();
+        final Appender listApp = list.get("List");
         ((ListAppender) listApp).clear();
-        final Appender<?> eventApp = list.get("EventLogger");
+        final Appender eventApp = list.get("EventLogger");
         ((ListAppender) eventApp).clear();
     }
 }

--- a/taglib/src/test/java/org/apache/logging/log4j/taglib/CatchingTagTest.java
+++ b/taglib/src/test/java/org/apache/logging/log4j/taglib/CatchingTagTest.java
@@ -93,14 +93,13 @@ public class CatchingTagTest {
         verify("catching WARN M-CATCHING[ EXCEPTION ] E java.lang.Error: This is the last test.");
     }
 
-    @SuppressWarnings("unchecked")
     private void verify(final String expected) {
         final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        final Map<String, Appender<?>> list = ctx.getConfiguration().getAppenders();
-        final Appender<?> listApp = list.get("List");
+        final Map<String, Appender> list = ctx.getConfiguration().getAppenders();
+        final Appender listApp = list.get("List");
         assertNotNull("Missing Appender", listApp);
         assertTrue("Not a ListAppender", listApp instanceof ListAppender);
-        final List<String> events = ((ListAppender<String>) listApp).getMessages();
+        final List<String> events = ((ListAppender) listApp).getMessages();
         try
         {
             assertEquals("Incorrect number of messages.", 1, events.size());

--- a/taglib/src/test/java/org/apache/logging/log4j/taglib/EntryTagTest.java
+++ b/taglib/src/test/java/org/apache/logging/log4j/taglib/EntryTagTest.java
@@ -81,14 +81,13 @@ public class EntryTagTest {
         verify("entry params(log4j-test1.xml, 5792) TRACE M-ENTRY[ FLOW ] E");
     }
 
-    @SuppressWarnings("unchecked")
     private void verify(final String expected) {
         final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        final Map<String, Appender<?>> list = ctx.getConfiguration().getAppenders();
-        final Appender<?> listApp = list.get("List");
+        final Map<String, Appender> list = ctx.getConfiguration().getAppenders();
+        final Appender listApp = list.get("List");
         assertNotNull("Missing Appender", listApp);
         assertTrue("Not a ListAppender", listApp instanceof ListAppender);
-        final List<String> events = ((ListAppender<String>) listApp).getMessages();
+        final List<String> events = ((ListAppender) listApp).getMessages();
         try
         {
             assertEquals("Incorrect number of messages.", 1, events.size());

--- a/taglib/src/test/java/org/apache/logging/log4j/taglib/ExitTagTest.java
+++ b/taglib/src/test/java/org/apache/logging/log4j/taglib/ExitTagTest.java
@@ -88,14 +88,13 @@ public class ExitTagTest {
         verify("exit with(5792) TRACE M-EXIT[ FLOW ] E");
     }
 
-    @SuppressWarnings("unchecked")
     private void verify(final String expected) {
         final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        final Map<String, Appender<?>> list = ctx.getConfiguration().getAppenders();
-        final Appender<?> listApp = list.get("List");
+        final Map<String, Appender> list = ctx.getConfiguration().getAppenders();
+        final Appender listApp = list.get("List");
         assertNotNull("Missing Appender", listApp);
         assertTrue("Not a ListAppender", listApp instanceof ListAppender);
-        final List<String> events = ((ListAppender<String>) listApp).getMessages();
+        final List<String> events = ((ListAppender) listApp).getMessages();
         try
         {
             assertEquals("Incorrect number of messages.", 1, events.size());

--- a/taglib/src/test/java/org/apache/logging/log4j/taglib/LoggingMessageTagSupportTest.java
+++ b/taglib/src/test/java/org/apache/logging/log4j/taglib/LoggingMessageTagSupportTest.java
@@ -293,14 +293,13 @@ public class LoggingMessageTagSupportTest {
                 "This is another test");
     }
 
-    @SuppressWarnings("unchecked")
     private void verify(final String expected) {
         final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        final Map<String, Appender<?>> list = ctx.getConfiguration().getAppenders();
-        final Appender<?> listApp = list.get("List");
+        final Map<String, Appender> list = ctx.getConfiguration().getAppenders();
+        final Appender listApp = list.get("List");
         assertNotNull("Missing Appender", listApp);
         assertTrue("Not a ListAppender", listApp instanceof ListAppender);
-        final List<String> events = ((ListAppender<String>) listApp).getMessages();
+        final List<String> events = ((ListAppender) listApp).getMessages();
         try
         {
             assertEquals("Incorrect number of messages.", 1, events.size());


### PR DESCRIPTION
Remove the generic from Appender<T> and subsequently change all the places that
    pull this generic through the code base. This is mostly removal of places that try
    to be generic but are not.
    
    This also removes the need for a lot of casts, annotations and <?> generics.
    
    Also fix a large number of raw class usages where generic classes such
    as Map or Class are not used with generics. Explicitly do not touch
    the APIs we implement (log4j 1.2 etc.).
