### PR TITLE
LOG4J2-2109: Added "log4j.formatMsgNoLookups" global configuration

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MessagePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MessagePatternConverter.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.util.ArrayUtils;
+import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MultiformatMessage;
@@ -55,7 +56,7 @@ public final class MessagePatternConverter extends LogEventPatternConverter {
         this.formats = options;
         this.config = config;
         final int noLookupsIdx = loadNoLookups(options);
-        this.noLookups = noLookupsIdx >= 0;
+        this.noLookups = Constants.FORMAT_MESSAGES_PATTERN_DISABLE_LOOKUPS || noLookupsIdx >= 0;
         this.textRenderer = loadMessageRenderer(noLookupsIdx >= 0 ? ArrayUtils.remove(options, noLookupsIdx) : options);
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
@@ -55,6 +55,15 @@ public final class Constants {
             "log4j.format.msg.async", false);
 
     /**
+     * LOG4J2-2109 if {@code true}, MessagePatternConverter will always operate as though
+     * <pre>%m{nolookups}</pre> is configured.
+     *
+     * @since 2.10
+     */
+    public static final boolean FORMAT_MESSAGES_PATTERN_DISABLE_LOOKUPS = PropertiesUtil.getProperties().getBooleanProperty(
+            "log4j.formatMsgNoLookups", false);
+
+    /**
      * {@code true} if we think we are running in a web container, based on the boolean value of system property
      * "log4j2.is.webapp", or (if this system property is not set) whether the  {@code javax.servlet.Servlet} class
      * is present in the classpath.

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/MessagePatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/MessagePatternConverterTest.java
@@ -17,12 +17,15 @@
 package org.apache.logging.log4j.core.pattern;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
+import org.apache.logging.log4j.core.config.builder.impl.DefaultConfigurationBuilder;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
@@ -72,6 +75,44 @@ public class MessagePatternConverterTest {
         final StringBuilder sb = new StringBuilder();
         converter.format(event, sb);
         assertEquals("Unexpected result", "${date:now:buhu}", sb.toString());
+    }
+
+    @Test
+    public void testLookupEnabledByDefault() {
+        assertFalse("Expected lookups to be enabled", Constants.FORMAT_MESSAGES_PATTERN_DISABLE_LOOKUPS);
+    }
+
+    @Test
+    public void testLookup() {
+        final Configuration config = new DefaultConfigurationBuilder()
+                .addProperty("foo", "bar")
+                .build(true);
+        final MessagePatternConverter converter = MessagePatternConverter.newInstance(config, null);
+        final Message msg = new ParameterizedMessage("${foo}");
+        final LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName("MyLogger") //
+                .setLevel(Level.DEBUG) //
+                .setMessage(msg).build();
+        final StringBuilder sb = new StringBuilder();
+        converter.format(event, sb);
+        assertEquals("Unexpected result", "bar", sb.toString());
+    }
+
+    @Test
+    public void testDisabledLookup() {
+        final Configuration config = new DefaultConfigurationBuilder()
+                .addProperty("foo", "bar")
+                .build(true);
+        final MessagePatternConverter converter = MessagePatternConverter.newInstance(
+                config, new String[] {"nolookups"});
+        final Message msg = new ParameterizedMessage("${foo}");
+        final LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName("MyLogger") //
+                .setLevel(Level.DEBUG) //
+                .setMessage(msg).build();
+        final StringBuilder sb = new StringBuilder();
+        converter.format(event, sb);
+        assertEquals("Expected the raw pattern string without lookup", "${foo}", sb.toString());
     }
 
     @Test

--- a/src/site/xdoc/manual/configuration.xml.vm
+++ b/src/site/xdoc/manual/configuration.xml.vm
@@ -2231,6 +2231,14 @@ public class AwesomeTest {
     <td>Prints a stacktrace to the <a href="#StatusMessages">status logger</a> at DEBUG level
     when the LoggerContext is started. For debug purposes.</td>
   </tr>
+  <tr>
+      <td><a name="formatMsgNoLookups"/>log4j.formatMsgNoLookups</td>
+      <td>FORMAT_MESSAGES_PATTERN_DISABLE_LOOKUPS</td>
+      <td><a name="log4j.formatMsgNoLookups" />log4j.formatMsgNoLookups</td>
+      <td>false</td>
+      <td>Disables message pattern lookups globally when set to <tt>true</tt>.
+          This is equivalent to defining all message patterns using <tt>%m{nolookups}</tt>.</td>
+  </tr>
 </table>
 
         </subsection>


### PR DESCRIPTION
This allows applications to globally disable message pattern
from looking up replacements without specifying "%m{nolookups}".