### PR TITLE
LOG4J2-1227

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/MapLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/MapLookup.java
@@ -118,7 +118,7 @@ public class MapLookup implements StrLookup {
 
     @Override
     public String lookup(final LogEvent event, final String key) {
-        final boolean isMapMessage = event.getMessage() instanceof MapMessage;
+        final boolean isMapMessage = event != null && event.getMessage() instanceof MapMessage;
         if (map == null && !isMapMessage) {
             return null;
         }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/MapLookupTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/MapLookupTest.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
 
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.MapMessage;
 import org.junit.Test;
 
 /**
@@ -64,4 +67,26 @@ public class MapLookupTest {
         assertEquals(null, lookup.lookup("foo.txt"));
     }
 
+    @Test
+    public void testEventMapMessage() {
+      final HashMap<String, String> map = new HashMap<>();
+      map.put("A", "B");
+      final HashMap<String, String> eventMap = new HashMap<>();
+      eventMap.put("A1", "B1");
+      final MapMessage message = new MapMessage(eventMap);
+      final LogEvent event = Log4jLogEvent.newBuilder()
+                .setMessage(message)
+                .build();
+      final MapLookup lookup = new MapLookup(map);
+      assertEquals("B", lookup.lookup(event, "A"));
+      assertEquals("B1", lookup.lookup(event, "A"));
+    }
+
+    @Test
+    public void testNullEvent() {
+      final HashMap<String, String> map = new HashMap<>();
+      map.put("A", "B");
+      final MapLookup lookup = new MapLookup(map);
+      assertEquals("B", lookup.lookup(null, "A"));
+    }
 }


### PR DESCRIPTION
Test if the event is null before using it, to avoid NullPointerException.
Add some unit tests.