### PR TITLE
Fix stack locator calc location on JDK 9

### DIFF
--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -68,8 +68,12 @@ public class StackLocator {
     }
 
     public StackTraceElement calcLocation(final String fqcnOfLogger) {
-        return stackWalker.walk(s -> s.dropWhile(f -> f.getClassName().equals(fqcnOfLogger)).
-                dropWhile(f -> f.getClassName().equals(fqcnOfLogger)).findFirst()).get().toStackTraceElement();
+        return stackWalker.walk(
+                s -> s.dropWhile(f -> !f.getClassName().equals(fqcnOfLogger)) // drop the top frames until we reach the logger
+                        .dropWhile(f -> f.getClassName().equals(fqcnOfLogger)) // drop the logger frames
+                        .findFirst())
+                .get()
+                .toStackTraceElement();
     }
 
     public StackTraceElement getStackTraceElement(final int depth) {


### PR DESCRIPTION
This commit fixes a bug in StackLocator#calcLocation on JDK 9. The particular issue here is that on JDK 9, all stack trace locations report as line 71 of StackLocatorUtil. This is due to a bug in the JDK 9 implementation of StackLocator. The bug is that instead of dropping the top frames of the stack until the first frame that matches the fully-qualified class name of the logger, the implementation would drop all frames from the top that match the fully-qualified class name of the logger. Of course, at this point in the stack trace, there would be none. The fix is to reverse the condition, that we drop all frames until we reach a frame matching the fully-qualified class name of the logger, and then drop all frames matching the fully-qualified class name of the logger. This commit also adds a test that was broken before this change and now passes.
