### PR TITLE
LOG4J2-1989 - Clarify javadoc for AbstractTriggeringPolicy.java

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/AbstractTriggeringPolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/AbstractTriggeringPolicy.java
@@ -20,7 +20,7 @@ package org.apache.logging.log4j.core.appender.rolling;
 import org.apache.logging.log4j.core.AbstractLifeCycle;
 
 /**
- * Convenience abstract class for extends triggering policies to extend {@link AbstractLifeCycle} and implement
+ * Abstract convenience class for triggering policies that extend {@link AbstractLifeCycle} and implement
  * {@link TriggeringPolicy}.
  */
 public abstract class AbstractTriggeringPolicy extends AbstractLifeCycle implements TriggeringPolicy {


### PR DESCRIPTION
This clarifies the javadoc for AbstractTriggeringPolicy.