### PR TITLE
LOG4J2-1500 BUGFIX - Adding null check when attempting to get an attributes

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/DefaultMergeStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/DefaultMergeStrategy.java
@@ -260,10 +260,12 @@ public class DefaultMergeStrategy implements MergeStrategy {
     }
 
     private boolean isSameName(final Node node1, final Node node2) {
-        return node1.getAttributes().get(NAME).toLowerCase().equals(node2.getAttributes().get(NAME).toLowerCase());
+        return node1.getAttributes().get(NAME) != null &&
+                node1.getAttributes().get(NAME).toLowerCase().equals(node2.getAttributes().get(NAME).toLowerCase());
     }
 
     private boolean isSameReference(final Node node1, final Node node2) {
-        return node1.getAttributes().get(REF).toLowerCase().equals(node2.getAttributes().get(REF).toLowerCase());
+        return node1.getAttributes().get(REF) != null &&
+                node1.getAttributes().get(REF).toLowerCase().equals(node2.getAttributes().get(REF).toLowerCase());
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CompositeConfigurationTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CompositeConfigurationTest.java
@@ -18,6 +18,7 @@ package org.apache.logging.log4j.core.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Map;
 
@@ -106,6 +107,22 @@ public class CompositeConfigurationTest {
                         appendersMap.size());
                 assertTrue(appendersMap.get("File") instanceof FileAppender);
                 assertTrue(appendersMap.get("STDOUT") instanceof ConsoleAppender);
+            }
+        };
+        runTest(lcr, test);
+    }
+
+    @Test
+    public void testAttributeCheckWhenMergingConfigurations() {
+        final LoggerContextRule lcr = new LoggerContextRule("classpath:log4j-comp-root-loggers.xml,log4j-comp-logger.json");
+        final Statement test = new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    final CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
+                } catch (NullPointerException e) {
+                    fail("Should not throw NullPointerException when there are different nodes.");
+                }
             }
         };
         runTest(lcr, test);

--- a/log4j-core/src/test/resources/log4j-comp-root-loggers.xml
+++ b/log4j-core/src/test/resources/log4j-comp-root-loggers.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration status="ERROR" name="LoggerConfigTest">
+    <Appenders>
+        <Console name="STDOUT">
+            <PatternLayout pattern="%m%n"/>
+        </Console>
+        <File name="File" fileName="${filename}" bufferedIO="false">
+            <PatternLayout>
+                <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
+            </PatternLayout>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="cat1" level="debug" additivity="false">
+            <AppenderRef ref="File"/>
+        </Logger>
+
+        <Logger name="cat3" level="debug" additivity="false">
+            <AppenderRef ref="File"/>
+        </Logger>
+
+        <Root level="error">
+            <AppenderRef ref="STDOUT"/>
+            <Property name="hostname">server1</Property>
+        </Root>
+    </Loggers>
+
+</Configuration>


### PR DESCRIPTION
View the referenced JIRA ticket with details on the problem. when dealing with multiple log4j2 configuration files.