### PR TITLE
LOG4J2-1527 - Ensure getFormattedMessage returns a message.

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
@@ -210,6 +210,9 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
      */
     @Override
     public String getFormattedMessage() {
+        if (this.messageText == null) {
+            return getMessage().getFormattedMessage();
+        }
         return messageText.toString();
     }
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/RingBufferLogEventTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/RingBufferLogEventTest.java
@@ -175,4 +175,14 @@ public class RingBufferLogEventTest {
         assertEquals(evt.getSource(), actual.getSource());
         assertEquals(evt.getThrownProxy(), actual.getThrownProxy());
     }
+
+    @Test
+    public void testMessageTextNeverThrowsNpe() {
+        final RingBufferLogEvent evt = new RingBufferLogEvent();
+        try {
+            evt.getFormattedMessage();
+        } catch (NullPointerException e) {
+            fail("the messageText field was not set");
+        }
+    }
 }


### PR DESCRIPTION
One way to see this problem is by changing "GcFreeLoggingTestUtil.executeLogging()"
from: System.setProperty("log4j2.is.webapp", "false");
to: System.setProperty("log4j2.is.webapp", "true");
