### PR TITLE
LOG4J2-1488 Add support for period in ISO8601 format

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormat.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormat.java
@@ -75,6 +75,11 @@ public class FixedDateFormat {
         ISO8601_BASIC("yyyyMMdd'T'HHmmss,SSS", "yyyyMMdd'T'", 2, ' ', 0, ',', 1),
 
         /**
+         * ISO8601_BASIC time format: {@code "yyyyMMdd'T'HHmmss.SSS"}.
+         */
+        ISO8601_BASIC_PERIOD("yyyyMMdd'T'HHmmss.SSS", "yyyyMMdd'T'", 2, ' ', 0, '.', 1),
+
+        /**
          * ISO8601 time format: {@code "yyyy-MM-dd'T'HH:mm:ss,SSS"}.
          */
         ISO8601("yyyy-MM-dd'T'HH:mm:ss,SSS", "yyyy-MM-dd'T'", 2, ':', 1, ',', 1),

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormat.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormat.java
@@ -77,7 +77,12 @@ public class FixedDateFormat {
         /**
          * ISO8601 time format: {@code "yyyy-MM-dd'T'HH:mm:ss,SSS"}.
          */
-        ISO8601("yyyy-MM-dd'T'HH:mm:ss,SSS", "yyyy-MM-dd'T'", 2, ':', 1, ',', 1);
+        ISO8601("yyyy-MM-dd'T'HH:mm:ss,SSS", "yyyy-MM-dd'T'", 2, ':', 1, ',', 1),
+
+        /**
+         * ISO8601 time format: {@code "yyyy-MM-dd'T'HH:mm:ss.SSS"}.
+         */
+        ISO8601_PERIOD("yyyy-MM-dd'T'HH:mm:ss.SSS", "yyyy-MM-dd'T'", 2, ':', 1, '.', 1);
 
         private final String pattern;
         private final String datePattern;

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/DatePatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/DatePatternConverterTest.java
@@ -191,6 +191,17 @@ public class DatePatternConverterTest {
     }
 
     @Test
+    public void testFormatDateStringBuilderIso8601WithPeriod() {
+        final String[] pattern = {FixedDateFormat.FixedFormat.ISO8601_PERIOD.name()};
+        final DatePatternConverter converter = DatePatternConverter.newInstance(pattern);
+        final StringBuilder sb = new StringBuilder();
+        converter.format(date(2001, 1, 1), sb);
+
+        final String expected = "2001-02-01T14:15:16.123";
+        assertEquals(expected, sb.toString());
+    }
+
+    @Test
     public void testFormatDateStringBuilderOriginalPattern() {
         final String[] pattern = {"yyyy/MM/dd HH-mm-ss.SSS"};
         final DatePatternConverter converter = DatePatternConverter.newInstance(pattern);

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/DatePatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/DatePatternConverterTest.java
@@ -202,6 +202,17 @@ public class DatePatternConverterTest {
     }
 
     @Test
+    public void testFormatDateStringBuilderIso8601BasicWithPeriod() {
+        final String[] pattern = {FixedDateFormat.FixedFormat.ISO8601_BASIC_PERIOD.name()};
+        final DatePatternConverter converter = DatePatternConverter.newInstance(pattern);
+        final StringBuilder sb = new StringBuilder();
+        converter.format(date(2001, 1, 1), sb);
+
+        final String expected = "20010201T141516.123";
+        assertEquals(expected, sb.toString());
+    }
+
+    @Test
     public void testFormatDateStringBuilderOriginalPattern() {
         final String[] pattern = {"yyyy/MM/dd HH-mm-ss.SSS"};
         final DatePatternConverter converter = DatePatternConverter.newInstance(pattern);


### PR DESCRIPTION
Add support for period in ISO8601 format as per the documentation: "millisecond separator may be either a comma ',' or a period '.'"

Also Java's `java.time.Instant.toString()` and JavaScript's `new Date().toISOString()` use '.' as well.