### PR TITLE
[LOG4J2-1733] Add syncSend configuration property to Kafka Appender

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppender.java
@@ -56,13 +56,16 @@ public final class KafkaAppender extends AbstractAppender {
         @PluginAttribute("topic") 
         private String topic;
         
+        @PluginAttribute(value = "syncSend", defaultBoolean = true)
+        private boolean syncSend;
+
         @PluginElement("Properties") 
         private Property[] properties;
 
         @SuppressWarnings("resource")
         @Override
         public KafkaAppender build() {
-            final KafkaManager kafkaManager = new KafkaManager(getConfiguration().getLoggerContext(), getName(), topic, properties);
+            final KafkaManager kafkaManager = new KafkaManager(getConfiguration().getLoggerContext(), getName(), topic, syncSend, properties);
             return new KafkaAppender(getName(), getLayout(), getFilter(), isIgnoreExceptions(), kafkaManager);
         }
 
@@ -79,6 +82,11 @@ public final class KafkaAppender extends AbstractAppender {
             return asBuilder();
         }
 
+        public B setSyncSend(boolean syncSend) {
+            this.syncSend = syncSend;
+            return asBuilder();
+        }
+
         public B setProperties(Property[] properties) {
             this.properties = properties;
             return asBuilder();
@@ -92,9 +100,10 @@ public final class KafkaAppender extends AbstractAppender {
             @Required(message = "No name provided for KafkaAppender") @PluginAttribute("name") final String name,
             @PluginAttribute(value = "ignoreExceptions", defaultBoolean = true) final boolean ignoreExceptions,
             @Required(message = "No topic provided for KafkaAppender") @PluginAttribute("topic") final String topic,
+            @PluginAttribute(value = "SyncSend", defaultBoolean = true) final boolean syncSend,
             @PluginElement("Properties") final Property[] properties,
             @PluginConfiguration final Configuration configuration) {
-        final KafkaManager kafkaManager = new KafkaManager(configuration.getLoggerContext(), name, topic, properties);
+        final KafkaManager kafkaManager = new KafkaManager(configuration.getLoggerContext(), name, topic, syncSend, properties);
         return new KafkaAppender(name, layout, filter, ignoreExceptions, kafkaManager);
     }
 

--- a/src/site/xdoc/manual/appenders.xml
+++ b/src/site/xdoc/manual/appenders.xml
@@ -1386,6 +1386,14 @@ public class JpaLogEntity extends AbstractLogEventWrapperEntity {
                 <a href="#FailoverAppender">FailoverAppender</a>.</td>
             </tr>
             <tr>
+              <td>syncSend</td>
+              <td>boolean</td>
+              <td>The default is <code>true</code>, causing sends to block until the record has been acknowledged by the
+                Kafka server. When set to <code>false</code> sends return immediately, allowing for lower latency and significantly
+                higher throughput.
+              </td>
+            </tr>
+            <tr>
               <td>properties</td>
               <td>Property[]</td>
               <td>
@@ -1407,9 +1415,10 @@ public class JpaLogEntity extends AbstractLogEventWrapperEntity {
     </Kafka>
   </Appenders>]]></pre>
           <p>
-            This appender is synchronous and will block until the record has been acknowledged by the Kafka server, timeout for this
-            can be set with the <code>timeout.ms</code> property (defaults to 30 seconds). Wrap with
-            <a href="http://logging.apache.org/log4j/2.x/manual/appenders.html#AsyncAppender">Async appender</a> to log asynchronously.
+            This appender is synchronous by default and will block until the record has been acknowledged by the Kafka server, timeout
+            for this can be set with the <code>timeout.ms</code> property (defaults to 30 seconds). Wrap with
+            <a href="http://logging.apache.org/log4j/2.x/manual/appenders.html#AsyncAppender">Async appender</a> and/or set syncSend to
+            <code>false</code> to log asynchronously.
           </p>
           <p>
             This appender requires the <a href="http://kafka.apache.org/">Kafka client library</a>. Note that you need to use a version of


### PR DESCRIPTION
… to support asynchronous sends

This change is backwards compatible, as the property is set to "true" by default. The implementation mirrors the implementation of the KafkaLog4jAppender in the Apache Kafka project (which is however based on log4j instead of log4j2).

The asynchronous send is relevant, as it significantly improves throughput to the Kafka broker. On my machine, setting the property to false, lead to a throughput improvement of approximately 50x.
