### PR TITLE
Add common suffix support for the throwable pattern

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverter.java
@@ -108,11 +108,10 @@ public class ThrowablePatternConverter extends LogEventPatternConverter {
         final Throwable t = event.getThrown();
 
         if (isSubShortOption()) {
-            formatSubShortOption(t, buffer);
+            formatSubShortOption(t, getSuffix(event), buffer);
         }
         else if (t != null && options.anyLines()) {
-            String suffix = getSuffix(event);
-            formatOption(t, suffix, buffer);
+            formatOption(t, getSuffix(event), buffer);
         }
     }
 
@@ -125,7 +124,7 @@ public class ThrowablePatternConverter extends LogEventPatternConverter {
                 ThrowableFormatOptions.CLASS_NAME.equalsIgnoreCase(rawOption);
     }
 
-    private void formatSubShortOption(final Throwable t, final StringBuilder buffer) {
+    private void formatSubShortOption(final Throwable t, final String suffix, final StringBuilder buffer) {
         StackTraceElement[] trace;
         StackTraceElement throwingMethod = null;
         int len;
@@ -164,6 +163,11 @@ public class ThrowablePatternConverter extends LogEventPatternConverter {
                 buffer.append(' ');
             }
             buffer.append(toAppend);
+
+            if (Strings.isNotBlank(suffix)) {
+                buffer.append(' ');
+                buffer.append(suffix);
+            }
         }
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverter.java
@@ -111,7 +111,8 @@ public class ThrowablePatternConverter extends LogEventPatternConverter {
             formatSubShortOption(t, buffer);
         }
         else if (t != null && options.anyLines()) {
-            formatOption(t, buffer);
+            String suffix = getSuffix(event);
+            formatOption(t, suffix, buffer);
         }
     }
 
@@ -166,7 +167,7 @@ public class ThrowablePatternConverter extends LogEventPatternConverter {
         }
     }
 
