### PR TITLE
Fixed doc issue LOG4J2-1840

### DIFF
--- a/src/site/xdoc/manual/layouts.xml.vm
+++ b/src/site/xdoc/manual/layouts.xml.vm
@@ -1211,7 +1211,7 @@ WARN  [main]: Message 2</pre>
               </td>
               <td>
                 <p>Replaces occurrences of 'regex', a regular expression, with its replacement 'substitution' in the
-                  string resulting from evaluation of the pattern. For example, "%replace(%msg}{\s}{}" will remove
+                  string resulting from evaluation of the pattern. For example, "%replace{%msg}{\s}{}" will remove
                   all spaces contained in the event message.
                 </p>
                 <p>The pattern can be arbitrarily complex and in particular can contain multiple conversion keywords.


### PR DESCRIPTION
Example has a simple typo that would make it not work. 

On the following page
https://logging.apache.org/log4j/log4j-2.3/manual/layouts.html

replace
{pattern} {regex} {substitution}

has a typo in the example (open parens used instead of open curly braces)
"%replace(%msg}{\s}{}"

it has to be
"%replace{%msg}{s}{}"


![screen shot 2017-03-09 at 3 31 04 pm](https://cloud.githubusercontent.com/assets/8023357/23775423/75c3f83a-04dd-11e7-8589-ed03d626249f.png)

