### PR TITLE
LOG4J2-2190 support writing JSON object in message field

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/Initializers.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/Initializers.java
@@ -22,6 +22,8 @@ import org.apache.logging.log4j.ThreadContext.ContextStack;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.ExtendedStackTraceElement;
 import org.apache.logging.log4j.core.impl.ThrowableProxy;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
 
 import com.fasterxml.jackson.databind.Module.SetupContext;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -78,11 +80,15 @@ class Initializers {
      * Used to set up {@link SimpleModule} from different {@link SimpleModule} subclasses.
      */
     static class SimpleModuleInitializer {
-        void initialize(final SimpleModule simpleModule) {
+        void initialize(final SimpleModule simpleModule, final boolean objectMessageAsJsonObject) {
             // Workaround because mix-ins do not work for classes that already have a built-in deserializer.
             // See Jackson issue 429.
             simpleModule.addDeserializer(StackTraceElement.class, new Log4jStackTraceElementDeserializer());
             simpleModule.addDeserializer(ContextStack.class, new MutableThreadContextStackDeserializer());
+            if (objectMessageAsJsonObject) {
+            	    simpleModule.addSerializer(ObjectMessage.class, new ObjectMessageSerializer());
+            }
+            simpleModule.addSerializer(Message.class, new MessageSerializer());
         }
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/Log4jJsonModule.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/Log4jJsonModule.java
@@ -34,16 +34,18 @@ class Log4jJsonModule extends SimpleModule {
     private final boolean encodeThreadContextAsList;
     private final boolean includeStacktrace;
     private final boolean stacktraceAsString;
+    private final boolean objectMessageAsJsonObject;
 
-    Log4jJsonModule(final boolean encodeThreadContextAsList, final boolean includeStacktrace, final boolean stacktraceAsString) {
+    Log4jJsonModule(final boolean encodeThreadContextAsList, final boolean includeStacktrace, final boolean stacktraceAsString, final boolean objectMessageAsJsonObject) {
         super(Log4jJsonModule.class.getName(), new Version(2, 0, 0, null, null, null));
         this.encodeThreadContextAsList = encodeThreadContextAsList;
         this.includeStacktrace = includeStacktrace;
         this.stacktraceAsString = stacktraceAsString;
+        this.objectMessageAsJsonObject = objectMessageAsJsonObject;
         // MUST init here.
         // Calling this from setupModule is too late!
         //noinspection ThisEscapedInObjectConstruction
-        new SimpleModuleInitializer().initialize(this);
+        new SimpleModuleInitializer().initialize(this, objectMessageAsJsonObject);
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/Log4jJsonObjectMapper.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/Log4jJsonObjectMapper.java
@@ -33,14 +33,14 @@ public class Log4jJsonObjectMapper extends ObjectMapper {
      * Create a new instance using the {@link Log4jJsonModule}.
      */
     public Log4jJsonObjectMapper() {
-        this(false, true, false);
+        this(false, true, false, false);
     }
 
     /**
      * Create a new instance using the {@link Log4jJsonModule}.
      */
-    public Log4jJsonObjectMapper(final boolean encodeThreadContextAsList, final boolean includeStacktrace, final boolean stacktraceAsString) {
-        this.registerModule(new Log4jJsonModule(encodeThreadContextAsList, includeStacktrace, stacktraceAsString));
+    public Log4jJsonObjectMapper(final boolean encodeThreadContextAsList, final boolean includeStacktrace, final boolean stacktraceAsString, final boolean objectMessageAsJsonObject) {
+        this.registerModule(new Log4jJsonModule(encodeThreadContextAsList, includeStacktrace, stacktraceAsString, objectMessageAsJsonObject));
         this.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/Log4jXmlModule.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/Log4jXmlModule.java
@@ -38,7 +38,7 @@ final class Log4jXmlModule extends JacksonXmlModule {
         this.stacktraceAsString = stacktraceAsString;
         // MUST init here.
         // Calling this from setupModule is too late!
-        new SimpleModuleInitializer().initialize(this);
+        new SimpleModuleInitializer().initialize(this, false);
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/Log4jYamlModule.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/Log4jYamlModule.java
@@ -43,7 +43,7 @@ final class Log4jYamlModule extends SimpleModule {
         // MUST init here.
         // Calling this from setupModule is too late!
         //noinspection ThisEscapedInObjectConstruction
-        new SimpleModuleInitializer().initialize(this);
+        new SimpleModuleInitializer().initialize(this, false);
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/LogEventJsonMixIn.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/LogEventJsonMixIn.java
@@ -91,7 +91,6 @@ abstract class LogEventJsonMixIn implements LogEvent {
     public abstract Marker getMarker();
 
     @JsonProperty(JsonConstants.ELT_MESSAGE)
-    @JsonSerialize(using = MessageSerializer.class)
     @JsonDeserialize(using = SimpleMessageDeserializer.class)
     @JacksonXmlProperty(namespace = XmlConstants.XML_NAMESPACE, localName = XmlConstants.ELT_MESSAGE)
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/ObjectMessageSerializer.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/ObjectMessageSerializer.java
@@ -14,19 +14,34 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.jackson;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.logging.log4j.categories.Layouts;
-import org.junit.experimental.categories.Category;
+import java.io.IOException;
 
-@Category(Layouts.Json.class)
-public class LevelMixInJsonTest extends LevelMixInTest {
+import org.apache.logging.log4j.message.ObjectMessage;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+
+/**
+ * <p>
+ * <em>Consider this class private.</em>
+ * </p>
+ */
+final class ObjectMessageSerializer extends StdScalarSerializer<ObjectMessage> {
+
+    private static final long serialVersionUID = 1L;
+
+    ObjectMessageSerializer() {
+        super(ObjectMessage.class);
+    }
 
     @Override
-    protected ObjectMapper newObjectMapper() {
-        return new Log4jJsonObjectMapper(false, true, false, false);
+    public void serialize(final ObjectMessage value, final JsonGenerator jgen, final SerializerProvider provider) throws IOException,
+            JsonGenerationException {
+        jgen.writeObject(value.getParameter());
     }
 
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/JacksonFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/JacksonFactory.java
@@ -45,11 +45,13 @@ abstract class JacksonFactory {
         private final boolean encodeThreadContextAsList;
         private final boolean includeStacktrace;
         private final boolean stacktraceAsString;
+        private final boolean objectMessageAsJsonObject;
 
-        public JSON(final boolean encodeThreadContextAsList, final boolean includeStacktrace, final boolean stacktraceAsString) {
+        public JSON(final boolean encodeThreadContextAsList, final boolean includeStacktrace, final boolean stacktraceAsString, final boolean objectMessageAsJsonObject) {
             this.encodeThreadContextAsList = encodeThreadContextAsList;
             this.includeStacktrace = includeStacktrace;
             this.stacktraceAsString = stacktraceAsString;
+            this.objectMessageAsJsonObject = objectMessageAsJsonObject;
         }
 
         @Override
@@ -74,13 +76,14 @@ abstract class JacksonFactory {
 
         @Override
         protected ObjectMapper newObjectMapper() {
-            return new Log4jJsonObjectMapper(encodeThreadContextAsList, includeStacktrace, stacktraceAsString);
+            return new Log4jJsonObjectMapper(encodeThreadContextAsList, includeStacktrace, stacktraceAsString, objectMessageAsJsonObject);
         }
 
         @Override
         protected PrettyPrinter newPrettyPrinter() {
             return new DefaultPrettyPrinter();
         }
+
     }
 
     static class XML extends JacksonFactory {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/JsonLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/JsonLayout.java
@@ -80,6 +80,9 @@ public final class JsonLayout extends AbstractJacksonLayout {
         @PluginBuilderAttribute
         private boolean propertiesAsList;
 
+        @PluginBuilderAttribute
+        private boolean objectMessageAsJsonObject;
+
         @PluginElement("AdditionalField")
         private KeyValuePair[] additionalFields;
 
@@ -96,7 +99,7 @@ public final class JsonLayout extends AbstractJacksonLayout {
             return new JsonLayout(getConfiguration(), isLocationInfo(), isProperties(), encodeThreadContextAsList,
                     isComplete(), isCompact(), getEventEol(), headerPattern, footerPattern, getCharset(),
                     isIncludeStacktrace(), isStacktraceAsString(), isIncludeNullDelimiter(),
-                    getAdditionalFields());
+                    getAdditionalFields(), getObjectMessageAsJsonObject());
         }
 
         public boolean isPropertiesAsList() {
@@ -105,6 +108,15 @@ public final class JsonLayout extends AbstractJacksonLayout {
 
         public B setPropertiesAsList(final boolean propertiesAsList) {
             this.propertiesAsList = propertiesAsList;
+            return asBuilder();
+        }
+
+        public boolean getObjectMessageAsJsonObject() {
+            return objectMessageAsJsonObject;
+        }
+
+        public B setObjectMessageAsJsonObject(final boolean objectMessageAsJsonObject) {
+            this.objectMessageAsJsonObject = objectMessageAsJsonObject;
             return asBuilder();
         }
 
@@ -128,7 +140,7 @@ public final class JsonLayout extends AbstractJacksonLayout {
             final boolean encodeThreadContextAsList,
             final boolean complete, final boolean compact, final boolean eventEol, final String headerPattern,
             final String footerPattern, final Charset charset, final boolean includeStacktrace) {
-        super(config, new JacksonFactory.JSON(encodeThreadContextAsList, includeStacktrace, false).newWriter(
+        super(config, new JacksonFactory.JSON(encodeThreadContextAsList, includeStacktrace, false, false).newWriter(
                 locationInfo, properties, compact),
                 charset, compact, complete, eventEol,
                 PatternLayout.newSerializerBuilder().setConfiguration(config).setPattern(headerPattern).setDefaultPattern(DEFAULT_HEADER).build(),
@@ -142,8 +154,8 @@ public final class JsonLayout extends AbstractJacksonLayout {
                        final String headerPattern, final String footerPattern, final Charset charset,
                        final boolean includeStacktrace, final boolean stacktraceAsString,
                        final boolean includeNullDelimiter,
-                       final KeyValuePair[] additionalFields) {
-        super(config, new JacksonFactory.JSON(encodeThreadContextAsList, includeStacktrace, stacktraceAsString).newWriter(
+                       final KeyValuePair[] additionalFields, final boolean objectMessageAsJsonObject) {
+        super(config, new JacksonFactory.JSON(encodeThreadContextAsList, includeStacktrace, stacktraceAsString, objectMessageAsJsonObject).newWriter(
                 locationInfo, properties, compact),
                 charset, compact, complete, eventEol,
                 PatternLayout.newSerializerBuilder().setConfiguration(config).setPattern(headerPattern).setDefaultPattern(DEFAULT_HEADER).build(),
@@ -253,7 +265,7 @@ public final class JsonLayout extends AbstractJacksonLayout {
             final boolean includeStacktrace) {
         final boolean encodeThreadContextAsList = properties && propertiesAsList;
         return new JsonLayout(config, locationInfo, properties, encodeThreadContextAsList, complete, compact, eventEol,
-                headerPattern, footerPattern, charset, includeStacktrace, false, false, null);
+                headerPattern, footerPattern, charset, includeStacktrace, false, false, null, false);
     }
 
     @PluginBuilderFactory
@@ -268,7 +280,7 @@ public final class JsonLayout extends AbstractJacksonLayout {
      */
     public static JsonLayout createDefaultLayout() {
         return new JsonLayout(new DefaultConfiguration(), false, false, false, false, false, false,
-                DEFAULT_HEADER, DEFAULT_FOOTER, StandardCharsets.UTF_8, true, false, false, null);
+                DEFAULT_HEADER, DEFAULT_FOOTER, StandardCharsets.UTF_8, true, false, false, null, false);
     }
 
     @Override

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/jackson/StackTraceElementMixInTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/jackson/StackTraceElementMixInTest.java
@@ -81,7 +81,7 @@ public class StackTraceElementMixInTest {
     public void testFromJsonWithLog4jModule() throws Exception {
         final ObjectMapper mapper = new ObjectMapper();
         final boolean encodeThreadContextAsList = false;
-        final SimpleModule module = new Log4jJsonModule(encodeThreadContextAsList, true, false);
+        final SimpleModule module = new Log4jJsonModule(encodeThreadContextAsList, true, false, false);
         module.addDeserializer(StackTraceElement.class, new Log4jStackTraceElementDeserializer());
         mapper.registerModule(module);
         final StackTraceElement expected = new StackTraceElement("package.SomeClass", "someMethod", "SomeClass.java", 123);

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/JsonLayoutTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/JsonLayoutTest.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.jackson.Log4jJsonObjectMapper;
 import org.apache.logging.log4j.core.lookup.JavaLookup;
 import org.apache.logging.log4j.core.util.KeyValuePair;
+import org.apache.logging.log4j.message.ObjectMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.test.appender.ListAppender;
@@ -144,7 +145,7 @@ public class JsonLayoutTest {
         assertEquals(str, !compact || eventEol, str.contains("\n"));
         assertEquals(str, locationInfo, str.contains("source"));
         assertEquals(str, includeContext, str.contains("contextMap"));
-        final Log4jLogEvent actual = new Log4jJsonObjectMapper(contextMapAslist, includeStacktrace, false).readValue(str, Log4jLogEvent.class);
+        final Log4jLogEvent actual = new Log4jJsonObjectMapper(contextMapAslist, includeStacktrace, false, false).readValue(str, Log4jLogEvent.class);
         LogEventFixtures.assertEqualLogEvents(expected, actual, locationInfo, includeContext, includeStacktrace);
         if (includeContext) {
             this.checkMapEntry("MDC.A", "A_Value", compact, str, contextMapAslist);
@@ -342,7 +343,7 @@ public class JsonLayoutTest {
         // @formatter:on
         final String str = layout.toSerializable(expected);
         assertTrue(str, str.contains("\"loggerName\":\"a.B\""));
-        final Log4jLogEvent actual = new Log4jJsonObjectMapper(propertiesAsList, true, false).readValue(str, Log4jLogEvent.class);
+        final Log4jLogEvent actual = new Log4jJsonObjectMapper(propertiesAsList, true, false, false).readValue(str, Log4jLogEvent.class);
         assertEquals(expected.getLoggerName(), actual.getLoggerName());
         assertEquals(expected, actual);
     }
@@ -415,6 +416,38 @@ public class JsonLayoutTest {
         // @formatter:off
         return layout.toSerializable(expected);
     }
+    
+    @Test
+    public void testObjectMessageAsJsonString() {
+    		final String str = prepareJSONForObjectMessageAsJsonObjectTests(1234, false);
+		assertTrue(str, str.contains("\"message\":\"" + this.getClass().getCanonicalName() + "$TestClass@"));
+    }
+    
+    @Test
+    public void testObjectMessageAsJsonObject() {
+    		final String str = prepareJSONForObjectMessageAsJsonObjectTests(1234, true);
+    		assertTrue(str, str.contains("\"message\":{\"value\":1234}"));
+    }
+    
+    private String prepareJSONForObjectMessageAsJsonObjectTests(final int value, final boolean objectMessageAsJsonObject) {
+    	final TestClass testClass = new TestClass();
+		testClass.setValue(value);
+		// @formatter:off
+		final Log4jLogEvent expected = Log4jLogEvent.newBuilder()
+            .setLoggerName("a.B")
+            .setLoggerFqcn("f.q.c.n")
+            .setLevel(Level.DEBUG)
+            .setMessage(new ObjectMessage(testClass))
+            .setThreadName("threadName")
+            .setTimeMillis(1).build();
+        // @formatter:off
+		final AbstractJacksonLayout layout = JsonLayout.newBuilder()
+				.setCompact(true)
+				.setObjectMessageAsJsonObject(objectMessageAsJsonObject)
+				.build();
+        // @formatter:off
+        return layout.toSerializable(expected);
+    }
 
     @Test
     public void testIncludeNullDelimiterTrue() throws Exception {
@@ -439,4 +472,16 @@ public class JsonLayoutTest {
     private String toPropertySeparator(final boolean compact) {
         return compact ? ":" : " : ";
     }
+    
+	private static class TestClass {
+		private int value;
+
+		public int getValue() {
+			return value;
+		}
+
+		public void setValue(int value) {
+			this.value = value;
+		}
+	}
 }

--- a/src/site/xdoc/manual/layouts.xml.vm
+++ b/src/site/xdoc/manual/layouts.xml.vm
@@ -466,6 +466,11 @@ logger.debug("one={}, two={}, three={}", 1, 2, 3);
               <td>boolean</td>
               <td>Whether to include NULL byte as delimiter after each event (optional, default to false).</td>
             </tr>
+            <tr>
+              <td>objectMessageAsJsonObject</td>
+              <td>boolean</td>
+              <td>If true, ObjectMessage is serialized as JSON object to the "message" field of the output log. Defaults to false.</td>
+            </tr>
             <caption align="top">JsonLayout Parameters</caption>
           </table>
           <p>


### PR DESCRIPTION
If we can make message as a Json object, user does not need to deserialize twice (first the whole log event, second the message field).
Also, @JsonSerialize annotation defined in LogEventJsonMixIn prevents user to override the serializer.