### PR TITLE
trim levels read from properties file to remove trailing spaces

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
@@ -43,7 +43,6 @@ import org.apache.logging.log4j.core.config.builder.api.ScriptFileComponentBuild
 import org.apache.logging.log4j.core.util.Builder;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.Strings;
-import org.apache.maven.settings.building.StringSettingsSource;
 
 /**
  * Helper builder for parsing properties files into a PropertiesConfiguration.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
@@ -43,6 +43,7 @@ import org.apache.logging.log4j.core.config.builder.api.ScriptFileComponentBuild
 import org.apache.logging.log4j.core.util.Builder;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.Strings;
+import org.apache.maven.settings.building.StringSettingsSource;
 
 /**
  * Helper builder for parsing properties files into a PropertiesConfiguration.
@@ -241,7 +242,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
             throw new ConfigurationException("No ref attribute provided for AppenderRef " + key);
         }
         final AppenderRefComponentBuilder appenderRefBuilder = builder.newAppenderRef(ref);
-        final String level = (String) properties.remove("level");
+        final String level = Strings.trimToNull((String) properties.remove("level"));
         if (!Strings.isEmpty(level)) {
             appenderRefBuilder.addAttribute("level", level);
         }
@@ -254,7 +255,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
         if (Strings.isEmpty(name)) {
             throw new ConfigurationException("No name attribute provided for Logger " + key);
         }
-        final String level = (String) properties.remove("level");
+        final String level = Strings.trimToNull((String) properties.remove("level"));
         final String type = (String) properties.remove(CONFIG_TYPE);
         final LoggerComponentBuilder loggerBuilder;
         boolean includeLocation;
@@ -287,7 +288,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
     }
 
     private RootLoggerComponentBuilder createRootLogger(final Properties properties) {
-        final String level = (String) properties.remove("level");
+        final String level = Strings.trimToNull((String) properties.remove("level"));
         final String type = (String) properties.remove(CONFIG_TYPE);
         final String location = (String) properties.remove("includeLocation");
         final boolean includeLocation;

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationTrailingSpaceOnLevelTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationTrailingSpaceOnLevelTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.config.properties;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LifeCycle;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.filter.ThresholdFilter;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ */
+public class PropertiesConfigurationTrailingSpaceOnLevelTest {
+
+    @ClassRule
+    public static LoggerContextRule context = new LoggerContextRule("log4j2-properties-trailing-space-on-level.properties");
+
+    @Test
+    public void testPropertiesConfiguration() {
+        final Configuration config = context.getConfiguration();
+        assertNotNull("No configuration created", config);
+        assertEquals("Incorrect State: " + config.getState(), config.getState(), LifeCycle.State.STARTED);
+        final Map<String, Appender> appenders = config.getAppenders();
+        assertNotNull(appenders);
+        assertTrue("Incorrect number of Appenders: " + appenders.size(), appenders.size() == 1);
+        final Map<String, LoggerConfig> loggers = config.getLoggers();
+        assertNotNull(loggers);
+        assertTrue("Incorrect number of LoggerConfigs: " + loggers.size(), loggers.size() == 2);
+        final Filter filter = config.getFilter();
+        assertNotNull("No Filter", filter);
+        assertTrue("Not a Threshold Filter", filter instanceof ThresholdFilter);
+        final Logger logger = LogManager.getLogger(getClass());
+        
+        assertEquals("Incorrect level "+logger.getLevel(), Level.DEBUG, logger.getLevel());
+        
+        logger.debug("Welcome to Log4j!");
+        
+        
+    }
+}

--- a/log4j-core/src/test/resources/log4j2-properties-trailing-space-on-level.properties
+++ b/log4j-core/src/test/resources/log4j2-properties-trailing-space-on-level.properties
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+status = ERROR
+dest = err
+
+filter.Threshold.type = ThresholdFilter
+filter.Threshold.level = DEBUG
+
+appender.Stdout.type = Console
+appender.Stdout.name = StdOut
+appender.Stdout.target = SYSTEM_OUT
+appender.Stdout.layout.type = PatternLayout
+appender.Stdout.layout.pattern = %d [%t] %-5level: %msg%n%throwable
+appender.Stdout.filter.marker.type = MarkerFilter
+appender.Stdout.filter.marker.onMatch = DENY
+appender.Stdout.filter.marker.onMisMatch = NEUTRAL
+appender.Stdout.filter.marker.marker = FLOW
+
+logger.log4j.name = org.apache.logging.log4j
+logger.log4j.appenderRef.console.ref = StdOut
+#added a trailing space to the level on purpose in order to test for correct initialzation of level
+logger.log4j.level = DEBUG 
+logger.log4j.additivity = false
+
+rootLogger.appenderRef.console.ref = StdOut
+rootLogger.level = ERROR


### PR DESCRIPTION
trim levels after reading them from properties and before initializing any loggers.

If the level in a properties file contains a trailing space log4j2 won't initialize the logger correctly. In Effect the logger for whicht the level is defined will keep the inherited loglevel.