### PR TITLE
[LOG4J2-2301] Mixed async loggers no longer forget parameter values

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
@@ -72,6 +72,8 @@ import org.apache.logging.log4j.util.Strings;
 @Plugin(name = "asyncLogger", category = Node.CATEGORY, printObject = true)
 public class AsyncLoggerConfig extends LoggerConfig {
 
+    private static final ThreadLocal<Boolean> ASYNC_ON_CURRENT_THREAD = new ThreadLocal<>();
+    private static final ThreadLocal<Boolean> ASYNC_LOGGER_ENTERED = new ThreadLocal<>();
     private final AsyncLoggerConfigDelegate delegate;
 
     protected AsyncLoggerConfig(final String name,
@@ -85,24 +87,58 @@ public class AsyncLoggerConfig extends LoggerConfig {
         delegate.setLogEventFactory(getLogEventFactory());
     }
 
-    /**
-     * Passes on the event to a separate thread that will call
-     * {@link #asyncCallAppenders(LogEvent)}.
-     */
+    private static final LogPredicate IS_ASYNC_CONFIG = new LogPredicate() {
+        @Override
+        public boolean allow(LoggerConfig config) {
+            return config instanceof AsyncLoggerConfig;
+        }
+    };
+
+    private static final LogPredicate NOT_ASYNC_CONFIG = new LogPredicate() {
+        @Override
+        public boolean allow(LoggerConfig config) {
+            return !IS_ASYNC_CONFIG.allow(config);
+        }
+    };
+
+    public void log(final LogEvent event, final LogPredicate predicate) {
+        if (ASYNC_ON_CURRENT_THREAD.get() != null) {
+            super.log(event, predicate == null ? IS_ASYNC_CONFIG : predicate);
+        } else {
+            // Detect the first time we encounter an AsyncLoggerConfig. We must log
+            // to all non-async loggers first, then pass the event to the background
+            // thread once where all async logging is executed.
+            if (ASYNC_LOGGER_ENTERED.get() == null) {
+                ASYNC_LOGGER_ENTERED.set(Boolean.TRUE);
+                try {
+                    super.log(event, predicate == null ? NOT_ASYNC_CONFIG : predicate);
+                    if (!isFiltered(event)) {
+                        // Passes on the event to a separate thread that will call
+                        // asyncCallAppenders(LogEvent).
+                        populateLazilyInitializedFields(event);
+                        if (!delegate.tryEnqueue(event, this)) {
+                            handleQueueFull(event);
+                        }
+                    }
+                } finally {
+                    ASYNC_LOGGER_ENTERED.remove();
+                }
+            } else {
+                super.log(event, predicate == null ? NOT_ASYNC_CONFIG : predicate);
+            }
+        }
+    }
+
     @Override
     protected void callAppenders(final LogEvent event) {
-        populateLazilyInitializedFields(event);
-
-        if (!delegate.tryEnqueue(event, this)) {
-            handleQueueFull(event);
-        }
+        super.callAppenders(event);
     }
 
     private void handleQueueFull(final LogEvent event) {
         if (AbstractLogger.getRecursionDepth() > 1) { // LOG4J2-1518, LOG4J2-2031
             // If queue is full AND we are in a recursive call, call appender directly to prevent deadlock
             AsyncQueueFullMessageUtil.logWarningToStatusLogger();
-            callAppendersInCurrentThread(event);
+            logToAsyncLoggerConfigsOnCurrentThread(event);
         } else {
             // otherwise, we leave it to the user preference
             final EventRoute eventRoute = delegate.getEventRoute(event.getLevel());
@@ -115,17 +151,28 @@ public class AsyncLoggerConfig extends LoggerConfig {
         event.getThreadName();
     }
 
-    void callAppendersInCurrentThread(final LogEvent event) {
-        super.callAppenders(event);
-    }
-
-    void callAppendersInBackgroundThread(final LogEvent event) {
+    void logInBackgroundThread(final LogEvent event) {
         delegate.enqueueEvent(event, this);
     }
 
-    /** Called by AsyncLoggerConfigHelper.RingBufferLog4jEventHandler. */
-    void asyncCallAppenders(final LogEvent event) {
-        super.callAppenders(event);
+    /**
+     * Called by AsyncLoggerConfigHelper.RingBufferLog4jEventHandler.
+     *
+     * This method will log the provided event to only configs of type {@link AsyncLoggerConfig} (not
+     * default {@link LoggerConfig} definitions), which will be invoked on the <b>calling thread</b>.
+     */
+    void logToAsyncLoggerConfigsOnCurrentThread(final LogEvent event) {
+        // If ASYNC_ON_CURRENT_THREAD is already set, we don't want to unset it prematurely
+        if (ASYNC_ON_CURRENT_THREAD.get() != null) {
+            log(event, IS_ASYNC_CONFIG);
+        } else {
+            ASYNC_ON_CURRENT_THREAD.set(Boolean.TRUE);
+            try {
+                log(event, IS_ASYNC_CONFIG);
+            } finally {
+                ASYNC_ON_CURRENT_THREAD.remove();
+            }
+        }
     }
 
     private String displayName() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigDisruptor.java
@@ -108,7 +108,7 @@ public class AsyncLoggerConfigDisruptor extends AbstractLifeCycle implements Asy
         public void onEvent(final Log4jEventWrapper event, final long sequence, final boolean endOfBatch)
                 throws Exception {
             event.event.setEndOfBatch(endOfBatch);
-            event.loggerConfig.asyncCallAppenders(event.event);
+            event.loggerConfig.logToAsyncLoggerConfigsOnCurrentThread(event.event);
             event.clear();
 
             notifyIntermediateProgress(sequence);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/EventRoute.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/EventRoute.java
@@ -43,7 +43,7 @@ public enum EventRoute {
 
         @Override
         public void logMessage(final AsyncLoggerConfig asyncLoggerConfig, final LogEvent event) {
-            asyncLoggerConfig.callAppendersInBackgroundThread(event);
+            asyncLoggerConfig.logInBackgroundThread(event);
         }
 
         @Override
@@ -62,7 +62,7 @@ public enum EventRoute {
 
         @Override
         public void logMessage(final AsyncLoggerConfig asyncLoggerConfig, final LogEvent event) {
-            asyncLoggerConfig.callAppendersInCurrentThread(event);
+            asyncLoggerConfig.logToAsyncLoggerConfigsOnCurrentThread(event);
         }
 
         @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.async.AsyncLoggerConfig;
 import org.apache.logging.log4j.core.async.AsyncLoggerContext;
 import org.apache.logging.log4j.core.async.AsyncLoggerContextSelector;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
@@ -402,7 +403,7 @@ public class LoggerConfig extends AbstractFilterable {
         }
         final LogEvent logEvent = logEventFactory.createEvent(loggerName, marker, fqcn, level, data, props, t);
         try {
-            log(logEvent, null);
+            log(logEvent, LoggerConfigPredicate.ALL);
         } finally {
             // LOG4J2-1583 prevent scrambled logs when logging calls are nested (logging in toString())
             ReusableLogEventFactory.release(logEvent);
@@ -415,7 +416,7 @@ public class LoggerConfig extends AbstractFilterable {
      * @param event The log event.
      */
     public void log(final LogEvent event) {
-        log(event, null);
+        log(event, LoggerConfigPredicate.ALL);
     }
 
     /**
@@ -425,7 +426,7 @@ public class LoggerConfig extends AbstractFilterable {
      * @param predicate predicate for which LoggerConfig instances to append to.
      *                  A null value is equivalent to a true predicate.
      */
-    public void log(final LogEvent event, final LogPredicate predicate) {
+    protected void log(final LogEvent event, final LoggerConfigPredicate predicate) {
         if (!isFiltered(event)) {
             processLogEvent(event, predicate);
         }
@@ -441,15 +442,15 @@ public class LoggerConfig extends AbstractFilterable {
         return reliabilityStrategy;
     }
 
-    private void processLogEvent(final LogEvent event, LogPredicate predicate) {
+    private void processLogEvent(final LogEvent event, LoggerConfigPredicate predicate) {
         event.setIncludeLocation(isIncludeLocation());
-        if (predicate == null || predicate.allow(this)) {
+        if (predicate.allow(this)) {
             callAppenders(event);
         }
         logParent(event, predicate);
     }
 
-    private void logParent(final LogEvent event, final LogPredicate predicate) {
+    private void logParent(final LogEvent event, final LoggerConfigPredicate predicate) {
         if (additive && parent != null) {
             parent.log(event, predicate);
         }
@@ -590,7 +591,26 @@ public class LoggerConfig extends AbstractFilterable {
         }
     }
 
-    protected interface LogPredicate {
-        boolean allow(LoggerConfig config);
+    protected enum LoggerConfigPredicate {
+        ALL() {
+            @Override
+            boolean allow(LoggerConfig config) {
+                return true;
+            }
+        },
+        ASYNCHRONOUS_ONLY() {
+            @Override
+            boolean allow(LoggerConfig config) {
+                return config instanceof AsyncLoggerConfig;
+            }
+        },
+        SYNCHRONOUS_ONLY() {
+            @Override
+            boolean allow(LoggerConfig config) {
+                return !ASYNCHRONOUS_ONLY.allow(config);
+            }
+        };
+
+        abstract boolean allow(LoggerConfig config);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -402,7 +402,7 @@ public class LoggerConfig extends AbstractFilterable {
         }
         final LogEvent logEvent = logEventFactory.createEvent(loggerName, marker, fqcn, level, data, props, t);
         try {
-            log(logEvent);
+            log(logEvent, null);
         } finally {
             // LOG4J2-1583 prevent scrambled logs when logging calls are nested (logging in toString())
             ReusableLogEventFactory.release(logEvent);
@@ -415,8 +415,19 @@ public class LoggerConfig extends AbstractFilterable {
      * @param event The log event.
      */
     public void log(final LogEvent event) {
+        log(event, null);
+    }
+
+    /**
+     * Logs an event.
+     *
+     * @param event The log event.
+     * @param predicate predicate for which LoggerConfig instances to append to.
+     *                  A null value is equivalent to a true predicate.
+     */
+    public void log(final LogEvent event, final LogPredicate predicate) {
         if (!isFiltered(event)) {
-            processLogEvent(event);
+            processLogEvent(event, predicate);
         }
     }
 
@@ -430,15 +441,17 @@ public class LoggerConfig extends AbstractFilterable {
         return reliabilityStrategy;
     }
 
-    private void processLogEvent(final LogEvent event) {
+    private void processLogEvent(final LogEvent event, LogPredicate predicate) {
         event.setIncludeLocation(isIncludeLocation());
-        callAppenders(event);
-        logParent(event);
+        if (predicate == null || predicate.allow(this)) {
+            callAppenders(event);
+        }
+        logParent(event, predicate);
     }
 
-    private void logParent(final LogEvent event) {
+    private void logParent(final LogEvent event, final LogPredicate predicate) {
         if (additive && parent != null) {
-            parent.log(event);
+            parent.log(event, predicate);
         }
     }
 
@@ -577,4 +590,7 @@ public class LoggerConfig extends AbstractFilterable {
         }
     }
 
+    protected interface LogPredicate {
+        boolean allow(LoggerConfig config);
+    }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest4.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest4.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.core.CoreLoggerContexts;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -32,6 +31,7 @@ import java.io.File;
 import java.io.FileReader;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -50,7 +50,6 @@ public class AsyncLoggerConfigTest4 {
     }
 
     @Test
-    @Ignore("Ignored until LOG4J2-2301 is resolved")
     public void testParameters() throws Exception {
         final File file = new File("target", "AsyncLoggerConfigTest4.log");
         assertTrue("Deleted old file before test", !file.exists() || file.delete());
@@ -62,10 +61,12 @@ public class AsyncLoggerConfigTest4 {
         final BufferedReader reader = new BufferedReader(new FileReader(file));
         final String line1 = reader.readLine();
         final String line2 = reader.readLine();
+        final String line3 = reader.readLine();
         reader.close();
         file.delete();
 
         assertThat(line1, containsString("Additive logging: {} for the price of {}! [2,1] Additive logging: 2 for the price of 1!"));
         assertThat(line2, containsString("Additive logging: {} for the price of {}! [2,1] Additive logging: 2 for the price of 1!"));
+        assertNull("Expected only two lines to be logged", line3);
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest4.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest4.java
@@ -62,11 +62,15 @@ public class AsyncLoggerConfigTest4 {
         final String line1 = reader.readLine();
         final String line2 = reader.readLine();
         final String line3 = reader.readLine();
+        final String line4 = reader.readLine();
+        final String line5 = reader.readLine();
         reader.close();
         file.delete();
 
         assertThat(line1, containsString("Additive logging: {} for the price of {}! [2,1] Additive logging: 2 for the price of 1!"));
         assertThat(line2, containsString("Additive logging: {} for the price of {}! [2,1] Additive logging: 2 for the price of 1!"));
-        assertNull("Expected only two lines to be logged", line3);
+        assertThat(line3, containsString("Additive logging: {} for the price of {}! [2,1] Additive logging: 2 for the price of 1!"));
+        assertThat(line4, containsString("Additive logging: {} for the price of {}! [2,1] Additive logging: 2 for the price of 1!"));
+        assertNull("Expected only two lines to be logged", line5);
     }
 }

--- a/log4j-core/src/test/resources/AsyncLoggerConfigTest4.xml
+++ b/log4j-core/src/test/resources/AsyncLoggerConfigTest4.xml
@@ -12,9 +12,15 @@
     </RandomAccessFile>
   </Appenders>
   <Loggers>
-    <AsyncLogger name="com.foo.Bar" level="trace">
+    <Logger name="com.foo.Bar" level="trace">
+      <AppenderRef ref="File"/>
+    </Logger>
+    <AsyncLogger name="com.foo" level="trace">
       <AppenderRef ref="File"/>
     </AsyncLogger>
+    <Logger name="com" level="trace">
+      <AppenderRef ref="File"/>
+    </Logger>
     <AsyncRoot level="info">
       <AppenderRef ref="File"/>
     </AsyncRoot>


### PR DESCRIPTION
Previously each AsyncLoggerConfig would individually enqueue an
event on the async delegate disruptor. In practice this caused
us to trade reusable message parameters away at the first
AsyncLoggerConfig in our path, causing the rest to get an array
of nulls.

Now we begin by traversing the configuration and logging to all
synchronous loggers first, then enqueue the event to the highest
level asynchronous logger allowing the asynchronous loggers to be
traversed on the background thread.