### PR TITLE
[LOG4J2-1699] Log File Permissions with PosixFilePermission feedback from jira

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FileManager.java
@@ -125,10 +125,28 @@ public class FileManager extends OutputStreamManager {
         this.bufferSize = buffer.capacity();
 
         final Set<String> views = FileSystems.getDefault().supportedFileAttributeViews();
-        this.filePermissions = filePermissions != null && views.contains("posix")
-                                ? PosixFilePermissions.fromString(filePermissions) : null;
-        this.fileOwner = views.contains("owner") ? fileOwner : null;
-        this.fileGroup = views.contains("posix") ? fileGroup : null;
+        if (views.contains("posix")) {
+            this.filePermissions = filePermissions != null ? PosixFilePermissions.fromString(filePermissions) : null;
+            this.fileGroup = fileGroup;
+        } else {
+            this.filePermissions = null;
+            this.fileGroup = null;
+            if (filePermissions != null) {
+                LOGGER.warn("Posix file attribute permissions defined but it is not supported by this files system.");
+            }
+            if (fileGroup != null) {
+                LOGGER.warn("Posix file attribute group defined but it is not supported by this files system.");
+            }
+        }
+
+        if (views.contains("owner")) {
+            this.fileOwner = fileOwner;
+        } else {
+            this.fileOwner = null;
+            if (fileOwner != null) {
+                LOGGER.warn("Owner file attribute defined but it is not supported by this files system.");
+            }
+        }
 
         // Supported and defined
         this.posixSupported = filePermissions != null || fileOwner != null || fileGroup != null;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FileManager.java
@@ -198,7 +198,7 @@ public class FileManager extends OutputStreamManager {
 
                 FileUtils.defineFilePosixAttributeView(path, filePermissions, fileOwner, fileGroup);
             } catch (final Exception e) {
-                LOGGER.error("Could not define path attribute view on \"{}\" got {}", path, e.getMessage(), e);
+                LOGGER.error("Could not define attribute view on path \"{}\" got {}", path, e.getMessage(), e);
             }
         }
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FileManager.java
@@ -111,7 +111,7 @@ public class FileManager extends OutputStreamManager {
     }
 
     /**
-     * @since 2.8.3
+     * @since 2.9
      */
     protected FileManager(final LoggerContext loggerContext, final String fileName, final OutputStream os, final boolean append, final boolean locking,
             final boolean createOnDemand, final String advertiseURI, final Layout<? extends Serializable> layout,

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DefaultRolloverStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DefaultRolloverStrategy.java
@@ -569,7 +569,7 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
             return new RolloverDescriptionImpl(currentFileName, false, null, null);
         }
 
-        if (compressAction != null && manager.isPosixSupported()) {
+        if (compressAction != null && manager.isAttributeViewEnabled()) {
             // Propagate posix attribute view to rolled/compressed file
             // @formatter:off
             Action posixAttributeViewAction = PosixViewAttributeAction.newBuilder()

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DefaultRolloverStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DefaultRolloverStrategy.java
@@ -570,7 +570,7 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
         }
 
         if (compressAction != null && manager.isAttributeViewEnabled()) {
-            // Propagate posix attribute view to rolled/compressed file
+            // Propagate posix attribute view to compressed file
             // @formatter:off
             Action posixAttributeViewAction = PosixViewAttributeAction.newBuilder()
                                                         .withBasePath(compressedName)

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DefaultRolloverStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DefaultRolloverStrategy.java
@@ -569,7 +569,7 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
             return new RolloverDescriptionImpl(currentFileName, false, null, null);
         }
 
-        if (manager.isPosixSupported()) {
+        if (compressAction != null && manager.isPosixSupported()) {
             // Propagate posix attribute view to rolled/compressed file
             // @formatter:off
             Action posixAttributeViewAction = PosixViewAttributeAction.newBuilder()
@@ -583,11 +583,7 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
                                                         .withFileGroup(manager.getFileGroup())
                                                         .build();
             // @formatter:on
-            if (compressAction == null) {
-                compressAction = posixAttributeViewAction;
-            } else {
-                compressAction = new CompositeAction(Arrays.asList(compressAction, posixAttributeViewAction), false);
-            }
+            compressAction = new CompositeAction(Arrays.asList(compressAction, posixAttributeViewAction), false);
         }
 
         final FileRenameAction renameAction = new FileRenameAction(new File(currentFileName), new File(renameTo),

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DirectWriteRolloverStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DirectWriteRolloverStrategy.java
@@ -369,7 +369,7 @@ public class DirectWriteRolloverStrategy extends AbstractRolloverStrategy implem
             }
         }
 
-        if (manager.isPosixSupported()) {
+        if (compressAction != null && manager.isPosixSupported()) {
             // Propagate posix attribute view to rolled/compressed file
             // @formatter:off
             Action posixAttributeViewAction = PosixViewAttributeAction.newBuilder()
@@ -383,11 +383,7 @@ public class DirectWriteRolloverStrategy extends AbstractRolloverStrategy implem
                                                     .withFileGroup(manager.getFileGroup())
                                                     .build();
             // @formatter:on
-            if (compressAction == null) {
-                compressAction = posixAttributeViewAction;
-            } else {
-                compressAction = new CompositeAction(Arrays.asList(compressAction, posixAttributeViewAction), false);
-            }
+            compressAction = new CompositeAction(Arrays.asList(compressAction, posixAttributeViewAction), false);
         }
 
         final Action asyncAction = merge(compressAction, customActions, stopCustomActionsOnError);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DirectWriteRolloverStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DirectWriteRolloverStrategy.java
@@ -369,7 +369,7 @@ public class DirectWriteRolloverStrategy extends AbstractRolloverStrategy implem
             }
         }
 
