### PR TITLE
LOG4J2-2252 Reusable LogEvents should pass along the original format string

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
@@ -55,7 +55,7 @@ public class ReusableObjectMessage implements ReusableMessage, ParameterVisitabl
      */
     @Override
     public String getFormat() {
-        return getFormattedMessage();
+        return obj instanceof String ? (String) obj : null;
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
@@ -43,7 +43,7 @@ public class ReusableSimpleMessage implements ReusableMessage, CharSequence, Par
 
     @Override
     public String getFormat() {
-        return getFormattedMessage();
+        return charSequence instanceof String ? (String) charSequence : null;
     }
 
     @Override

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessage.java
@@ -16,10 +16,11 @@
  */
 package org.apache.logging.log4j.message;
 
+import org.apache.logging.log4j.util.StringBuilderFormattable;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import org.apache.logging.log4j.util.StringBuilderFormattable;
 
 /**
  * The simplest possible implementation of Message. It just returns the String given as the constructor argument.
@@ -75,7 +76,7 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
      */
     @Override
     public String getFormat() {
-        return getFormattedMessage();
+        return message;
     }
 
     /**

--- a/log4j-api/src/test/java/org/apache/logging/log4j/message/ReusableObjectMessageTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/message/ReusableObjectMessageTest.java
@@ -49,8 +49,8 @@ public class ReusableObjectMessageTest {
     }
 
     @Test
-    public void testGetFormat_InitiallyNullString() throws Exception {
-        assertEquals("null", new ReusableObjectMessage().getFormat());
+    public void testGetFormat_InitiallyNull() throws Exception {
+        assertNull(new ReusableObjectMessage().getFormat());
     }
 
     @Test

--- a/log4j-api/src/test/java/org/apache/logging/log4j/message/ReusableSimpleMessageTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/message/ReusableSimpleMessageTest.java
@@ -50,7 +50,7 @@ public class ReusableSimpleMessageTest {
 
     @Test
     public void testGetFormat_InitiallyStringNull() throws Exception {
-        assertEquals("null", new ReusableSimpleMessage().getFormat());
+        assertNull(new ReusableSimpleMessage().getFormat());
     }
 
     @Test

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
@@ -77,6 +77,7 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
     private String threadName;
     private String loggerName;
     private Message message;
+    private String messageFormat;
     private StringBuilder messageText;
     private Object[] parameters;
     private transient Throwable thrown;
@@ -129,6 +130,7 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
         if (msg instanceof ReusableMessage) {
             final ReusableMessage reusable = (ReusableMessage) msg;
             reusable.formatTo(getMessageTextForWriting());
+            messageFormat = reusable.getFormat();
             if (parameters != null) {
                 parameters = reusable.swapParameters(parameters);
                 parameterCount = reusable.getParameterCount();
@@ -229,7 +231,7 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
      */
     @Override
     public String getFormat() {
-        return null;
+        return messageFormat;
     }
 
     /**
@@ -405,6 +407,7 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
         this.fqcn = null;
         this.level = null;
         this.message = null;
+        this.messageFormat = null;
         this.thrown = null;
         this.thrownProxy = null;
         this.contextStack = null;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
@@ -54,6 +54,7 @@ public class MutableLogEvent implements LogEvent, ReusableMessage, ParameterVisi
     private String threadName;
     private String loggerName;
     private Message message;
+    private String messageFormat;
     private StringBuilder messageText;
     private Object[] parameters;
     private Throwable thrown;
@@ -124,6 +125,7 @@ public class MutableLogEvent implements LogEvent, ReusableMessage, ParameterVisi
         level = null;
         loggerName = null;
         message = null;
+        messageFormat = null;
         thrown = null;
         thrownProxy = null;
         source = null;
@@ -209,6 +211,7 @@ public class MutableLogEvent implements LogEvent, ReusableMessage, ParameterVisi
         if (msg instanceof ReusableMessage) {
             final ReusableMessage reusable = (ReusableMessage) msg;
             reusable.formatTo(getMessageTextForWriting());
+            this.messageFormat = msg.getFormat();
             if (parameters != null) {
                 parameters = reusable.swapParameters(parameters);
                 parameterCount = reusable.getParameterCount();
@@ -241,7 +244,7 @@ public class MutableLogEvent implements LogEvent, ReusableMessage, ParameterVisi
      */
     @Override
     public String getFormat() {
-        return null;
+        return messageFormat;
     }
 
     /**

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/MutableLogEventTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/MutableLogEventTest.java
@@ -28,7 +28,9 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.logging.log4j.message.ReusableMessageFactory;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.util.FilteredObjectInputStream;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
@@ -110,6 +112,32 @@ public class MutableLogEventTest {
         assertEquals("throwns", source.getThrown(), mutable.getThrown());
         assertEquals("proxy", source.getThrownProxy(), mutable.getThrownProxy());
         assertEquals("millis", source.getTimeMillis(), mutable.getTimeMillis());
+    }
+
+    @Test
+    public void testInitFromReusableCopiesFormatString() {
+        Message message = ReusableMessageFactory.INSTANCE.newMessage("msg in a {}", "bottle");
+        final Log4jLogEvent source = Log4jLogEvent.newBuilder() //
+                .setContextData(CONTEXT_DATA) //
+                .setContextStack(STACK) //
+                .setEndOfBatch(true) //
+                .setIncludeLocation(true) //
+                .setLevel(Level.FATAL) //
+                .setLoggerFqcn("a.b.c.d.e") //
+                .setLoggerName("my name is Logger") //
+                .setMarker(MarkerManager.getMarker("on your marks")) //
+                .setMessage(message) //
+                .setNanoTime(1234567) //
+                .setSource(new StackTraceElement("myclass", "mymethod", "myfile", 123)) //
+                .setThreadId(100).setThreadName("threadname").setThreadPriority(10) //
+                .setThrown(new RuntimeException("run")) //
+                .setTimeMillis(987654321)
+                .build();
+        final MutableLogEvent mutable = new MutableLogEvent();
+        mutable.initFrom(source);
+        assertEquals("format", "msg in a {}", mutable.getFormat());
+        assertEquals("formatted", "msg in a bottle", mutable.getFormattedMessage());
+        assertEquals("parameters", new String[] {"bottle"}, mutable.getParameters());
     }
 
     @Test


### PR DESCRIPTION
This allows custom layouts to group logged messages parameterized
values without creating new single-use messages for each event.

This slightly modifies the getFormat implementation of some
message types to avoid doing unnecessary work to load the
format string.