### PR TITLE
fixes capitalization of log4j2.ContextDataInjector property name in Documentation

### DIFF
--- a/src/site/xdoc/manual/configuration.xml.vm
+++ b/src/site/xdoc/manual/configuration.xml.vm
@@ -1811,7 +1811,7 @@ public class AwesomeTest {
     </td>
   </tr>
   <tr>
-    <td><a name="contextDataInjector"/>log4j2.contextDataInjector</td>
+    <td><a name="ContextDataInjector"/>log4j2.ContextDataInjector</td>
     <td>LOG4J_CONTEXT_DATA_INJECTOR</td>
     <td><a name="log4j2.ContextDataInjector"/>log4j2.ContextDataInjector</td>
     <td>&nbsp;</td>

--- a/src/site/xdoc/manual/extending.xml
+++ b/src/site/xdoc/manual/extending.xml
@@ -534,7 +534,7 @@ ListAppender list2 = ListAppender.newBuilder().setName("List1").setEntryPerNewLi
             The default implementation is ThreadContextDataInjector, which obtains context attributes from the ThreadContext.
           </p><p>
           Applications may replace the default ContextDataInjector by setting the value of the system property
-          <tt>log4j2.contextDataInjector</tt> to the name of the custom ContextDataInjector class.
+          <tt>log4j2.ContextDataInjector</tt> to the name of the custom ContextDataInjector class.
         </p><p>
           Implementors should be aware there are some subtleties related to thread-safety and implementing a
           context data injector in a garbage-free manner.


### PR DESCRIPTION
See here:

https://github.com/apache/logging-log4j2/blob/master/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ContextDataInjectorFactory.java#L65

