### PR TITLE
Property log4j.skipJansi should have a default of true

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
@@ -243,7 +243,7 @@ public final class ConsoleAppender extends AbstractOutputStreamAppender<OutputSt
             throw new IllegalStateException("Unsupported default encoding " + enc, ex);
         }
         final PropertiesUtil propsUtil = PropertiesUtil.getProperties();
-        if (!propsUtil.isOsWindows() || propsUtil.getBooleanProperty("log4j.skipJansi")) {
+        if (!propsUtil.isOsWindows() || propsUtil.getBooleanProperty("log4j.skipJansi", true)) {
             return outputStream;
         }
         try {


### PR DESCRIPTION
The current default forces Win platforms to install an obscure jansi
native library (for pretty print console messages) or always set this
property to true, even for trivial unit tests.
