### PR TITLE
ReusableMessages implement "Clearable"

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/Clearable.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/Clearable.java
@@ -1,0 +1,17 @@
+package org.apache.logging.log4j.message;
+
+/**
+ * {@link Clearable} objects may be reset to a reusable state.
+ *
+ * This type should be folded into {@link ReusableMessage} for 3.0.
+ *
+ * @since 2.11.1
+ */
+public interface Clearable {
+
+    /**
+     * Resets the object to a clean state.
+     */
+    void clear();
+
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
@@ -77,17 +77,15 @@ public final class ReusableMessageFactory implements MessageFactory2, Serializab
     }
 
     /**
-     * Switches the {@code reserved} flag off if the specified message is a ReusableParameterizedMessage,
-     * otherwise does nothing. This flag is used internally to verify that a reusable message is no longer in use and
+     * Invokes {@link Clearable#clear()} when possible.
+     * This flag is used internally to verify that a reusable message is no longer in use and
      * can be reused.
      * @param message the message to make available again
      * @since 2.7
      */
     public static void release(final Message message) { // LOG4J2-1583
-        if (message instanceof ReusableParameterizedMessage) {
-            ((ReusableParameterizedMessage) message).reserved = false;
-        } else if (message instanceof ReusableObjectMessage) {
-            ((ReusableObjectMessage) message).set(null);
+        if (message instanceof Clearable) {
+            ((Clearable) message).clear();
         }
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.util.StringBuilders;
  * @since 2.6
  */
 @PerformanceSensitive("allocation")
-public class ReusableObjectMessage implements ReusableMessage, ParameterVisitable {
+public class ReusableObjectMessage implements ReusableMessage, ParameterVisitable, Clearable {
     private static final long serialVersionUID = 6922476812535519960L;
 
     private transient Object obj;
@@ -120,5 +120,10 @@ public class ReusableObjectMessage implements ReusableMessage, ParameterVisitabl
     @Override
     public Message memento() {
         return new ObjectMessage(obj);
+    }
+
+    @Override
+    public void clear() {
+        obj = null;
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.util.StringBuilders;
  * @since 2.6
  */
 @PerformanceSensitive("allocation")
-public class ReusableParameterizedMessage implements ReusableMessage, ParameterVisitable {
+public class ReusableParameterizedMessage implements ReusableMessage, ParameterVisitable, Clearable {
 
     private static final int MIN_BUILDER_SIZE = 512;
     private static final int MAX_PARMS = 10;
@@ -340,5 +340,12 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
     public String toString() {
         return "ReusableParameterizedMessage[messagePattern=" + getFormat() + ", stringArgs=" +
                 Arrays.toString(getParameters()) + ", throwable=" + getThrowable() + ']';
+    }
+
+    @Override
+    public void clear() { // LOG4J2-1583
+        // This method does not clear parameter values, those are expected to be swapped to a
+        // reusable message, which is responsible for clearing references.
+        reserved = false;
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.util.PerformanceSensitive;
  * @since 2.6
  */
 @PerformanceSensitive("allocation")
-public class ReusableSimpleMessage implements ReusableMessage, CharSequence, ParameterVisitable {
+public class ReusableSimpleMessage implements ReusableMessage, CharSequence, ParameterVisitable, Clearable {
     private static final long serialVersionUID = -9199974506498249809L;
     private static Object[] EMPTY_PARAMS = new Object[0];
     private CharSequence charSequence;
@@ -104,6 +104,11 @@ public class ReusableSimpleMessage implements ReusableMessage, CharSequence, Par
     @Override
     public CharSequence subSequence(final int start, final int end) {
         return charSequence.subSequence(start, end);
+    }
+
+    @Override
+    public void clear() {
+        charSequence = null;
     }
 }
 


### PR DESCRIPTION
Follow up from LOG4J2-2362, fixed via 4050cf63950b3fa2ff41cc54918b2281de9095ef

This aims to provide a cleaner reset mechanism for messages.