### PR TITLE
Fix a bug in StringBuilderEncoder.encode()

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/OutputStreamManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/OutputStreamManager.java
@@ -285,7 +285,7 @@ public class OutputStreamManager extends AbstractManager implements ByteBufferDe
     protected synchronized void flushBuffer(final ByteBuffer buf) {
         buf.flip();
         if (buf.limit() > 0) {
-            writeToDestination(buf.array(), 0, buf.limit());
+            writeToDestination(buf.array(), buf.arrayOffset(), buf.remaining());
         }
         buf.clear();
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/OutputStreamManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/OutputStreamManager.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.layout.ByteBufferDestination;
+import org.apache.logging.log4j.core.layout.ByteBufferDestinationHelper;
 import org.apache.logging.log4j.core.util.Constants;
 
 /**
@@ -209,7 +210,8 @@ public class OutputStreamManager extends AbstractManager implements ByteBufferDe
      * @param length The number of bytes to write.
      * @throws AppenderLoggingException if an error occurs.
      */
-    protected void write(final byte[] bytes, final int offset, final int length) {
+    @Override
+    public void write(final byte[] bytes, final int offset, final int length) {
         write(bytes, offset, length, false);
     }
 
@@ -344,5 +346,15 @@ public class OutputStreamManager extends AbstractManager implements ByteBufferDe
     public ByteBuffer drain(final ByteBuffer buf) {
         flushBuffer(buf);
         return buf;
+    }
+
+    @Override
+    public void write(ByteBuffer data) {
+        if (data.remaining() == 0) {
+          return;
+        }
+        synchronized (this) {
+          ByteBufferDestinationHelper.writeToUnsynchronized(data, this);
+        }
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/AbstractLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/AbstractLayout.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.core.layout;
 
 import java.io.Serializable;
-import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -209,30 +208,6 @@ public abstract class AbstractLayout<T extends Serializable> implements Layout<T
     @Override
     public void encode(final LogEvent event, final ByteBufferDestination destination) {
         final byte[] data = toByteArray(event);
-        writeTo(data, 0, data.length, destination);
-    }
-
-    /**
-     * Writes the specified data to the specified destination.
-     *
-     * @param data the data to write
-     * @param offset where to start in the specified data array
-     * @param length the number of bytes to write
-     * @param destination the {@code ByteBufferDestination} to write to
-     */
-    public static void writeTo(final byte[] data, int offset, int length, final ByteBufferDestination destination) {
-        int chunk = 0;
-        synchronized (destination) {
-            ByteBuffer buffer = destination.getByteBuffer();
-            do {
-                if (length > buffer.remaining()) {
-                    buffer = destination.drain(buffer);
-                }
-                chunk = Math.min(length, buffer.remaining());
-                buffer.put(data, offset, chunk);
-                offset += chunk;
-                length -= chunk;
-            } while (length > 0);
-        }
+        destination.write(data, 0, data.length);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/ByteBufferDestination.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/ByteBufferDestination.java
@@ -44,4 +44,21 @@ public interface ByteBufferDestination {
      * @return a buffer with more available space (which may or may not be the same instance)
      */
     ByteBuffer drain(ByteBuffer buf);
+
+    /**
+     * Writes the given data to this ByteBufferDestination entirely. Call of this method should *not* be protected
+     * with synchronized on this ByteBufferDestination instance. ByteBufferDestination implementations should
+     * synchronize themselves inside this method, if needed.
+     */
+    void write(ByteBuffer data);
+
+    /**
+     * Writes the given data to this ByteBufferDestination. Call of this method should *not* be protected with
+     * synchronized on this ByteBufferDestination instance. ByteBufferDestination implementations should
+     * synchronize themselves inside this method, if needed.
+     * <p>
+     * This method should behave identically to {@code write(ByteBuffer.wrap(data, offset, length)}. It is provided to
+     * allow callers not to generate extra garbage.
+     */
+    void write(byte[] data, int offset, int length);
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/ByteBufferDestinationHelper.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/ByteBufferDestinationHelper.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.layout;
+
+import java.nio.ByteBuffer;
+
+public final class ByteBufferDestinationHelper {
+
+    private ByteBufferDestinationHelper() {
+    }
+
+    /**
+     * Writes the specified data to the specified destination. Doesn't synchronize on the destination object. The helper
+     * method for {@link ByteBufferDestination#write(ByteBuffer)} implementations.
+     *
+     * @param data        the data to write
+     * @param destination the {@code ByteBufferDestination} to write to
+     */
+    public static void writeToUnsynchronized(ByteBuffer data, ByteBufferDestination destination) {
+        ByteBuffer buf = destination.getByteBuffer();
+        while (data.remaining() > buf.remaining()) {
+            int dataLimit = data.limit();
+            data.limit(Math.min(data.limit(), data.position() + buf.remaining()));
+            buf.put(data);
+            data.limit(dataLimit);
+            buf = destination.drain(buf);
+        }
+        buf.put(data);
+        // No drain in the end.
+    }
+
+    /**
+     * Writes the specified data to the specified destination. Doesn't synchronize on the destination object. The helper
+     * method for {@link ByteBufferDestination#write(byte[], int, int)} implementations.
+     *
+     * @param data        the data to write
+     * @param offset      where to start in the specified data array
+     * @param length      the number of bytes to write
+     * @param destination the {@code ByteBufferDestination} to write to
+     */
+    public static void writeToUnsynchronized(final byte[] data, int offset, int length,
+            final ByteBufferDestination destination) {
+        ByteBuffer buffer = destination.getByteBuffer();
+        while (length > buffer.remaining()) {
+            int chunk = buffer.remaining();
+            buffer.put(data, offset, chunk);
+            offset += chunk;
+            length -= chunk;
+            buffer = destination.drain(buffer);
+        }
+        buffer.put(data, offset, length);
+        // No drain in the end.
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/LockingStringBuilderEncoder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/LockingStringBuilderEncoder.java
@@ -51,15 +51,17 @@ public class LockingStringBuilderEncoder implements Encoder<StringBuilder> {
 
     @Override
     public void encode(final StringBuilder source, final ByteBufferDestination destination) {
-        synchronized (destination) {
-            try {
+        try {
+            // This synchronized is needed to be able to call destination.getByteBuffer()
+            synchronized (destination) {
                 TextEncoderHelper.encodeText(charsetEncoder, cachedCharBuffer, destination.getByteBuffer(), source,
-                        destination);
-            } catch (final Exception ex) {
-                logEncodeTextException(ex, source, destination);
-                TextEncoderHelper.encodeTextFallBack(charset, source, destination);
+                    destination);
             }
+        } catch (final Exception ex) {
+            logEncodeTextException(ex, source, destination);
+            TextEncoderHelper.encodeTextFallBack(charset, source, destination);
         }
+
     }
 
     private void logEncodeTextException(final Exception ex, final StringBuilder text,

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/StringBuilderEncoder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/StringBuilderEncoder.java
@@ -53,12 +53,12 @@ public class StringBuilderEncoder implements Encoder<StringBuilder> {
     public void encode(final StringBuilder source, final ByteBufferDestination destination) {
         final ByteBuffer temp = getByteBuffer();
         temp.clear();
-        temp.limit(Math.min(temp.capacity(), destination.getByteBuffer().capacity()));
+        temp.limit(Math.min(temp.capacity(), destination.getByteBuffer().remaining()));
         final CharsetEncoder charsetEncoder = getCharsetEncoder();
 
         final int estimatedBytes = estimateBytes(source.length(), charsetEncoder.maxBytesPerChar());
         if (temp.remaining() < estimatedBytes) {
-            encodeSynchronized(getCharsetEncoder(), getCharBuffer(), source, destination);
+            encodeSynchronized(charsetEncoder, getCharBuffer(), source, destination);
         } else {
             encodeWithThreadLocals(charsetEncoder, getCharBuffer(), temp, source, destination);
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/StringBuilderEncoder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/StringBuilderEncoder.java
@@ -51,43 +51,11 @@ public class StringBuilderEncoder implements Encoder<StringBuilder> {
 
     @Override
     public void encode(final StringBuilder source, final ByteBufferDestination destination) {
-        final ByteBuffer temp = getByteBuffer();
-        temp.clear();
-        temp.limit(Math.min(temp.capacity(), destination.getByteBuffer().remaining()));
-        final CharsetEncoder charsetEncoder = getCharsetEncoder();
-
-        final int estimatedBytes = estimateBytes(source.length(), charsetEncoder.maxBytesPerChar());
-        if (temp.remaining() < estimatedBytes) {
-            encodeSynchronized(charsetEncoder, getCharBuffer(), source, destination);
-        } else {
-            encodeWithThreadLocals(charsetEncoder, getCharBuffer(), temp, source, destination);
-        }
-    }
-
-    private void encodeWithThreadLocals(final CharsetEncoder charsetEncoder, final CharBuffer charBuffer,
-            final ByteBuffer temp, final StringBuilder source, final ByteBufferDestination destination) {
         try {
-            TextEncoderHelper.encodeTextWithCopy(charsetEncoder, charBuffer, temp, source, destination);
+            TextEncoderHelper.encodeText(getCharsetEncoder(), getCharBuffer(), getByteBuffer(), source, destination);
         } catch (final Exception ex) {
             logEncodeTextException(ex, source, destination);
             TextEncoderHelper.encodeTextFallBack(charset, source, destination);
-        }
-    }
-
-    private static int estimateBytes(final int charCount, final float maxBytesPerChar) {
-        return (int) (charCount * (double) maxBytesPerChar);
-    }
-
-    private void encodeSynchronized(final CharsetEncoder charsetEncoder, final CharBuffer charBuffer,
-            final StringBuilder source, final ByteBufferDestination destination) {
-        synchronized (destination) {
-            try {
-                TextEncoderHelper.encodeText(charsetEncoder, charBuffer, destination.getByteBuffer(), source,
-                        destination);
-            } catch (final Exception ex) {
-                logEncodeTextException(ex, source, destination);
-                TextEncoderHelper.encodeTextFallBack(charset, source, destination);
-            }
         }
     }
 
@@ -116,6 +84,8 @@ public class StringBuilderEncoder implements Encoder<StringBuilder> {
         if (result == null) {
             result = ByteBuffer.wrap(new byte[byteBufferSize]);
             byteBufferThreadLocal.set(result);
+        } else {
+            result.clear();
         }
         return result;
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/TextEncoderHelper.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/TextEncoderHelper.java
@@ -176,7 +176,7 @@ public class TextEncoderHelper {
         final int length = Math.min(source.length() - offset, destination.remaining());
         final char[] array = destination.array();
         final int start = destination.position();
-        source.getChars(offset, offset + length, array, start);
+        source.getChars(offset, offset + length, array, destination.arrayOffset() + start);
         destination.position(start + length);
         return length;
     }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/PatternLayoutTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/PatternLayoutTest.java
@@ -100,7 +100,7 @@ public class PatternLayoutTest {
         layout.encode(event, destination);
         final ByteBuffer byteBuffer = destination.getByteBuffer();
         byteBuffer.flip(); // set limit to position, position back to zero
-        assertEquals(expectedStr, new String(byteBuffer.array(), 0, byteBuffer.limit()));
+        assertEquals(expectedStr, new String(byteBuffer.array(), byteBuffer.arrayOffset(), byteBuffer.remaining()));
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/PatternLayoutTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/PatternLayoutTest.java
@@ -88,6 +88,16 @@ public class PatternLayoutTest {
         public ByteBuffer drain(final ByteBuffer buf) {
             throw new IllegalStateException("Unexpected message larger than 2048 bytes");
         }
+
+        @Override
+        public void write(final ByteBuffer data) {
+            byteBuffer.put(data);
+        }
+
+        @Override
+        public void write(final byte[] data, final int offset, final int length) {
+            byteBuffer.put(data, offset, length);
+        }
     }
 
     private void assertToByteArray(final String expectedStr, final PatternLayout layout, final LogEvent event) {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/SpyByteBufferDestination.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/SpyByteBufferDestination.java
@@ -60,4 +60,14 @@ public class SpyByteBufferDestination implements ByteBufferDestination {
         buf.clear();
         return buf;
     }
+
+    @Override
+    public void write(final ByteBuffer data) {
+        ByteBufferDestinationHelper.writeToUnsynchronized(data, this);
+    }
+
+    @Override
+    public void write(final byte[] data, final int offset, final int length) {
+        ByteBufferDestinationHelper.writeToUnsynchronized(data, offset, length, this);
+    }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/StringBuilderEncoderTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/StringBuilderEncoderTest.java
@@ -189,7 +189,6 @@ public class StringBuilderEncoderTest {
         final SpyByteBufferDestination destination = new SpyByteBufferDestination(3, 50);
         helper.encode(text, destination);
 
-        assertEquals("drained", 7, destination.drainPoints.size());
         destination.drain(destination.getByteBuffer());
 
         final byte[] bytes = text.toString().getBytes(SHIFT_JIS);

--- a/log4j-core/src/test/java/org/apache/logging/log4j/test/appender/EncodingListAppender.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/test/appender/EncodingListAppender.java
@@ -52,6 +52,16 @@ public class EncodingListAppender extends ListAppender {
         public ByteBuffer drain(final ByteBuffer buf) {
             throw new IllegalStateException("Unexpected message larger than 4096 bytes");
         }
+
+        @Override
+        public void write(final ByteBuffer data) {
+            byteBuffer.put(data);
+        }
+
+        @Override
+        public void write(final byte[] data, final int offset, final int length) {
+            byteBuffer.put(data, offset, length);
+        }
     }
 
     @Override

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/AbstractStringLayoutStringEncodingBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/AbstractStringLayoutStringEncodingBenchmark.java
@@ -194,9 +194,9 @@ public class AbstractStringLayoutStringEncodingBenchmark {
         return checksum;
     }
 
-    private static long consume(final byte[] bytes, final int offset, final int length) {
+    private static long consume(final byte[] bytes, final int offset, final int limit) {
         long checksum = 0;
-        for (int i = offset; i < length; i++) {
+        for (int i = offset; i < limit; i++) {
             checksum += bytes[i];
         }
         return checksum;
@@ -255,7 +255,7 @@ public class AbstractStringLayoutStringEncodingBenchmark {
         @Override
         public ByteBuffer drain(final ByteBuffer buf) {
             buf.flip();
-            consume(buf.array(), buf.position(), buf.limit());
+            consume(buf.array(), buf.arrayOffset() + buf.position(), buf.arrayOffset() + buf.limit());
             buf.clear();
             return buf;
         }

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/AbstractStringLayoutStringEncodingBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/AbstractStringLayoutStringEncodingBenchmark.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.core.StringLayout;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.layout.AbstractStringLayout;
 import org.apache.logging.log4j.core.layout.ByteBufferDestination;
+import org.apache.logging.log4j.core.layout.ByteBufferDestinationHelper;
 import org.apache.logging.log4j.core.layout.Encoder;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.SimpleMessage;
@@ -258,6 +259,16 @@ public class AbstractStringLayoutStringEncodingBenchmark {
             consume(buf.array(), buf.arrayOffset() + buf.position(), buf.arrayOffset() + buf.limit());
             buf.clear();
             return buf;
+        }
+
+        @Override
+        public void write(ByteBuffer data) {
+            ByteBufferDestinationHelper.writeToUnsynchronized(data, this);
+        }
+
+        @Override
+        public void write(final byte[] data, final int offset, final int length) {
+            ByteBufferDestinationHelper.writeToUnsynchronized(data, offset, length, this);
         }
 
         public void reset() {

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/TextEncoderHelperBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/TextEncoderHelperBenchmark.java
@@ -182,7 +182,7 @@ public class TextEncoderHelperBenchmark {
         final int length = Math.min(source.length() - offset, destination.remaining());
         final char[] array = destination.array();
         final int start = destination.position();
-        source.getChars(offset, offset+length, array, start);
+        source.getChars(offset, offset + length, array, destination.arrayOffset() + start);
         destination.position(start + length);
         return length;
     }

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/TextEncoderHelperBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/TextEncoderHelperBenchmark.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.ThreadContext.ContextStack;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.layout.ByteBufferDestination;
+import org.apache.logging.log4j.core.layout.ByteBufferDestinationHelper;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.layout.StringBuilderEncoder;
 import org.apache.logging.log4j.message.Message;
@@ -79,6 +80,16 @@ public class TextEncoderHelperBenchmark {
             count += buf.limit();
             buf.clear();
             return buf;
+        }
+
+        @Override
+        public void write(final ByteBuffer data) {
+            ByteBufferDestinationHelper.writeToUnsynchronized(data, this);
+        }
+
+        @Override
+        public void write(final byte[] data, final int offset, final int length) {
+            ByteBufferDestinationHelper.writeToUnsynchronized(data, offset, length, this);
         }
     }
 

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/nogc/DemoAppender.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/nogc/DemoAppender.java
@@ -47,10 +47,10 @@ public class DemoAppender extends AbstractAppender implements ByteBufferDestinat
         }
     }
 
-    private void consume(final byte[] data, final int offset, final int length) {
+    private void consume(final byte[] data, final int offset, final int limit) {
         // need to do something with the result or the JVM may optimize everything away
         long sum = 0;
-        for (int i = offset; i < length; i++) {
+        for (int i = offset; i < limit; i++) {
             sum += data[i];
         }
         checksum += sum;
@@ -64,7 +64,7 @@ public class DemoAppender extends AbstractAppender implements ByteBufferDestinat
     @Override
     public ByteBuffer drain(final ByteBuffer buf) {
         buf.flip();
-        consume(buf.array(), buf.position(), buf.limit());
+        consume(buf.array(), buf.arrayOffset() + buf.position(), buf.arrayOffset() + buf.limit());
         buf.clear();
         return buf;
     }

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/nogc/DemoAppender.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/nogc/DemoAppender.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.layout.ByteBufferDestination;
+import org.apache.logging.log4j.core.layout.ByteBufferDestinationHelper;
 
 /**
  * Demo Appender that does not do any I/O.
@@ -67,5 +68,15 @@ public class DemoAppender extends AbstractAppender implements ByteBufferDestinat
         consume(buf.array(), buf.arrayOffset() + buf.position(), buf.arrayOffset() + buf.limit());
         buf.clear();
         return buf;
+    }
+
+    @Override
+    public void write(ByteBuffer data) {
+        ByteBufferDestinationHelper.writeToUnsynchronized(data, this);
+    }
+
+    @Override
+    public void write(final byte[] data, final int offset, final int length) {
+        ByteBufferDestinationHelper.writeToUnsynchronized(data, offset, length, this);
     }
 }

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/util/DemoAppender.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/util/DemoAppender.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.layout.ByteBufferDestination;
+import org.apache.logging.log4j.core.layout.ByteBufferDestinationHelper;
 import org.apache.logging.log4j.core.util.Constants;
 
 import java.nio.ByteBuffer;
@@ -58,6 +59,16 @@ public class DemoAppender extends AbstractAppender implements ByteBufferDestinat
         consume(buf.array(), buf.position(), buf.limit());
         buf.clear();
         return buf;
+    }
+
+    @Override
+    public void write(ByteBuffer data) {
+        ByteBufferDestinationHelper.writeToUnsynchronized(data, this);
+    }
+
+    @Override
+    public void write(final byte[] data, final int offset, final int length) {
+        ByteBufferDestinationHelper.writeToUnsynchronized(data, offset, length, this);
     }
 
     private void consume(final byte[] data, final int offset, final int length) {


### PR DESCRIPTION
Headroom for char sequence encoded data is overestimated.