-        if (compressAction != null && manager.isPosixSupported()) {
+        if (compressAction != null && manager.isAttributeViewEnabled()) {
             // Propagate posix attribute view to rolled/compressed file
             // @formatter:off
             Action posixAttributeViewAction = PosixViewAttributeAction.newBuilder()

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DirectWriteRolloverStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DirectWriteRolloverStrategy.java
@@ -370,7 +370,7 @@ public class DirectWriteRolloverStrategy extends AbstractRolloverStrategy implem
         }
 
         if (compressAction != null && manager.isAttributeViewEnabled()) {
-            // Propagate posix attribute view to rolled/compressed file
+            // Propagate posix attribute view to compressed file
             // @formatter:off
             Action posixAttributeViewAction = PosixViewAttributeAction.newBuilder()
                                                     .withBasePath(compressedName)

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
@@ -631,8 +631,8 @@ public class RollingFileManager extends FileManager {
                 RollingFileManager rm = new RollingFileManager(data.getLoggerContext(), data.fileName, data.pattern, os,
                     data.append, data.createOnDemand, size, time, data.policy, data.strategy, data.advertiseURI,
                     data.layout, data.filePermissions, data.fileOwner, data.fileGroup, writeHeader, buffer);
-                if (os != null && rm.isPosixSupported()) {
-                    rm.definePathAttributeView(file.toPath());
+                if (os != null && rm.isAttributeViewEnabled()) {
+                    rm.defineAttributeView(file.toPath());
                 }
 
                 return rm;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
@@ -119,7 +119,7 @@ public class RollingFileManager extends FileManager {
     }
 
     /**
-     * @since 2.8.3
+     * @since 2.9
      */
     protected RollingFileManager(final LoggerContext loggerContext, final String fileName, final String pattern, final OutputStream os,
             final boolean append, final boolean createOnDemand, final long size, final long time,

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
@@ -207,8 +207,8 @@ public class RollingRandomAccessFileManager extends RollingFileManager {
                 RollingRandomAccessFileManager rrm = new RollingRandomAccessFileManager(data.getLoggerContext(), raf, name, data.pattern,
                         NullOutputStream.getInstance(), data.append, data.immediateFlush, data.bufferSize, size, time, data.policy,
                         data.strategy, data.advertiseURI, data.layout, data.filePermissions, data.fileOwner, data.fileGroup, writeHeader);
-                if (rrm.isPosixSupported()) {
-                    rrm.definePathAttributeView(file.toPath());
+                if (rrm.isAttributeViewEnabled()) {
+                    rrm.defineAttributeView(file.toPath());
                 }
                 return rrm;
             } catch (final IOException ex) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/PosixViewAttributeAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/PosixViewAttributeAction.java
@@ -122,13 +122,13 @@ public class PosixViewAttributeAction extends AbstractPathAction {
 
             if (filePermissions == null && Strings.isEmpty(filePermissionsString)
                         && Strings.isEmpty(fileOwner) && Strings.isEmpty(fileGroup)) {
-                LOGGER.error("Posix file attribute view not valid because nor permissions, user and group defined.");
+                LOGGER.error("Posix file attribute view not valid because nor permissions, user or group defined.");
                 return null;
             }
 
             if (!FileUtils.isFilePosixAttributeViewSupported()) {
-                LOGGER.warn("Posix file attribute view defined but it is not supported by this file system.");
-//                return null; // FIXME Should we avoid operations not permitted or unsupported exception ?
+                LOGGER.warn("Posix file attribute view defined but it is not supported by this files system.");
+                return null;
             }
 
             return new PosixViewAttributeAction(basePath, followLinks, maxDepth, pathConditions,

--- a/src/site/xdoc/manual/appenders.xml
+++ b/src/site/xdoc/manual/appenders.xml
@@ -2535,7 +2535,7 @@ public class JpaLogEntity extends AbstractLogEventWrapperEntity {
             DefaultRolloverStrategy to run at rollover. Since 2.8 if no file name is configured then
             <a href="#DirectWriteRolloverStrategy">DirectWriteRolloverStrategy</a> will be used instead of
             DefaultRolloverStrategy.
-            Since log4j-2.8.3, a <a href="#CustomPosixViewAttributeOnRollover">custom POSIX file attribute view action</a> can be configured in the
+            Since log4j-2.9, a <a href="#CustomPosixViewAttributeOnRollover">custom POSIX file attribute view action</a> can be configured in the
             DefaultRolloverStrategy to run at rollover, if not defined, inherited POSIX file attribute view from the RollingFileAppender will be applied.
           </p>
           <p>
@@ -3520,7 +3520,7 @@ public class JpaLogEntity extends AbstractLogEventWrapperEntity {
           <a name="CustomPosixViewAttributeOnRollover"/>
           <h5>Log Archive File Attribute View Policy: Custom file attribute on Rollover</h5>
           <p>
-            Log4j-2.8.3 introduces a <tt>PosixViewAttribute</tt> action that gives users more control
+            Log4j-2.9 introduces a <tt>PosixViewAttribute</tt> action that gives users more control
             over which file attribute permissions, owner and group should be applied.
             The PosixViewAttribute action lets users configure one or more conditions that select the eligible files
             relative to a base directory.


### PR DESCRIPTION
item 2: Better log at configuration step if file attribute view are defined but underlying files system doesnt support it
item 3: Exception catch and logged if OperationNotSupported or Operation not permitted are thrown while changing file attribute permissions, user or group
item 4: No need to apply file posix attribute if file is just rolled  not compressed, both in DirectWriteRolloverStrategy and DefaultRolloverStrategy.

Changed next release version in documentation and javadoc.