### PR TITLE
LOG4J2-2129 Added missing entries in module-info.java for Log4J API

### DIFF
--- a/log4j-api-java9/src/assembly/java9.xml
+++ b/log4j-api-java9/src/assembly/java9.xml
@@ -35,6 +35,9 @@
         <exclude>module-info.class</exclude>
         <exclude>**/Dummy.class</exclude>
         <exclude>**/spi/Provider.class</exclude>
+        <exclude>**/util/PropertySource.class</exclude>
+        <exclude>**/message/ThreadDumpMessage.class</exclude>
+        <exclude>**/message/ThreadDumpMessage$ThreadInfoFactory.class</exclude>
       </excludes>
     </fileSet>
     <fileSet>

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/log4j/util/PropertySource.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/log4j/util/PropertySource.java
@@ -14,15 +14,11 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-module org.apache.logging.log4j {
-    exports org.apache.logging.log4j;
-    exports org.apache.logging.log4j.message;
-    exports org.apache.logging.log4j.simple;
-    exports org.apache.logging.log4j.spi;
-    exports org.apache.logging.log4j.status;
-    exports org.apache.logging.log4j.util;
+package org.apache.logging.log4j.util;
 
-    uses org.apache.logging.log4j.spi.Provider;
-    uses org.apache.logging.log4j.util.PropertySource;
-    uses org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
+/**
+ * This is a dummy class and is only here to allow module-info.java to compile. It will not
+ * be copied into the log4j-api module.
+ */
+public class PropertySource {
 }

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/message/ThreadDumpMessage.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/message/ThreadDumpMessage.java
@@ -14,15 +14,14 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-module org.apache.logging.log4j {
-    exports org.apache.logging.log4j;
-    exports org.apache.logging.log4j.message;
-    exports org.apache.logging.log4j.simple;
-    exports org.apache.logging.log4j.spi;
-    exports org.apache.logging.log4j.status;
-    exports org.apache.logging.log4j.util;
+package org.apache.logging.log4j.message;
 
-    uses org.apache.logging.log4j.spi.Provider;
-    uses org.apache.logging.log4j.util.PropertySource;
-    uses org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
+/**
+ * This is a dummy class and is only here to allow module-info.java to compile. It will not
+ * be copied into the log4j-api module.
+ */
+public class ThreadDumpMessage {
+    public static interface ThreadInfoFactory {
+
+    }
 }


### PR DESCRIPTION
This is only a quick fix for my sample project (https://github.com/bbucko/log4j2-jpms-sample).