### PR TITLE
LOG4J2-2312 LOG4J2-2341 Fix jackson layout with async loggers

### DIFF
--- a/log4j-layout-jackson-json/pom.xml
+++ b/log4j-layout-jackson-json/pom.xml
@@ -55,6 +55,11 @@
       <type>test-jar</type>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/log4j-layout-jackson-json/src/test/java/org/apache/logging/log4j/jackson/json/layout/JsonLayoutTest.java
+++ b/log4j-layout-jackson-json/src/test/java/org/apache/logging/log4j/jackson/json/layout/JsonLayoutTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.jackson.json.layout;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -33,12 +35,15 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.BasicConfigurationFactory;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.async.RingBufferLogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.impl.MutableLogEvent;
 import org.apache.logging.log4j.core.layout.LogEventFixtures;
 import org.apache.logging.log4j.core.lookup.JavaLookup;
+import org.apache.logging.log4j.core.time.internal.DummyNanoClock;
+import org.apache.logging.log4j.core.time.internal.SystemClock;
 import org.apache.logging.log4j.core.util.KeyValuePair;
 import org.apache.logging.log4j.jackson.AbstractJacksonLayout;
 import org.apache.logging.log4j.jackson.json.Log4jJsonObjectMapper;
@@ -49,6 +54,7 @@ import org.apache.logging.log4j.message.ReusableMessageFactory;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.test.appender.ListAppender;
+import org.apache.logging.log4j.util.SortedArrayStringMap;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -498,6 +504,37 @@ public class JsonLayoutTest {
             final String str = layout.toSerializable(mutableLogEvent);
             final String expectedMessage = "Testing " + TestObj.TO_STRING_VALUE;
             assertTrue(str, str.contains("\"message\":\"" + expectedMessage + '"'));
+            final Log4jLogEvent actual = new Log4jJsonObjectMapper(propertiesAsList, true, false, false).readValue(str, Log4jLogEvent.class);
+            assertEquals(expectedMessage, actual.getMessage().getFormattedMessage());
+        } finally {
+            ReusableMessageFactory.release(message);
+        }
+    }
+
+    // Test for LOG4J2-2312 LOG4J2-2341
+    @Test
+    public void testLayoutRingBufferEventReusableMessageWithCurlyBraces() throws Exception {
+        final boolean propertiesAsList = false;
+        final AbstractJacksonLayout layout = JsonLayout.newBuilder()
+                .setLocationInfo(false)
+                .setProperties(false)
+                .setPropertiesAsList(propertiesAsList)
+                .setComplete(false)
+                .setCompact(true)
+                .setEventEol(false)
+                .setCharset(StandardCharsets.UTF_8)
+                .setIncludeStacktrace(true)
+                .build();
+        Message message = ReusableMessageFactory.INSTANCE.newMessage("Testing {}", new TestObj());
+        try {
+            RingBufferLogEvent ringBufferEvent = new RingBufferLogEvent();
+            ringBufferEvent.setValues(
+                    null, "a.B", null, "f.q.c.n", Level.DEBUG, message,
+                    null, new SortedArrayStringMap(), ThreadContext.EMPTY_STACK, 1L,
+                    "threadName", 1, null, new SystemClock(), new DummyNanoClock());
+            final String str = layout.toSerializable(ringBufferEvent);
+            final String expectedMessage = "Testing " + TestObj.TO_STRING_VALUE;
+            assertThat(str, containsString("\"message\":\"" + expectedMessage + '"'));
             final Log4jLogEvent actual = new Log4jJsonObjectMapper(propertiesAsList, true, false, false).readValue(str, Log4jLogEvent.class);
             assertEquals(expectedMessage, actual.getMessage().getFormattedMessage());
         } finally {

--- a/log4j-layout-jackson/src/main/java/org/apache/logging/log4j/jackson/AbstractJacksonLayout.java
+++ b/log4j-layout-jackson/src/main/java/org/apache/logging/log4j/jackson/AbstractJacksonLayout.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
-import org.apache.logging.log4j.core.impl.MutableLogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.layout.AbstractStringLayout;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 import org.apache.logging.log4j.core.util.KeyValuePair;
@@ -219,7 +219,7 @@ public abstract class AbstractJacksonLayout extends AbstractStringLayout {
         // TODO Jackson-based layouts have certain filters set up for Log4jLogEvent.
         // TODO Need to set up the same filters for MutableLogEvent but don't know how...
         // This is a workaround.
-        return event instanceof MutableLogEvent ? ((MutableLogEvent) event).createMemento() : event;
+        return event instanceof Log4jLogEvent ? event : Log4jLogEvent.createMemento(event);
     }
     private static ResolvableKeyValuePair[] prepareAdditionalFields(final Configuration config,
             final KeyValuePair[] additionalFields) {

--- a/log4j-layout-jackson/src/main/java/org/apache/logging/log4j/jackson/layout/AbstractJacksonLayout.java
+++ b/log4j-layout-jackson/src/main/java/org/apache/logging/log4j/jackson/layout/AbstractJacksonLayout.java
@@ -44,7 +44,7 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
-import org.apache.logging.log4j.core.impl.MutableLogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.layout.AbstractStringLayout;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 import org.apache.logging.log4j.core.util.KeyValuePair;
@@ -245,7 +245,7 @@ abstract class AbstractJacksonLayout extends AbstractStringLayout {
         // TODO Jackson-based layouts have certain filters set up for Log4jLogEvent.
         // TODO Need to set up the same filters for MutableLogEvent but don't know how...
         // This is a workaround.
-        return event instanceof MutableLogEvent ? ((MutableLogEvent) event).createMemento() : event;
+        return event instanceof Log4jLogEvent ? event : Log4jLogEvent.createMemento(event);
     }
     private static ResolvableKeyValuePair[] prepareAdditionalFields(final Configuration config,
             final KeyValuePair[] additionalFields) {

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -197,6 +197,9 @@
       <action issue="LOG4J2-2362" dev="ckozak" type="fix">
         Fixed a memory leak in which ReusableObjectMessage would hold a reference to the most recently logged object.
       </action>
+      <action issue="LOG4J2-2312" dev="ckozak" type="fix">
+        Jackson layouts used with AsyncLoggerContextSelector output the expected format rather than only a json string of the message text.
+      </action>
     </release>
     <release version="2.11.1" date="2018-MM-DD" description="GA Release 2.11.1">
       <action issue="LOG4J2-1721" dev="rgoers" type="update" due-to="Phokham Nonava">
@@ -303,6 +306,9 @@
       </action>
       <action issue="LOG4J2-2362" dev="ckozak" type="fix">
         Fixed a memory leak in which ReusableObjectMessage would hold a reference to the most recently logged object.
+      </action>
+      <action issue="LOG4J2-2312" dev="ckozak" type="fix">
+        Jackson layouts used with AsyncLoggerContextSelector output the expected format rather than only a json string of the message text.
       </action>
     </release>
     <release version="2.11.0" date="2018-xx-xx" description="GA Release 2.11.0">


### PR DESCRIPTION
AsyncLoggerContextSelector RingBufferLogEvents were not properly
handled by the jackson layout. Currently the jackson layout
implementation requires Log4jLogEvent instances, so we must
convert all other LogEvent implementations into these.