### PR TITLE
LOG4J2-2101: MapMessage correctly handles non-string map values

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
@@ -200,7 +200,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiformatMes
      * @param map The Map to add.
      */
     public void putAll(final Map<String, String> map) {
-        for (final Map.Entry<String, ?> entry : map.entrySet()) {
+        for (final Map.Entry<String, String> entry : map.entrySet()) {
             data.putValue(entry.getKey(), entry.getValue());
         }
     }
@@ -211,7 +211,11 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiformatMes
      * @return The value of the element or null if the key is not present.
      */
     public String get(final String key) {
-        return data.getValue(key);
+        Object result = data.getValue(key);
+        if (result == null) {
+            return null;
+        }
+        return String.valueOf(result);
     }
 
     /**
@@ -220,7 +224,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiformatMes
      * @return The previous value of the element.
      */
     public String remove(final String key) {
-        final String result = data.getValue(key);
+        final String result = get(key);
         data.remove(key);
         return result;
     }
@@ -338,7 +342,10 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiformatMes
     public void asXml(final StringBuilder sb) {
         sb.append("<Map>\n");
         for (int i = 0; i < data.size(); i++) {
-            sb.append("  <Entry key=\"").append(data.getKeyAt(i)).append("\">").append((String)data.getValueAt(i))
+            sb.append("  <Entry key=\"")
+                    .append(data.getKeyAt(i))
+                    .append("\">")
+                    .append(data.<Object>getValueAt(i))
                     .append("</Entry>\n");
         }
         sb.append("</Map>");

--- a/log4j-api/src/test/java/org/apache/logging/log4j/message/MapMessageTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/message/MapMessageTest.java
@@ -18,6 +18,9 @@ package org.apache.logging.log4j.message;
 
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.*;
 
 /**
@@ -98,5 +101,39 @@ public class MapMessageTest {
         final String result2 = msg.getFormattedMessage(new String[]{"Java"});
         final String expected2 = "{key1=\"value1\", key2=\"value2\", key3=\"value3\"}";
         assertEquals(expected2, result2);
+    }
+
+    @Test
+    public void testGetNonStringValue() {
+        final String key = "Key";
+        final MapMessage<?, Object> msg = new MapMessage<>()
+                .with(key, 1L);
+        assertEquals("1", msg.get(key));
+    }
+
+    @Test
+    public void testRemoveNonStringValue() {
+        final String key = "Key";
+        final MapMessage<?, Object> msg = new MapMessage<>()
+                .with(key, 1L);
+        assertEquals("1", msg.remove(key));
+    }
+
+    @Test
+    public void testJSONFormatNonStringValue() {
+        final MapMessage<?, Object> msg = new MapMessage<>()
+                .with("key", 1L);
+        final String result = msg.getFormattedMessage(new String[]{"JSON"});
+        final String expected = "{\"key\":\"1\"}";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void testXMLFormatNonStringValue() {
+        final MapMessage<?, Object> msg = new MapMessage<>()
+                .with("key", 1L);
+        final String result = msg.getFormattedMessage(new String[]{"XML"});
+        final String expected = "<Map>\n  <Entry key=\"key\">1</Entry>\n</Map>";
+        assertEquals(expected, result);
     }
 }


### PR DESCRIPTION
Previously formatting non-string values worked, however filtering,
which uess the "get" method would fail due to MapMessage attempting
to cast values to String.