### PR TITLE
Fix rollover to work when filePattern contains no directory components

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/AbstractRolloverStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/AbstractRolloverStrategy.java
@@ -104,7 +104,11 @@ public abstract class AbstractRolloverStrategy implements RolloverStrategy {
         TreeMap<Integer, Path> eligibleFiles = new TreeMap<>();
         File file = new File(path);
         File parent = file.getParentFile();
-        parent.mkdirs();
+        if (parent == null) {
+            parent = new File(".");
+        } else {
+            parent.mkdirs();
+        }
         if (!path.contains("--1")) {
             return eligibleFiles;
         }


### PR DESCRIPTION
Prior to this patch, the following config threw NPE at `parent.mkdirs()` because `parent` was null when using e.g.:
```xml
        <RollingRandomAccessFile name="FILE"
                                 fileName="foo.log"
                                 filePattern="foo-%d{yyyy-MM-dd}-%i.log.gz"
                                 immediateFlush="false">
```
while this config did not:
```xml
        <RollingRandomAccessFile name="FILE"
                                 fileName="foo.log"
                                 filePattern="./foo-%d{yyyy-MM-dd}-%i.log.gz"
                                 immediateFlush="false">
```
e.g. by adding `./` in front of the filePattern value.