### PR TITLE
LOG4J2-1216: Nested pattern layout options broken

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
@@ -271,32 +271,27 @@ public final class PatternParser {
      */
     private static int extractOptions(final String pattern, final int start, final List<String> options) {
         int i = start;
-        while (i < pattern.length() && pattern.charAt(i) == '{') {
-            final int begin = i++;
-            int end;
-            int depth = 0;
-            do {
-                end = pattern.indexOf('}', i);
-                if (end == -1) {
-                    break;
+        while (i < pattern.length()  &&  pattern.charAt(i) == '{') {
+            i++;                      // skip opening "{"
+            final int begin = i;      // position of first real char
+            int depth = 1;            // already inside one level
+            while (depth > 0  &&  i < pattern.length()) {
+                char c = pattern.charAt(i);
+                if (c == '{') {
+                    depth++;
+                } else if (c == '}') {
+                    depth--;
+                    // TODO(?) maybe escaping of { and } with \ or %
                 }
-                final int next = pattern.indexOf("{", i);
-                if (next != -1 && next < end) {
-                    i = end + 1;
-                    ++depth;
-                } else if (depth > 0) {
-                    --depth;
-                }
-            } while (depth > 0);
+                i++;
+            } // while
 
-            if (end == -1) {
-                break;
+            if (depth > 0) {          // option not closed, continue with pattern after closing bracket
+                return pattern.indexOf('}', start) + 1;
             }
 
-            final String r = pattern.substring(begin + 1, end);
-            options.add(r);
-            i = end + 1;
-        }
+            options.add(pattern.substring(begin, i-1));
+        } // while
 
         return i;
     }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/PatternParserTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/PatternParserTest.java
@@ -54,6 +54,7 @@ public class PatternParserTest {
     private final String mdcMsgPattern3 = "%m : %X{key2}%n";
     private final String mdcMsgPattern4 = "%m : %X{key3}%n";
     private final String mdcMsgPattern5 = "%m : %X{key1},%X{key2},%X{key3}%n";
+    private final String deeplyNestedPattern = "%notEmpty{ %maxLen{%X{var}}{3} }";
 
     private static String badPattern = "[%d{yyyyMMdd HH:mm:ss,SSS] %-5p [%c{10}] - %m%n";
     private static String customPattern = "[%d{yyyyMMdd HH:mm:ss,SSS}] %-5p [%-25.25c{1}:%-4L] - %m%n";
@@ -114,7 +115,7 @@ public class PatternParserTest {
             formatter.format(event, buf);
         }
         final String str = buf.toString();
-        final String expected = "INFO  [PatternParserTest        :100 ] - Hello, world" + Strings.LINE_SEPARATOR;
+        final String expected = "INFO  [PatternParserTest        :101 ] - Hello, world" + Strings.LINE_SEPARATOR;
         assertTrue("Expected to end with: " + expected + ". Actual: " + str, str.endsWith(expected));
     }
 
@@ -331,5 +332,22 @@ public class PatternParserTest {
 
         pp.parse("%N");
         assertTrue(config.getNanoClock() instanceof SystemNanoClock);
+    }
+
+    @Test
+    public void testDeeplyNestedPattern() {
+        final List<PatternFormatter> formatters = parser.parse(deeplyNestedPattern);
+        assertNotNull(formatters);
+        assertEquals(1, formatters.size());
+
+        final Map<String, String> mdc = new HashMap<>();
+        mdc.put("var", "1234");
+        final Log4jLogEvent event = Log4jLogEvent.newBuilder() //
+            .setContextMap(mdc).build();
+        final StringBuilder buf = new StringBuilder();
+        formatters.get(0).format(event, buf);
+        final String expected = " 123 ";
+        assertEquals(expected, buf.toString());
+
     }
 }


### PR DESCRIPTION
Change is for the most part as suggested by the original reported of the issue in the Jira, I only added a unit test. I made one small modification:
```
if (depth > 0) {          // option not closed, continue with pattern on opening "{"
    return begin-1;
}
```
Turned to:
```
if (depth > 0) {          // option not closed, continue with pattern after closing bracket
   return pattern.indexOf('}', start) + 1;
}
```
Because the original version was breaking PatternParserTest#testCustomPattern.

Also it seems there are 3 unit test in core that are broken on head.