### PR TITLE
(LOG4J2-1864) Support capped collection for MongoDB Log-Provider

### DIFF
--- a/log4j-nosql/src/main/java/org/apache/logging/log4j/nosql/appender/mongodb/MongoDbConnection.java
+++ b/log4j-nosql/src/main/java/org/apache/logging/log4j/nosql/appender/mongodb/MongoDbConnection.java
@@ -54,8 +54,16 @@ public final class MongoDbConnection extends AbstractNoSqlConnection<BasicDBObje
     private final DBCollection collection;
     private final WriteConcern writeConcern;
 
-    public MongoDbConnection(final DB database, final WriteConcern writeConcern, final String collectionName) {
-        this.collection = database.getCollection(collectionName);
+    public MongoDbConnection(final DB database, final WriteConcern writeConcern, final String collectionName,
+            final Boolean isCapped, final Integer collectionSize) {
+        if (database.collectionExists(collectionName)) {
+            collection = database.getCollection(collectionName);
+        } else {
+            BasicDBObject options = new BasicDBObject();
+            options.put("capped", isCapped);
+            options.put("size", collectionSize);
+            this.collection = database.createCollection(collectionName, options);
+        }
         this.writeConcern = writeConcern;
     }
 

--- a/log4j-nosql/src/test/java/org/apache/logging/log4j/nosql/appender/MongoDbCappedTest.java
+++ b/log4j-nosql/src/test/java/org/apache/logging/log4j/nosql/appender/MongoDbCappedTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.nosql.appender;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.categories.Appenders;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Ignore("Requires a running MongoDB server")
+@Category(Appenders.MongoDb.class)
+public class MongoDbCappedTest {
+
+    @ClassRule
+    public static LoggerContextRule context = new LoggerContextRule("log4j2-mongodb-capped.xml");
+
+    @Test
+    public void test() {
+        final Logger logger = LogManager.getLogger();
+        logger.info("Hello log");
+    }
+}

--- a/log4j-nosql/src/test/resources/log4j2-mongodb-capped.xml
+++ b/log4j-nosql/src/test/resources/log4j2-mongodb-capped.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration status="error">
+  <Appenders>
+    <NoSql name="MongoDbAppender">
+      <MongoDb databaseName="test" collectionName="applog" server="localhost" capped="true" collectionSize="1073741824" />
+    </NoSql>
+  </Appenders>
+  <Loggers>
+    <Root level="ALL">
+      <AppenderRef ref="MongoDbAppender" />
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
MongoDB supports sth. called [capped collections](https://docs.mongodb.com/manual/core/capped-collections/). If the nosql-mongodb-appender supports this feature, the mongodb-collection could never "overflow" and stick to a defined maximum size.

What do you think? :) We'd love to have this feature.