### PR TITLE
LOG4J2-2032 Curly braces in parameters should not be treated as placeholders

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MementoMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MementoMessage.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.message;
+
+/**
+ * Represents a Message that is snapshot of another Message at some point of time.
+ */
+public class MementoMessage implements Message {
+
+    private final String format;
+    private final Object[] parameters;
+    private final String formattedMessage;
+    private final Throwable throwable;
+
+    public MementoMessage(String format, Object[] parameters, String formattedMessage, Throwable throwable) {
+        this.format = format;
+        this.parameters = parameters;
+        this.formattedMessage = formattedMessage;
+        this.throwable = throwable;
+    }
+
+    @Override
+    public String getFormattedMessage() {
+        return formattedMessage;
+    }
+
+    @Override
+    public String getFormat() {
+        return format;
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public Throwable getThrowable() {
+        return throwable;
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
@@ -295,7 +295,7 @@ public class MutableLogEvent implements LogEvent, ReusableMessage {
             return message;
         }
         final Object[] params = parameters == null ? new Object[0] : Arrays.copyOf(parameters, parameterCount);
-        return new ParameterizedMessage(messageText.toString(), params);
+        return new MementoMessage(null, params, messageText.toString(), thrown);
     }
 
     @Override

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncAppenderConfigTest_LOG4J2_2032.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncAppenderConfigTest_LOG4J2_2032.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.async;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.categories.AsyncLoggers;
+import org.apache.logging.log4j.core.CoreLoggerContexts;
+import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+
+@Category(AsyncLoggers.class)
+public class AsyncAppenderConfigTest_LOG4J2_2032 {
+
+    @BeforeClass
+    public static void beforeClass() {
+        System.setProperty("Log4jLogEventFactory", "org.apache.logging.log4j.core.impl.ReusableLogEventFactory");
+        System.setProperty("log4j2.messageFactory", "org.apache.logging.log4j.message.ReusableMessageFactory");
+        System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncAppenderConfigTest-LOG4J2-2032.xml");
+    }
+
+    @Test
+    public void doNotProcessPlaceholdersTwice() throws Exception {
+        final File file = new File("target", "AsyncAppenderConfigTest-LOG4J2-2032.log");
+        assertTrue("Deleted old file before test", !file.exists() || file.delete());
+
+        final Logger log = LogManager.getLogger("com.foo.Bar");
+        log.info("Text containing curly braces: {}", "Curly{}");
+        CoreLoggerContexts.stopLoggerContext(file); // stop async thread
+
+        final BufferedReader reader = new BufferedReader(new FileReader(file));
+        final String line1 = reader.readLine();
+        reader.close();
+        file.delete();
+        System.out.println(line1);
+        assertTrue("line1 correct", line1.contains(" Text containing curly braces: Curly{} "));
+    }
+
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/net/ssl/SslConfigurationTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/net/ssl/SslConfigurationTest.java
@@ -18,11 +18,13 @@ package org.apache.logging.log4j.core.net.ssl;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.ConnectException;
 import java.net.UnknownHostException;
 
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
+import org.apache.http.conn.ConnectTimeoutException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -104,6 +106,8 @@ public class SslConfigurationTest {
             }
         } catch (final UnknownHostException offline) {
             // this exception is thrown on Windows when offline
+        } catch (final ConnectException connectionTimeout) {
+            // this exception is thrown on Windows when host is behind a proxy that does not allow connection to external network
         }
     }
 
@@ -124,6 +128,8 @@ public class SslConfigurationTest {
             }
         } catch (final UnknownHostException offline) {
             // this exception is thrown on Windows when offline
+        } catch (final ConnectException connectionTimeout) {
+            // this exception is thrown on Windows when host is behind a proxy that does not allow connection to external network
         }
     }
 

--- a/log4j-core/src/test/resources/AsyncAppenderConfigTest-LOG4J2-2032.xml
+++ b/log4j-core/src/test/resources/AsyncAppenderConfigTest-LOG4J2-2032.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="ERROR">
+  <Appenders>
+    <File name="File" 
+          fileName="target/AsyncAppenderConfigTest-LOG4J2-2032.log"
+          bufferedIO="false" 
+          immediateFlush="true" 
+          append="false">
+      <PatternLayout>
+        <Pattern>%level{length=1} %date{MMdd-HHmm:ss,SSS} %logger{1.} %message %X [%thread]%n</Pattern>
+      </PatternLayout>
+    </File>
+    <Async name="Async">
+      <AppenderRef ref="File"/>
+    </Async>
+  </Appenders>
+  
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="Async"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LOG4J2-2032

When logging event parameter contains two consecutive opening and
closing curly braces - for example {} in the middle of parameter,
they should not be treated as a placeholder.