### PR TITLE
LOG4J2-673 – plugin preloading fails in shaded jar files

### DIFF
--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessorTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessorTest.java
@@ -34,13 +34,14 @@ import static org.junit.Assert.*;
 public class PluginProcessorTest {
 
     private static final PluginCache pluginCache = new PluginCache();
+    private static final String PLUGIN_CACHE_FILE = PluginProcessor.getResourceNameForPackage("org.apache.logging.log4j");
 
     private final Plugin p = FakePlugin.class.getAnnotation(Plugin.class);
 
     @BeforeClass
     public static void setUpClass() throws Exception {
         final Enumeration<URL> resources =
-            PluginProcessor.class.getClassLoader().getResources(PluginProcessor.PLUGIN_CACHE_FILE);
+            PluginProcessor.class.getClassLoader().getResources(PLUGIN_CACHE_FILE);
         pluginCache.loadCacheFiles(resources);
     }
 

--- a/log4j-core/src/test/resources/AsyncLoggersWithAsyncAppenderTest.xml
+++ b/log4j-core/src/test/resources/AsyncLoggersWithAsyncAppenderTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="ERROR">
+<Configuration status="ERROR"  packages="org.apache.logging.log4j">
   <Appenders>
     <List name="List">
       <PatternLayout pattern="%c %m"/>
@@ -8,7 +8,7 @@
       <AppenderRef ref="List"/>
     </Async>
   </Appenders>
-  
+
   <Loggers>
     <Root level="trace">
       <AppenderRef ref="Async"/>

--- a/log4j-core/src/test/resources/AsyncLoggersWithAsyncLoggerConfigTest.xml
+++ b/log4j-core/src/test/resources/AsyncLoggersWithAsyncLoggerConfigTest.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="ERROR">
+<Configuration status="ERROR" packages="org.apache.logging.log4j">
   <Appenders>
     <List name="List">
       <PatternLayout pattern="%c %m"/>
     </List>
   </Appenders>
-  
+
   <Loggers>
     <AsyncRoot level="trace">
       <AppenderRef ref="List"/>

--- a/log4j-core/src/test/resources/log4j-Level.xml
+++ b/log4j-core/src/test/resources/log4j-Level.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="XMLConfigTest">
+<Configuration status="OFF" name="XMLConfigTest" packages="org.apache.logging.log4j">
 
   <Appenders>
     <Console name="STDOUT">

--- a/log4j-core/src/test/resources/log4j-advertiser.xml
+++ b/log4j-core/src/test/resources/log4j-advertiser.xml
@@ -17,7 +17,7 @@
 
 -->
 <Configuration status="OFF" dest="target/status.log" name="XMLConfigTest"
-               advertiser="memory">
+               advertiser="memory" packages="org.apache.logging.log4j">
   <ThresholdFilter level="debug"/>
 
   <Appenders>

--- a/log4j-core/src/test/resources/log4j-asynch-no-location.xml
+++ b/log4j-core/src/test/resources/log4j-asynch-no-location.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="RoutingTest">
+<Configuration status="OFF" name="RoutingTest"  packages="org.apache.logging.log4j">
 
   <Appenders>
     <Console name="STDOUT">

--- a/log4j-core/src/test/resources/log4j-asynch.xml
+++ b/log4j-core/src/test/resources/log4j-asynch.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="RoutingTest">
+<Configuration status="OFF" name="RoutingTest" packages="org.apache.logging.log4j">
 
   <Appenders>
     <Console name="STDOUT">

--- a/log4j-core/src/test/resources/log4j-burst.xml
+++ b/log4j-core/src/test/resources/log4j-burst.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="BurstTest">
+<Configuration status="OFF" name="BurstTest" packages="org.apache.logging.log4j">
   <Appenders>
     <List name="ListAppender">
       <PatternLayout pattern="%-5p %d{dd-MMM-yyyy HH:mm:ss} %t %m%n"/>

--- a/log4j-core/src/test/resources/log4j-collectionLogging.xml
+++ b/log4j-core/src/test/resources/log4j-collectionLogging.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="XMLConfigTest">
+<Configuration status="OFF" name="XMLConfigTest" packages="org.apache.logging.log4j">
 
   <Appenders>
     <Console name="STDOUT">

--- a/log4j-core/src/test/resources/log4j-customLevel.xml
+++ b/log4j-core/src/test/resources/log4j-customLevel.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="XMLConfigTest">
+<Configuration status="OFF" name="XMLConfigTest" packages="org.apache.logging.log4j">
 
   <Appenders>
     <Console name="STDOUT">

--- a/log4j-core/src/test/resources/log4j-failover.xml
+++ b/log4j-core/src/test/resources/log4j-failover.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="FailoverTest">
+<Configuration status="OFF" name="FailoverTest" packages="org.apache.logging.log4j">
   <Appenders>
     <AlwaysFail name="Fail" />
     <FailOnce name="Once"/>

--- a/log4j-core/src/test/resources/log4j-jmsqueue-failover.xml
+++ b/log4j-core/src/test/resources/log4j-jmsqueue-failover.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="FailoverTest">
+<Configuration status="OFF" name="FailoverTest" packages="org.apache.logging.log4j">
   <Appenders>
     <List name="List"/>
     <JMSQueue name="Log4j2Queue" queueBindingName="Log4j2Queue" factoryBindingName="QueueConnectionFactory"

--- a/log4j-core/src/test/resources/log4j-jmstopic-failover.xml
+++ b/log4j-core/src/test/resources/log4j-jmstopic-failover.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="FailoverTest">
+<Configuration status="OFF" name="FailoverTest" packages="org.apache.logging.log4j">
   <Appenders>
     <List name="List"/>
     <JMSTopic name="Log4j2Topic" topicBindingName="Log4j2Topic" factoryBindingName="TopicConnectionFactory"

--- a/log4j-core/src/test/resources/log4j-loggerprops.xml
+++ b/log4j-core/src/test/resources/log4j-loggerprops.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="OFF" strict="false" name="DSI">
+<Configuration status="OFF" strict="false" name="DSI" packages="org.apache.logging.log4j">
   <Properties>
      <Property name="test2">test2default</Property>
   </Properties>

--- a/log4j-core/src/test/resources/log4j-reference-level.json
+++ b/log4j-core/src/test/resources/log4j-reference-level.json
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-{ "configuration": { "status": "error", "XMLConfigTest": "RoutingTest",
+{ "configuration": { "status": "error", "XMLConfigTest": "RoutingTest", "packages": "org.apache.logging.log4j",
     "appenders": {
         "appender": [
             { "type": "Console", "name": "STDOUT", "PatternLayout": { "pattern": "%m%n" }},

--- a/log4j-core/src/test/resources/log4j-reference-level.xml
+++ b/log4j-core/src/test/resources/log4j-reference-level.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="XMLConfigTest">
+<Configuration status="OFF" name="XMLConfigTest" packages="org.apache.logging.log4j">
   <Appenders>
     <Console name="STDOUT">
       <PatternLayout pattern="%m%n"/>

--- a/log4j-core/src/test/resources/log4j-replace.xml
+++ b/log4j-core/src/test/resources/log4j-replace.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="RegexReplacementTest">
+<Configuration status="OFF" name="RegexReplacementTest" packages="org.apache.logging.log4j">
   <Appenders>
     <List name="List">
        <PatternLayout>

--- a/log4j-core/src/test/resources/log4j-rewrite.xml
+++ b/log4j-core/src/test/resources/log4j-rewrite.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="RoutingTest">
+<Configuration status="OFF" name="RoutingTest" packages="org.apache.logging.log4j">
 
   <Appenders>
     <Console name="STDOUT">

--- a/log4j-core/src/test/resources/log4j-rootthrowablefilter.xml
+++ b/log4j-core/src/test/resources/log4j-rootthrowablefilter.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="XMLConfigTest">
+<Configuration status="OFF" name="XMLConfigTest" packages="org.apache.logging.log4j">
   <Properties>
     <Property name="filters">org.junit,org.apache.maven,sun.reflect,java.lang.reflect</Property>
   </Properties>

--- a/log4j-core/src/test/resources/log4j-routing-by-jndi.xml
+++ b/log4j-core/src/test/resources/log4j-routing-by-jndi.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="RoutingByJndiTest">
+<Configuration status="OFF" name="RoutingByJndiTest" packages="org.apache.logging.log4j">
 
   <ThresholdFilter level="debug"/>
 

--- a/log4j-core/src/test/resources/log4j-routing.json
+++ b/log4j-core/src/test/resources/log4j-routing.json
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-{ "configuration": { "status": "error", "name": "RoutingTest",
+{ "configuration": { "status": "error", "name": "RoutingTest", "packages": "org.apache.logging.log4j",
       "properties": {
         "property": { "name": "filename", "value" : "target/rolling1/rollingtest-$${sd:type}.log" }
       },

--- a/log4j-core/src/test/resources/log4j-routing.xml
+++ b/log4j-core/src/test/resources/log4j-routing.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="RoutingTest">
+<Configuration status="OFF" name="RoutingTest" packages="org.apache.logging.log4j">
   <Properties>
     <Property name="filename">target/routing1/routingtest-$${sd:type}.log</Property>
   </Properties>

--- a/log4j-core/src/test/resources/log4j-routing2.json
+++ b/log4j-core/src/test/resources/log4j-routing2.json
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-{ "configuration": { "status": "error", "name": "RoutingTest",
+{ "configuration": { "status": "error", "name": "RoutingTest",  "packages": "org.apache.logging.log4j",
       "properties": {
         "property": { "name": "filename", "value" : "target/rolling1/rollingtest-$${sd:type}.log" }
       },

--- a/log4j-core/src/test/resources/log4j-routing3.xml
+++ b/log4j-core/src/test/resources/log4j-routing3.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="RoutingTest">
+<Configuration status="OFF" name="RoutingTest" packages="org.apache.logging.log4j">
   <Properties>
     <Property name="filename">target/routing1/routingtest.log</Property>
   </Properties>

--- a/log4j-core/src/test/resources/log4j-strict1.xml
+++ b/log4j-core/src/test/resources/log4j-strict1.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" strict="true" name="XMLConfigTest">
+<Configuration status="OFF" strict="true" name="XMLConfigTest" packages="org.apache.logging.log4j">
   <Properties>
     <Property name="filename">target/test.log</Property>
   </Properties>

--- a/log4j-core/src/test/resources/log4j-style.xml
+++ b/log4j-core/src/test/resources/log4j-style.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="StyleTest">
+<Configuration status="OFF" name="StyleTest" packages="org.apache.logging.log4j">
   <Appenders>
     <List name="List">
        <PatternLayout>

--- a/log4j-core/src/test/resources/log4j-test1.json
+++ b/log4j-core/src/test/resources/log4j-test1.json
@@ -2,6 +2,7 @@
     "Configuration" : {
         "status": "warn",
         "name": "YAMLConfigTest",
+        "packages": "org.apache.logging.log4j",
 
         "properties" : {
             "property" : {

--- a/log4j-core/src/test/resources/log4j-test1.xml
+++ b/log4j-core/src/test/resources/log4j-test1.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="XMLConfigTest">
+<Configuration status="OFF" name="XMLConfigTest" packages="org.apache.logging.log4j">
   <Properties>
     <Property name="filename">target/test-xml.log</Property>
   </Properties>

--- a/log4j-core/src/test/resources/log4j-test1.yaml
+++ b/log4j-core/src/test/resources/log4j-test1.yaml
@@ -1,6 +1,7 @@
 Configuration:
   status: warn
   name: YAMLConfigTest
+  packages: "org.apache.logging.log4j"
   properties:
     property:
       name: filename

--- a/log4j-core/src/test/resources/log4j-test2.xml
+++ b/log4j-core/src/test/resources/log4j-test2.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="XMLConfigTest" monitorInterval="1">
+<Configuration status="OFF" name="XMLConfigTest" monitorInterval="1" packages="org.apache.logging.log4j">
   <Appenders>
     <RollingFile name="HostFile" fileName="target/${hostName}.log" filePattern="target/${hostName}-%d{MM-dd-yyyy}-%i.log">
       <PatternLayout>

--- a/log4j-core/src/test/resources/log4j-throwable.xml
+++ b/log4j-core/src/test/resources/log4j-throwable.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="XMLConfigTest">
+<Configuration status="OFF" name="XMLConfigTest" packages="org.apache.logging.log4j">
   <Properties>
     <Property name="filters">org.junit,org.apache.maven,sun.reflect,java.lang.reflect</Property>
   </Properties>

--- a/log4j-core/src/test/resources/log4j-throwablefilter.xml
+++ b/log4j-core/src/test/resources/log4j-throwablefilter.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration status="OFF" name="XMLConfigTest">
+<Configuration status="OFF" name="XMLConfigTest" packages="org.apache.logging.log4j">
   <Properties>
     <Property name="filters">org.junit,org.apache.maven,sun.reflect,java.lang.reflect</Property>
   </Properties>

--- a/log4j-core/src/test/resources/log4j2-calling-class.xml
+++ b/log4j-core/src/test/resources/log4j2-calling-class.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration name="CallerInformationTest" status="OFF">
+<Configuration name="CallerInformationTest" status="OFF" packages="org.apache.logging.log4j">
   <Appenders>
     <List name="Class">
       <PatternLayout pattern="%class"/>

--- a/log4j-core/src/test/resources/log4j2-config.xml
+++ b/log4j-core/src/test/resources/log4j2-config.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration name="ConfigTest" status="OFF" monitorInterval="5">
+<Configuration name="ConfigTest" status="OFF" monitorInterval="5" packages="org.apache.logging.log4j">
   <Appenders>
     <Console name="STDOUT">
       <PatternLayout pattern="%m%n"/>

--- a/log4j-core/src/test/resources/log4j2-mapfilter.xml
+++ b/log4j-core/src/test/resources/log4j2-mapfilter.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration name="ConfigTest" status="OFF">
+<Configuration name="ConfigTest" status="OFF" packages="org.apache.logging.log4j">
   <MapFilter onMatch="ACCEPT" onMismatch="NEUTRAL" operator="or">
     <KeyValuePair key="eventId" value="Login"/>
     <KeyValuePair key="eventId" value="Logout"/>

--- a/log4j-core/src/test/resources/missingRootLogger.xml
+++ b/log4j-core/src/test/resources/missingRootLogger.xml
@@ -16,7 +16,7 @@
  limitations under the License.
 
 -->
-<Configuration name="MissingRootTest">
+<Configuration name="MissingRootTest" packages="org.apache.logging.log4j">
   <Appenders>
     <List name="List">
       <PatternLayout>

--- a/log4j-jcl/src/test/resources/log4j-test1.xml
+++ b/log4j-jcl/src/test/resources/log4j-test1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration packages="org.apache.logging.log4j.test" status="debug" name="LoggerTest">
+<Configuration packages="org.apache.logging.log4j,org.apache.logging.log4j.test" status="debug" name="LoggerTest">
   <properties>
     <property name="filename">target/test.log</property>
   </properties>

--- a/log4j-slf4j-impl/src/test/resources/log4j-test1.xml
+++ b/log4j-slf4j-impl/src/test/resources/log4j-test1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration packages="org.apache.logging.log4j.test" status="error" name="LoggerTest">
+<configuration packages="org.apache.logging.log4j,org.apache.logging.log4j.test" status="error" name="LoggerTest">
   <properties>
     <property name="filename">target/test.log</property>
   </properties>

--- a/log4j-taglib/src/test/resources/log4j-test1.xml
+++ b/log4j-taglib/src/test/resources/log4j-test1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration packages="org.apache.logging.log4j.test" status="warn" name="TaglibLoggerTest">
+<Configuration packages="org.apache.logging.log4j,org.apache.logging.log4j.test" status="warn" name="TaglibLoggerTest">
   <properties>
     <property name="filename">target/test.log</property>
   </properties>


### PR DESCRIPTION
Support for plugin preloading through the standard javax.annotation.processing tool was adding in LOG4J2-595

But the plugin processor always creates and stores the processed "Plugin" annotated classes into the same file. This works fine when the classpath consists of individual jar files, but fails when shaded jar files are used.

The fix saves the dat file in a location under META-INF that matches the shared package all the processed plugins are found under.
The package attribute in the config file is then used so that multiple dat files can be loaded at runtime.
This means that the package attribute is no longer deprecated.
