### PR TITLE
LOG4J2-2318: AsyncQueueFullMessageUtil logs to StatusLogger

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
@@ -50,7 +50,6 @@ import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.util.Log4jThread;
-import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.spi.AbstractLogger;
 
 /**
@@ -163,8 +162,8 @@ public final class AsyncAppender extends AbstractAppender {
             if (blocking) {
                 if (AbstractLogger.getRecursionDepth() > 1) { // LOG4J2-1518, LOG4J2-2031
                     // If queue is full AND we are in a recursive call, call appender directly to prevent deadlock
-                    final Message message = AsyncQueueFullMessageUtil.transform(logEvent.getMessage());
-                    logMessageInCurrentThread(new Log4jLogEvent.Builder(logEvent).setMessage(message).build());
+                    AsyncQueueFullMessageUtil.logWarningToStatusLogger();
+                    logMessageInCurrentThread(logEvent);
                 } else {
                     // delegate to the event router (which may discard, enqueue and block, or log in current thread)
                     final EventRoute route = asyncQueueFullPolicy.getRoute(thread.getId(), memento.getLevel());

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLogger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLogger.java
@@ -170,8 +170,8 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
     private void handleRingBufferFull(final RingBufferLogEventTranslator translator) {
         if (AbstractLogger.getRecursionDepth() > 1) { // LOG4J2-1518, LOG4J2-2031
             // If queue is full AND we are in a recursive call, call appender directly to prevent deadlock
-            final Message message = AsyncQueueFullMessageUtil.transform(translator.message);
-            logMessageInCurrentThread(translator.fqcn, translator.level, translator.marker, message,
+            AsyncQueueFullMessageUtil.logWarningToStatusLogger();
+            logMessageInCurrentThread(translator.fqcn, translator.level, translator.marker, translator.message,
                     translator.thrown);
             return;
         }
@@ -321,8 +321,8 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
                                       final Throwable thrown) {
         if (AbstractLogger.getRecursionDepth() > 1) { // LOG4J2-1518, LOG4J2-2031
             // If queue is full AND we are in a recursive call, call appender directly to prevent deadlock
-            final Message message = AsyncQueueFullMessageUtil.transform(msg);
-            logMessageInCurrentThread(fqcn, level, marker, message, thrown);
+            AsyncQueueFullMessageUtil.logWarningToStatusLogger();
+            logMessageInCurrentThread(fqcn, level, marker, msg, thrown);
             return;
         }
         final EventRoute eventRoute = loggerDisruptor.getEventRoute(level);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
@@ -102,8 +102,8 @@ public class AsyncLoggerConfig extends LoggerConfig {
     private void handleQueueFull(final LogEvent event) {
         if (AbstractLogger.getRecursionDepth() > 1) { // LOG4J2-1518, LOG4J2-2031
             // If queue is full AND we are in a recursive call, call appender directly to prevent deadlock
-            final Message message = AsyncQueueFullMessageUtil.transform(event.getMessage());
-            callAppendersInCurrentThread(new Log4jLogEvent.Builder(event).setMessage(message).build());
+            AsyncQueueFullMessageUtil.logWarningToStatusLogger();
+            callAppendersInCurrentThread(event);
         } else {
             // otherwise, we leave it to the user preference
             final EventRoute eventRoute = delegate.getEventRoute(event.getLevel());

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncQueueFullMessageUtil.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncQueueFullMessageUtil.java
@@ -16,30 +16,25 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.logging.log4j.status.StatusLogger;
 
 /**
  * <b>Consider this class private.</b>
  * <p>
- * Transforms the specified user message to append an internal Log4j2 message explaining why this message appears out
- * of order in the appender.
+ * Logs a warning to the {@link StatusLogger} when events are logged out of order to avoid deadlocks.
  * </p>
  */
-public class AsyncQueueFullMessageUtil {
+public final class AsyncQueueFullMessageUtil {
+    private AsyncQueueFullMessageUtil() {
+        // Utility Class
+    }
+
     /**
-     * Returns a new {@code Message} based on the original message that appends an internal Log4j2 message
-     * explaining why this message appears out of order in the appender.
-     * <p>
-     * Any parameter objects present in the original message are not included in the returned message.
-     * </p>
-     * @param message the message to replace
-     * @return a new {@code Message} object
+     * Logs a warning to the {@link StatusLogger} explaining why a message appears out of order in the appender.
      */
-    public static Message transform(Message message) {
-        SimpleMessage result = new SimpleMessage(message.getFormattedMessage() +
-                " (Log4j2 logged this message out of order to prevent deadlock caused by domain " +
-                "objects logging from their toString method when the async queue is full - LOG4J2-2031)");
-        return result;
+    public static void logWarningToStatusLogger() {
+        StatusLogger.getLogger()
+                .warn("LOG4J2-2031: Log4j2 logged an event out of order to prevent deadlock caused by domain " +
+                        "objects logging from their toString method when the async queue is full");
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest.java
@@ -96,8 +96,8 @@ public class QueueFullAsyncLoggerLoggingFromToStringTest extends QueueFullAbstra
 
         final Stack<String> actual = transform(blockingAppender.logEvents);
         assertEquals("Jumped the queue: test(2)+domain1(65)+domain2(61)=128: queue full",
-                "Logging in toString() #127 (Log4j2 logged this message out of order to prevent deadlock caused by domain objects logging from their toString method when the async queue is full - LOG4J2-2031)", actual.pop());
-        assertEquals("Logging in toString() #128 (Log4j2 logged this message out of order to prevent deadlock caused by domain objects logging from their toString method when the async queue is full - LOG4J2-2031)", actual.pop());
+                "Logging in toString() #127", actual.pop());
+        assertEquals("Logging in toString() #128", actual.pop());
         assertEquals("logging naughty object #0 Who's bad?!", actual.pop());
 
         for (int i = 0; i < 127; i++) {

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -139,6 +139,9 @@
       <action issue="LOG4J2-2317" dev="ckozak" type="fix">
         MutableLogEvent.getNonNullImmutableMessage and Log4jLogEvent.makeMessageImmutable retain format and parameters.
       </action>
+      <action issue="LOG4J2-2318" dev="ckozak" type="fix">
+        Messages are no longer mutated when the asynchronous queue is full. A warning is logged to the status logger instead.
+      </action>
     </release>
     <release version="2.11.1" date="2018-MM-DD" description="GA Release 2.11.1">
       <action issue="LOG4J2-2268" dev="rgoers" type="fix" due-to="Tilman Hausherr">


### PR DESCRIPTION
We no longer mutate messages when logging them out of order.