### PR TITLE
[LOG4J2-1216] fix PatternParser for patterns without closing brackets

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
@@ -287,7 +287,11 @@ public final class PatternParser {
             } // while
 
             if (depth > 0) { // option not closed, continue with pattern after closing bracket
-                return pattern.indexOf('}', start) + 1;
+                i = pattern.lastIndexOf('}');
+                if (i == -1 || i < start) {
+                    return start + 1;
+                }
+                return i + 1;
             }
 
             options.add(pattern.substring(begin, i - 1));

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
@@ -289,7 +289,9 @@ public final class PatternParser {
             if (depth > 0) { // option not closed, continue with pattern after closing bracket
                 i = pattern.lastIndexOf('}');
                 if (i == -1 || i < start) {
-                    return start + 1;
+                    // if no closing bracket could be found or there is no closing bracket
+                    // after the the start of our parsing process
+                    return begin;
                 }
                 return i + 1;
             }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
@@ -289,8 +289,8 @@ public final class PatternParser {
             if (depth > 0) { // option not closed, continue with pattern after closing bracket
                 i = pattern.lastIndexOf('}');
                 if (i == -1 || i < start) {
-                    // if no closing bracket could be found or there is no closing bracket
-                    // after the the start of our parsing process
+                    // if no closing bracket could be found or there is no closing bracket behind the starting
+                    // character of our parsing process continue parsing after the first opening bracket
                     return begin;
                 }
                 return i + 1;

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/PatternParserTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/PatternParserTest.java
@@ -161,7 +161,6 @@ public class PatternParserTest {
         assertTrue("Expected to end with: " + expected + ". Actual: " + str, str.endsWith(expected));
     }
 
-
     @Test
     public void testBadPattern() {
         final Calendar cal = Calendar.getInstance();
@@ -230,18 +229,12 @@ public class PatternParserTest {
 
     @Test
     public void testNanoPatternShort() {
-        final List<PatternFormatter> formatters = parser.parse("%N");
-        assertNotNull(formatters);
-        assertEquals(1, formatters.size());
-        assertTrue(formatters.get(0).getConverter() instanceof NanoTimePatternConverter);
+        testFirstConverter("%N", NanoTimePatternConverter.class);
     }
 
     @Test
     public void testNanoPatternLong() {
-        final List<PatternFormatter> formatters = parser.parse("%nano");
-        assertNotNull(formatters);
-        assertEquals(1, formatters.size());
-        assertTrue(formatters.get(0).getConverter() instanceof NanoTimePatternConverter);
+        testFirstConverter("%nano", NanoTimePatternConverter.class);
     }
 
     @Test
@@ -348,6 +341,20 @@ public class PatternParserTest {
         formatters.get(0).format(event, buf);
         final String expected = " 123 ";
         assertEquals(expected, buf.toString());
+    }
 
+    @Test
+    public void testMissingClosingBracket() {
+        testFirstConverter("%d{", DatePatternConverter.class);
+    }
+
+    @Test
+    public void testClosingBracketButWrongPlace() {
+        final List<PatternFormatter> formatters = parser.parse("}%d{");
+        assertNotNull(formatters);
+        assertEquals(2, formatters.size());
+
+        validateConverter(formatters, 0, "Literal");
+        validateConverter(formatters, 1, "Date");
     }
 }


### PR DESCRIPTION
This fixes an endless parsing for broken patterns without closing brackets like "%d{" or patterns where closing brackets only exist for parts of the pattern before a "{" like "}%d{".