### PR TITLE
Documentation bug for purgeAscending method.

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DefaultRolloverStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DefaultRolloverStrategy.java
@@ -310,8 +310,8 @@ public class DefaultRolloverStrategy implements RolloverStrategy {
      * Purges and renames old log files in preparation for rollover. The oldest file will have the smallest index, the
      * newest the highest.
      *
-     * @param lowIndex low index
-     * @param highIndex high index. Log file associated with high index will be deleted if needed.
+     * @param lowIndex low index. Log file associated with low index will be deleted if needed.
+     * @param highIndex high index. 
      * @param manager The RollingFileManager
      * @return true if purge was successful and rollover should be attempted.
      */


### PR DESCRIPTION
For "@param highIndex  Log file associated with high index will be deleted if needed. "
That is incorrect it seems, that applies to purgeDescending.

That message should be under lowIndex with message "@param lowIndex. Log file associated with low index will be deleted if needed. "

Because purgeAscending deletes the one with the low index if required, if I'm not wrong.