-    private void formatOption(final Throwable throwable, final StringBuilder buffer) {
+    private void formatOption(final Throwable throwable, final String suffix, final StringBuilder buffer) {
         final StringWriter w = new StringWriter();
 
         throwable.printStackTrace(new PrintWriter(w));
@@ -174,12 +175,14 @@ public class ThrowablePatternConverter extends LogEventPatternConverter {
         if (len > 0 && !Character.isWhitespace(buffer.charAt(len - 1))) {
             buffer.append(' ');
         }
-        if (!options.allLines() || !Strings.LINE_SEPARATOR.equals(options.getSeparator())) {
+        if (!options.allLines() || !Strings.LINE_SEPARATOR.equals(options.getSeparator()) || Strings.isNotBlank(suffix)) {
             final StringBuilder sb = new StringBuilder();
             final String[] array = w.toString().split(Strings.LINE_SEPARATOR);
             final int limit = options.minLines(array.length) - 1;
             for (int i = 0; i <= limit; ++i) {
                 sb.append(array[i]);
+                sb.append(' ');
+                sb.append(suffix);
                 if (i < limit) {
                     sb.append(options.getSeparator());
                 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverter.java
@@ -183,10 +183,13 @@ public class ThrowablePatternConverter extends LogEventPatternConverter {
             final StringBuilder sb = new StringBuilder();
             final String[] array = w.toString().split(Strings.LINE_SEPARATOR);
             final int limit = options.minLines(array.length) - 1;
+            final boolean suffixNotBlank = Strings.isNotBlank(suffix);
             for (int i = 0; i <= limit; ++i) {
                 sb.append(array[i]);
-                sb.append(' ');
-                sb.append(suffix);
+                if (suffixNotBlank) {
+                    sb.append(' ');
+                    sb.append(suffix);
+                }
                 if (i < limit) {
                     sb.append(options.getSeparator());
                 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverterTest.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.logging.log4j.util.Strings;
 import org.junit.Test;
 
 public class ThrowablePatternConverterTest {
@@ -35,6 +36,16 @@ public class ThrowablePatternConverterTest {
         public String getLocalizedMessage() {
             return "I am localized.";
         }
+    }
+
+    private boolean everyLineEndsWith(final String text, final String suffix) {
+        String[] lines = text.split(Strings.LINE_SEPARATOR);
+        for (String line: lines) {
+            if (!line.trim().endsWith(suffix)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
@@ -72,6 +83,32 @@ public class ThrowablePatternConverterTest {
         // System.out.print(result);
         assertTrue("Incorrect start of msg", result.startsWith("java.lang.IllegalArgumentException: IllegalArgument"));
         assertTrue("Missing nested exception", result.contains("java.lang.NullPointerException: null pointer"));
+    }
+
+    @Test
+    public void testFullWithSuffix() {
+        final String[] options = { "full", "suffix(test suffix)" };
+        final ThrowablePatternConverter converter = ThrowablePatternConverter.newInstance(null, options);
+        Throwable parent;
+        try {
+            try {
+                throw new NullPointerException("null pointer");
+            } catch (final NullPointerException e) {
+                throw new IllegalArgumentException("IllegalArgument", e);
+            }
+        } catch (final IllegalArgumentException e) {
+            parent = e;
+        }
+        final LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName("testLogger") //
+                .setLoggerFqcn(this.getClass().getName()) //
+                .setLevel(Level.DEBUG) //
+                .setMessage(new SimpleMessage("test exception")) //
+                .setThrown(parent).build();
+        final StringBuilder sb = new StringBuilder();
+        converter.format(event, sb);
+        final String result = sb.toString();
+        assertTrue("Each line of full stack trace should end with the specified suffix", everyLineEndsWith(result, "test suffix"));
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverterTest.java
@@ -86,32 +86,6 @@ public class ThrowablePatternConverterTest {
     }
 
     @Test
-    public void testFullWithSuffix() {
-        final String[] options = { "full", "suffix(test suffix)" };
-        final ThrowablePatternConverter converter = ThrowablePatternConverter.newInstance(null, options);
-        Throwable parent;
-        try {
-            try {
-                throw new NullPointerException("null pointer");
-            } catch (final NullPointerException e) {
-                throw new IllegalArgumentException("IllegalArgument", e);
-            }
-        } catch (final IllegalArgumentException e) {
-            parent = e;
-        }
-        final LogEvent event = Log4jLogEvent.newBuilder() //
-                .setLoggerName("testLogger") //
-                .setLoggerFqcn(this.getClass().getName()) //
-                .setLevel(Level.DEBUG) //
-                .setMessage(new SimpleMessage("test exception")) //
-                .setThrown(parent).build();
-        final StringBuilder sb = new StringBuilder();
-        converter.format(event, sb);
-        final String result = sb.toString();
-        assertTrue("Each line of full stack trace should end with the specified suffix", everyLineEndsWith(result, "test suffix"));
-    }
-
-    @Test
     public void testShortClassName() {
         final String packageName = "org.apache.logging.log4j.core.pattern.";
         final String[] options = { "short.className" };
@@ -220,6 +194,51 @@ public class ThrowablePatternConverterTest {
         converter.format(event, sb);
         final String result = sb.toString();
         assertEquals("The method names should be same", "testShortMethodName", result);
+    }
+
+    @Test
+    public void testFullWithSuffix() {
+        final String[] options = { "full", "suffix(test suffix)" };
+        final ThrowablePatternConverter converter = ThrowablePatternConverter.newInstance(null, options);
+        Throwable parent;
+        try {
+            try {
+                throw new NullPointerException("null pointer");
+            } catch (final NullPointerException e) {
+                throw new IllegalArgumentException("IllegalArgument", e);
+            }
+        } catch (final IllegalArgumentException e) {
+            parent = e;
+        }
+        final LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName("testLogger") //
+                .setLoggerFqcn(this.getClass().getName()) //
+                .setLevel(Level.DEBUG) //
+                .setMessage(new SimpleMessage("test exception")) //
+                .setThrown(parent).build();
+        final StringBuilder sb = new StringBuilder();
+        converter.format(event, sb);
+        final String result = sb.toString();
+        assertTrue("Each line of full stack trace should end with the specified suffix", everyLineEndsWith(result, "test suffix"));
+    }
+
+    @Test
+    public void testShortOptionWithSuffix() {
+        final String packageName = "org.apache.logging.log4j.core.pattern.";
+        final String[] options = { "short.className", "suffix(test suffix)" };
+        final ThrowablePatternConverter converter = ThrowablePatternConverter.newInstance(null, options);
+        final Throwable cause = new NullPointerException("null pointer");
+        final Throwable parent = new IllegalArgumentException("IllegalArgument", cause);
+        final LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName("testLogger") //
+                .setLoggerFqcn(this.getClass().getName()) //
+                .setLevel(Level.DEBUG) //
+                .setMessage(new SimpleMessage("test exception")) //
+                .setThrown(parent).build();
+        final StringBuilder sb = new StringBuilder();
+        converter.format(event, sb);
+        final String result = sb.toString();
+        assertTrue("Each line should end with suffix", everyLineEndsWith(result, "test suffix"));
     }
 
 }


### PR DESCRIPTION
The previous [PR-61](https://github.com/apache/logging-log4j2/pull/61) brought about the ability to append any wished suffix to each line of the stack trace for the `%xEx` and `%rEx` pattern, but with no support for the `%throwable` pattern. This PR is intended to provide the `%throwable` pattern with the same ability.