### PR TITLE
[LOG4J2-2197] Document default property value support

### DIFF
--- a/src/site/xdoc/manual/configuration.xml.vm
+++ b/src/site/xdoc/manual/configuration.xml.vm
@@ -1018,7 +1018,7 @@ rootLogger.appenderRef.stdout.ref = STDOUT
               </tr>
               <tr>
                 <td>env</td>
-                <td>System environment variables</td>
+                <td>System environment variables. The formats are <code>${dollar}{env:ENV_NAME}</code> and <code>${dollar}{env:ENV_NAME:-default_value}</code>.</td>
               </tr>
               <tr>
                 <td>jndi</td>
@@ -1053,7 +1053,7 @@ rootLogger.appenderRef.stdout.ref = STDOUT
               </tr>
               <tr>
                 <td>sys</td>
-                <td>System properties</td>
+                <td>System properties. The formats are <code>${dollar}{sys:some.property}</code> and <code>${dollar}{sys:some.property:-default_value}</code>.</td>
               </tr>
             </table>
           <p>

--- a/src/site/xdoc/manual/lookups.xml
+++ b/src/site/xdoc/manual/lookups.xml
@@ -81,6 +81,16 @@
     <pattern>%d %p %c{1.} [%t] $${env:USER} %m%n</pattern>
   </PatternLayout>
 </File>]]></pre>
+          <p>
+            This lookup also supports default value syntax. In the below sample, when <code>USER</code> environment
+            variable is undefined, the default value <code>jdoe</code> is used:
+          </p>
+          <pre class="prettyprint linenums"><![CDATA[
+<File name="Application" fileName="application.log">
+  <PatternLayout>
+    <pattern>%d %p %c{1.} [%t] $${env:USER:-jdoe} %m%n</pattern>
+  </PatternLayout>
+</File>]]></pre>           
         </subsection>
         <a name="JavaLookup"/>
         <subsection name="Java Lookup">
@@ -421,6 +431,14 @@ logger.info(PERFORMANCE, "Message in Performance.log");]]></pre>
 <Appenders>
   <File name="ApplicationLog" fileName="${sys:logPath}/app.log"/>
 </Appenders>]]></pre>
+          <p>
+            This lookup also supports default value syntax. In the below sample, when <code>logPath</code> system
+            property is undefined, the default value <code>/var/logs</code> is used:
+          </p>
+          <pre class="prettyprint linenums"><![CDATA[
+<Appenders>
+  <File name="ApplicationLog" fileName="${sys:logPath:-/var/logs}/app.log"/>
+</Appenders>]]></pre>            
         </subsection>
         <a name="WebLookup"/>
         <subsection name="Web Lookup">


### PR DESCRIPTION
Complete the documentation about the default environment and system properties syntaxes :
Updated pages are : 
- https://logging.apache.org/log4j/2.x/manual/lookups.html
- https://logging.apache.org/log4j/2.x/manual/configuration.html