### PR TITLE
LOG4J2-2105: ClassLoaderContextSelector more resilient to multiple classloaders

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerContextSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerContextSelector.java
@@ -49,11 +49,11 @@ public class AsyncLoggerContextSelector extends ClassLoaderContextSelector {
     @Override
     protected String toContextMapKey(final ClassLoader loader) {
         // LOG4J2-666 ensure unique name across separate instances created by webapp classloaders
-        return "AsyncContext@" + Integer.toHexString(System.identityHashCode(loader));
+        return "AsyncContext@" + super.toContextMapKey(loader);
     }
 
     @Override
     protected String defaultContextName() {
-        return "DefaultAsyncContext@" + Thread.currentThread().getName();
+        return "DefaultAsyncContext";
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/ClassLoaderContextSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/ClassLoaderContextSelector.java
@@ -172,7 +172,12 @@ public class ClassLoaderContextSelector implements ContextSelector {
     }
 
     protected String toContextMapKey(final ClassLoader loader) {
-        return Integer.toHexString(System.identityHashCode(loader));
+        try {
+            return Integer.toHexString(System.identityHashCode(
+                    loader.loadClass(ClassLoaderContextSelector.class.getName())));
+        } catch (ClassNotFoundException e) {
+            return Integer.toHexString(System.identityHashCode(loader));
+        }
     }
 
     protected LoggerContext getDefault() {


### PR DESCRIPTION
When log4j classes are shared between ClassLoader instances, we
can avoid creating additional contexts.