### PR TITLE
LOG4J2-813

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/MarkerManager.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/MarkerManager.java
@@ -228,7 +228,7 @@ public final class MarkerManager {
 
         @Override
         public boolean hasParents() {
-            return this.parents == null;
+            return this.parents != null;
         }
 
         @Override

--- a/log4j-api/src/test/java/org/apache/logging/log4j/MarkerTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/MarkerTest.java
@@ -94,4 +94,13 @@ public class MarkerTest {
         assertTrue("TEST1 is not an instance of PARENT", test1.isInstanceOf(parent));
         assertTrue("TEST1 is not an instance of EXISTING", test1.isInstanceOf(existing));
     }
+
+    @Test
+    public void testHasParents() {
+        final Marker parent = MarkerManager.getMarker("PARENT");
+        final Marker existing = MarkerManager.getMarker("EXISTING");
+        assertFalse(existing.hasParents());
+        existing.setParents(parent);
+        assertTrue(existing.hasParents());
+    }
 }


### PR DESCRIPTION
Fix org.apache.logging.log4j.MarkerManager.Log4jMarker#hasParents().

The method previously returned false when it should have returned
true, and true when it should have returned false.