### PR TITLE
Add a new LuceneAppender which writes logging events to a lucene index library.

### DIFF
--- a/log4j-nosql/pom.xml
+++ b/log4j-nosql/pom.xml
@@ -54,7 +54,13 @@
       <groupId>com.datastax.cassandra</groupId>
       <artifactId>cassandra-driver-core</artifactId>
       <optional>true</optional>
-    </dependency>
+    </dependency>    
+	<dependency>
+	    <groupId>org.apache.lucene</groupId>
+	    <artifactId>lucene-analyzers-common</artifactId>
+	    <version>5.5.4</version>
+	    <optional>true</optional>
+	</dependency>  
     <!-- Test Dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/log4j-nosql/src/main/java/org/apache/logging/log4j/nosql/appender/lucene/LuceneAnalyzer.java
+++ b/log4j-nosql/src/main/java/org/apache/logging/log4j/nosql/appender/lucene/LuceneAnalyzer.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.nosql.appender.lucene;
+
+import org.apache.lucene.analysis.Analyzer;
+
+/**
+ * "Tokenizes" the entire stream as a single token, but case insensitive.
+ */
+public class LuceneAnalyzer extends Analyzer {
+	
+	public LuceneAnalyzer() {
+	}
+
+	@Override
+	protected TokenStreamComponents createComponents(final String fieldName) {
+		return new TokenStreamComponents(new LuceneTokenizer());
+	}
+}

