### PR TITLE
change Log4jAPIVersion to maven version

### DIFF
--- a/log4j-core/src/main/resources/META-INF/log4j-provider.properties
+++ b/log4j-core/src/main/resources/META-INF/log4j-provider.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 
 LoggerContextFactory = org.apache.logging.log4j.core.impl.Log4jContextFactory
-Log4jAPIVersion = 2.1.0
+Log4jAPIVersion = 2.8.0
 FactoryPriority= 10


### PR DESCRIPTION
If we assembly log4j in a together (with maven-assembl-plugin) this wrong version leads to "ERROR StatusLogger No log4j2 configuration file found. Using default configuration: logging only errors to the console." errors, even if the log4j2.xml in in the root of our assembled jar