### PR TITLE
LOG4J2-2253: Added ReusableMessage.forEachParameter

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterConsumer.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterConsumer.java
@@ -1,0 +1,26 @@
+package org.apache.logging.log4j.message;
+
+/**
+ * An operation that accepts two input arguments and returns no result.
+ *
+ * <p>
+ * The third parameter lets callers pass in a stateful object to be modified with the key-value pairs,
+ * so the ParameterConsumer implementation itself can be stateless and potentially reusable.
+ * </p>
+ *
+ * @param <S> state data
+ * @see ReusableMessage
+ * @since 2.11
+ */
+public interface ParameterConsumer<S> {
+
+    /**
+     * Performs an operation given the specified arguments.
+     *
+     * @param parameter the parameter
+     * @param parameterIndex Index of the parameter
+     * @param state
+     */
+    void accept(Object parameter, short parameterIndex, S state);
+
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterVisitableMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterVisitableMessage.java
@@ -1,0 +1,30 @@
+package org.apache.logging.log4j.message;
+
+import org.apache.logging.log4j.util.PerformanceSensitive;
+
+/**
+ * Allows message parameters to be iterated over without any allocation
+ * or memory copies.
+ *
+ * @since 2.11
+ */
+@PerformanceSensitive("allocation")
+public interface ParameterVisitableMessage extends Message {
+
+    /**
+     * Performs the given action for each parameter until all values
+     * have been processed or the action throws an exception.
+     * <p>
+     * The second parameter lets callers pass in a stateful object to be modified with the key-value pairs,
+     * so the TriConsumer implementation itself can be stateless and potentially reusable.
+     * </p>
+     *
+     * @param action The action to be performed for each key-value pair in this collection
+     * @param state the object to be passed as the third parameter to each invocation on the
+     *          specified ParameterConsumer.
+     * @param <S> type of the third parameter
+     * @since 2.11
+     */
+    <S> void forEachParameter(ParameterConsumer<S> action, S state);
+
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.util.StringBuilders;
  * @since 2.6
  */
 @PerformanceSensitive("allocation")
-public class ReusableObjectMessage implements ReusableMessage {
+public class ReusableObjectMessage implements ReusableMessage, ParameterVisitableMessage {
     private static final long serialVersionUID = 6922476812535519960L;
 
     private transient Object obj;
@@ -110,6 +110,11 @@ public class ReusableObjectMessage implements ReusableMessage {
     @Override
     public short getParameterCount() {
         return 0;
+    }
+
+    @Override
+    public <S> void forEachParameter(ParameterConsumer<S> action, S state) {
+        action.accept(obj, (short) 0, state);
     }
 
     @Override

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.util.StringBuilders;
  * @since 2.6
  */
 @PerformanceSensitive("allocation")
-public class ReusableParameterizedMessage implements ReusableMessage {
+public class ReusableParameterizedMessage implements ReusableMessage, ParameterVisitableMessage {
 
     private static final int MIN_BUILDER_SIZE = 512;
     private static final int MAX_PARMS = 10;
@@ -102,6 +102,14 @@ public class ReusableParameterizedMessage implements ReusableMessage {
     @Override
     public short getParameterCount() {
         return (short) argCount;
+    }
+
+    @Override
+    public <S> void forEachParameter(ParameterConsumer<S> action, S state) {
+        Object[] parameters = getParams();
+        for (short i = 0; i < argCount; i++) {
+            action.accept(parameters[i], i, state);
+        }
     }
 
     @Override

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.util.PerformanceSensitive;
  * @since 2.6
  */
 @PerformanceSensitive("allocation")
-public class ReusableSimpleMessage implements ReusableMessage, CharSequence {
+public class ReusableSimpleMessage implements ReusableMessage, CharSequence, ParameterVisitableMessage {
     private static final long serialVersionUID = -9199974506498249809L;
     private static Object[] EMPTY_PARAMS = new Object[0];
     private CharSequence charSequence;
@@ -78,6 +78,10 @@ public class ReusableSimpleMessage implements ReusableMessage, CharSequence {
     @Override
     public short getParameterCount() {
         return 0;
+    }
+
+    @Override
+    public <S> void forEachParameter(ParameterConsumer<S> action, S state) {
     }
 
     @Override

--- a/log4j-api/src/test/java/org/apache/logging/log4j/message/ReusableParameterizedMessageTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/message/ReusableParameterizedMessageTest.java
@@ -19,6 +19,9 @@ package org.apache.logging.log4j.message;
 import org.apache.logging.log4j.junit.Mutable;
 import org.junit.Test;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import static org.junit.Assert.*;
 
 /**
@@ -143,5 +146,24 @@ public class ReusableParameterizedMessageTest {
         final Throwable EXCEPTION2 = new UnsupportedOperationException("#2");
         msg.set(testMsg, "msgs", EXCEPTION2);
         assertSame(EXCEPTION2, msg.getThrowable());
+    }
+
+    @Test
+    public void testParameterConsumer() {
+        final String testMsg = "Test message {}";
+        final ReusableParameterizedMessage msg = new ReusableParameterizedMessage();
+        final Throwable EXCEPTION1 = new IllegalAccessError("#1");
+        msg.set(testMsg, "msg", EXCEPTION1);
+        List<Object> expected = new LinkedList<>();
+        expected.add("msg");
+        expected.add(EXCEPTION1);
+        final List<Object> actual = new LinkedList<>();
+        msg.forEachParameter(new ParameterConsumer<Void>() {
+            @Override
+            public void accept(Object parameter, short parameterIndex, Void state) {
+                actual.add(parameter);
+            }
+        }, null);
+        assertEquals(expected, actual);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
@@ -32,11 +32,7 @@ import org.apache.logging.log4j.core.time.NanoClock;
 import org.apache.logging.log4j.core.util.*;
 import org.apache.logging.log4j.core.time.Instant;
 import org.apache.logging.log4j.core.time.MutableInstant;
-import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.logging.log4j.message.ReusableMessage;
-import org.apache.logging.log4j.message.SimpleMessage;
-import org.apache.logging.log4j.message.TimestampMessage;
+import org.apache.logging.log4j.message.*;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.StringBuilders;
 import org.apache.logging.log4j.util.StringMap;
@@ -48,7 +44,7 @@ import com.lmax.disruptor.EventFactory;
  * When the Disruptor is started, the RingBuffer is populated with event objects. These objects are then re-used during
  * the life of the RingBuffer.
  */
-public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequence {
+public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequence, ParameterVisitableMessage {
 
     /** The {@code EventFactory} for {@code RingBufferLogEvent}s. */
     public static final Factory FACTORY = new Factory();
@@ -281,6 +277,15 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
     @Override
     public short getParameterCount() {
         return parameterCount;
+    }
+
+    @Override
+    public <S> void forEachParameter(ParameterConsumer<S> action, S state) {
+        if (parameters != null) {
+            for (short i = 0; i < parameterCount; i++) {
+                action.accept(parameters[i], i, state);
+            }
+        }
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
@@ -42,7 +42,7 @@ import org.apache.logging.log4j.util.Strings;
  * Mutable implementation of the {@code LogEvent} interface.
  * @since 2.6
  */
-public class MutableLogEvent implements LogEvent, ReusableMessage {
+public class MutableLogEvent implements LogEvent, ReusableMessage, ParameterVisitableMessage {
     private static final Message EMPTY = new SimpleMessage(Strings.EMPTY);
 
     private int threadPriority;
@@ -252,6 +252,15 @@ public class MutableLogEvent implements LogEvent, ReusableMessage {
     @Override
     public Object[] getParameters() {
         return parameters == null ? null : Arrays.copyOf(parameters, parameterCount);
+    }
+
+    @Override
+    public <S> void forEachParameter(ParameterConsumer<S> action, S state) {
+        if (parameters != null) {
+            for (short i = 0; i < parameterCount; i++) {
+                action.accept(parameters[i], i, state);
+            }
+        }
     }
 
     /**

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/RingBufferLogEventTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/RingBufferLogEventTest.java
@@ -32,6 +32,7 @@ import org.apache.logging.log4j.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.time.internal.DummyNanoClock;
 import org.apache.logging.log4j.core.time.internal.FixedPreciseClock;
+import org.apache.logging.log4j.message.ParameterConsumer;
 import org.apache.logging.log4j.util.FilteredObjectInputStream;
 import org.apache.logging.log4j.util.StringMap;
 import org.apache.logging.log4j.core.impl.ThrowableProxy;
@@ -188,5 +189,16 @@ public class RingBufferLogEventTest {
         } catch (final NullPointerException e) {
             fail("the messageText field was not set");
         }
+    }
+
+    @Test
+    public void testForEachParameterNothingSet() {
+        final RingBufferLogEvent evt = new RingBufferLogEvent();
+        evt.forEachParameter(new ParameterConsumer<Void>() {
+            @Override
+            public void accept(Object parameter, short parameterIndex, Void state) {
+                fail("Should not have been called");
+            }
+        }, null);
     }
 }


### PR DESCRIPTION
This method allows us to iterate over parameters in a
ReusableMessage without array creation.