### PR TITLE
(doc) Remove wrong xml tag "<Log4j1XmlLayout>"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ sudo: true
 dist: trusty
 
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ sudo: true
 dist: trusty
 
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 
 env:
   global:

--- a/src/site/xdoc/manual/migration.xml
+++ b/src/site/xdoc/manual/migration.xml
@@ -189,9 +189,7 @@
             <pre class="prettyprint linenums"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
 <Configuration>
   <Appenders>
-    <File name="A1" fileName="A1.log" append="false">
-      <Log4j1XmlLayout />
-    </File>
+    <File name="A1" fileName="A1.log" append="false"/>
     <Console name="STDOUT" target="SYSTEM_OUT">
       <PatternLayout pattern="%level - %m%n"/>
     </Console>


### PR DESCRIPTION
This is a trivial correction of the documentation, removing an old log4j1-tag from the log4j2-config.