### PR TITLE
PatternFormatter avoids identityToString until collisions detected

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -19,12 +19,12 @@ package org.apache.logging.log4j.message;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.StringBuilders;
 
 /**
@@ -449,7 +449,7 @@ final class ParameterFormatter {
      * @param str    the StringBuilder that o will be appended to
      * @param dejaVu a list of container identities that were already used.
      */
-    static void recursiveDeepToString(final Object o, final StringBuilder str, final Set<String> dejaVu) {
+    static void recursiveDeepToString(final Object o, final StringBuilder str, final Set<Object> dejaVu) {
         if (appendSpecialTypes(o, str)) {
             return;
         }
@@ -491,7 +491,7 @@ final class ParameterFormatter {
     }
 
     private static void appendPotentiallyRecursiveValue(final Object o, final StringBuilder str,
-            final Set<String> dejaVu) {
+            final Set<Object> dejaVu) {
         final Class<?> oClass = o.getClass();
         if (oClass.isArray()) {
             appendArray(o, str, dejaVu, oClass);
@@ -502,7 +502,7 @@ final class ParameterFormatter {
         }
     }
 
-    private static void appendArray(final Object o, final StringBuilder str, Set<String> dejaVu,
+    private static void appendArray(final Object o, final StringBuilder str, Set<Object> dejaVu,
             final Class<?> oClass) {
         if (oClass == byte[].class) {
             str.append(Arrays.toString((byte[]) o));
@@ -522,14 +522,12 @@ final class ParameterFormatter {
             str.append(Arrays.toString((char[]) o));
         } else {
             if (dejaVu == null) {
-                dejaVu = new HashSet<>();
+                dejaVu = identityHashSet();
             }
             // special handling of container Object[]
-            final String id = identityToString(o);
-            if (dejaVu.contains(id)) {
-                str.append(RECURSION_PREFIX).append(id).append(RECURSION_SUFFIX);
+            if (!dejaVu.add(o)) {
+                str.append(RECURSION_PREFIX).append(identityToString(o)).append(RECURSION_SUFFIX);
             } else {
-                dejaVu.add(id);
                 final Object[] oArray = (Object[]) o;
                 str.append('[');
                 boolean first = true;
@@ -539,7 +537,7 @@ final class ParameterFormatter {
                     } else {
                         str.append(", ");
                     }
-                    recursiveDeepToString(current, str, new HashSet<>(dejaVu));
+                    recursiveDeepToString(current, str, identityHashSet(dejaVu));
                 }
                 str.append(']');
             }
@@ -547,16 +545,14 @@ final class ParameterFormatter {
         }
     }
 
-    private static void appendMap(final Object o, final StringBuilder str, Set<String> dejaVu) {
+    private static void appendMap(final Object o, final StringBuilder str, Set<Object> dejaVu) {
         // special handling of container Map
         if (dejaVu == null) {
-            dejaVu = new HashSet<>();
+            dejaVu = identityHashSet();
         }
-        final String id = identityToString(o);
-        if (dejaVu.contains(id)) {
-            str.append(RECURSION_PREFIX).append(id).append(RECURSION_SUFFIX);
+        if (!dejaVu.add(o)) {
+            str.append(RECURSION_PREFIX).append(identityToString(o)).append(RECURSION_SUFFIX);
         } else {
-            dejaVu.add(id);
             final Map<?, ?> oMap = (Map<?, ?>) o;
             str.append('{');
             boolean isFirst = true;
@@ -569,24 +565,22 @@ final class ParameterFormatter {
                 }
                 final Object key = current.getKey();
                 final Object value = current.getValue();
-                recursiveDeepToString(key, str, new HashSet<>(dejaVu));
+                recursiveDeepToString(key, str, identityHashSet(dejaVu));
                 str.append('=');
-                recursiveDeepToString(value, str, new HashSet<>(dejaVu));
+                recursiveDeepToString(value, str, identityHashSet(dejaVu));
             }
             str.append('}');
         }
     }
 
-    private static void appendCollection(final Object o, final StringBuilder str, Set<String> dejaVu) {
+    private static void appendCollection(final Object o, final StringBuilder str, Set<Object> dejaVu) {
         // special handling of container Collection
         if (dejaVu == null) {
-            dejaVu = new HashSet<>();
+            dejaVu = identityHashSet();
         }
-        final String id = identityToString(o);
-        if (dejaVu.contains(id)) {
-            str.append(RECURSION_PREFIX).append(id).append(RECURSION_SUFFIX);
+        if (!dejaVu.add(o)) {
+            str.append(RECURSION_PREFIX).append(identityToString(o)).append(RECURSION_SUFFIX);
         } else {
-            dejaVu.add(id);
             final Collection<?> oCol = (Collection<?>) o;
             str.append('[');
             boolean isFirst = true;
@@ -596,7 +590,7 @@ final class ParameterFormatter {
                 } else {
                     str.append(", ");
                 }
-                recursiveDeepToString(anOCol, str, new HashSet<>(dejaVu));
+                recursiveDeepToString(anOCol, str, identityHashSet(dejaVu));
             }
             str.append(']');
         }
@@ -652,4 +646,13 @@ final class ParameterFormatter {
         return obj.getClass().getName() + '@' + Integer.toHexString(System.identityHashCode(obj));
     }
 
+    private static <T> Set<T> identityHashSet() {
+        return Collections.newSetFromMap(new IdentityHashMap<T, Boolean>());
+    }
+
+    private static <T> Set<T> identityHashSet(Collection<T> from) {
+        Set<T> result = Collections.newSetFromMap(new IdentityHashMap<T, Boolean>(from.size() * 2));
+        result.addAll(from);
+        return result;
+    }
 }


### PR DESCRIPTION
This implementation uses an IdentityHashMap backed Set to avoid
building a string and hashing it unnecessarily.