### PR TITLE
[LOG4J2-2355] Avoid NullPointerException in PropertiesUtil.reload()

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -330,13 +330,17 @@ public final class PropertiesUtil {
                 source.forEach(new BiConsumer<String, String>() {
                     @Override
                     public void accept(final String key, final String value) {
-                        literal.put(key, value);
-                        final List<CharSequence> tokens = PropertySource.Util.tokenize(key);
-                        if (tokens.isEmpty()) {
-                            normalized.put(source.getNormalForm(Collections.singleton(key)), value);
-                        } else {
-                            normalized.put(source.getNormalForm(tokens), value);
-                            tokenized.put(tokens, value);
+                        if (value != null) {
+                            literal.put(key, value);
+                            final List<CharSequence> tokens = PropertySource.Util.tokenize(key);
+                            if (tokens.isEmpty()) {
+                                normalized.put(source.getNormalForm(Collections.singleton(key)), value);
+                            } else {
+                                normalized.put(source.getNormalForm(tokens), value);
+                                tokenized.put(tokens, value);
+                            }
+                        } else  {
+                            LowLevelLogUtil.log("Property " + key + " was skipped because of null value.");
                         }
                     }
                 });


### PR DESCRIPTION
SystemPropertiesPropertySource.forEach(..) uses Property.getProperty(..)
to resolve values.  If that value is a non-String, the value will be
null.  Since `literal` is a ConcurrentHashMap, a put(..) with null value
will yield a NullPointerException.

This is especially hard to debug in the case of e.g. StatusLogger,
which initializes PropertiesUtil as a static variable.  The class is
unable to load, throws a NoClassDefFoundError, and hides the
NullPointerException.

Here's what I got when I had a Property value that was a File:

Caused by: java.lang.NoClassDefFoundError: Could not initialize class org.apache.logging.log4j.util.PropertiesUtil
	at org.apache.logging.log4j.status.StatusLogger.<clinit>(StatusLogger.java:78)
	at org.apache.logging.log4j.LogManager.<clinit>(LogManager.java:60)