### PR TITLE
failing test - irregular log4j2.json nodes order

### DIFF
--- a/failing-test/pom.xml
+++ b/failing-test/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>log4j</artifactId>
+        <groupId>org.apache.logging.log4j</groupId>
+        <version>2.9-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>failing-test</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.8.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.8.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.8.7</version>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/failing-test/src/main/java/Runner.java
+++ b/failing-test/src/main/java/Runner.java
@@ -1,0 +1,20 @@
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Runner {
+    private static final Logger logger = LogManager.getLogger(Runner.class.getName());
+
+    public static void main(String[] args) {
+        System.out.println("@@@ Start @@@");
+
+        // "properties" node in resources/log4j2.json config file is the last node (not regular json nodes order)
+        // due to this, log4j2 framework doesn't act normally
+        // this log msg is not printed correctly - "${layout}" is printed.
+        // if we set "properties" node to be before "appenders" node, everything will work as expected.
+        // why would json-node order matter? the nodes order in a JSON shouldn't matter ...
+        logger.log(Level.INFO, "*** My Testing Msg 1");
+
+        System.out.println("@@@ Stop @@@");
+    }
+}

--- a/failing-test/src/main/resources/log4j2.json
+++ b/failing-test/src/main/resources/log4j2.json
@@ -1,0 +1,28 @@
+{
+  "configuration": {
+    "status": "error",
+    "name": "LoggerBootstrapConfig",
+    "appenders": {
+      "Console": {
+        "name": "STDOUT",
+        "PatternLayout": {
+          "pattern": "${layout}"
+        }
+      }
+    },
+    "loggers": {
+      "root": {
+        "level": "info",
+        "AppenderRef": {
+          "ref": "STDOUT"
+        }
+      }
+    },
+    "properties": {
+      "property": {
+        "name": "layout",
+        "value": "%-5p [%d{ISO8601}] %c{2} %m%n"
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1299,6 +1299,7 @@
     <module>log4j-liquibase</module>
     <module>log4j-api-scala_2.10</module>
     <module>log4j-api-scala_2.11</module>
+      <module>failing-test</module>
   </modules>
   <profiles>
     <profile>


### PR DESCRIPTION
Failing test, showing that log4j2.json config file nodes specific order can fail log4j2 framework functionality.

Test description:
 "properties" node in resources/log4j2.json config file is the last node (not regular json nodes order)
 due to this, log4j2 framework doesn't act normally
 this log msg is not printed correctly - "${layout}" is printed.
 if we set "properties" node to be before "appenders" node, everything will work as expected.
 why would json-node order matter? the nodes order in a JSON shouldn't matter ...