### PR TITLE
Fix not logging correct throwable

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
@@ -100,8 +100,10 @@ public class ReusableParameterizedMessage implements ReusableMessage {
     }
 
     private void initThrowable(final Object[] params, final int argCount, final int usedParams) {
-        if (usedParams < argCount && this.throwable == null && params[argCount - 1] instanceof Throwable) {
+        if (usedParams < argCount && params[argCount - 1] instanceof Throwable) {
             this.throwable = (Throwable) params[argCount - 1];
+        } else {
+            this.throwable = null;
         }
     }
 


### PR DESCRIPTION
2.6 release is re-logging previously logged throwables instead of logging the one that was passed in