### PR TITLE
[LOG4J2-2118] Modify MutableLogEvent to preserve message format string.

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
@@ -56,6 +56,7 @@ public class MutableLogEvent implements LogEvent, ReusableMessage {
     private String loggerName;
     private Message message;
     private StringBuilder messageText;
+    private String messageFormat;
     private Object[] parameters;
     private Throwable thrown;
     private ThrowableProxy thrownProxy;
@@ -124,6 +125,7 @@ public class MutableLogEvent implements LogEvent, ReusableMessage {
         level = null;
         loggerName = null;
         message = null;
+        messageFormat = null;
         thrown = null;
         thrownProxy = null;
         source = null;
@@ -208,6 +210,7 @@ public class MutableLogEvent implements LogEvent, ReusableMessage {
     public void setMessage(final Message msg) {
         if (msg instanceof ReusableMessage) {
             final ReusableMessage reusable = (ReusableMessage) msg;
+            messageFormat = msg.getFormat();
             reusable.formatTo(getMessageTextForWriting());
             if (parameters != null) {
                 parameters = reusable.swapParameters(parameters);
@@ -241,7 +244,10 @@ public class MutableLogEvent implements LogEvent, ReusableMessage {
      */
     @Override
     public String getFormat() {
-        return null;
+        if (message == null) {
+            return messageFormat;
+        }
+        return message.getFormat();
     }
 
     /**
@@ -295,7 +301,7 @@ public class MutableLogEvent implements LogEvent, ReusableMessage {
             return message;
         }
         final Object[] params = parameters == null ? new Object[0] : Arrays.copyOf(parameters, parameterCount);
-        return new ParameterizedMessage(messageText.toString(), params);
+        return new ParameterizedMessage(getFormat(), params);
     }
 
     @Override

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/MutableLogEventTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/MutableLogEventTest.java
@@ -110,6 +110,7 @@ public class MutableLogEventTest {
         assertNull("logger", mutable.getLoggerName());
         assertNull("marker", mutable.getMarker());
         assertEquals("msg", mutable, mutable.getMessage());
+        assertNull("format", mutable.getFormat());
         assertEquals("nanoTm", 0, mutable.getNanoTime());
         assertEquals("tid", 0, mutable.getThreadId());
         assertNull("tname", mutable.getThreadName());
@@ -145,6 +146,7 @@ public class MutableLogEventTest {
         assertNotNull("logger", mutable.getLoggerName());
         assertNotNull("marker", mutable.getMarker());
         assertEquals("msg", new ParameterizedMessage("message in a {}", "bottle"), mutable.getMessage());
+        assertEquals("format", mutable.getFormat(), "message in a {}");
         assertNotEquals("nanoTm", 0, mutable.getNanoTime());
         assertNotEquals("tid", 0, mutable.getThreadId());
         assertNotNull("tname", mutable.getThreadName());
@@ -163,6 +165,7 @@ public class MutableLogEventTest {
         assertNull("logger", mutable.getLoggerName());
         assertNull("marker", mutable.getMarker());
         assertEquals("msg", mutable, mutable.getMessage());
+        assertNull("format", mutable.getFormat());
         assertNull("thrwn", mutable.getThrown());
 
         assertNull("source", mutable.getSource());
@@ -211,6 +214,7 @@ public class MutableLogEventTest {
         assertEquals(evt.getContextMap(), evt2.getContextMap());
         assertEquals(evt.getContextStack(), evt2.getContextStack());
         assertEquals(evt.getMessage(), evt2.getMessage());
+        assertEquals(evt.getFormat(), evt2.getMessage().getFormat());
         assertNotNull(evt2.getSource());
         assertEquals(evt.getSource(), evt2.getSource());
         assertEquals(evt.getThreadName(), evt2.getThreadName());


### PR DESCRIPTION
Addresses [LOG4J2-2118](https://issues.apache.org/jira/browse/LOG4J2-2118)