### PR TITLE
AsyncLoggerConfig optimization

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
@@ -87,7 +87,14 @@ public class AsyncLoggerConfig extends LoggerConfig {
     }
 
     protected void log(final LogEvent event, final LoggerConfigPredicate predicate) {
-        if (predicate == LoggerConfigPredicate.ALL && ASYNC_LOGGER_ENTERED.get() == null) { // See LOG4J2-2301
+        // See LOG4J2-2301
+        if (predicate == LoggerConfigPredicate.ALL &&
+                ASYNC_LOGGER_ENTERED.get() == null &&
+                // Optimization: AsyncLoggerConfig is identical to LoggerConfig
+                // when no appenders are present. Avoid splitting for synchronous
+                // and asynchronous execution paths until encountering an
+                // AsyncLoggerConfig with appenders.
+                hasAppenders()) {
             // This is the first AsnycLoggerConfig encountered by this LogEvent
             ASYNC_LOGGER_ENTERED.set(Boolean.TRUE);
             try {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -565,6 +565,10 @@ public class LoggerConfig extends AbstractFilterable {
         return Boolean.parseBoolean(includeLocationConfigValue);
     }
 
+    protected final boolean hasAppenders() {
+        return !appenders.isEmpty();
+    }
+
     /**
      * The root Logger.
      */


### PR DESCRIPTION
AsyncLoggerConfig behaves exactly like a standard LoggerConfig
when no appenders are present. This potentially avoids unnecessarily
adding events to the background thread when an AsyncLoggerConfig
is used to set level without adding appenders directly.