### PR TITLE
Mark FileRenameAction as successful when using alternative ways to mo…

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/FileRenameAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/FileRenameAction.java
@@ -129,9 +129,9 @@ public class FileRenameAction extends AbstractAction {
                         try {
                             Files.copy(Paths.get(source.getAbsolutePath()), Paths.get(destination.getAbsolutePath()),
                                     StandardCopyOption.REPLACE_EXISTING);
-                            result = true;
                             try {
                                 Files.delete(Paths.get(source.getAbsolutePath()));
+                                result = true;
                                 LOGGER.trace("Renamed file {} to {} using copy and delete",
                                         source.getAbsolutePath(), destination.getAbsolutePath());
                             } catch (final IOException exDelete) {
@@ -139,6 +139,7 @@ public class FileRenameAction extends AbstractAction {
                                         exDelete.getClass().getName(), exDelete.getMessage());
                                 try {
                                     new PrintWriter(source.getAbsolutePath()).close();
+                                    result = true;
                                     LOGGER.trace("Renamed file {} to {} with copy and truncation",
                                             source.getAbsolutePath(), destination.getAbsolutePath());
                                 } catch (final IOException exOwerwrite) {
@@ -180,3 +181,4 @@ public class FileRenameAction extends AbstractAction {
     }
 
 }
+

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/FileRenameAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/FileRenameAction.java
@@ -139,7 +139,6 @@ public class FileRenameAction extends AbstractAction {
                                         exDelete.getClass().getName(), exDelete.getMessage());
                                 try {
                                     new PrintWriter(source.getAbsolutePath()).close();
-                                    result = true;
                                     LOGGER.trace("Renamed file {} to {} with copy and truncation",
                                             source.getAbsolutePath(), destination.getAbsolutePath());
                                 } catch (final IOException exOwerwrite) {
@@ -181,4 +180,3 @@ public class FileRenameAction extends AbstractAction {
     }
 
 }
-

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/FileRenameAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/FileRenameAction.java
@@ -124,11 +124,12 @@ public class FileRenameAction extends AbstractAction {
                 } catch (final IOException exMove) {
                     LOGGER.error("Unable to move file {} to {}: {} {}", source.getAbsolutePath(),
                             destination.getAbsolutePath(), exMove.getClass().getName(), exMove.getMessage());
-                    final boolean result = source.renameTo(destination);
+                    boolean result = source.renameTo(destination);
                     if (!result) {
                         try {
                             Files.copy(Paths.get(source.getAbsolutePath()), Paths.get(destination.getAbsolutePath()),
                                     StandardCopyOption.REPLACE_EXISTING);
+                            result = true;
                             try {
                                 Files.delete(Paths.get(source.getAbsolutePath()));
                                 LOGGER.trace("Renamed file {} to {} using copy and delete",


### PR DESCRIPTION
If the primary strategy for moving a file (Files.move) fails, then the code tries other strategies but never returned successfully.