### PR TITLE
POC: declarative runtime null-checks

### DIFF
--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -339,6 +339,16 @@
       <artifactId>HdrHistogram</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <scope>provided</scope><!-- make the jar eligible for compilation only -->
+    </dependency>
+    <dependency>
+      <groupId>tech.harmonysoft</groupId>
+      <artifactId>traute-javac</artifactId>
+      <scope>provided</scope><!-- make the jar eligible for compilation only -->
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AbstractAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AbstractAppender.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.core.config.plugins.validation.constraints.Requi
 import org.apache.logging.log4j.core.filter.AbstractFilterable;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.util.Integers;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Abstract base class for Appenders. Although Appenders do not have to extend this class, doing so will simplify their
@@ -146,10 +147,10 @@ public abstract class AbstractAppender extends AbstractFilterable implements App
      * @param ignoreExceptions If true, exceptions will be logged and suppressed. If false errors will be logged and
      *            then passed to the application.
      */
-    protected AbstractAppender(final String name, final Filter filter, final Layout<? extends Serializable> layout,
-            final boolean ignoreExceptions) {
+    protected AbstractAppender(@NotNull final String name, final Filter filter,
+                               final Layout<? extends Serializable> layout, final boolean ignoreExceptions) {
         super(filter);
-        this.name = Objects.requireNonNull(name, "name");
+        this.name = name;
         this.layout = layout;
         this.ignoreExceptions = ignoreExceptions;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,8 @@
     <mockitoVersion>2.12.0</mockitoVersion>
     <argLine>-Xms256m -Xmx1024m</argLine>
     <javaTargetVersion>1.7</javaTargetVersion>
+    <jetbrainsAnnotationsVersion>15.0</jetbrainsAnnotationsVersion>
+    <trauteVersion>1.0.10</trauteVersion>
     <module.name />
   </properties>
   <pluginRepositories>
@@ -806,6 +808,18 @@
         <artifactId>groovy-all</artifactId>
         <version>2.4.12</version>
       </dependency>
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>${jetbrainsAnnotationsVersion}</version>
+        <scope>provided</scope><!-- make the jar eligible for compilation only -->
+      </dependency>
+      <dependency>
+        <groupId>tech.harmonysoft</groupId>
+        <artifactId>traute-javac</artifactId>
+        <version>${trauteVersion}</version>
+        <scope>provided</scope><!-- make the jar eligible for compilation only -->
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>
@@ -881,6 +895,10 @@
               <Xmaxwarns>10000</Xmaxwarns>
               <Xlint />
             </compilerArguments>
+            <compilerArgs>
+              <arg>-Xplugin:Traute</arg>
+              <arg>-Atraute.failure.text.parameter=$${PARAMETER_NAME}</arg>
+            </compilerArgs>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Hello,

I'd like to contribute to log4j by replacing explicit *Objects.requireNonNull()* checks by parameter's *NotNull* annotation and *javac* plugin which enhances resulting bytecode by the corresponding runtime check.  

Example - we mark *AbstractAppender*'s *name* parameter by a *NotNull* annotation - [link](https://github.com/denis-zhdanov/logging-log4j2/commit/69e2f0cc20950b18bbf1e93661e09189913b5a18#diff-0460d1e99cf5e9ce995fd26d05eabe6e) and resulting bytecode looks as below:  

```
javap -c ./log4j-core/target/classes/org/apache/logging/log4j/core/appender/AbstractAppender.class

...
protected org.apache.logging.log4j.core.appender.AbstractAppender(java.lang.String, org.apache.logging.log4j.core.Filter, org.apache.logging.log4j.core.Layout<? extends java.io.Serializable>, boolean);
    Code:
        ...
      18: ifnonnull     31
      21: new           #6                  // class java/lang/NullPointerException
      24: dup
      25: ldc           #7                  // String name
      27: invokespecial #8                  // Method java/lang/NullPointerException."<init>":(Ljava/lang/String;)V
      30: athrow
```

I.e. the suggestion is to replace all *Objects.requireNonNull()* calls in the project by corresponding annotations on method arguments. The checks are inserted by the [Traute](http://traute.oss.harmonysoft.tech/) *javac* plugin (I'm its author).  

Please let me know if you're interested in that, I'm ok to provide a PR for the full project source code then.