### PR TITLE
Apply ThreadContextRule to Log4j1XmlLayoutTest

### DIFF
--- a/log4j-1.2-api/src/test/java/org/apache/log4j/layout/Log4j1XmlLayoutTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/layout/Log4j1XmlLayoutTest.java
@@ -21,11 +21,16 @@ import static org.junit.Assert.assertEquals;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.impl.ContextDataFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.junit.ThreadContextRule;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.util.StringMap;
+import org.junit.Rule;
 import org.junit.Test;
 
 public class Log4j1XmlLayoutTest {
+
+    @Rule
+    public ThreadContextRule threadContextRule = new ThreadContextRule();
 
     @Test
     public void testWithoutThrown() {


### PR DESCRIPTION
NDC value is leaking into the test intermittently causing a
comparison to fail.