### PR TITLE
[LOG4J2-2322] Custom async ContextSelectors disable location by default

### DIFF
--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerCustomSelectorLocationTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerCustomSelectorLocationTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.async;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.categories.AsyncLoggers;
+import org.apache.logging.log4j.core.CoreLoggerContexts;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.apache.logging.log4j.core.selector.ContextSelector;
+import org.apache.logging.log4j.core.util.Constants;
+import org.apache.logging.log4j.util.Strings;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Category(AsyncLoggers.class)
+public class AsyncLoggerCustomSelectorLocationTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        final File file = new File("target", "AsyncLoggerCustomSelectorLocationTest.log");
+        file.delete();
+        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR,
+                CustomAsyncContextSelector.class.getName());
+        System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
+                "AsyncLoggerCustomSelectorLocationTest.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+    }
+
+    @Test
+    public void testCustomAsyncSelectorLocation() throws Exception {
+        final File file = new File("target", "AsyncLoggerCustomSelectorLocationTest.log");
+        final Logger log = LogManager.getLogger("com.foo.Bar");
+        final Logger logIncludingLocation = LogManager.getLogger("com.include.location.Bar");
+        final String msg = "Async logger msg with location";
+        log.info(msg);
+        logIncludingLocation.info(msg);
+        CoreLoggerContexts.stopLoggerContext(false, file); // stop async thread
+
+        final BufferedReader reader = new BufferedReader(new FileReader(file));
+        final String firstLine = reader.readLine();
+        final String secondLine = reader.readLine();
+        final String thirdLine = reader.readLine();
+        reader.close();
+        file.delete();
+        // By default we expect location to be disabled
+        assertThat(firstLine, containsString(msg));
+        assertThat(firstLine, not(containsString("testCustomAsyncSelectorLocation")));
+        // Configuration allows us to retain location
+        assertThat(secondLine, containsString(msg));
+        assertThat(secondLine, containsString("testCustomAsyncSelectorLocation"));
+        assertThat(thirdLine, nullValue());
+    }
+
+    public static final class CustomAsyncContextSelector implements ContextSelector {
+        private static final LoggerContext CONTEXT = new AsyncLoggerContext("AsyncDefault");
+        @Override
+        public LoggerContext getContext(String fqcn, ClassLoader loader, boolean currentContext) {
+            return CONTEXT;
+        }
+
+        @Override
+        public LoggerContext getContext(String fqcn, ClassLoader loader, boolean currentContext, URI configLocation) {
+            return CONTEXT;
+        }
+
+        @Override
+        public List<LoggerContext> getLoggerContexts() {
+            return Collections.singletonList(CONTEXT);
+        }
+
+        @Override
+        public void removeContext(LoggerContext context) {
+            // does not remove anything
+        }
+    }
+}

--- a/log4j-core/src/test/resources/AsyncLoggerCustomSelectorLocationTest.xml
+++ b/log4j-core/src/test/resources/AsyncLoggerCustomSelectorLocationTest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="OFF">
+  <Appenders>
+    <RandomAccessFile name="RandomAccessFile" fileName="target/AsyncLoggerCustomSelectorLocationTest.log"
+                      immediateFlush="false" append="false">
+      <PatternLayout>
+        <Pattern>%d %p %c{1.} [%t] %X{aKey} %location %m %ex%n</Pattern>
+      </PatternLayout>
+    </RandomAccessFile>
+  </Appenders>
+  <Loggers>
+    <Logger name="com.include.location" includeLocation="true"/>
+    <Root level="info">
+      <AppenderRef ref="RandomAccessFile"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -151,6 +151,10 @@
       <action issue="LOG4J2-2321" dev="ckozak" type="fix">
         AsyncLogger uses the correct level when unspecified. This provides parity between AsyncLogger and Logger.
       </action>
+      <action issue="LOG4J2-2322" dev="ckozak" type="fix">
+        Custom ContextSelector implementations which select an AsyncLoggerContext disable LoggerConfig.includeLocation
+        by default for parity with AsyncLoggerContextSelector.
+      </action>
     </release>
     <release version="2.11.1" date="2018-MM-DD" description="GA Release 2.11.1">
       <action issue="LOG4J2-2268" dev="rgoers" type="fix" due-to="Tilman Hausherr">


### PR DESCRIPTION
AsyncLoggerContextSelector disables "includeLocation" on loggers
unless specified. Custom ContextSelector implementations will
trigger this logic as well.