### PR TITLE
LOG4J2-2107: MapMessage allocation-free pattern conversion

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
@@ -24,10 +24,10 @@ import org.apache.logging.log4j.util.BiConsumer;
 import org.apache.logging.log4j.util.EnglishEnums;
 import org.apache.logging.log4j.util.IndexedReadOnlyStringMap;
 import org.apache.logging.log4j.util.IndexedStringMap;
+import org.apache.logging.log4j.util.MultiFormatStringBuilderFormattable;
 import org.apache.logging.log4j.util.PerformanceSensitive;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
-import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.StringBuilders;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.logging.log4j.util.TriConsumer;
@@ -48,9 +48,9 @@ import org.apache.logging.log4j.util.TriConsumer;
  */
 @PerformanceSensitive("allocation")
 @AsynchronouslyFormattable
-public class MapMessage<M extends MapMessage<M, V>, V> implements MultiformatMessage, StringBuilderFormattable {
+public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStringBuilderFormattable {
 
-    private static final long serialVersionUID = -5031471831131487120L;    
+    private static final long serialVersionUID = -5031471831131487120L;
 
     /**
      * When set as the format specifier causes the Map to be formatted as XML.
@@ -365,17 +365,20 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiformatMes
      */
     @Override
     public String getFormattedMessage(final String[] formats) {
+        return format(getFormat(formats), new StringBuilder()).toString();
+    }
+
+    private MapFormat getFormat(final String[] formats) {
         if (formats == null || formats.length == 0) {
-            return asString();
+            return null;
         }
         for (int i = 0; i < formats.length; i++) {
             final MapFormat mapFormat = MapFormat.lookupIgnoreCase(formats[i]);
             if (mapFormat != null) {
-                return format(mapFormat, new StringBuilder()).toString();
+                return mapFormat;
             }
         }
-        return asString();
-
+        return null;
     }
 
     protected void appendMap(final StringBuilder sb) {
@@ -429,6 +432,11 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiformatMes
     @Override
     public void formatTo(final StringBuilder buffer) {
         format((MapFormat) null, buffer);
+    }
+
+    @Override
+    public void formatTo(String[] formats, StringBuilder buffer) {
+        format(getFormat(formats), buffer);
     }
 
     @Override

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
@@ -20,7 +20,7 @@ package org.apache.logging.log4j.message;
 import java.util.Map;
 
 import org.apache.logging.log4j.util.EnglishEnums;
-import org.apache.logging.log4j.util.StringBuilderFormattable;
+import org.apache.logging.log4j.util.MultiFormatStringBuilderFormattable;
 import org.apache.logging.log4j.util.StringBuilders;
 
 /**
@@ -35,7 +35,7 @@ import org.apache.logging.log4j.util.StringBuilders;
  * @see <a href="https://tools.ietf.org/html/rfc5424">RFC 5424</a>
  */
 @AsynchronouslyFormattable
-public class StructuredDataMessage extends MapMessage<StructuredDataMessage, String> implements StringBuilderFormattable {
+public class StructuredDataMessage extends MapMessage<StructuredDataMessage, String> implements MultiFormatStringBuilderFormattable {
 
     private static final long serialVersionUID = 1703221292892071920L;
     private static final int MAX_LENGTH = 32;
@@ -253,6 +253,11 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
         asString(Format.FULL, null, buffer);
     }
 
+    @Override
+    public void formatTo(String[] formats, StringBuilder buffer) {
+        asString(getFormat(formats), null, buffer);
+    }
+
     /**
      * Returns the message.
      * @return the message.
@@ -367,18 +372,22 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      */
     @Override
     public String getFormattedMessage(final String[] formats) {
+        return asString(getFormat(formats), null);
+    }
+
+    private Format getFormat(String[] formats) {
         if (formats != null && formats.length > 0) {
             for (int i = 0; i < formats.length; i++) {
                 final String format = formats[i];
                 if (Format.XML.name().equalsIgnoreCase(format)) {
-                    return asXml();
+                    return Format.XML;
                 } else if (Format.FULL.name().equalsIgnoreCase(format)) {
-                    return asString(Format.FULL, null);
+                    return Format.FULL;
                 }
             }
-            return asString(null, null);
+            return null;
         }
-        return asString(Format.FULL, null);
+        return Format.FULL;
     }
 
     private String asXml() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/MultiFormatStringBuilderFormattable.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/MultiFormatStringBuilderFormattable.java
@@ -1,0 +1,25 @@
+package org.apache.logging.log4j.util;
+
+import org.apache.logging.log4j.message.MultiformatMessage;
+
+/**
+ * A Message that can render itself in more than one way. The format string is used by the
+ * Message implementation as extra information that it may use to help it to determine how
+ * to format itself. For example, MapMessage accepts a format of "XML" to tell it to render
+ * the Map as XML instead of its default format of {key1="value1" key2="value2"}.
+ *
+ * @since 2.10
+ */
+public interface MultiFormatStringBuilderFormattable extends MultiformatMessage, StringBuilderFormattable {
+
+    /**
+     * Writes a text representation of this object into the specified {@code StringBuilder}, ideally without allocating
+     * temporary objects.
+     *
+     * @param formats An array of Strings that provide extra information about how to format the message.
+     * Each MultiFormatStringBuilderFormattable implementation is free to use the provided formats however they choose.
+     * @param buffer the StringBuilder to write into
+     */
+    void formatTo(String[] formats, StringBuilder buffer);
+
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MessagePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MessagePatternConverter.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MultiformatMessage;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.MultiFormatStringBuilderFormattable;
 import org.apache.logging.log4j.util.PerformanceSensitive;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
@@ -114,9 +115,12 @@ public final class MessagePatternConverter extends LogEventPatternConverter {
             final boolean doRender = textRenderer != null;
             final StringBuilder workingBuilder = doRender ? new StringBuilder(80) : toAppendTo;
 
-            final StringBuilderFormattable stringBuilderFormattable = (StringBuilderFormattable) msg;
             final int offset = workingBuilder.length();
-            stringBuilderFormattable.formatTo(workingBuilder);
+            if (msg instanceof MultiFormatStringBuilderFormattable) {
+                ((MultiFormatStringBuilderFormattable) msg).formatTo(formats, workingBuilder);
+            } else {
+                ((StringBuilderFormattable) msg).formatTo(workingBuilder);
+            }
 
             // TODO can we optimize this?
             if (config != null && !noLookups) {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/MessagePatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/MessagePatternConverterTest.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.message.StringMapMessage;
+import org.apache.logging.log4j.message.StructuredDataMessage;
 import org.junit.Test;
 
 /**
@@ -144,5 +145,19 @@ public class MessagePatternConverterTest {
         StringBuilder sb = new StringBuilder();
         converter.format(event, sb);
         assertEquals("Unexpected result", "key=\"val\"", sb.toString());
+    }
+
+    @Test
+    public void testStructuredDataFormatFull() throws Exception {
+        final MessagePatternConverter converter = MessagePatternConverter.newInstance(null, new String[]{"FULL"});
+        Message msg = new StructuredDataMessage("id", "message", "type")
+                .with("key", "val");
+        LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName("MyLogger") //
+                .setLevel(Level.DEBUG) //
+                .setMessage(msg).build();
+        StringBuilder sb = new StringBuilder();
+        converter.format(event, sb);
+        assertEquals("Unexpected result", "type [id key=\"val\"] message", sb.toString());
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/MessagePatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/MessagePatternConverterTest.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.logging.log4j.message.StringMapMessage;
 import org.junit.Test;
 
 /**
@@ -101,5 +102,47 @@ public class MessagePatternConverterTest {
         sb = new StringBuilder();
         converter.format(event, sb);
         assertEquals("Incorrect length: " + sb, 4, sb.length());
+    }
+
+    @Test
+    public void testMapMessageFormatJson() throws Exception {
+        final MessagePatternConverter converter = MessagePatternConverter.newInstance(null, new String[]{"json"});
+        Message msg = new StringMapMessage()
+                .with("key", "val");
+        LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName("MyLogger") //
+                .setLevel(Level.DEBUG) //
+                .setMessage(msg).build();
+        StringBuilder sb = new StringBuilder();
+        converter.format(event, sb);
+        assertEquals("Unexpected result", "{\"key\":\"val\"}", sb.toString());
+    }
+
+    @Test
+    public void testMapMessageFormatXml() throws Exception {
+        final MessagePatternConverter converter = MessagePatternConverter.newInstance(null, new String[]{"xml"});
+        Message msg = new StringMapMessage()
+                .with("key", "val");
+        LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName("MyLogger") //
+                .setLevel(Level.DEBUG) //
+                .setMessage(msg).build();
+        StringBuilder sb = new StringBuilder();
+        converter.format(event, sb);
+        assertEquals("Unexpected result", "<Map>\n  <Entry key=\"key\">val</Entry>\n</Map>", sb.toString());
+    }
+
+    @Test
+    public void testMapMessageFormatDefault() throws Exception {
+        final MessagePatternConverter converter = MessagePatternConverter.newInstance(null, null);
+        Message msg = new StringMapMessage()
+                .with("key", "val");
+        LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName("MyLogger") //
+                .setLevel(Level.DEBUG) //
+                .setMessage(msg).build();
+        StringBuilder sb = new StringBuilder();
+        converter.format(event, sb);
+        assertEquals("Unexpected result", "key=\"val\"", sb.toString());
     }
 }


### PR DESCRIPTION
Fixes an issue causing MessagePatternConverter to greedily format
MapMessage instances as StringBuilderFormattable ignoring format.