### PR TITLE
Fix typo in documentation

### DIFF
--- a/src/site/xdoc/manual/customconfig.xml
+++ b/src/site/xdoc/manual/customconfig.xml
@@ -210,7 +210,7 @@ builder.add( builder.newLogger( "TestLogger", Level.DEBUG )
 
 builder.add( builder.newRootLogger( Level.DEBUG )
     .add( builder.newAppenderRef( "rolling" ) ) );
-LoggerContext ctx = Configurator.intitialize(builder.build());
+LoggerContext ctx = Configurator.initialize(builder.build());
 ]]></pre>
         </subsection>
 


### PR DESCRIPTION
Hello, found while updating a legacy project from log4j1 to log4j2, and reading the docs (which are great, by the way, a life saver. Thanks!)