### PR TITLE
Add a new LuceneAppender which writes logging events to a lucene index library.

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/lucene/LuceneAnalyzer.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/lucene/LuceneAnalyzer.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.appender.lucene;
+
+import org.apache.lucene.analysis.Analyzer;
+
+/**
+ * "Tokenizes" the entire stream as a single token, but case insensitive.
+ */
+public class LuceneAnalyzer extends Analyzer {
+	
+	public LuceneAnalyzer() {
+	}
+
+	@Override
+	protected TokenStreamComponents createComponents(final String fieldName) {
+		return new TokenStreamComponents(new LuceneTokenizer());
+	}
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/lucene/LuceneAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/lucene/LuceneAppender.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.appender.lucene;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Paths;
+import java.util.Calendar;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.appender.AppenderLoggingException;
+import org.apache.logging.log4j.core.appender.db.ColumnMapping;
+import org.apache.logging.log4j.core.appender.db.jdbc.ColumnConfig;
+import org.apache.logging.log4j.core.appender.db.jdbc.JdbcAppender.Builder;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.core.util.Booleans;
+import org.apache.logging.log4j.util.Strings;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.NumericRangeQuery;
+import org.apache.lucene.store.FSDirectory;
+
+/**
+ * This Appender writes logging events to a lucene index library. It takes a list of
+ * {@link IndexField} with which determines which fields are written to the index library.
+ * <Lucene name="lucene" ignoreExceptions="true" target="/target/lucene/index">
+ *    <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/>
+ *    
+ *	  <IndexField name="time" pattern="%d{UNIX_MILLIS}" type="LongField"/>
+ *	  <IndexField name="level" pattern="%-5level" />
+ *	  <IndexField name="content" pattern="%d{HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/>
+ * </Lucene>
+ */
+@Plugin(name = "Lucene", category = Node.CATEGORY, elementType = Appender.ELEMENT_TYPE, printObject = true)
+public class LuceneAppender extends AbstractAppender {
+	/**
+	 * index directory
+	 */
+	private final String target;
+	/**
+	 * Index expiration time (seconds)
+	 */
+	private final int expiryTime;
+	/**
+	 * IndexField array.
+	 */
+	private final LuceneIndexField[] indexFields;
+	/**
+	 * Periodically clear the index and submit the IndexWriter thread pool
+	 */
+	private final ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(2);
+	/**
+	 * IndexWriter corresponding to each index directory.
+	 */
+	private static final ConcurrentHashMap<String, IndexWriter> writerMap = new ConcurrentHashMap<String, IndexWriter>();
+	
+	static{
+		Runtime.getRuntime().addShutdownHook(new Thread() {
+			@Override
+			public void run() {
+				for(IndexWriter writer: writerMap.values()){
+					if(null!=writer && writer.isOpen()){
+						try {
+							writer.commit();
+							writer.close();
+						} catch (IOException e) {
+							LOGGER.error(e.getMessage(), e);
+						}
+					}
+				}
+				writerMap.clear();
+			}
+		});
+		
+	}
+
+	protected LuceneAppender(String name, boolean ignoreExceptions, Filter filter,
+			Layout<? extends Serializable> layout, String target, Integer expiryTime, LuceneIndexField[] indexFields) {
+		super(name, filter, layout, ignoreExceptions);
+		this.target = target;
+		this.expiryTime = expiryTime;
+		this.indexFields = indexFields;
+		
+		initIndexWriter();
+		registerCommitTimer();
+		if (this.expiryTime != 0){
+			registerClearTimer();
+		}
+	}
+
+	/**
+	 * IndexWriter initialization.
+	 */
+	private IndexWriter initIndexWriter() {
+		if (null == writerMap.get(target)) {
+			try {
+				FSDirectory fsDir = FSDirectory.open(Paths.get(this.target));
+				IndexWriterConfig writerConfig = new IndexWriterConfig(new LuceneAnalyzer());
+				writerMap.putIfAbsent(target, new IndexWriter(fsDir, writerConfig));
+			} catch (IOException e) {
+				LOGGER.error("IndexWriter initialization failed!" + e.getMessage(), e);
+			}
+		}
+		return writerMap.get(target);
+	}
+
+	/**
+	 * Register IndexWriter commit timertask.
+	 */
+	private void registerCommitTimer() {
+		scheduledExecutor.scheduleAtFixedRate(new Runnable() {
+			@Override
+			public void run() {
+				IndexWriter indexWriter = initIndexWriter();
+				if (null!=indexWriter && indexWriter.numRamDocs()>0) {
+					try {
+						indexWriter.commit();
+					} catch (IOException e) {
+						LOGGER.error("IndexWriter commit failed!"+e.getMessage(),e);
+					}
+				}
+			}
+		}, 1, 1, TimeUnit.MINUTES);
+	}
+	
+	/**
+	 * Register IndexWriter clean timertask.
+	 * Delete the index before {@link LuceneAppender#expiryTime} second every day at 0.
+	 * 
+	 * @see LuceneAppender#expiryTime
+	 */
+	private void registerClearTimer() {
+		Calendar calendar = Calendar.getInstance();
+		long curMillis = calendar.getTimeInMillis();
+		calendar.add(Calendar.DAY_OF_MONTH, 1);
+		calendar.set(Calendar.HOUR_OF_DAY, 0);
+		calendar.set(Calendar.MINUTE, 0);
+		calendar.set(Calendar.SECOND, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
+		long difMinutes = (calendar.getTimeInMillis() - curMillis) / (1000 * 60);
+
+		scheduledExecutor.scheduleAtFixedRate(new Runnable() {
+			@Override
+			public void run() {
+				LOGGER.info("delete index start!",target,expiryTime);
+				IndexWriter indexWriter = initIndexWriter();
+				if (null != indexWriter) {
+					Long start = 0L;
+					Long end = System.currentTimeMillis() - expiryTime * 1000;
+					NumericRangeQuery<Long> rangeQuery = NumericRangeQuery.newLongRange("timestamp", start, end, true, true);
+					try {
+						indexWriter.deleteDocuments(rangeQuery);
+						indexWriter.commit();
+						LOGGER.info("delete index end! ",target,expiryTime);
+					}catch (IOException e) {
+						LOGGER.error("delete index failed! "+e.getMessage(),e);
+					}
+				}
+			}
+		}, difMinutes, 1440, TimeUnit.MINUTES);
+	}
+
+	/**
+	 * create lucene index.
+	 * 
+	 * @param event
+	 */
+	@Override
+	public void append(LogEvent event) {
+		if (null != indexFields && indexFields.length > 0) {
+			IndexWriter indexWriter = initIndexWriter();
+			if(null != indexWriter){
+				Document doc = new Document();
+				doc.add(new LongField("timestamp", event.getTimeMillis(), Field.Store.YES));
+				try {
+					for (LuceneIndexField field : indexFields) {
+						String value = field.getLayout().toSerializable(event);
+						if (Strings.isEmpty(value) || value.matches("[$]\\{.+\\}")) {
+							return;
+						}
+						value = value.trim();
+						String type = field.getType();
+						if (Strings.isNotEmpty(type)) {
+							Class<?> clazz = Class.forName("org.apache.lucene.document." + type);
+							if (clazz == LongField.class) {
+								doc.add(new LongField(field.getName(), Long.valueOf(value), Field.Store.YES));
+							} else if (clazz == StringField.class) {
+								doc.add(new StringField(field.getName(), value, Field.Store.YES));
+							} else if (clazz == TextField.class) {
+								doc.add(new TextField(field.getName(), value, Field.Store.YES));
+							} else {
+								throw new UnsupportedOperationException(type + " type currently not supported.");
+							}
+						} else {
+							doc.add(new TextField(field.getName(), value, Field.Store.YES));
+						}
+					}
+					indexWriter.addDocument(doc);
+				} catch (Exception e) {
+					LOGGER.error(e.getMessage(), e);
+					if (!ignoreExceptions()) {
+						throw new AppenderLoggingException(e);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+     * Factory method for creating a lucene appender within the plugin manager.
+     *
+     */
+	@PluginFactory
+	public static LuceneAppender createAppender(@PluginAttribute("name") final String name,
+			@PluginAttribute("ignoreExceptions") final String ignore, @PluginAttribute("target") String target,
+			@PluginAttribute(value = "expiryTime") final Integer expiryTime,
+			@PluginElement("Filter") final Filter filter,
+			@PluginElement("Layout") Layout<? extends Serializable> layout,
+			@PluginElement("IndexField") final LuceneIndexField[] indexFields) {
+		if (Strings.isEmpty(name)) {
+			LOGGER.error("LuceneAppender‘s name attribute is required.");
+			return null;
+		}
+		if (Strings.isEmpty(target)) {
+			LOGGER.error("LuceneAppender‘s target attribute is required.");
+			return null;
+		}
+		if (null == indexFields || indexFields.length < 1) {
+			LOGGER.error("LuceneAppender must contain IndexField sub elements.");
+			return null;
+		}
+
+		if (null == layout) {
+			layout = PatternLayout.createDefaultLayout();
+		}
+		return new LuceneAppender(name, Booleans.parseBoolean(ignore, true), filter, layout, target, expiryTime, indexFields);
+	}
+
+	@Override
+	public final void start() {
+		if (null == writerMap.get(target)) {
+			LOGGER.error("No IndexWriter set for the appender named [{}].", this.getName());
+		}
+		super.start();
+	}
+
+	@Override
+	public boolean stop(final long timeout, final TimeUnit timeUnit) {
+		setStopping();
+		boolean stopped = super.stop(timeout, timeUnit, false);
+		IndexWriter indexWriter = writerMap.get(target);
+		if (null != indexWriter) {
+			try {
+				indexWriter.close();
+				writerMap.remove(target);
+			} catch (IOException e) {
+				LOGGER.error(e.getMessage(), e);
+			}
+		}
+		setStopped();
+		return stopped;
+	}
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/lucene/LuceneIndexField.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/lucene/LuceneIndexField.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.appender.lucene;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Strings;
+
+/**
+ * {@link LuceneAppender}'s configuration element that logs the log event attributes to the Field in the Lucene document.
+ */
+@Plugin(name="IndexField", category=Node.CATEGORY, printObject=true)
+public final class LuceneIndexField {
+    private static final Logger LOGGER = StatusLogger.getLogger();
+
+    private final String name;
+    private final PatternLayout layout;
+    private final String type;
+
+    private LuceneIndexField(final String columnName, final PatternLayout layout,final String type) {
+        this.name = columnName;
+        this.layout = layout;
+        this.type = type;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public PatternLayout getLayout() {
+        return this.layout;
+    }
+
+
+	public String getType() {
+		return type;
+	}
+
+	@Override
+    public String toString() {
+        return "{name=" + this.name + ", layout=" + this.layout + " }";
+    }
+
+    /**
+     * Factory method for creating a LuceneIndexField config within the plugin manager.
+     *
+     * @param config The configuration object
+     * @param name The name of the index field as it exists within the lucene document.
+     * @param pattern The {@link PatternLayout} pattern to insert in this indexfield. Mutually exclusive with
+     *                {@code value!=null} and {@code isEventDate=true}
+     * @return the created indexField config.
+     */
+    @PluginFactory
+    public static LuceneIndexField createIndexFieldConfig(
+            @PluginConfiguration final Configuration config,
+            @PluginAttribute("name") final String name,
+            @PluginAttribute("pattern") final String pattern,
+            @PluginAttribute("type") final String type) {
+        if (Strings.isEmpty(name) || Strings.isEmpty(pattern)) {
+            LOGGER.error("IndexField标签必须包含name和pattern属性。");
+            return null;
+        }
+
+        final PatternLayout layout = PatternLayout.newBuilder()
+        		.withPattern(pattern)
+        		.withConfiguration(config)
+        		.withAlwaysWriteExceptions(false)
+        		.build();
+        return new LuceneIndexField(name,layout,type);
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/lucene/LuceneTokenizer.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/lucene/LuceneTokenizer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.appender.lucene;
+
+import org.apache.lucene.analysis.util.CharTokenizer;
+
+/**
+ * Emits the entire input as a single token.
+ */
+public class LuceneTokenizer extends CharTokenizer {
+	
+	public LuceneTokenizer() {
+	}
+
+	@Override
+	protected boolean isTokenChar(int c) {
+		return true;
+	}
+
+	@Override
+	protected int normalize(int c) {
+		return Character.toLowerCase(c);
+	}
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/lucene/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/lucene/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+/**
+ * The classes in this package provide appenders for lucene and related configuration scheme.
+ */
+package org.apache.logging.log4j.core.appender.lucene;


### PR DESCRIPTION
Add a new LuceneAppender which writes logging events to a lucene index library.The log4j2.xml configuration is as follows:
&lt;Lucene name="lucene" ignoreExceptions="true" target="/target/lucene/index" expiryTime=“1296000”&gt;
    &lt;PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/&gt;
	  &lt;IndexField name="time" pattern="%d{UNIX_MILLIS}" type="LongField"/&gt;
	  &lt;IndexField name="level" pattern="%-5level" /&gt;
	  &lt;IndexField name="content" pattern="%d{HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/&gt;
&lt;/Lucene&gt;

this appender relies on the Lucene 5.5.4 version.