### PR TITLE
Add two new LuceneAppender which writes logging events to a lucene index library.

### DIFF
--- a/log4j-lucene5/pom.xml
+++ b/log4j-lucene5/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.apache.logging.log4j</groupId>
+		<artifactId>log4j</artifactId>
+		<version>3.0.0-SNAPSHOT</version>
+	</parent>
+	<groupId>org.apache.logging.log4j</groupId>
+	<artifactId>log4j-lucene5</artifactId>
+	<version>3.0.0-SNAPSHOT</version>
+	<name>log4j-lucene5</name>
+	<url>http://maven.apache.org</url>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-analyzers-common</artifactId>
+			<version>${lucene5.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<type>test-jar</type>
+		</dependency>
+	</dependencies>
+</project>

--- a/log4j-lucene5/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene5Analyzer.java
+++ b/log4j-lucene5/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene5Analyzer.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.lucene.appender;
+
+import org.apache.lucene.analysis.Analyzer;
+
+/**
+ * "Tokenizes" the entire stream as a single token, but case insensitive.
+ */
+public class Lucene5Analyzer extends Analyzer {
+	
+	public Lucene5Analyzer() {
+	}
+
+	@Override
+	protected TokenStreamComponents createComponents(final String fieldName) {
+		return new TokenStreamComponents(new Lucene5Tokenizer());
+	}
+}

--- a/log4j-lucene5/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene5Appender.java
+++ b/log4j-lucene5/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene5Appender.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.lucene.appender;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Paths;
+import java.util.Calendar;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.appender.AppenderLoggingException;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.Scheduled;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+import org.apache.logging.log4j.core.util.CronExpression;
+import org.apache.logging.log4j.util.Strings;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.NumericRangeQuery;
+import org.apache.lucene.store.FSDirectory;
+
+/**
+ * This Appender writes logging events to a lucene index library. It takes a list of
+ * {@link IndexField} with which determines which fields are written to the index library.
+ * <Lucene name="lucene" ignoreExceptions="true" target="/target/lucene/index">
+ *    <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/>
+ *    
+ *	  <IndexField name="time" pattern="%d{UNIX_MILLIS}" type="Long"/>
+ *	  <IndexField name="level" pattern="%-5level" />
+ *	  <IndexField name="content" pattern="%d{HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/>
+ * </Lucene>
+ */
+@Plugin(name = "Lucene", category = Node.CATEGORY, elementType = Appender.ELEMENT_TYPE, printObject = true)
+@Scheduled
+public class Lucene5Appender extends AbstractAppender {
+	/**
+	 * index directory
+	 */
+	private final String target;
+	/**
+	 * Index expiration time (seconds)
+	 */
+	private final Integer expiryTime;
+	/**
+	 * IndexField array.
+	 */
+	private final Lucene5IndexField[] indexFields;	
+	
+	/**
+	 * IndexWriter corresponding to each index directory.
+	 */
+	private static final ConcurrentHashMap<String, IndexWriter> writerMap = new ConcurrentHashMap<String, IndexWriter>();
+	
+	private final Configuration configuration;
+	
+	protected Lucene5Appender(String name, boolean ignoreExceptions, Filter filter,
+			Layout<? extends Serializable> layout, String target, Integer expiryTime, Lucene5IndexField[] indexFields,final Configuration configuration) {
+		super(name, filter, layout, ignoreExceptions);
+		this.target = target;
+		this.expiryTime = expiryTime;
+		this.indexFields = indexFields;
+		this.configuration = configuration;
+		initIndexWriter();
+		initialize();
+	}
+	
+	@Override
+	public void initialize() {
+		try {
+			registerCommitTimer();
+			if (this.expiryTime != null){
+				registerClearTimer();
+			}
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+		super.initialize();
+	}
+
+	
+	/**
+	 * IndexWriter initialization.
+	 */
+	private IndexWriter initIndexWriter() {
+		if (null == writerMap.get(target)) {
+			try {
+				FSDirectory fsDir = FSDirectory.open(Paths.get(this.target));
+				IndexWriterConfig writerConfig = new IndexWriterConfig(new Lucene5Analyzer());
+				writerMap.putIfAbsent(target, new IndexWriter(fsDir, writerConfig));
+			} catch (IOException e) {
+				LOGGER.error("IndexWriter initialization failed!" + e.getMessage(), e);
+			}
+		}
+		return writerMap.get(target);
+	}
+
+	/**
+	 * Register IndexWriter commit timertask.
+	 */
+	private void registerCommitTimer() throws Exception {		
+		configuration.getScheduler().scheduleWithCron(new CronExpression("0 1/1 * * * ? "), new Runnable() {
+			@Override
+			public void run() {
+				IndexWriter indexWriter = initIndexWriter();
+				if (null != indexWriter && indexWriter.numRamDocs() > 0) {
+					try {
+						indexWriter.commit();
+					} catch (IOException e) {
+						LOGGER.error("IndexWriter commit failed!" + e.getMessage(), e);
+					}
+				}
+			}
+		});
+	}
+	
+	/**
+	 * Register IndexWriter clean timertask.
+	 * Delete the index before {@link Lucene5Appender#expiryTime} second every day at 0.
+	 * 
+	 * @see Lucene5Appender#expiryTime
+	 */
+	private void registerClearTimer() throws Exception {
+		Calendar calendar = Calendar.getInstance();
+		long curMillis = calendar.getTimeInMillis();
+		calendar.add(Calendar.DAY_OF_MONTH, 1);
+		calendar.set(Calendar.HOUR_OF_DAY, 0);
+		calendar.set(Calendar.MINUTE, 0);
+		calendar.set(Calendar.SECOND, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
+		long difMinutes = (calendar.getTimeInMillis() - curMillis) / (1000 * 60);		
+		configuration.getScheduler().scheduleAtFixedRate(new Runnable() {
+			@Override
+			public void run() {
+				LOGGER.info("delete index start!",target,expiryTime);
+				IndexWriter indexWriter = initIndexWriter();
+				if (null != indexWriter) {
+					Long start = 0L;
+					Long end = System.currentTimeMillis() - expiryTime * 1000;
+					NumericRangeQuery<Long> rangeQuery = NumericRangeQuery.newLongRange("timestamp", start, end, true, true);
+					try {
+						indexWriter.deleteDocuments(rangeQuery);
+						indexWriter.commit();
+						LOGGER.info("delete index end! ",target,expiryTime);
+					}catch (IOException e) {
+						LOGGER.error("delete index failed! "+e.getMessage(),e);
+					}
+				}
+			}
+		}, difMinutes, 1440, TimeUnit.MINUTES);
+	}
+
+	/**
+	 * create lucene index.
+	 * 
+	 * @param event
+	 */
+	@Override
+	public void append(LogEvent event) {
+		if (null != indexFields && indexFields.length > 0) {
+			IndexWriter indexWriter = initIndexWriter();
+			if(null != indexWriter){
+				Document doc = new Document();
+				doc.add(new LongField("timestamp", event.getTimeMillis(), Field.Store.YES));
+				try {
+					for (Lucene5IndexField field : indexFields) {
+						String value = field.getLayout().toSerializable(event);
+						if (Strings.isEmpty(value) || value.matches("[$]\\{.+\\}")) {
+							return;
+						}
+						value = value.trim();
+						String type = field.getType();
+						if (Strings.isNotEmpty(type)) {
+							switch(type) {
+							case "Long":
+								doc.add(new LongField(field.getName(), Long.valueOf(value), Field.Store.YES));
+								break;
+							case "String":
+								doc.add(new StringField(field.getName(), value, Field.Store.YES));
+								break;
+							case "Text":
+								doc.add(new TextField(field.getName(), value, Field.Store.YES));
+								break;
+							default:
+								throw new UnsupportedOperationException(type + " type currently not supported.");
+							}
+						} else {
+							doc.add(new TextField(field.getName(), value, Field.Store.YES));
+						}
+					}
+					indexWriter.addDocument(doc);
+				} catch (Exception e) {
+					LOGGER.error(e.getMessage(), e);
+					if (!ignoreExceptions()) {
+						throw new AppenderLoggingException(e);
+					}
+				}
+			}
+		}
+	}
+	
+	@PluginBuilderFactory
+    public static <B extends Builder<B>> B newBuilder() {
+        return new Builder<B>().asBuilder();
+    }
+
+    public static class Builder<B extends Builder<B>> extends AbstractAppender.Builder<B>
+        implements org.apache.logging.log4j.core.util.Builder<Lucene5Appender> {
+
+        @PluginElement("IndexField")
+        @Required(message = "No IndexField provided")
+        private Lucene5IndexField[] indexField;        
+
+        @PluginBuilderAttribute        
+        private Integer expiryTime;
+
+        @PluginBuilderAttribute
+        @Required(message = "No target provided")
+        private String target;
+        
+        @PluginConfiguration
+        private Configuration configuration;
+        
+        public B withTarget(final String target){
+        	this.target = target;
+        	return this.asBuilder();
+        }
+        
+        public B withExpiryTime(final Integer expiryTime){
+        	this.expiryTime = expiryTime;
+        	return this.asBuilder();
+        }
+        
+        public B withIndexField(final Lucene5IndexField... indexField){
+        	this.indexField = indexField;
+        	return this.asBuilder();
+        }        
+        
+        public B withConfiguration(final Configuration config) {
+            this.configuration = config;
+            return asBuilder();
+        }
+
+        @Override
+        public Lucene5Appender build() {
+            return new Lucene5Appender(getName(), isIgnoreExceptions(),getFilter(), this.getLayout(),this.target,this.expiryTime,this.indexField,this.configuration);
+        }        
+    }	
+
+	@Override
+	public final void start() {
+		if (null == writerMap.get(target)) {
+			LOGGER.error("No IndexWriter set for the appender named [{}].", this.getName());
+		}
+		super.start();
+	}
+
+	@Override
+	public boolean stop(final long timeout, final TimeUnit timeUnit) {
+		setStopping();
+		boolean stopped = super.stop(timeout, timeUnit, false);
+		IndexWriter indexWriter = writerMap.get(target);
+		if (null != indexWriter) {
+			try {
+				indexWriter.commit();
+				indexWriter.close();
+				writerMap.remove(target);
+			} catch (IOException e) {
+				LOGGER.error(e.getMessage(), e);
+			}
+		}
+		setStopped();
+		return stopped;
+	}
+}

--- a/log4j-lucene5/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene5IndexField.java
+++ b/log4j-lucene5/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene5IndexField.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.lucene.appender;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+import org.apache.logging.log4j.core.filter.AbstractFilterable;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.status.StatusLogger;
+
+/**
+ * {@link Lucene5Appender}'s configuration element that logs the log event attributes to the Field in the Lucene document.
+ */
+@Plugin(name="IndexField", category=Node.CATEGORY, printObject=true)
+public final class Lucene5IndexField {
+    private static final Logger LOGGER = StatusLogger.getLogger();
+
+    private final String name;
+    private final PatternLayout layout;
+    private final String type;
+
+    private Lucene5IndexField(final String name, final PatternLayout layout,final String type) {
+        this.name = name;
+        this.layout = layout;
+        this.type = type;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public PatternLayout getLayout() {
+        return this.layout;
+    }
+
+
+	public String getType() {
+		return type;
+	}
+
+	@Override
+    public String toString() {
+        return "{name=" + this.name + ", layout=" + this.layout + " }";
+    }    
+    
+    @PluginBuilderFactory
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder<B extends Builder<B>> extends AbstractFilterable.Builder<B>
+    implements org.apache.logging.log4j.core.util.Builder<Lucene5IndexField>{
+    	
+    	@PluginConfiguration
+    	private Configuration configuration;
+	
+    	@PluginBuilderAttribute
+    	@Required(message = "No name provided")
+        private String name;
+
+        @PluginBuilderAttribute
+        @Required(message = "No pattern provided")
+        private String pattern;
+        
+        @PluginBuilderAttribute        
+        private String type;
+        
+        public B withName(final String name){
+        	this.name = name;
+        	return this.asBuilder();
+        }
+        
+        public B withPattern(final String pattern){
+        	this.pattern = pattern;
+        	return this.asBuilder();
+        }
+        
+        public B withType(final String type){
+        	this.type = type;
+        	return this.asBuilder();
+        }
+
+		@Override
+		public Lucene5IndexField build() {
+			final PatternLayout layout =
+                    PatternLayout.newBuilder()
+                        .withPattern(pattern)
+                        .withConfiguration(configuration)   
+                        .withAlwaysWriteExceptions(false)
+                        .build();
+			return new Lucene5IndexField(name,layout,type);
+		}
+    }
+}

--- a/log4j-lucene5/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene5Tokenizer.java
+++ b/log4j-lucene5/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene5Tokenizer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.lucene.appender;
+
+import org.apache.lucene.analysis.util.CharTokenizer;
+
+/**
+ * Emits the entire input as a single token.
+ */
+public class Lucene5Tokenizer extends CharTokenizer {
+	
+	public Lucene5Tokenizer() {
+	}
+
+	@Override
+	protected boolean isTokenChar(int c) {
+		return true;
+	}
+
+	@Override
+	protected int normalize(int c) {
+		return Character.toLowerCase(c);
+	}
+}

--- a/log4j-lucene5/src/main/java/org/apache/logging/log4j/lucene/appender/package-info.java
+++ b/log4j-lucene5/src/main/java/org/apache/logging/log4j/lucene/appender/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.lucene.appender;

--- a/log4j-lucene5/src/test/java/org/apache/logging/log4j/lucene/appender/Lucene5AppenderTest.java
+++ b/log4j-lucene5/src/test/java/org/apache/logging/log4j/lucene/appender/Lucene5AppenderTest.java
@@ -1,0 +1,116 @@
+package org.apache.logging.log4j.lucene.appender;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.junit.CleanFolders;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.FSDirectory;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class Lucene5AppenderTest {
+	private static final String CONFIGURATION_FILE = "log4j2-lucene.xml";
+	private static final String TARGET_FOLDER = "target/lucene";
+	private static final String FIELD_1 = "field1";
+	private static final String FIELD_2 = "field2";
+	private static final String LOGGER_NAME = "TestLogger";
+	private static final String LOG_MESSAGE = "Hello world!";
+	private static final String EXEPECTED_REGEX = "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3} \\[[^\\]]*\\] INFO "
+			+ LOGGER_NAME + " - " + LOG_MESSAGE;
+	private static final Path PATH = Paths.get(TARGET_FOLDER);
+	private static final int THREAD_COUNT = 50;
+
+	@Rule
+	public LoggerContextRule ctx = new LoggerContextRule(CONFIGURATION_FILE);
+
+	@Rule
+	public CleanFolders folders = new CleanFolders(PATH);
+
+	@Test
+	public void testSimple() throws Exception {
+		write();
+		verify(1);
+	}
+
+	@Test
+	public void testMultipleThreads() throws Exception {
+		final ExecutorService threadPool = Executors.newFixedThreadPool(THREAD_COUNT);
+		final LuceneAppenderRunner runner = new LuceneAppenderRunner();
+		for (int i = 0; i < THREAD_COUNT; ++i) {
+			threadPool.execute(runner);
+		}
+
+		// Waiting for lucene records to complete and submit
+		Thread.sleep(3000);
+
+		verify(THREAD_COUNT);
+	}
+
+	private final void write() throws Exception {
+		final Lucene5Appender appender = (Lucene5Appender) ctx.getRequiredAppender("LuceneAppender");
+		try {
+			appender.start();
+			assertTrue("Appender did not start", appender.isStarted());
+			final Log4jLogEvent event = Log4jLogEvent.newBuilder().setLoggerName(LOGGER_NAME)
+					.setLoggerFqcn(Lucene5AppenderTest.class.getName()).setLevel(Level.INFO)
+					.setMessage(new SimpleMessage(LOG_MESSAGE)).build();
+			appender.append(event);
+		} finally {
+			appender.stop();
+		}
+		assertFalse("Appender did not stop", appender.isStarted());
+	}
+
+	private final synchronized void verify(final int exepectedTotalHits) throws Exception {
+		final FSDirectory fsDir = FSDirectory.open(PATH);
+		final IndexReader reader = DirectoryReader.open(fsDir);
+		try {
+			final IndexSearcher searcher = new IndexSearcher(reader);
+			final TopDocs all = searcher.search(new MatchAllDocsQuery(), Integer.MAX_VALUE);
+			Assert.assertEquals(all.totalHits, exepectedTotalHits);
+			for (ScoreDoc scoreDoc : all.scoreDocs) {
+				final Document doc = searcher.doc(scoreDoc.doc);
+				Assert.assertEquals(doc.getFields().size(), 3);
+				final String field1 = doc.get(FIELD_1);
+				Assert.assertTrue("Unexpected field1: " + field1, Level.INFO.toString().equals(field1));
+				final String field2 = doc.get(FIELD_2);
+				final Pattern pattern = Pattern.compile(EXEPECTED_REGEX);
+				final Matcher matcher = pattern.matcher(field2);
+				Assert.assertTrue("Unexpected field2: " + field2, matcher.matches());
+			}
+		} finally {
+			reader.close();
+			fsDir.close();
+		}
+	}
+
+	private class LuceneAppenderRunner implements Runnable {
+		@Override
+		public void run() {
+			try {
+				write();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+}

--- a/log4j-lucene5/src/test/resources/log4j2-lucene.xml
+++ b/log4j-lucene5/src/test/resources/log4j2-lucene.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration name="LuceneAppenderTest" packages = "org.apache.logging.log4j.lucene.appender">
+  <Appenders>
+    <Lucene name="LuceneAppender" target = "target/lucene">
+    	<IndexField name = "field1" pattern = "%-5level" type="Text"/>
+    	<IndexField name = "field2" pattern = "%d [%t] %p %c - %m%n" />
+    </Lucene>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="LuceneAppender"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/log4j-lucene7/pom.xml
+++ b/log4j-lucene7/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.apache.logging.log4j</groupId>
+		<artifactId>log4j</artifactId>
+		<version>3.0.0-SNAPSHOT</version>
+	</parent>
+	<groupId>org.apache.logging.log4j</groupId>
+	<artifactId>log4j-lucene7</artifactId>
+	<version>3.0.0-SNAPSHOT</version>
+	<name>log4j-lucene7</name>
+	<url>http://maven.apache.org</url>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-analyzers-common</artifactId>
+			<version>${lucene7.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<type>test-jar</type>
+		</dependency>
+	</dependencies>
+</project>

--- a/log4j-lucene7/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene7Analyzer.java
+++ b/log4j-lucene7/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene7Analyzer.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.lucene.appender;
+
+import org.apache.lucene.analysis.Analyzer;
+
+/**
+ * "Tokenizes" the entire stream as a single token, but case insensitive.
+ */
+public class Lucene7Analyzer extends Analyzer {
+	
+	public Lucene7Analyzer() {
+	}
+
+	@Override
+	protected TokenStreamComponents createComponents(final String fieldName) {
+		return new TokenStreamComponents(new Lucene7Tokenizer());
+	}
+}

--- a/log4j-lucene7/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene7Appender.java
+++ b/log4j-lucene7/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene7Appender.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.lucene.appender;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Paths;
+import java.util.Calendar;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.appender.AppenderLoggingException;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.Scheduled;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+import org.apache.logging.log4j.core.util.CronExpression;
+import org.apache.logging.log4j.util.Strings;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.LongPoint;
+import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.store.FSDirectory;
+
+/**
+ * This Appender writes logging events to a lucene index library. It takes a list of
+ * {@link IndexField} with which determines which fields are written to the index library.
+ * <Lucene name="lucene" ignoreExceptions="true" target="/target/lucene/index">
+ *    <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/>
+ *    
+ *	  <IndexField name="time" pattern="%d{UNIX_MILLIS}" type="Long"/>
+ *	  <IndexField name="level" pattern="%-5level" />
+ *	  <IndexField name="content" pattern="%d{HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/>
+ * </Lucene>
+ */
+@Plugin(name = "Lucene", category = Node.CATEGORY, elementType = Appender.ELEMENT_TYPE, printObject = true)
+@Scheduled
+public class Lucene7Appender extends AbstractAppender {
+	/**
+	 * index directory
+	 */
+	private final String target;
+	/**
+	 * Index expiration time (seconds)
+	 */
+	private final Integer expiryTime;
+	/**
+	 * IndexField array.
+	 */
+	private final Lucene7IndexField[] indexFields;	
+	
+	/**
+	 * IndexWriter corresponding to each index directory.
+	 */
+	private static final ConcurrentHashMap<String, IndexWriter> writerMap = new ConcurrentHashMap<String, IndexWriter>();
+	
+	private final Configuration configuration;
+	
+	protected Lucene7Appender(String name, boolean ignoreExceptions, Filter filter,
+			Layout<? extends Serializable> layout, String target, Integer expiryTime, Lucene7IndexField[] indexFields,final Configuration configuration) {
+		super(name, filter, layout, ignoreExceptions);
+		this.target = target;
+		this.expiryTime = expiryTime;
+		this.indexFields = indexFields;
+		this.configuration = configuration;
+		initIndexWriter();
+		initialize();
+	}
+	
+	@Override
+	public void initialize() {
+		try {
+			registerCommitTimer();
+			if (this.expiryTime != null){
+				registerClearTimer();
+			}
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+		super.initialize();
+	}
+
+	
+	/**
+	 * IndexWriter initialization.
+	 */
+	private IndexWriter initIndexWriter() {
+		if (null == writerMap.get(target)) {
+			try {
+				FSDirectory fsDir = FSDirectory.open(Paths.get(this.target));
+				IndexWriterConfig writerConfig = new IndexWriterConfig(new Lucene7Analyzer());
+				writerMap.putIfAbsent(target, new IndexWriter(fsDir, writerConfig));
+			} catch (IOException e) {
+				LOGGER.error("IndexWriter initialization failed!" + e.getMessage(), e);
+			}
+		}
+		return writerMap.get(target);
+	}
+
+	/**
+	 * Register IndexWriter commit timertask.
+	 */
+	private void registerCommitTimer() throws Exception {		
+		configuration.getScheduler().scheduleWithCron(new CronExpression("0 1/1 * * * ? "), new Runnable() {
+			@Override
+			public void run() {
+				IndexWriter indexWriter = initIndexWriter();
+				if (null != indexWriter && indexWriter.numRamDocs() > 0) {
+					try {
+						indexWriter.commit();
+					} catch (IOException e) {
+						LOGGER.error("IndexWriter commit failed!" + e.getMessage(), e);
+					}
+				}
+			}
+		});
+	}
+	
+	/**
+	 * Register IndexWriter clean timertask.
+	 * Delete the index before {@link Lucene7Appender#expiryTime} second every day at 0.
+	 * 
+	 * @see Lucene7Appender#expiryTime
+	 */
+	private void registerClearTimer() throws Exception {
+		Calendar calendar = Calendar.getInstance();
+		long curMillis = calendar.getTimeInMillis();
+		calendar.add(Calendar.DAY_OF_MONTH, 1);
+		calendar.set(Calendar.HOUR_OF_DAY, 0);
+		calendar.set(Calendar.MINUTE, 0);
+		calendar.set(Calendar.SECOND, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
+		long difMinutes = (calendar.getTimeInMillis() - curMillis) / (1000 * 60);
+		configuration.getScheduler().scheduleAtFixedRate(new Runnable() {
+			@Override
+			public void run() {
+				LOGGER.info("delete index start!",target,expiryTime);
+				IndexWriter indexWriter = initIndexWriter();
+				if (null != indexWriter) {
+					Long start = 0L;
+					Long end = System.currentTimeMillis() - expiryTime * 1000;
+					Query rangeQuery = LongPoint.newRangeQuery("timestamp", start, end);
+					try {
+						indexWriter.deleteDocuments(rangeQuery);
+						indexWriter.commit();
+						LOGGER.info("delete index end! ",target,expiryTime);
+					}catch (IOException e) {
+						LOGGER.error("delete index failed! "+e.getMessage(),e);
+					}
+				}
+			}
+		}, difMinutes, 1440, TimeUnit.MINUTES);
+	}
+
+	/**
+	 * create lucene index.
+	 * 
+	 * @param event
+	 */
+	@Override
+	public void append(LogEvent event) {
+		if (null != indexFields && indexFields.length > 0) {
+			IndexWriter indexWriter = initIndexWriter();
+			if(null != indexWriter){
+				Document doc = new Document();
+				doc.add(new LongPoint("timestamp", event.getTimeMillis()));
+				doc.add(new StoredField("timestamp", event.getTimeMillis()));
+				try {
+					for (Lucene7IndexField field : indexFields) {
+						String value = field.getLayout().toSerializable(event);
+						if (Strings.isEmpty(value) || value.matches("[$]\\{.+\\}")) {
+							return;
+						}
+						value = value.trim();
+						String type = field.getType();
+						if (Strings.isNotEmpty(type)) {
+							switch(type) {
+							case "Long":
+								doc.add(new LongPoint(field.getName(), Long.valueOf(value)));
+								doc.add(new StoredField(field.getName(), Long.valueOf(value)));
+								break;
+							case "String":
+								doc.add(new StringField(field.getName(), value, Field.Store.YES));
+								break;
+							case "Text":
+								doc.add(new TextField(field.getName(), value, Field.Store.YES));
+								break;
+							default:
+								throw new UnsupportedOperationException(type + " type currently not supported.");	
+							}
+						} else {
+							doc.add(new TextField(field.getName(), value, Field.Store.YES));
+						}
+					}
+					indexWriter.addDocument(doc);
+					indexWriter.commit();
+				} catch (Exception e) {
+					LOGGER.error(e.getMessage(), e);
+					if (!ignoreExceptions()) {
+						throw new AppenderLoggingException(e);
+					}
+				}
+			}
+		}
+	}
+	
+	@PluginBuilderFactory
+    public static <B extends Builder<B>> B newBuilder() {
+        return new Builder<B>().asBuilder();
+    }
+
+    public static class Builder<B extends Builder<B>> extends AbstractAppender.Builder<B>
+        implements org.apache.logging.log4j.core.util.Builder<Lucene7Appender> {
+
+        @PluginElement("IndexField")
+        @Required(message = "No IndexField provided")
+        private Lucene7IndexField[] indexField;        
+
+        @PluginBuilderAttribute        
+        private Integer expiryTime;
+
+        @PluginBuilderAttribute
+        @Required(message = "No target provided")
+        private String target;
+        
+        @PluginConfiguration
+        private Configuration configuration;
+        
+        public B withTarget(final String target){
+        	this.target = target;
+        	return this.asBuilder();
+        }
+        
+        public B withExpiryTime(final Integer expiryTime){
+        	this.expiryTime = expiryTime;
+        	return this.asBuilder();
+        }
+        
+        public B withIndexField(final Lucene7IndexField... indexField){
+        	this.indexField = indexField;
+        	return this.asBuilder();
+        }        
+        
+        public B withConfiguration(final Configuration config) {
+            this.configuration = config;
+            return asBuilder();
+        }
+
+        @Override
+        public Lucene7Appender build() {
+            return new Lucene7Appender(getName(), isIgnoreExceptions(),getFilter(), this.getLayout(),this.target,this.expiryTime,this.indexField,this.configuration);
+        }        
+    }	
+
+	@Override
+	public final void start() {
+		if (null == writerMap.get(target)) {
+			LOGGER.error("No IndexWriter set for the appender named [{}].", this.getName());
+		}
+		super.start();
+	}
+
+	@Override
+	public boolean stop(final long timeout, final TimeUnit timeUnit) {
+		setStopping();
+		boolean stopped = super.stop(timeout, timeUnit, false);
+		IndexWriter indexWriter = writerMap.get(target);
+		if (null != indexWriter) {
+			try {
+				indexWriter.commit();
+				indexWriter.close();
+				writerMap.remove(target);
+			} catch (IOException e) {
+				LOGGER.error(e.getMessage(), e);
+			}
+		}
+		setStopped();
+		return stopped;
+	}
+}

--- a/log4j-lucene7/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene7IndexField.java
+++ b/log4j-lucene7/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene7IndexField.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.lucene.appender;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+import org.apache.logging.log4j.core.filter.AbstractFilterable;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.status.StatusLogger;
+
+/**
+ * {@link Lucene7Appender}'s configuration element that logs the log event attributes to the Field in the Lucene document.
+ */
+@Plugin(name="IndexField", category=Node.CATEGORY, printObject=true)
+public final class Lucene7IndexField {
+    private static final Logger LOGGER = StatusLogger.getLogger();
+
+    private final String name;
+    private final PatternLayout layout;
+    private final String type;
+
+    private Lucene7IndexField(final String name, final PatternLayout layout,final String type) {
+        this.name = name;
+        this.layout = layout;
+        this.type = type;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public PatternLayout getLayout() {
+        return this.layout;
+    }
+
+
+	public String getType() {
+		return type;
+	}
+
+	@Override
+    public String toString() {
+        return "{name=" + this.name + ", layout=" + this.layout + " }";
+    }    
+    
+    @PluginBuilderFactory
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder<B extends Builder<B>> extends AbstractFilterable.Builder<B>
+    implements org.apache.logging.log4j.core.util.Builder<Lucene7IndexField>{
+    	
+    	@PluginConfiguration
+    	private Configuration configuration;
+	
+    	@PluginBuilderAttribute
+    	@Required(message = "No name provided")
+        private String name;
+
+        @PluginBuilderAttribute
+        @Required(message = "No pattern provided")
+        private String pattern;
+        
+        @PluginBuilderAttribute        
+        private String type;
+        
+        public B withName(final String name){
+        	this.name = name;
+        	return this.asBuilder();
+        }
+        
+        public B withPattern(final String pattern){
+        	this.pattern = pattern;
+        	return this.asBuilder();
+        }
+        
+        public B withType(final String type){
+        	this.type = type;
+        	return this.asBuilder();
+        }
+
+		@Override
+		public Lucene7IndexField build() {
+			final PatternLayout layout =
+                    PatternLayout.newBuilder()
+                        .withPattern(pattern)
+                        .withConfiguration(configuration)   
+                        .withAlwaysWriteExceptions(false)
+                        .build();
+			return new Lucene7IndexField(name,layout,type);
+		}
+    }
+}

--- a/log4j-lucene7/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene7Tokenizer.java
+++ b/log4j-lucene7/src/main/java/org/apache/logging/log4j/lucene/appender/Lucene7Tokenizer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.lucene.appender;
+
+import org.apache.lucene.analysis.util.CharTokenizer;
+
+/**
+ * Emits the entire input as a single token.
+ */
+public class Lucene7Tokenizer extends CharTokenizer {
+	
+	public Lucene7Tokenizer() {
+	}
+
+	@Override
+	protected boolean isTokenChar(int c) {
+		return true;
+	}
+
+	@Override
+	protected int normalize(int c) {
+		return Character.toLowerCase(c);
+	}
+}

--- a/log4j-lucene7/src/main/java/org/apache/logging/log4j/lucene/appender/package-info.java
+++ b/log4j-lucene7/src/main/java/org/apache/logging/log4j/lucene/appender/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.lucene.appender;

--- a/log4j-lucene7/src/test/java/org/apache/logging/log4j/lucene/appender/Lucene7AppenderTest.java
+++ b/log4j-lucene7/src/test/java/org/apache/logging/log4j/lucene/appender/Lucene7AppenderTest.java
@@ -1,0 +1,114 @@
+package org.apache.logging.log4j.lucene.appender;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.junit.CleanFolders;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.FSDirectory;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class Lucene7AppenderTest {
+	private static final String CONFIGURATION_FILE = "log4j2-lucene.xml";
+	private static final String TARGET_FOLDER = "target/lucene";
+	private static final String FIELD_1 = "field1";
+	private static final String FIELD_2 = "field2";
+	private static final String LOGGER_NAME = "TestLogger";
+	private static final String LOG_MESSAGE = "Hello world!";
+	private static final String EXEPECTED_REGEX = "^\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2},\\d{3} \\[[^\\]]*\\] INFO "
+			+ LOGGER_NAME + " - " + LOG_MESSAGE;
+	private static final Path PATH = Paths.get(TARGET_FOLDER);
+	private static final int THREAD_COUNT = 50;
+
+	@Rule
+	public LoggerContextRule ctx = new LoggerContextRule(CONFIGURATION_FILE);
+
+	@Rule
+	public CleanFolders folders = new CleanFolders(PATH);
+
+	@Test
+	public void testSimple() throws Exception {
+		write();
+		verify(1);
+	}
+
+	@Test
+	public void testMultipleThreads() throws Exception {
+		final ExecutorService threadPool = Executors.newFixedThreadPool(THREAD_COUNT);
+		final LuceneAppenderRunner runner = new LuceneAppenderRunner();
+		for (int i = 0; i < THREAD_COUNT; ++i) {
+			threadPool.execute(runner);
+		}
+		// Waiting for lucene records to complete and submit
+		Thread.sleep(3000);
+		verify(THREAD_COUNT);
+	}
+
+	private final void write() throws Exception {
+		final Lucene7Appender appender = (Lucene7Appender) ctx.getRequiredAppender("LuceneAppender");
+		try {
+			appender.start();
+			assertTrue("Appender did not start", appender.isStarted());
+			final Log4jLogEvent event = Log4jLogEvent.newBuilder().setLoggerName(LOGGER_NAME)
+					.setLoggerFqcn(Lucene7AppenderTest.class.getName()).setLevel(Level.INFO)
+					.setMessage(new SimpleMessage(LOG_MESSAGE)).build();
+			appender.append(event);
+		} finally {
+			appender.stop();
+		}
+		assertFalse("Appender did not stop", appender.isStarted());
+	}
+
+	private final synchronized void verify(final int exepectedTotalHits) throws Exception {
+		final FSDirectory fsDir = FSDirectory.open(PATH);
+		final IndexReader reader = DirectoryReader.open(fsDir);
+		try {
+			final IndexSearcher searcher = new IndexSearcher(reader);
+			final TopDocs all = searcher.search(new MatchAllDocsQuery(), Integer.MAX_VALUE);
+			Assert.assertEquals(all.totalHits, exepectedTotalHits);
+			for (ScoreDoc scoreDoc : all.scoreDocs) {
+				final Document doc = searcher.doc(scoreDoc.doc);
+				Assert.assertEquals(doc.getFields().size(), 3);
+				final String field1 = doc.get(FIELD_1);
+				Assert.assertTrue("Unexpected field1: " + field1, Level.INFO.toString().equals(field1));
+				final String field2 = doc.get(FIELD_2);
+				final Pattern pattern = Pattern.compile(EXEPECTED_REGEX);
+				final Matcher matcher = pattern.matcher(field2);
+				Assert.assertTrue("Unexpected field2: " + field2, matcher.matches());
+			}
+		} finally {
+			reader.close();
+			fsDir.close();
+		}
+	}
+
+	private class LuceneAppenderRunner implements Runnable {
+		@Override
+		public void run() {
+			try {
+				write();
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+}

--- a/log4j-lucene7/src/test/resources/log4j2-lucene.xml
+++ b/log4j-lucene7/src/test/resources/log4j2-lucene.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration name="LuceneAppenderTest" packages = "org.apache.logging.log4j.lucene.appender">
+  <Appenders>
+    <Lucene name="LuceneAppender" target = "target/lucene">
+    	<IndexField name = "field1" pattern = "%-5level" type="Text"/>
+    	<IndexField name = "field2" pattern = "%d [%t] %p %c - %m%n" />
+    </Lucene>
+  </Appenders>
+  <Loggers>
+    <Root level="info">
+      <AppenderRef ref="LuceneAppender"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -218,11 +218,13 @@
     <errorprone.version>2.3.0</errorprone.version>
     <plexus.errorprone.version>2.8.4</plexus.errorprone.version>
     <remote.resources.plugin.version>1.5</remote.resources.plugin.version>
+    <lucene5.version>5.5.5</lucene5.version>
+    <lucene7.version>7.3.0</lucene7.version>
     <manifestfile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestfile>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <docLabel>Site Documentation</docLabel>
-    <projectDir />
+    <projectDir/>
     <commonsLoggingVersion>1.2</commonsLoggingVersion>
     <javax.persistence>2.2.0</javax.persistence>
     <osgi.api.version>6.0.0</osgi.api.version>
@@ -233,7 +235,7 @@
     <mockitoVersion>2.13.0</mockitoVersion>
     <argLine>-Xms256m -Xmx1024m</argLine>
     <javaTargetVersion>1.7</javaTargetVersion>
-    <module.name />
+    <module.name/>
   </properties>
   <pluginRepositories>
     <pluginRepository>
@@ -904,7 +906,7 @@
             <maxmem>1024</maxmem>
             <compilerArguments>
               <Xmaxwarns>10000</Xmaxwarns>
-              <Xlint />
+              <Xlint/>
             </compilerArguments>
             <compilerId>javac-with-errorprone</compilerId>
             <forceJavacCompilerUse>true</forceJavacCompilerUse>
@@ -1172,7 +1174,7 @@
             </goals>
             <configuration>
               <skip>true</skip>
-              <resourceBundles />
+              <resourceBundles/>
             </configuration>
           </execution>
         </executions>
@@ -1405,6 +1407,8 @@
     <module>log4j-appserver</module>
     <module>log4j-smtp</module>
     <module>log4j-osgi</module>
+    <module>log4j-lucene7</module>
+    <module>log4j-lucene5</module>
   </modules>
   <profiles>
     <profile>


### PR DESCRIPTION
Add two new LuceneAppender which writes logging events to a lucene index library.The log4j2.xml configuration is as follows:
&lt;Lucene name="lucene" ignoreExceptions="true" target="/target/lucene/index" expiryTime=“1296000”&gt;
&lt;PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/&gt;
&lt;IndexField name="time" pattern="%d{UNIX_MILLIS}" type="Long"/&gt;
&lt;IndexField name="level" pattern="%-5level" /&gt;
&lt;IndexField name="content" pattern="%d{HH:mm:ss.SSS} %-5level %class{36} %L %M - %msg%xEx%n"/&gt;
&lt;/Lucene&gt;

this appender relies on the Lucene 5.5.5 or 7.3.0 version.
this patch adds the corresponding test cases.