### PR TITLE
[LOG4J2-2305] Make java.util.ServiceLoader properly work in OSGi by using the Service Loader Mediator Specification

### DIFF
--- a/log4j-slf4j-impl/pom.xml
+++ b/log4j-slf4j-impl/pom.xml
@@ -109,6 +109,12 @@
               org.apache.logging.slf4j,
               org.slf4j.impl
             </Export-Package>
+            <Require-Capability>
+              osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"
+            </Require-Capability>
+            <Provide-Capability>
+              osgi.serviceloader;osgi.serviceloader=org.slf4j.spi.SLF4JServiceProvider
+            </Provide-Capability>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
slf4j needs a similar change I propsed as PR in https://github.com/qos-ch/slf4j/pull/198,
but by using a fragment that gap can be taken care of.

As a workaround one can create a fragment like the one for the slf4j-api bundle propsed in the other PR, e. g. with Gradle using

```groovy
plugins {
    id 'osgi'
}

task log4jSlf4jImplFragmentJar(type: Jar) {
    baseName = project.name + '-log4jSlf4jImplFragment'
    manifest = osgiManifest {
        name = 'net.kautler.test.osgi.log4j.slf4j.impl.fragment'
        symbolicName = 'net.kautler.test.osgi.log4j.slf4j.impl.fragment'
        version = '1.0.0'
        classesDir = temporaryDir
        classpath = files()
        instruction 'Fragment-Host', 'org.apache.logging.log4j.slf4j-impl'
        instruction 'Require-Capability', '' +
                'osgi.extender;' +
                'filter:="(osgi.extender=osgi.serviceloader.registrar)"'
        instruction 'Provide-Capability', '' +
                'osgi.serviceloader;' +
                'osgi.serviceloader=org.slf4j.spi.SLF4JServiceProvider'
    }
}
```