### PR TITLE
LOG4J2-1157 - log4j2 exception covers real compiler error

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessor.java
@@ -91,6 +91,7 @@ public class PluginProcessor extends AbstractProcessor {
                 new PluginAliasesElementVisitor(elementUtils);
         for (final Element element : elements) {
             final Plugin plugin = element.getAnnotation(Plugin.class);
+            if (plugin == null) continue;
             final PluginEntry entry = element.accept(pluginVisitor, plugin);
             final Map<String, PluginEntry> category = pluginCache.getCategory(entry.getCategory());
             category.put(entry.getKey(), entry);


### PR DESCRIPTION
*First of all*: I cannot provide a unittest because the problem occurs while compiling a project and I have no idea how this could be done in a junit test without a very huge overhead. Understanding the problem and reviewing the code should be enough.

*Explanation:*
If you have a project you use log4j2 as logging framework and you have a class which is annotated with the log4j2 ```Plugin``` annotation and you have a different class with a not existing annotation, you can not compile the project. (You can run in that problem by forget a dependency or delete a jar, where the annotation is defined in.) This is rather normal, but the java compiler produces a "wrong" error message. The problem - the not existing annotation - is covered by a log4j2 error message and so you get something like:

```
java.lang.NullPointerException: Plugin annotation is null.
	at java.util.Objects.requireNonNull(Objects.java:226)
	at org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor$PluginElementVisitor.visitType(PluginProcessor.java:126)
	at org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor$PluginElementVisitor.visitType(PluginProcessor.java:116)
	at com.sun.tools.javac.code.Symbol$ClassSymbol.accept(Symbol.java:892)
	at org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor.collectPlugins(PluginProcessor.java:95)
	at org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor.process(PluginProcessor.java:73)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment.callProcessor(JavacProcessingEnvironment.java:793)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment.discoverAndRunProcs(JavacProcessingEnvironment.java:722)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment.access$1700(JavacProcessingEnvironment.java:97)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment$Round.run(JavacProcessingEnvironment.java:1029)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment.doProcessing(JavacProcessingEnvironment.java:1163)
	at com.sun.tools.javac.main.JavaCompiler.processAnnotations(JavaCompiler.java:1108)
	at com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:824)
	at com.sun.tools.javac.main.Main.compile(Main.java:439)
	at com.sun.tools.javac.main.Main.compile(Main.java:353)
	at com.sun.tools.javac.main.Main.compile(Main.java:342)
	at com.sun.tools.javac.main.Main.compile(Main.java:333)
	at com.sun.tools.javac.Main.compile(Main.java:94)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.plexus.compiler.javac.JavacCompiler.compileInProcess(JavacCompiler.java:554)
	at org.codehaus.plexus.compiler.javac.JavacCompiler.compile(JavacCompiler.java:161)
	at org.apache.maven.plugin.AbstractCompilerMojo.execute(AbstractCompilerMojo.java:605)
	at org.apache.maven.plugin.CompilerMojo.execute(CompilerMojo.java:128)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:101)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:209)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:84)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:59)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.singleThreadedBuild(LifecycleStarter.java:183)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:161)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:320)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:156)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:537)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:196)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:141)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:290)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:230)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:409)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:352)
```

But the correct error message should be:
```
COMPILATION ERROR : 
-------------------------------------------------------------
xxx/SomeClass.java:[3,1] error: cannot find symbol
xxx/SomeClass.java:[3,1] error: cannot find symbol
```

The problem is the ```RoundEnvironment```. Because it returns an element in the list (```getElementsAnnotatedWith```) that's ```null```, so the ```collectPlugins``` method in the ```PluginProcessor``` tries to call ```accept``` on ```null``` and we get a NPE. A simple check for ```null``` solves the issue and the compiler error is shown again.
