### PR TITLE
LOGS-494: allow composite configurations

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
@@ -113,7 +113,7 @@ public abstract class AbstractConfiguration extends AbstractFilterable implement
     private LoggerConfig root = new LoggerConfig();
     private final ConcurrentMap<String, Object> componentMap = new ConcurrentHashMap<>();
     private final ConfigurationSource configurationSource;
-    private ScriptManager scriptManager;
+    protected ScriptManager scriptManager;
     private final ConfigurationScheduler configurationScheduler = new ConfigurationScheduler();
     private final WatchManager watchManager = new WatchManager(configurationScheduler);
     private AsyncLoggerConfigDisruptor asyncLoggerConfigDisruptor;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/CompositeConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/CompositeConfiguration.java
@@ -1,0 +1,113 @@
+package org.apache.logging.log4j.core.config;
+
+import org.apache.logging.log4j.core.Filter;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+public class CompositeConfiguration
+    extends AbstractConfiguration
+{
+
+    private List<? extends AbstractConfiguration> configurations;
+
+    private static final List<String> names = new ArrayList<>();
+
+    private static final String APPENDERS = "appenders";
+
+    private static final String PROPERTIES = "properties";
+
+    private static final String LOGGERS = "loggers";
+
+
+    static
+    {
+        names.add( APPENDERS );
+        names.add( PROPERTIES );
+        names.add( LOGGERS );
+    }
+
+    /**
+     * Constructor.
+     */
+    public CompositeConfiguration( List<? extends AbstractConfiguration> configurations )
+    {
+        super( ConfigurationSource.NULL_SOURCE );
+        this.configurations = configurations;
+    }
+
+    @Override
+    protected void setup()
+    {
+        AbstractConfiguration primaryConfiguration = configurations.get( 0 );
+        staffChildConfiguration( primaryConfiguration );
+        rootNode = primaryConfiguration.rootNode;
+        for ( AbstractConfiguration amendingConfiguration : configurations.subList( 1, configurations.size() ) )
+        {
+            staffChildConfiguration( amendingConfiguration );
+            Node currentRoot = amendingConfiguration.rootNode;
+            for ( Node childNode : currentRoot.getChildren() )
+            {
+                mergeNodes( rootNode, childNode );
+            }
+        }
+    }
+
+    private void staffChildConfiguration( AbstractConfiguration childConfiguration )
+    {
+        childConfiguration.pluginManager = pluginManager;
+        childConfiguration.scriptManager = scriptManager;
+        childConfiguration.setup();
+    }
+
+    private void mergeNodes( Node rootNode, Node childNode )
+    {
+        // first find the right rootNode child we will merge with
+        boolean isFilter = Filter.class.isAssignableFrom(childNode.getType().getPluginClass());
+        for ( Node rootChildNode : rootNode.getChildren() )
+        {
+            if (isFilter && Filter.class.isAssignableFrom(rootChildNode.getType().getPluginClass())) {
+                //for filters we have a simple replace, as only one filter can exist
+                rootNode.getChildren().remove(rootChildNode);
+                rootNode.getChildren().add(childNode);
+                return;
+            }
+            if ( rootChildNode.getType() != childNode.getType()
+                || !names.contains( rootChildNode.getName().toLowerCase() ) )
+            {
+                continue;
+            }
+
+            List<Node> grandChilds = rootChildNode.getChildren();
+
+            switch ( rootChildNode.getName().toLowerCase() )
+            {
+                case LOGGERS: /** fallthrough */
+                case PROPERTIES:
+                    grandChilds.addAll( childNode.getChildren() );
+                    break;
+                case APPENDERS:
+                    for ( Node appender : childNode.getChildren() )
+                    {
+                        Iterator<Node> it = grandChilds.iterator();
+                        while ( it.hasNext() )
+                        {
+                            Node currentAppender = it.next();
+                            // check if there's already an appender with the very same name. If so remove it
+                            if ( Objects.equals( currentAppender.getAttributes().get( "name" ),
+                                appender.getAttributes().get( "name" ) ) )
+                            {
+                                it.remove();
+                                break;
+                            }
+                        }
+                        // add appender (might actually be replace with one with the same name was previously found
+                        grandChilds.add( appender );
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jContextFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jContextFactory.java
@@ -17,13 +17,17 @@
 package org.apache.logging.log4j.core.impl;
 
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.AbstractConfiguration;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.config.CompositeConfiguration;
 import org.apache.logging.log4j.core.selector.ClassLoaderContextSelector;
 import org.apache.logging.log4j.core.selector.ContextSelector;
 import org.apache.logging.log4j.core.util.Cancellable;
@@ -235,6 +239,54 @@ public class Log4jContextFactory implements LoggerContextFactory, ShutdownCallba
                 ctx.start(config);
                 ContextAnchor.THREAD_CONTEXT.remove();
             } else {
+                ctx.start();
+            }
+        }
+        return ctx;
+    }
+
+    public LoggerContext getContext( final String fqcn, final ClassLoader loader, final Object externalContext,
+                                     final boolean currentContext, final List<URI> configLocations, final String name )
+    {
+        final LoggerContext ctx =
+            selector.getContext( fqcn, loader, currentContext, null/*this probably needs to change*/ );
+        if ( externalContext != null && ctx.getExternalContext() == null )
+        {
+            ctx.setExternalContext( externalContext );
+        }
+        if ( name != null )
+        {
+            ctx.setName( name );
+        }
+        if ( ctx.getState() == LifeCycle.State.INITIALIZED )
+        {
+            if ( ( configLocations != null && !configLocations.isEmpty() ) )
+            {
+                ContextAnchor.THREAD_CONTEXT.set( ctx );
+                List<AbstractConfiguration> configurations = new ArrayList<>( configLocations.size() );
+                for ( URI configLocation : configLocations )
+                {
+                    Configuration currentReadConfiguration =
+                        ConfigurationFactory.getInstance().getConfiguration( name, configLocation );
+                    if ( currentReadConfiguration instanceof AbstractConfiguration )
+                    {
+                        configurations.add( (AbstractConfiguration) currentReadConfiguration );
+                    }
+                    else
+                    {
+                        LOGGER.error(
+                            "Found configuration {}, which is no AbstractConfiguration and can't be handled by CompositeConfiguration",
+                            configLocation );
+                    }
+                }
+                CompositeConfiguration compositeConfiguration = new CompositeConfiguration( configurations );
+                LOGGER.debug( "Starting LoggerContext[name={}] from configurations at {}", ctx.getName(),
+                    configLocations );
+                ctx.start( compositeConfiguration );
+                ContextAnchor.THREAD_CONTEXT.remove();
+            }
+            else
+            {
                 ctx.start();
             }
         }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CompositeConfigurationTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CompositeConfigurationTest.java
@@ -1,0 +1,141 @@
+package org.apache.logging.log4j.core.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.appender.FileAppender;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.filter.ThresholdFilter;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class CompositeConfigurationTest
+{
+
+    @Test
+    public void compositeConfigurationUsed()
+    {
+        final LoggerContextRule lcr =
+            new LoggerContextRule( "classpath:log4j-comp-appender.xml;log4j-comp-appender.json" );
+        Statement test = new Statement()
+        {
+            @Override
+            public void evaluate()
+                throws Throwable
+            {
+                assertTrue( lcr.getConfiguration() instanceof CompositeConfiguration );
+            }
+        };
+        runTest( lcr, test );
+    }
+
+    @Test
+    public void compositeProperties()
+    {
+        final LoggerContextRule lcr =
+            new LoggerContextRule( "classpath:log4j-comp-properties.xml;log4j-comp-properties.json" );
+        Statement test = new Statement()
+        {
+            @Override
+            public void evaluate()
+                throws Throwable
+            {
+                CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
+                assertEquals( "json", config.getStrSubstitutor().replace( "${propertyShared}" ) );
+                assertEquals( "xml", config.getStrSubstitutor().replace( "${propertyXml}" ) );
+                assertEquals( "json", config.getStrSubstitutor().replace( "${propertyJson}" ) );
+            }
+        };
+        runTest( lcr, test );
+    }
+
+    @Test
+    public void compositeAppenders()
+    {
+        final LoggerContextRule lcr =
+            new LoggerContextRule( "classpath:log4j-comp-appender.xml;log4j-comp-appender.json" );
+        Statement test = new Statement()
+        {
+            @Override
+            public void evaluate()
+                throws Throwable
+            {
+                CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
+                Map<String, Appender> appender = config.getAppenders();
+                assertEquals( 3, appender.size() );
+                assertTrue( appender.get( "STDOUT" ) instanceof ConsoleAppender );
+                assertTrue( appender.get( "File" ) instanceof FileAppender );
+                assertTrue( appender.get( "Override" ) instanceof RollingFileAppender );
+            }
+        };
+        runTest( lcr, test );
+    }
+
+    @Test
+    public void compositeLogger()
+    {
+        final LoggerContextRule lcr = new LoggerContextRule( "classpath:log4j-comp-logger.xml;log4j-comp-logger.json" );
+        Statement test = new Statement()
+        {
+            @Override
+            public void evaluate()
+                throws Throwable
+            {
+                CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
+                Map<String, Appender> appendersMap = config.getLogger( "cat1" ).getAppenders();
+                assertEquals( 1, appendersMap.size() );
+                assertTrue( appendersMap.get( "STDOUT" ) instanceof ConsoleAppender );
+
+                appendersMap = config.getLogger( "cat2" ).getAppenders();
+                assertEquals( 1, appendersMap.size() );
+                assertTrue( appendersMap.get( "File" ) instanceof FileAppender );
+
+                appendersMap = config.getLogger( "cat3" ).getAppenders();
+                assertEquals( 1, appendersMap.size() );
+                assertTrue( appendersMap.get( "File" ) instanceof FileAppender );
+
+                appendersMap = config.getRootLogger().getAppenders();
+                assertEquals( 2, appendersMap.size() );
+                assertTrue( appendersMap.get( "File" ) instanceof FileAppender );
+                assertTrue( appendersMap.get( "STDOUT" ) instanceof ConsoleAppender );
+            }
+        };
+        runTest( lcr, test );
+    }
+
+    @Test
+    public void overrideFilter()
+    {
+        final LoggerContextRule lcr = new LoggerContextRule( "classpath:log4j-comp-filter.xml;log4j-comp-filter.json" );
+        Statement test = new Statement()
+        {
+            @Override
+            public void evaluate()
+                throws Throwable
+            {
+                CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
+                assertTrue( config.getFilter() instanceof ThresholdFilter );
+            }
+        };
+        runTest( lcr, test );
+    }
+
+    private void runTest( LoggerContextRule rule, Statement statement )
+    {
+        try
+        {
+            rule.apply( statement, Description.createTestDescription( getClass(),
+                Thread.currentThread().getStackTrace()[1].getMethodName() ) ).evaluate();
+        }
+        catch ( Throwable throwable )
+        {
+            throw new RuntimeException( throwable );
+        }
+    }
+}

--- a/log4j-core/src/test/resources/log4j-comp-appender.json
+++ b/log4j-core/src/test/resources/log4j-comp-appender.json
@@ -1,0 +1,34 @@
+{
+    "Configuration" : {
+        "status": "warn",
+        "name": "YAMLConfigTest",
+        "appenders": {
+            "Console": {
+                "name": "STDOUT",
+                "PatternLayout": {
+                    "Pattern": "%m%n"
+                }
+            },
+            "RollingFile": {
+                "name": "Override",
+                "fileName": "target/log4j-appender-override.log",
+                "filePattern": "target/log4j-appender-override-$${date:yyyy-MM}.log",
+                "PatternLayout": {
+                    "Pattern": "%m%n"
+                },
+                "SizeBasedTriggeringPolicy": {
+                    "size": "500"
+                }
+            }
+        },
+        "Loggers" : {
+            "Root" : {
+                "level" : "error",
+                "AppenderRef" : {
+                    "ref" : "STDOUT"
+                }
+
+            }
+        }
+    }
+}

--- a/log4j-core/src/test/resources/log4j-comp-appender.xml
+++ b/log4j-core/src/test/resources/log4j-comp-appender.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration status="DEBUG" name="XMLConfigTest">
+    <Appenders>
+        <File name="File" fileName="target/log4j-comp-appender.log" bufferedIO="false">
+            <PatternLayout>
+                <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
+            </PatternLayout>
+        </File>
+        <File name="Override" fileName="target/log4j-comp-appender.log" bufferedIO="false">
+            <PatternLayout>
+                <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
+            </PatternLayout>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Root level="ERROR">
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+
+</Configuration>

--- a/log4j-core/src/test/resources/log4j-comp-filter.json
+++ b/log4j-core/src/test/resources/log4j-comp-filter.json
@@ -1,0 +1,9 @@
+{
+    "Configuration" : {
+        "status": "warn",
+        "name": "YAMLConfigTest",
+        "thresholdFilter" : {
+            "level": "debug"
+        }
+    }
+}

--- a/log4j-core/src/test/resources/log4j-comp-filter.xml
+++ b/log4j-core/src/test/resources/log4j-comp-filter.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration status="ERROR" name="XMLConfigTest">
+  <BurstFilter level="INFO" rate="16" maxBurst="100"/>
+
+  <Appenders>
+    <Console name="STDOUT">
+      <PatternLayout pattern="%m%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Root level="error">
+      <AppenderRef ref="STDOUT"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/log4j-core/src/test/resources/log4j-comp-logger.json
+++ b/log4j-core/src/test/resources/log4j-comp-logger.json
@@ -1,0 +1,36 @@
+{
+    "Configuration" : {
+        "status": "warn",
+        "name": "YAMLConfigTest",
+        "Loggers" : {
+            "logger" : [
+                {
+                    "name" : "cat1",
+                    "level" : "debug",
+                    "additivity" : false,
+                    "AppenderRef" : {
+                        "ref" : "STDOUT"
+                    }
+                },
+                {
+                    "name" : "cat2",
+                    "level" : "debug",
+                    "additivity" : false,
+                    "AppenderRef" : {
+                        "ref" : "File"
+                    }
+
+                }
+            ],
+            "Root" : {
+                "level" : "error",
+                "AppenderRef" : [{
+                    "ref" : "STDOUT"
+                },
+                {
+                    "ref" : "File"
+                }]
+            }
+        }
+    }
+}

--- a/log4j-core/src/test/resources/log4j-comp-logger.xml
+++ b/log4j-core/src/test/resources/log4j-comp-logger.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration status="ERROR" name="XMLConfigTest">
+    <Appenders>
+        <Console name="STDOUT">
+            <PatternLayout pattern="%m%n"/>
+        </Console>
+        <File name="File" fileName="${filename}" bufferedIO="false">
+            <PatternLayout>
+                <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
+            </PatternLayout>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="cat1" level="debug" additivity="false">
+            <AppenderRef ref="File"/>
+        </Logger>
+
+        <Logger name="cat3" level="debug" additivity="false">
+            <AppenderRef ref="File"/>
+        </Logger>
+    </Loggers>
+
+</Configuration>

--- a/log4j-core/src/test/resources/log4j-comp-properties.json
+++ b/log4j-core/src/test/resources/log4j-comp-properties.json
@@ -1,0 +1,16 @@
+{
+    "Configuration" : {
+        "status": "warn",
+        "name": "YAMLConfigTest",
+
+        "properties" : {
+            "property" : [{
+                "name" : "propertyShared",
+                "value": "json"
+            },{
+                "name" : "propertyJson",
+                "value": "json"
+            }]
+        }
+    }
+}

--- a/log4j-core/src/test/resources/log4j-comp-properties.xml
+++ b/log4j-core/src/test/resources/log4j-comp-properties.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration status="OFF" name="XMLConfigTest">
+  <Properties>
+    <Property name="propertyShared">xml</Property>
+    <Property name="propertyXml">xml</Property>
+  </Properties>
+</Configuration>


### PR DESCRIPTION
Allow composite log configuration, by simply specifying multiple log files. Later ones overriding/amending previous log configs. It's possible to mix various config types together.