### PR TITLE
LOG4J2-1203 Added Pattern encoding for CRLF only

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/EncodingPatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/EncodingPatternConverter.java
@@ -153,6 +153,25 @@ public final class EncodingPatternConverter extends LogEventPatternConverter {
                     }
                 }
             }
+        },
+
+        CRLF {
+            @Override
+            void escape(final StringBuilder toAppendTo, final int start) {
+                for (int i = toAppendTo.length() - 1; i >= start; i--) { // backwards: length may change
+                    final char c = toAppendTo.charAt(i);
+                    switch (c) {
+                        case '\r':
+                            toAppendTo.setCharAt(i, '\\');
+                            toAppendTo.insert(i + 1, 'r');
+                            break;
+                        case '\n':
+                            toAppendTo.setCharAt(i, '\\');
+                            toAppendTo.insert(i + 1, 'n');
+                            break;
+                    }
+                }
+            }
         };
 
         /**

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/EncodingPatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/EncodingPatternConverterTest.java
@@ -67,4 +67,23 @@ public class EncodingPatternConverterTest {
 
         assertEquals(expected, sb.toString());
     }
+
+    @Test
+    public void testCrlfEscaping() {
+        final LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName(EncodingPatternConverterTest.class.getName()) //
+                .setLevel(Level.DEBUG) //
+                .setMessage(new SimpleMessage("Test \r\n<div class=\"test\">this\r</div> & \n<div class='test'>that</div>"))
+                .build();
+        final StringBuilder sb = new StringBuilder();
+        final LoggerContext ctx = LoggerContext.getContext();
+        final String[] options = new String[]{"%msg", "CRLF"};
+        final EncodingPatternConverter converter = EncodingPatternConverter
+            .newInstance(ctx.getConfiguration(), options);
+        assertNotNull("Error creating converter", converter);
+        converter.format(event, sb);
+        assertEquals(
+            "Test \\r\\n<div class=\"test\">this\\r</div> & \\n<div class='test'>that</div>",
+            sb.toString());
+    }
 }

--- a/src/site/xdoc/manual/layouts.xml.vm
+++ b/src/site/xdoc/manual/layouts.xml.vm
@@ -780,8 +780,8 @@ WARN  [main]: Message 2</pre>
             </tr>
             <tr>
               <td align="center">
-                <b>enc</b>{<i>pattern</i>}{[HTML|JSON]}<br />
-                <b>encode</b>{<i>pattern</i>}{[HTML|JSON]}
+                <b>enc</b>{<i>pattern</i>}{[HTML|JSON|CRLF]}<br />
+                <b>encode</b>{<i>pattern</i>}{[HTML|JSON|CRLF]}
               </td>
               <td>
                 <p>
@@ -841,6 +841,17 @@ WARN  [main]: Message 2</pre>
                   For example, the pattern <code>{"message": "%enc{%m}{JSON}"}</code> could be used to output a
                   valid JSON document containing the log message as a string value.
                 </p>
+                <p>Using the CRLF encoding format, the following characters are replaced:</p>
+                <table>
+                  <tr>
+                    <th>Character</th>
+                    <th>Replacement</th>
+                  </tr>
+                  <tr>
+                    <td>'\r', '\n'</td>
+                    <td>Converted into escaped strings "\\r" and "\\n" respectively</td>
+                  </tr>
+                </table>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
Added a Pattern encoding format limited to just CRLF for use cases
where you do not want full HTML or JSON encoding, but do want to
protected against CR and/or LF injection attacks in logs.