### PR TITLE
[LOG4J2-1561] append MDC information to each line of the exception stacktrace

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MdcThrowablePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MdcThrowablePatternConverter.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.pattern;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.impl.ExtendedStackTraceElement;
+import org.apache.logging.log4j.core.impl.ThrowableProxy;
+import org.apache.logging.log4j.core.util.Constants;
+
+/**
+ * Able to append MDC info to each line of the stacktrace of the thrown throwable object in
+ * {@link LogEvent}.
+ */
+@Plugin(name = "MdcThrowablePatternConverter", category = PatternConverter.CATEGORY)
+@ConverterKeys({"cEx", "cThrowable", "cException"})
+public class MdcThrowablePatternConverter extends ThrowablePatternConverter {
+
+    private static final String CAUSED_BY = "Caused By: ";
+
+    private final List<String> mdcKeys;
+
+    /**
+     * Obtain an instance of this ThrowablePatternConverter.
+     *
+     * @see PatternParser#createConverter(String, StringBuilder, Map, List, boolean)
+     */
+    public static MdcThrowablePatternConverter newInstance(String[] options) {
+        return new MdcThrowablePatternConverter(options);
+    }
+
+
+    /**
+     * Constructor.
+     *
+     * @param options options, may be null.
+     */
+    private MdcThrowablePatternConverter(final String[] options) {
+        super("MdcThrowable", "throwable", null);
+        if (options == null || options.length == 0) {
+            this.mdcKeys = Collections.emptyList();
+        } else {
+            String option = options[0];
+            String[] keys = option.split("\\s*,\\s*");
+            Arrays.sort(keys);
+            this.mdcKeys = Arrays.asList(keys);
+        }
+    }
+
+    @Override
+    public void format(final LogEvent event, final StringBuilder buffer) {
+        ThrowableProxy throwable = event.getThrownProxy();
+
+        String suffix = assembleSuffix(event.getContextMap());
+
+        while (throwable != null) {
+            formatThrowable(throwable, buffer, suffix);
+            ThrowableProxy causeProxy = throwable.getCauseProxy();
+            if (causeProxy != null && !causeProxy.equals(throwable)) {
+                throwable = causeProxy;
+                buffer.append(CAUSED_BY);
+            } else {
+                throwable = null;
+            }
+        }
+    }
+
+    private String assembleSuffix(final Map<String, String> contextMap) {
+        if (mdcKeys.isEmpty()) {
+            List<String> mdcKeys = new ArrayList<>(contextMap.keySet());
+            Collections.sort(mdcKeys);
+            return assembleMdcInfoString(contextMap, mdcKeys);
+        } else if (mdcKeys.size() == 1) {
+            String value = contextMap.get(mdcKeys.get(0));
+            return value == null ? "" : value;
+        } else {
+            return assembleMdcInfoString(contextMap, mdcKeys);
+        }
+    }
+
+    private String assembleMdcInfoString(final Map<String, String> contextMap, final Iterable<String> mdcKeys) {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("{");
+        for (String key : mdcKeys) {
+            if (stringBuilder.length() > 1) {
+                stringBuilder.append(", ");
+            }
+            String value = contextMap.get(key);
+            stringBuilder.append(key).append("=").append(value);
+        }
+        stringBuilder.append("}");
+        return stringBuilder.toString();
+    }
+
+    private void formatThrowable(final ThrowableProxy throwable, final StringBuilder buffer, final String suffix) {
+        ExtendedStackTraceElement[] extendedStackTrace = throwable.getExtendedStackTrace();
+        int count = throwable.getCommonElementCount();
+
+        buffer.append(throwable.getThrowable()).append(" ").append(suffix).append(Constants.LINE_SEPARATOR);
+
+        for (int i = 0; i < extendedStackTrace.length - count; i++) {
+            buffer.append("\tat ").append(extendedStackTrace[i]).append(" ").append(suffix).append(Constants.LINE_SEPARATOR);
+        }
+
+        if (count > 0) {
+            buffer.append("\t").append("... ").append(count).append(" more").append(" ").append(suffix).append(Constants.LINE_SEPARATOR);
+        }
+    }
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/MdcThrowablePatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/MdcThrowablePatternConverterTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.pattern;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.core.util.Constants;
+import org.apache.logging.log4j.junit.ThreadContextMapRule;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author jerry on 16/8/16.
+ */
+public class MdcThrowablePatternConverterTest {
+
+    @Rule
+    public final ThreadContextMapRule threadContextRule = new ThreadContextMapRule();
+
+    @Before
+    public void setup() {
+        ThreadContext.put("subject", "I");
+        ThreadContext.put("verb", "love");
+        ThreadContext.put("object", "Log4j");
+    }
+
+    @Test
+    public void testConvertWithNoKey() {
+        final Message msg = new SimpleMessage("Hello");
+        final Throwable throwable = new Exception("test exception");
+        final MdcThrowablePatternConverter converter = MdcThrowablePatternConverter.newInstance(null);
+        final LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName("MyLogger") //
+                .setLevel(Level.DEBUG) //
+                .setMessage(msg) //
+                .setThrown(throwable)//
+                .build();
+        final StringBuilder sb = new StringBuilder();
+        converter.format(event, sb);
+        final String str = sb.toString();
+
+        final String suffix = "{object=Log4j, subject=I, verb=love}";
+        String[] lines = str.split(Pattern.quote(Constants.LINE_SEPARATOR));
+        for (String line : lines) {
+            assertTrue("expect line \"" + line + "\" ends with \"" + suffix + "\", but was not", line.endsWith(suffix));
+        }
+    }
+
+    @Test
+    public void testConvertWithOneKey() {
+        final Message msg = new SimpleMessage("Hello");
+        final Throwable throwable = new Exception("test exception");
+        final MdcThrowablePatternConverter converter = MdcThrowablePatternConverter.newInstance(new String[]{"verb"});
+        final LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName("MyLogger") //
+                .setLevel(Level.DEBUG) //
+                .setMessage(msg) //
+                .setThrown(throwable)//
+                .build();
+        final StringBuilder sb = new StringBuilder();
+        converter.format(event, sb);
+        final String str = sb.toString();
+
+        final String suffix = " love";
+        String[] lines = str.split(Pattern.quote(Constants.LINE_SEPARATOR));
+        for (String line : lines) {
+            assertTrue("expect line \"" + line + "\" ends with \"" + suffix + "\", but was not", line.endsWith(suffix));
+        }
+    }
+
+    @Test
+    public void testConvertWithMultiKey() {
+        final Message msg = new SimpleMessage("Hello");
+        final Throwable throwable = new Exception("test exception");
+        final MdcThrowablePatternConverter converter = MdcThrowablePatternConverter.newInstance(new String[]{"verb, object"});
+        final LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName("MyLogger") //
+                .setLevel(Level.DEBUG) //
+                .setMessage(msg) //
+                .setThrown(throwable)//
+                .build();
+        final StringBuilder sb = new StringBuilder();
+        converter.format(event, sb);
+        final String str = sb.toString();
+
+        final String suffix = "{object=Log4j, verb=love}";
+        String[] lines = str.split(Pattern.quote(Constants.LINE_SEPARATOR));
+        for (String line : lines) {
+            assertTrue("expect line \"" + line + "\" ends with \"" + suffix + "\", but was not", line.endsWith(suffix));
+        }
+    }
+
+}


### PR DESCRIPTION
introduce MdcThrowablePatternConverter which is able to append MDC info to the end of each line of the stacktrace when the throwable object is thrown.
