### PR TITLE
LOG42-1743: Change CompositeConfiguration to copy grandchildren when …

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/DefaultMergeStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/DefaultMergeStrategy.java
@@ -176,6 +176,7 @@ public class DefaultMergeStrategy implements MergeStrategy {
                                         final Node childNode = new Node(loggerNode, sourceLoggerChild.getName(),
                                                 sourceLoggerChild.getType());
                                         childNode.getAttributes().putAll(sourceLoggerChild.getAttributes());
+                                        childNode.getChildren().addAll(sourceLoggerChild.getChildren());
                                         if (childNode.getName().equalsIgnoreCase("AppenderRef")) {
                                             for (final Node targetChild : targetNode.getChildren()) {
                                                 if (isSameReference(targetChild, childNode)) {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CompositeConfigurationTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CompositeConfigurationTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.core.config;
 
+import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
@@ -23,6 +24,7 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.config.composite.CompositeConfiguration;
+import org.apache.logging.log4j.core.filter.RegexFilter;
 import org.apache.logging.log4j.core.util.Throwables;
 import org.apache.logging.log4j.junit.LoggerContextRule;
 import org.junit.Assert;
@@ -155,6 +157,33 @@ public class CompositeConfigurationTest {
             }
         };
         runTest(lcr, test);
+    }
+
+    @Test
+    public void testAppenderRefFilterMerge() {
+        final LoggerContextRule lcr = new LoggerContextRule(
+                "classpath:log4j-comp-logger-ref.xml,log4j-comp-logger-ref.json");
+        final Statement test = new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                final CompositeConfiguration config = (CompositeConfiguration) lcr.getConfiguration();
+
+                List<AppenderRef> appenderRefList = config.getLogger("cat1").getAppenderRefs();
+                AppenderRef appenderRef = getAppenderRef(appenderRefList, "STDOUT");
+                assertTrue("Expected cat1 STDOUT appenderRef to have a regex filter",
+                        appenderRef.getFilter() != null && appenderRef.getFilter() instanceof RegexFilter);
+            }
+        };
+        runTest(lcr, test);
+    }
+
+    private AppenderRef getAppenderRef(List<AppenderRef> appenderRefList, String refName) {
+        for (AppenderRef ref : appenderRefList) {
+            if (ref.getRef().equalsIgnoreCase(refName)) {
+                return ref;
+            }
+        }
+        return null;
     }
 /*
     @Test

--- a/log4j-core/src/test/resources/log4j-comp-logger-ref.json
+++ b/log4j-core/src/test/resources/log4j-comp-logger-ref.json
@@ -1,0 +1,18 @@
+{
+    "Configuration" : {
+        "name": "LoggerConfigTest",
+        "Loggers" : {
+            "logger" : [
+                {
+                    "name" : "cat1",
+                    "level" : "debug",
+                    "additivity" : false,
+                    "AppenderRef" : {
+                        "ref" : "STDOUT",
+                        "RegexFilter": {"regex" : "TEST", "onMatch": "deny", "onMismatch": "accept"}
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/log4j-core/src/test/resources/log4j-comp-logger-ref.xml
+++ b/log4j-core/src/test/resources/log4j-comp-logger-ref.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration status="ERROR" name="LoggerConfigTest">
+    <Appenders>
+        <Console name="STDOUT">
+            <PatternLayout pattern="%m%n"/>
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="cat1" level="debug" additivity="false">
+            <AppenderRef ref="STDOUT"/>
+        </Logger>
+    </Loggers>
+
+</Configuration>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/LOG4J2-1743

This change allows e.g. Filters in AppenderRef sections of the Logger config to be added by composition