### PR TITLE
LOG4J2-2270 Strings::join([null]) should return EMPTY

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.util;
 
 import java.util.Iterator;
 import java.util.Locale;
-import java.util.Objects;
 
 /**
  * <em>Consider this class private.</em>
@@ -216,7 +215,10 @@ public final class Strings {
         }
         final Object first = iterator.next();
         if (!iterator.hasNext()) {
-            return Objects.toString(first);
+            if (first != null) {
+                return first.toString();
+            }
+            return EMPTY;
         }
 
         // two or more elements

--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/StringsTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/StringsTest.java
@@ -20,6 +20,9 @@ package org.apache.logging.log4j.util;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Iterator;
+
 public class StringsTest {
 
     /**
@@ -36,4 +39,19 @@ public class StringsTest {
         Assert.assertEquals("'Q'", Strings.quote("Q"));
     }
 
+    @Test
+    public void testjoin() {
+        Assert.assertEquals(null, Strings.join((Iterable<?>) null, '.'));
+        Assert.assertEquals(null, Strings.join((Iterator<?>) null, '.'));
+        Assert.assertEquals("", Strings.join((Arrays.asList()), '.'));
+
+        Assert.assertEquals("a", Strings.join(Arrays.asList("a"), '.'));
+        Assert.assertEquals("a.b", Strings.join(Arrays.asList("a", "b"), '.'));
+        Assert.assertEquals("a.b.c", Strings.join(Arrays.asList("a", "b", "c"), '.'));
+
+        Assert.assertEquals("", Strings.join(Arrays.asList((String)null), ':'));
+        Assert.assertEquals(":", Strings.join(Arrays.asList(null, null), ':'));
+        Assert.assertEquals("a:", Strings.join(Arrays.asList("a", null), ':'));
+        Assert.assertEquals(":b", Strings.join(Arrays.asList(null, "b"), ':'));
+    }
 }


### PR DESCRIPTION
- The javadoc of Strings::join states: 'Null objects or empty strings
within the iteration are represented by empty strings'.
But when call with an array of one element that is null, it returns
"null", where I expect EMPTY ("").
- Add unit tests on Strings::join. One would fail without the change