### PR TITLE
LOG4J2-649: Purging dynamically created routing sub-appenders

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/IdlePurgePolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/IdlePurgePolicy.java
@@ -1,0 +1,80 @@
+package org.apache.logging.log4j.core.appender.routing;
+
+import java.util.Calendar;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.util.Integers;
+import org.apache.logging.log4j.status.StatusLogger;
+
+/**
+ * 
+ * Policy is purging appenders that were not in use specified time in minutes
+ *
+ */
+@Plugin(name = "IdlePurgePolicy", category = "Core", printObject = true)
+public class IdlePurgePolicy implements PurgePolicy {
+
+    private static final Logger LOGGER = StatusLogger.getLogger();
+	private int timeToLive;
+	private final ConcurrentMap<String, Calendar> appendersUsage = new ConcurrentHashMap<>();
+	private RoutingAppender routingAppender;
+    
+	public IdlePurgePolicy(int timeToLive) {
+		this.timeToLive = timeToLive;		
+	}	
+
+    @Override
+	public void initialize(RoutingAppender routingAppender) {
+		this.routingAppender = routingAppender;		
+	}
+
+	/**
+	 * Purging appenders that were not in use specified time
+	 * 
+	 */
+	@Override
+	public void purge() {
+		Calendar calendar = Calendar.getInstance();
+		calendar.add(Calendar.MINUTE, -timeToLive);
+		
+    	for (Entry<String, Calendar> entry : appendersUsage.entrySet()) {
+			if(calendar.after(entry.getValue())) {				
+				appendersUsage.remove(entry.getKey());
+		       	routingAppender.deleteAppender(entry.getKey());
+			}
+		}
+	}
+
+	@Override
+	public void update(String key, LogEvent event) {
+		appendersUsage.put(key, Calendar.getInstance());
+	}
+
+	/**
+     * Create the Routes.
+     * @param pattern The pattern.
+     * @param routes An array of Route elements.
+     * @return The Routes container.
+     */
+    @PluginFactory
+    public static PurgePolicy createPurgePolicy(
+            @PluginAttribute("timetolive") final String time) {
+    	
+        if (time == null) {
+            LOGGER.error("A timeToLive is required");
+            return null;
+        }
+        
+        final int timeToLive = Integers.parseInt(time);
+        
+        return new IdlePurgePolicy(timeToLive);
+    }
+
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/PurgePolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/PurgePolicy.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
 package org.apache.logging.log4j.core.appender.routing;
 
 import org.apache.logging.log4j.core.LogEvent;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/PurgePolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/PurgePolicy.java
@@ -1,0 +1,31 @@
+package org.apache.logging.log4j.core.appender.routing;
+
+import org.apache.logging.log4j.core.LogEvent;
+
+/**
+ * 
+ * Policy for purging routed appenders
+ *
+ */
+public interface PurgePolicy {
+
+	/**
+	 * Activate purging appenders
+	 */
+	void purge();
+	
+	/**
+	 * 
+	 * @param routed appender key
+	 * @param event
+	 */
+	void update(String key, LogEvent event);
+
+	/**
+	 * Initialize with routing appender
+	 * 
+	 * @param routingAppender
+	 */
+	void initialize(RoutingAppender routingAppender);
+
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender.java
@@ -184,7 +184,7 @@ public final class RoutingAppender extends AbstractAppender {
      * @param key
      */
     public void deleteAppender(String key) {
-    	LOGGER.debug("Stopping route with key" + key);
+    	LOGGER.debug("Stopping route with key " + key);
     	AppenderControl control = appenders.remove(key);
     	control.getAppender().stop();
     }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderWithPurgingTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderWithPurgingTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.appender.routing;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.logging.log4j.EventLogger;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.junit.CleanFiles;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.apache.logging.log4j.message.StructuredDataMessage;
+import org.apache.logging.log4j.test.appender.ListAppender;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Testing Routing appender purge facilities
+ */
+public class RoutingAppenderWithPurgingTest {
+    private static final String CONFIG = "log4j-routing-purge.xml";
+    private static final String IDLE_LOG_FILE1 = "target/routing-purge-idle/routingtest-1.log";
+    private static final String IDLE_LOG_FILE2 = "target/routing-purge-idle/routingtest-2.log";
+    private static final String IDLE_LOG_FILE3 = "target/routing-purge-idle/routingtest-3.log";
+    private static final String MANUAL_LOG_FILE1 = "target/routing-purge-manual/routingtest-1.log";
+    private static final String MANUAL_LOG_FILE2 = "target/routing-purge-manual/routingtest-2.log";
+    private static final String MANUAL_LOG_FILE3 = "target/routing-purge-manual/routingtest-3.log";
+   
+
+    private ListAppender app;
+    private RoutingAppender routingAppenderIdle;
+    private RoutingAppender routingAppenderManual;
+
+    @Rule
+    public LoggerContextRule init = new LoggerContextRule(CONFIG);
+
+    @Rule
+    public CleanFiles files = new CleanFiles(IDLE_LOG_FILE1, IDLE_LOG_FILE2, IDLE_LOG_FILE3, 
+    		MANUAL_LOG_FILE1, MANUAL_LOG_FILE2, MANUAL_LOG_FILE3);
+	
+
+    @Before
+    public void setUp() throws Exception {
+        this.app = this.init.getListAppender("List");
+        this.routingAppenderIdle = this.init.getRequiredAppender("RoutingPurgeIdle", RoutingAppender.class);
+        this.routingAppenderManual = this.init.getRequiredAppender("RoutingPurgeManual", RoutingAppender.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        this.app.clear();
+    }
+
+    @Test
+    public void routingTest() throws InterruptedException {
+        StructuredDataMessage msg = new StructuredDataMessage("1", "This is a test 1", "Service");
+        EventLogger.logEvent(msg);
+        final List<LogEvent> list = app.getEvents();
+        assertNotNull("No events generated", list);
+        assertTrue("Incorrect number of events. Expected 1, got " + list.size(), list.size() == 1);
+        msg = new StructuredDataMessage("2", "This is a test 2", "Service");
+        EventLogger.logEvent(msg);
+        msg = new StructuredDataMessage("3", "This is a test 3", "Service");
+        EventLogger.logEvent(msg);
+        String[] files = {IDLE_LOG_FILE1, IDLE_LOG_FILE2, IDLE_LOG_FILE3, MANUAL_LOG_FILE1, MANUAL_LOG_FILE2, MANUAL_LOG_FILE3};
+        assertFileExistance(files);
+        
+        assertEquals("Incorrect number of appenders with IdlePurgePolicy.", 3, routingAppenderIdle.getAppenders().size());
+        assertEquals("Incorrect number of appenders manual purge.", 3, routingAppenderManual.getAppenders().size());
+        
+        Thread.sleep(4000);
+        EventLogger.logEvent(msg);
+        
+        assertEquals("Incorrect number of appenders with IdlePurgePolicy.", 1, routingAppenderIdle.getAppenders().size());
+        assertEquals("Incorrect number of appenders with manual purge.", 3, routingAppenderManual.getAppenders().size());
+        
+        routingAppenderManual.deleteAppender("1");
+        routingAppenderManual.deleteAppender("2");
+        routingAppenderManual.deleteAppender("3");
+        
+        assertEquals("Incorrect number of appenders with IdlePurgePolicy.", 1, routingAppenderIdle.getAppenders().size());
+        assertEquals("Incorrect number of appenders with manual purge.", 0, routingAppenderManual.getAppenders().size());
+    }
+    
+    private void assertFileExistance(String... files) {
+    	for (String file : files) {
+			assertTrue("File should exist - " + file + " file ", new File(file).exists());
+		}
+    }
+}

--- a/log4j-core/src/test/resources/log4j-routing-purge.xml
+++ b/log4j-core/src/test/resources/log4j-routing-purge.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration status="OFF" name="RoutingTest">
+  <Properties>
+    <Property name="filename-idle">target/routing-purge-idle/routingtest-$${sd:id}.log</Property>
+    <Property name="filename-manual">target/routing-purge-manual/routingtest-$${sd:id}.log</Property>
+  </Properties>
+  <ThresholdFilter level="debug"/>
+
+  <Appenders>
+    <Console name="STDOUT">
+      <PatternLayout pattern="%m%n"/>
+    </Console>
+    <List name="List">
+      <ThresholdFilter level="debug"/>
+    </List>
+    <Routing name="RoutingPurgeIdle">
+      <Routes pattern="$${sd:id}">
+        <Route>
+          <File name="Routing-${sd:id}" fileName="${filename-idle}">
+            <PatternLayout>
+              <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
+            </PatternLayout>
+          </File>
+        </Route>
+      </Routes>
+      <IdlePurgePolicy timeToLive="3" timeUnit="seconds" />
+    </Routing>
+    
+    <Routing name="RoutingPurgeManual">
+      <Routes pattern="$${sd:id}">
+        <Route>
+          <File name="Routing-${sd:id}" fileName="${filename-manual}">
+            <PatternLayout>
+              <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
+            </PatternLayout>
+          </File>
+        </Route>
+      </Routes>
+    </Routing>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="EventLogger" level="info" additivity="false">
+      <AppenderRef ref="RoutingPurgeIdle"/>
+      <AppenderRef ref="RoutingPurgeManual"/>
+      <AppenderRef ref="List"/>
+    </Logger>
+
+    <Root level="error">
+      <AppenderRef ref="STDOUT"/>
+    </Root>
+  </Loggers>
+
+</Configuration>


### PR DESCRIPTION
1. Added PurgePolicy interface
2. Added IdlePurgePolicy which is purging sub-appenders that were not in use last X time units
3. Added ability to access sub-appenders, so custom purging controlled
outside log4j2 also possible.