--- a/log4j-nosql/src/main/java/org/apache/logging/log4j/nosql/appender/lucene/LuceneAppender.java
+++ b/log4j-nosql/src/main/java/org/apache/logging/log4j/nosql/appender/lucene/LuceneAppender.java
@@ -1,0 +1,301 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.nosql.appender.lucene;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Paths;
+import java.util.Calendar;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.appender.AppenderLoggingException;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+import org.apache.logging.log4j.util.Strings;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.NumericRangeQuery;
+import org.apache.lucene.store.FSDirectory;
+
+/**
+ * This Appender writes logging events to a lucene index library. It takes a list of
+ * {@link IndexField} with which determines which fields are written to the index library.
+ * <Lucene name="lucene" ignoreExceptions="true" target="/target/lucene/index">
+ *    <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/>
+ *    
+ *	  <IndexField name="time" pattern="%d{UNIX_MILLIS}" type="LongField"/>
+ *	  <IndexField name="level" pattern="%-5level" />
+ *	  <IndexField name="content" pattern="%d{HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/>
+ * </Lucene>
+ */
+@Plugin(name = "Lucene", category = Node.CATEGORY, elementType = Appender.ELEMENT_TYPE, printObject = true)
+public class LuceneAppender extends AbstractAppender {
+	/**
+	 * index directory
+	 */
+	private final String target;
+	/**
+	 * Index expiration time (seconds)
+	 */
+	private final Integer expiryTime;
+	/**
+	 * IndexField array.
+	 */
+	private final LuceneIndexField[] indexFields;
+	/**
+	 * Periodically clear the index and submit the IndexWriter thread pool
+	 */
+	private final ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(2);
+	/**
+	 * IndexWriter corresponding to each index directory.
+	 */
+	private static final ConcurrentHashMap<String, IndexWriter> writerMap = new ConcurrentHashMap<String, IndexWriter>();
+	
+	static{
+		Runtime.getRuntime().addShutdownHook(new Thread() {
+			@Override
+			public void run() {
+				for(IndexWriter writer: writerMap.values()){
+					if(null!=writer && writer.isOpen()){
+						try {
+							writer.commit();
+							writer.close();
+						} catch (IOException e) {
+							LOGGER.error(e.getMessage(), e);
+						}
+					}
+				}
+				writerMap.clear();
+			}
+		});
+		
+	}
+
+	protected LuceneAppender(String name, boolean ignoreExceptions, Filter filter,
+			Layout<? extends Serializable> layout, String target, Integer expiryTime, LuceneIndexField[] indexFields) {
+		super(name, filter, layout, ignoreExceptions);
+		this.target = target;
+		this.expiryTime = expiryTime;
+		this.indexFields = indexFields;
+		
+		initIndexWriter();
+		registerCommitTimer();
+		if (this.expiryTime != null){
+			registerClearTimer();
+		}
+	}
+
+	/**
+	 * IndexWriter initialization.
+	 */
+	private IndexWriter initIndexWriter() {
+		if (null == writerMap.get(target)) {
+			try {
+				FSDirectory fsDir = FSDirectory.open(Paths.get(this.target));
+				IndexWriterConfig writerConfig = new IndexWriterConfig(new LuceneAnalyzer());
+				writerMap.putIfAbsent(target, new IndexWriter(fsDir, writerConfig));
+			} catch (IOException e) {
+				LOGGER.error("IndexWriter initialization failed!" + e.getMessage(), e);
+			}
+		}
+		return writerMap.get(target);
+	}
+
+	/**
+	 * Register IndexWriter commit timertask.
+	 */
+	private void registerCommitTimer() {
+		scheduledExecutor.scheduleAtFixedRate(new Runnable() {
+			@Override
+			public void run() {
+				IndexWriter indexWriter = initIndexWriter();
+				if (null!=indexWriter && indexWriter.numRamDocs()>0) {
+					try {
+						indexWriter.commit();
+					} catch (IOException e) {
+						LOGGER.error("IndexWriter commit failed!"+e.getMessage(),e);
+					}
+				}
+			}
+		}, 1, 1, TimeUnit.MINUTES);
+	}
+	
+	/**
+	 * Register IndexWriter clean timertask.
+	 * Delete the index before {@link LuceneAppender#expiryTime} second every day at 0.
+	 * 
+	 * @see LuceneAppender#expiryTime
+	 */
+	private void registerClearTimer() {
+		Calendar calendar = Calendar.getInstance();
+		long curMillis = calendar.getTimeInMillis();
+		calendar.add(Calendar.DAY_OF_MONTH, 1);
+		calendar.set(Calendar.HOUR_OF_DAY, 0);
+		calendar.set(Calendar.MINUTE, 0);
+		calendar.set(Calendar.SECOND, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
+		long difMinutes = (calendar.getTimeInMillis() - curMillis) / (1000 * 60);
+
+		scheduledExecutor.scheduleAtFixedRate(new Runnable() {
+			@Override
+			public void run() {
+				LOGGER.info("delete index start!",target,expiryTime);
+				IndexWriter indexWriter = initIndexWriter();
+				if (null != indexWriter) {
+					Long start = 0L;
+					Long end = System.currentTimeMillis() - expiryTime * 1000;
+					NumericRangeQuery<Long> rangeQuery = NumericRangeQuery.newLongRange("timestamp", start, end, true, true);
+					try {
+						indexWriter.deleteDocuments(rangeQuery);
+						indexWriter.commit();
+						LOGGER.info("delete index end! ",target,expiryTime);
+					}catch (IOException e) {
+						LOGGER.error("delete index failed! "+e.getMessage(),e);
+					}
+				}
+			}
+		}, difMinutes, 1440, TimeUnit.MINUTES);
+	}
+
+	/**
+	 * create lucene index.
+	 * 
+	 * @param event
+	 */
+	@Override
+	public void append(LogEvent event) {
+		if (null != indexFields && indexFields.length > 0) {
+			IndexWriter indexWriter = initIndexWriter();
+			if(null != indexWriter){
+				Document doc = new Document();
+				doc.add(new LongField("timestamp", event.getTimeMillis(), Field.Store.YES));
+				try {
+					for (LuceneIndexField field : indexFields) {
+						String value = field.getLayout().toSerializable(event);
+						if (Strings.isEmpty(value) || value.matches("[$]\\{.+\\}")) {
+							return;
+						}
+						value = value.trim();
+						String type = field.getType();
+						if (Strings.isNotEmpty(type)) {
+							Class<?> clazz = Class.forName("org.apache.lucene.document." + type);
+							if (clazz == LongField.class) {
+								doc.add(new LongField(field.getName(), Long.valueOf(value), Field.Store.YES));
+							} else if (clazz == StringField.class) {
+								doc.add(new StringField(field.getName(), value, Field.Store.YES));
+							} else if (clazz == TextField.class) {
+								doc.add(new TextField(field.getName(), value, Field.Store.YES));
+							} else {
+								throw new UnsupportedOperationException(type + " type currently not supported.");
+							}
+						} else {
+							doc.add(new TextField(field.getName(), value, Field.Store.YES));
+						}
+					}
+					indexWriter.addDocument(doc);
+				} catch (Exception e) {
+					LOGGER.error(e.getMessage(), e);
+					if (!ignoreExceptions()) {
+						throw new AppenderLoggingException(e);
+					}
+				}
+			}
+		}
+	}
+	
+	@PluginBuilderFactory
+    public static <B extends Builder<B>> B newBuilder() {
+        return new Builder<B>().asBuilder();
+    }
+
+    public static class Builder<B extends Builder<B>> extends AbstractAppender.Builder<B>
+        implements org.apache.logging.log4j.core.util.Builder<LuceneAppender> {
+
+        @PluginElement("IndexField")
+        @Required(message = "No IndexField provided")
+        private LuceneIndexField[] indexField;        
+
+        @PluginBuilderAttribute        
+        private Integer expiryTime;
+
+        @PluginBuilderAttribute
+        @Required(message = "No target provided")
+        private String target;
+        
+        public B withTarget(final String target){
+        	this.target = target;
+        	return this.asBuilder();
+        }
+        
+        public B withExpiryTime(final Integer expiryTime){
+        	this.expiryTime = expiryTime;
+        	return this.asBuilder();
+        }
+        
+        public B withIndexField(final LuceneIndexField... indexField){
+        	this.indexField = indexField;
+        	return this.asBuilder();
+        }        
+
+        @Override
+        public LuceneAppender build() {
+            return new LuceneAppender(getName(), isIgnoreExceptions(),getFilter(), this.getLayout(),this.target,this.expiryTime,this.indexField);
+        }        
+    }	
+
+	@Override
+	public final void start() {
+		if (null == writerMap.get(target)) {
+			LOGGER.error("No IndexWriter set for the appender named [{}].", this.getName());
+		}
+		super.start();
+	}
+
+	@Override
+	public boolean stop(final long timeout, final TimeUnit timeUnit) {
+		setStopping();
+		boolean stopped = super.stop(timeout, timeUnit, false);
+		IndexWriter indexWriter = writerMap.get(target);
+		if (null != indexWriter) {
+			try {
+				indexWriter.close();
+				writerMap.remove(target);
+			} catch (IOException e) {
+				LOGGER.error(e.getMessage(), e);
+			}
+		}
+		setStopped();
+		return stopped;
+	}
+}

--- a/log4j-nosql/src/main/java/org/apache/logging/log4j/nosql/appender/lucene/LuceneIndexField.java
+++ b/log4j-nosql/src/main/java/org/apache/logging/log4j/nosql/appender/lucene/LuceneIndexField.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.nosql.appender.lucene;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+import org.apache.logging.log4j.core.filter.AbstractFilterable;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.status.StatusLogger;
+
+/**
+ * {@link LuceneAppender}'s configuration element that logs the log event attributes to the Field in the Lucene document.
+ */
+@Plugin(name="IndexField", category=Node.CATEGORY, printObject=true)
+public final class LuceneIndexField {
+    private static final Logger LOGGER = StatusLogger.getLogger();
+
+    private final String name;
+    private final PatternLayout layout;
+    private final String type;
+
+    private LuceneIndexField(final String name, final PatternLayout layout,final String type) {
+        this.name = name;
+        this.layout = layout;
+        this.type = type;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public PatternLayout getLayout() {
+        return this.layout;
+    }
+
+
+	public String getType() {
+		return type;
+	}
+
+	@Override
+    public String toString() {
+        return "{name=" + this.name + ", layout=" + this.layout + " }";
+    }    
+    
+    @PluginBuilderFactory
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder<B extends Builder<B>> extends AbstractFilterable.Builder<B>
+    implements org.apache.logging.log4j.core.util.Builder<LuceneIndexField>{
+    	
+    	@PluginConfiguration
+    	private Configuration configuration;
+	
+    	@PluginBuilderAttribute
+    	@Required(message = "No name provided")
+        private String name;
+
+        @PluginBuilderAttribute
+        @Required(message = "No pattern provided")
+        private String pattern;
+        
+        @PluginBuilderAttribute        
+        private String type;
+        
+        public B withName(final String name){
+        	this.name = name;
+        	return this.asBuilder();
+        }
+        
+        public B withPattern(final String pattern){
+        	this.pattern = pattern;
+        	return this.asBuilder();
+        }
+        
+        public B withType(final String type){
+        	this.type = type;
+        	return this.asBuilder();
+        }
+
+		@Override
+		public LuceneIndexField build() {
+			final PatternLayout layout =
+                    PatternLayout.newBuilder()
+                        .withPattern(pattern)
+                        .withConfiguration(configuration)                        
+                        .build();
+			return new LuceneIndexField(name,layout,type);
+		}
+    }
+}

--- a/log4j-nosql/src/main/java/org/apache/logging/log4j/nosql/appender/lucene/LuceneTokenizer.java
+++ b/log4j-nosql/src/main/java/org/apache/logging/log4j/nosql/appender/lucene/LuceneTokenizer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.nosql.appender.lucene;
+
+import org.apache.lucene.analysis.util.CharTokenizer;
+
+/**
+ * Emits the entire input as a single token.
+ */
+public class LuceneTokenizer extends CharTokenizer {
+	
+	public LuceneTokenizer() {
+	}
+
+	@Override
+	protected boolean isTokenChar(int c) {
+		return true;
+	}
+
+	@Override
+	protected int normalize(int c) {
+		return Character.toLowerCase(c);
+	}
+}

--- a/log4j-nosql/src/main/java/org/apache/logging/log4j/nosql/appender/lucene/package-info.java
+++ b/log4j-nosql/src/main/java/org/apache/logging/log4j/nosql/appender/lucene/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+/**
+ * The classes in this package provide appenders for lucene and related configuration scheme.
+ */
+package org.apache.logging.log4j.nosql.appender.lucene;

--- a/log4j-nosql/src/test/java/org/apache/logging/log4j/nosql/appender/LuceneAppenderTest.java
+++ b/log4j-nosql/src/test/java/org/apache/logging/log4j/nosql/appender/LuceneAppenderTest.java
@@ -1,0 +1,116 @@
+package org.apache.logging.log4j.nosql.appender;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.junit.CleanFolders;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.FSDirectory;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class LuceneAppenderTest {
+	private static final String CONFIGURATION_FILE = "log4j2-lucene.xml";
+	private static final String TARGET_FOLDER = "target/lucene";
+	private static final String LEVEL = "level";
+	private static final String CONTENT = "content";
+	private static final String LOGGER_NAME = "TestLogger";
+	private static final String LOG_MESSAGE = "Hello world!";
+	private static final String EXEPECTED_REGEX = "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3} \\[[^\\]]*\\] INFO "
+			+ LOGGER_NAME + " - " + LOG_MESSAGE;
+	private static final Path PATH = Paths.get(TARGET_FOLDER);
+	private static final int THREAD_COUNT = 50;
+
+	@Rule
+	public LoggerContextRule ctx = new LoggerContextRule(CONFIGURATION_FILE);
+
+	@Rule
+	public CleanFolders folders = new CleanFolders(PATH);
+
+	@Test
+	public void testSimple() throws Exception {
+		write();
+		verify(1);
+	}
+
+	@Test
+	public void testMultipleThreads() throws Exception {
+		final ExecutorService threadPool = Executors.newFixedThreadPool(THREAD_COUNT);
+		final LuceneAppenderRunner runner = new LuceneAppenderRunner();
+		for (int i = 0; i < THREAD_COUNT; ++i) {
+			threadPool.execute(runner);
+		}
+
+		// Waiting for lucene records to complete and submit
+		Thread.sleep(3000);
+
+		verify(THREAD_COUNT);
+	}
+
+	private final void write() throws Exception {
+		final LuceneAppender appender = (LuceneAppender) ctx.getRequiredAppender("LuceneAppender");
+		try {
+			appender.start();
+			assertTrue("Appender did not start", appender.isStarted());
+			final Log4jLogEvent event = Log4jLogEvent.newBuilder().setLoggerName(LOGGER_NAME)
+					.setLoggerFqcn(LuceneAppenderTest.class.getName()).setLevel(Level.INFO)
+					.setMessage(new SimpleMessage(LOG_MESSAGE)).build();
+			appender.append(event);
+		} finally {
+			appender.stop();
+		}
+		assertFalse("Appender did not stop", appender.isStarted());
+	}
+
+	private final synchronized void verify(final int exepectedTotalHits) throws Exception {
+		final FSDirectory fsDir = FSDirectory.open(PATH);
+		final IndexReader reader = DirectoryReader.open(fsDir);
+		try {
+			final IndexSearcher searcher = new IndexSearcher(reader);
+			final TopDocs all = searcher.search(new MatchAllDocsQuery(), Integer.MAX_VALUE);
+			Assert.assertEquals(all.totalHits, exepectedTotalHits);
+			for (ScoreDoc scoreDoc : all.scoreDocs) {
+				final Document doc = searcher.doc(scoreDoc.doc);
+				Assert.assertEquals(doc.getFields().size(), 3);
+				final String field1 = doc.get(LEVEL);
+				Assert.assertTrue("Unexpected field1: " + field1, Level.INFO.toString().equals(field1));
+				final String field2 = doc.get(CONTENT);
+				final Pattern pattern = Pattern.compile(EXEPECTED_REGEX);
+				final Matcher matcher = pattern.matcher(field2);
+				Assert.assertTrue("Unexpected field2: " + field2, matcher.matches());
+			}
+		} finally {
+			reader.close();
+			fsDir.close();
+		}
+	}
+
+	private class LuceneAppenderRunner implements Runnable {
+		@Override
+		public void run() {
+			try {
+				write();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+}

--- a/log4j-nosql/src/test/resources/log4j2-lucene.xml
+++ b/log4j-nosql/src/test/resources/log4j2-lucene.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration name="LuceneAppenderTest" packages = "com.wb.testCase">
+  <Appenders>
+    <Lucene name="LuceneAppender" target = "target/lucene">
+    	<IndexField name = "level" pattern = "%-5level" />
+    	<IndexField name = "time" pattern = "%d{UNIX_MILLIS}" type="LongField"/>
+    	<IndexField name = "content" pattern = "%p %c - %m%n" />
+    </Lucene>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="LuceneAppender"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
Add a new LuceneAppender which writes logging events to a lucene index library.The log4j2.xml configuration is as follows:
&lt;Lucene name="lucene" ignoreExceptions="true" target="/target/lucene/index" expiryTime=“1296000”&gt;
&lt;PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/&gt;
&lt;IndexField name="time" pattern="%d{UNIX_MILLIS}" type="LongField"/&gt;
&lt;IndexField name="level" pattern="%-5level" /&gt;
&lt;IndexField name="content" pattern="%d{HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/&gt;
&lt;/Lucene&gt;

this appender relies on the Lucene 5.5.4 version.
this patch adds the corresponding test cases.