### PR TITLE
ParameterFormatter.deepToString checks more special types

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -392,8 +392,33 @@ final class ParameterFormatter {
         if (o == null) {
             return null;
         }
+        // Check special types to avoid unnecessary StringBuilder usage
         if (o instanceof String) {
             return (String) o;
+        }
+        if (o instanceof Integer) {
+            return Integer.toString((Integer) o);
+        }
+        if (o instanceof Long) {
+            return Long.toString((Long) o);
+        }
+        if (o instanceof Double) {
+            return Double.toString((Double) o);
+        }
+        if (o instanceof Boolean) {
+            return Boolean.toString((Boolean) o);
+        }
+        if (o instanceof Character) {
+            return Character.toString((Character) o);
+        }
+        if (o instanceof Short) {
+            return Short.toString((Short) o);
+        }
+        if (o instanceof Float) {
+            return Float.toString((Float) o);
+        }
+        if (o instanceof Byte) {
+            return Byte.toString((Byte) o);
         }
         final StringBuilder str = new StringBuilder();
         recursiveDeepToString(o, str, null);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
@@ -95,6 +95,8 @@ public final class StringBuilders {
             stringBuilder.append(((Short) obj).shortValue());
         } else if (obj instanceof Float) {
             stringBuilder.append(((Float) obj).floatValue());
+        } else if (obj instanceof Byte) {
+            stringBuilder.append(((Byte) obj).byteValue());
         } else {
             return false;
         }


### PR DESCRIPTION
This change allows us to avoid StringBuilder usage for primitives.