### PR TITLE
LOG4J2-965 Jansi: Fixes unnecessary closing of System.out

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
@@ -197,7 +197,7 @@ public final class ConsoleAppender extends AbstractOutputStreamAppender<OutputSt
             // We type the parameter as a wildcard to avoid a hard reference to Jansi.
             final Class<?> clazz = Loader.loadClass(JANSI_CLASS);
             final Constructor<?> constructor = clazz.getConstructor(OutputStream.class);
-            return (OutputStream) constructor.newInstance(printStream);
+            return new NoCloseOutputStream((OutputStream) constructor.newInstance(printStream));
         } catch (final ClassNotFoundException cnfe) {
             LOGGER.debug("Jansi is not installed, cannot find {}", JANSI_CLASS);
         } catch (final NoSuchMethodException nsme) {
@@ -206,6 +206,44 @@ public final class ConsoleAppender extends AbstractOutputStreamAppender<OutputSt
             LOGGER.warn("Unable to instantiate {}", JANSI_CLASS);
         }
         return printStream;
+    }
+
+    /**
+     * An delegator for OutputStream that does not close its delegate.
+     */
+    private static class NoCloseOutputStream extends OutputStream {
+
+        private final OutputStream delegate;
+
+        public NoCloseOutputStream(final OutputStream delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void close() {
+            // do not close delegate
+        }
+
+        @Override
+        public void flush() throws IOException {
+            delegate.flush();
+        }
+
+        @Override
+        public void write(final byte[] b) throws IOException {
+            delegate.write(b);
+        }
+
+        @Override
+        public void write(final byte[] b, final int off, final int len)
+                throws IOException {
+            delegate.write(b, off, len);
+        }
+
+        @Override
+        public void write(final int b) throws IOException {
+            delegate.write(b);
+        }
     }
 
     /**

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/ConsoleAppenderTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/ConsoleAppenderTest.java
@@ -38,7 +38,6 @@ import org.easymock.EasyMockSupport;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -58,7 +57,7 @@ public class ConsoleAppenderTest {
         System.setProperty(LOG4J_SKIP_JANSI, "true");
     }
     
-    private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ByteArrayOutputStream baos;
 
     EasyMockSupport mocks;
 
@@ -69,16 +68,25 @@ public class ConsoleAppenderTest {
         System.setProperty(LOG4J_SKIP_JANSI, "true");
         mocks = new EasyMockSupport();
         psMock = mocks.createMock("psMock", PrintStream.class);
+        baos = new ByteArrayOutputStream();
     }
 
-    private void testConsoleStreamManagerDoesNotClose(PrintStream ps, String targetName) {
+    private enum SystemSetter {
+        SYSTEM_OUT { void systemSet(final PrintStream printStream) { System.setOut(printStream); } },
+        SYSTEM_ERR { void systemSet(final PrintStream printStream) { System.setErr(printStream); } },
+        ;
+        abstract void systemSet(PrintStream printStream);
+    }
+
+    private void testConsoleStreamManagerDoesNotClose(PrintStream ps, String targetName, SystemSetter systemSetter) {
         try {
             psMock.write((byte[]) anyObject(), anyInt(), anyInt());
             expectLastCall().anyTimes();
             psMock.flush();
+            expectLastCall().anyTimes();
 
             mocks.replayAll();
-            System.setOut(psMock);
+            systemSetter.systemSet(psMock);
             final Layout<String> layout = PatternLayout.createLayout(null, null, null, null, false, false, null, null);
             final ConsoleAppender app = ConsoleAppender.createAppender(layout, null, targetName, "Console", "false",
                     "false");
@@ -92,23 +100,22 @@ public class ConsoleAppenderTest {
             app.stop();
             assertFalse("Appender did not stop", app.isStarted());
         } finally {
-            System.setOut(ps);
+            systemSetter.systemSet(ps);
         }
         mocks.verifyAll();
     }
 
     @Test
-    @Ignore
     public void testFollowSystemErr() {
-        testFollowSystemPrintStream(System.err, Target.SYSTEM_ERR);
+        testFollowSystemPrintStream(System.err, Target.SYSTEM_ERR, SystemSetter.SYSTEM_ERR);
     }
 
     @Test
     public void testFollowSystemOut() {
-        testFollowSystemPrintStream(System.out, Target.SYSTEM_OUT);
+        testFollowSystemPrintStream(System.out, Target.SYSTEM_OUT, SystemSetter.SYSTEM_OUT);
     }
 
-    private void testFollowSystemPrintStream(PrintStream ps, Target target) {
+    private void testFollowSystemPrintStream(PrintStream ps, Target target, SystemSetter systemSetter) {
         final ConsoleAppender app = ConsoleAppender.newBuilder().setTarget(target).setFollow(true)
                 .setIgnoreExceptions(false).build();
         app.start();
@@ -117,9 +124,12 @@ public class ConsoleAppenderTest {
                     Level.INFO, new SimpleMessage("Test"), null);
 
             assertTrue("Appender did not start", app.isStarted());
-            System.setOut(new PrintStream(baos));
-            app.append(event);
-            System.setOut(ps);
+            systemSetter.systemSet(new PrintStream(baos));
+            try {
+                app.append(event);
+            } finally {
+                systemSetter.systemSet(ps);
+            }
             final String msg = baos.toString();
             assertNotNull("No message", msg);
             assertTrue("Incorrect message: \"" + msg + "\"", msg.endsWith("Test" + Constants.LINE_SEPARATOR));
@@ -130,14 +140,13 @@ public class ConsoleAppenderTest {
     }
 
     @Test
-    @Ignore
     public void testSystemErrStreamManagerDoesNotClose() {
-        testConsoleStreamManagerDoesNotClose(System.err, "SYSTEM_ERR");
+        testConsoleStreamManagerDoesNotClose(System.err, "SYSTEM_ERR", SystemSetter.SYSTEM_ERR);
     }
 
     @Test
     public void testSystemOutStreamManagerDoesNotClose() {
-        testConsoleStreamManagerDoesNotClose(System.out, "SYSTEM_OUT");
+        testConsoleStreamManagerDoesNotClose(System.out, "SYSTEM_OUT", SystemSetter.SYSTEM_OUT);
     }
 
 }


### PR DESCRIPTION
When WindowsAnsiOutputStream is on the classpath, we wrap both System.out
and System.err with it and pass it to the OutputStreamManager, which upon
close, tries to close its underlying stream.

Here we solve this by wrapping WindowsAnsiOutputStream with a
NoCloseOutputStream, effectively ignoring the OutputStreamManager close.