### PR TITLE
Fix the default value of RandomAccessFileAppender.Builder append field

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RandomAccessFileAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RandomAccessFileAppender.java
@@ -53,7 +53,7 @@ public final class RandomAccessFileAppender extends AbstractOutputStreamAppender
         private String fileName;
 
         @PluginBuilderAttribute("append")
-        private boolean append;
+        private boolean append = true;
 
         @PluginBuilderAttribute("advertise")
         private boolean advertise;


### PR DESCRIPTION
See [LOG4J2-1853](https://issues.apache.org/jira/browse/LOG4J2-1853)