### PR TITLE
Update ParameterConsumer index type from short to int

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterConsumer.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterConsumer.java
@@ -21,6 +21,6 @@ public interface ParameterConsumer<S> {
      * @param parameterIndex Index of the parameter
      * @param state
      */
-    void accept(Object parameter, short parameterIndex, S state);
+    void accept(Object parameter, int parameterIndex, S state);
 
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
@@ -114,7 +114,7 @@ public class ReusableObjectMessage implements ReusableMessage, ParameterVisitabl
 
     @Override
     public <S> void forEachParameter(ParameterConsumer<S> action, S state) {
-        action.accept(obj, (short) 0, state);
+        action.accept(obj, 0, state);
     }
 
     @Override

--- a/log4j-api/src/test/java/org/apache/logging/log4j/message/ReusableParameterizedMessageTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/message/ReusableParameterizedMessageTest.java
@@ -160,7 +160,7 @@ public class ReusableParameterizedMessageTest {
         final List<Object> actual = new LinkedList<>();
         msg.forEachParameter(new ParameterConsumer<Void>() {
             @Override
-            public void accept(Object parameter, short parameterIndex, Void state) {
+            public void accept(Object parameter, int parameterIndex, Void state) {
                 actual.add(parameter);
             }
         }, null);

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/RingBufferLogEventTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/RingBufferLogEventTest.java
@@ -196,7 +196,7 @@ public class RingBufferLogEventTest {
         final RingBufferLogEvent evt = new RingBufferLogEvent();
         evt.forEachParameter(new ParameterConsumer<Void>() {
             @Override
-            public void accept(Object parameter, short parameterIndex, Void state) {
+            public void accept(Object parameter, int parameterIndex, Void state) {
                 fail("Should not have been called");
             }
         }, null);


### PR DESCRIPTION
Originally ParameterVisitable was built for ReusableMessage which
provides a "short getParameterCount()" method. Now that the
interface isn't bound to ReusableMessage it might as well use
integer.