### PR TITLE
[LOG4J2-2373] Reduce unnecessary char movement in StringBuilders.escapeJson

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
@@ -169,51 +169,79 @@ public final class StringBuilders {
     }
 
     public static void escapeJson(final StringBuilder toAppendTo, final int start) {
-        for (int i = toAppendTo.length() - 1; i >= start; i--) { // backwards: length may change
+        int escapeCount = 0;
+        for (int i = start; i < toAppendTo.length(); i++) {
             final char c = toAppendTo.charAt(i);
             switch (c) {
                 case '\b':
-                    toAppendTo.setCharAt(i, '\\');
-                    toAppendTo.insert(i + 1, 'b');
+                case '\t':
+                case '\f':
+                case '\n':
+                case '\r':
+                case '"':
+                case '\\':
+                    escapeCount++;
+                    break;
+                default:
+                    if (Character.isISOControl(c)) {
+                        escapeCount += 5;
+                    }
+            }
+        }
+
+        int lastChar = toAppendTo.length() - 1;
+        toAppendTo.setLength(toAppendTo.length() + escapeCount);
+        int lastPos = toAppendTo.length() - 1;
+
+        for (int i = lastChar; lastPos > i; i--) {
+            final char c = toAppendTo.charAt(i);
+            switch (c) {
+                case '\b':
+                    lastPos = escapeAndDecrement(toAppendTo, lastPos, 'b');
                     break;
 
                 case '\t':
-                    toAppendTo.setCharAt(i, '\\');
-                    toAppendTo.insert(i + 1, 't');
+                    lastPos = escapeAndDecrement(toAppendTo, lastPos, 't');
                     break;
 
                 case '\f':
-                    toAppendTo.setCharAt(i, '\\');
-                    toAppendTo.insert(i + 1, 'f');
+                    lastPos = escapeAndDecrement(toAppendTo, lastPos, 'f');
                     break;
 
                 case '\n':
-                    // Json string newline character must be encoded as literal "\n"
-                    toAppendTo.setCharAt(i, '\\');
-                    toAppendTo.insert(i + 1, 'n');
+                    lastPos = escapeAndDecrement(toAppendTo, lastPos, 'n');
                     break;
 
                 case '\r':
-                    toAppendTo.setCharAt(i, '\\');
-                    toAppendTo.insert(i + 1, 'r');
+                    lastPos = escapeAndDecrement(toAppendTo, lastPos, 'r');
                     break;
 
                 case '"':
                 case '\\':
-                    // only " and \ need to be escaped; other escapes are optional
-                    toAppendTo.insert(i, '\\');
+                    lastPos = escapeAndDecrement(toAppendTo, lastPos, c);
                     break;
 
                 default:
                     if (Character.isISOControl(c)) {
-                        // all iso control characters are in U+00xx
-                        toAppendTo.setCharAt(i, '\\');
-                        toAppendTo.insert(i + 1, "u0000");
-                        toAppendTo.setCharAt(i + 4, Chars.getUpperCaseHex((c & 0xF0) >> 4));
-                        toAppendTo.setCharAt(i + 5, Chars.getUpperCaseHex(c & 0xF));
+                        // all iso control characters are in U+00xx, JSON output format is "\\u00XX"
+                        toAppendTo.setCharAt(lastPos--, Chars.getUpperCaseHex(c & 0xF));
+                        toAppendTo.setCharAt(lastPos--, Chars.getUpperCaseHex((c & 0xF0) >> 4));
+                        toAppendTo.setCharAt(lastPos--, '0');
+                        toAppendTo.setCharAt(lastPos--, '0');
+                        toAppendTo.setCharAt(lastPos--, 'u');
+                        toAppendTo.setCharAt(lastPos--, '\\');
+                    } else {
+                        toAppendTo.setCharAt(lastPos, c);
+                        lastPos--;
                     }
             }
         }
+    }
+
+    private static int escapeAndDecrement(StringBuilder toAppendTo, int lastPos, char c) {
+        toAppendTo.setCharAt(lastPos--, c);
+        toAppendTo.setCharAt(lastPos--, '\\');
+        return lastPos;
     }
 
     public static void escapeXml(final StringBuilder toAppendTo, final int start) {

--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/StringBuildersTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/StringBuildersTest.java
@@ -47,5 +47,34 @@ public class StringBuildersTest {
         assertTrue("trimmed OK", sb.capacity() <= Constants.MAX_REUSABLE_MESSAGE_SIZE);
     }
 
+    @Test
+    public void escapeJsonCharactersCorrectly() {
+        String jsonValueNotEscaped = "{\"field\n1\":\"value_1\"}";
+        String jsonValueEscaped = "{\\\"field\\n1\\\":\\\"value_1\\\"}";
 
+        StringBuilder sb = new StringBuilder();
+        sb.append(jsonValueNotEscaped);
+        assertEquals(jsonValueNotEscaped, sb.toString());
+        StringBuilders.escapeJson(sb, 0);
+        assertEquals(jsonValueEscaped, sb.toString());
+
+        sb = new StringBuilder();
+        String jsonValuePartiallyEscaped = "{\"field\n1\":\\\"value_1\\\"}";
+        sb.append(jsonValueNotEscaped);
+        assertEquals(jsonValueNotEscaped, sb.toString());
+        StringBuilders.escapeJson(sb, 10);
+        assertEquals(jsonValuePartiallyEscaped, sb.toString());
+    }
+
+    @Test
+    public void escapeJsonCharactersISOControl() {
+        String jsonValueNotEscaped = "{\"field\n1\":\"value" + (char) 0x8F + "_1\"}";
+        String jsonValueEscaped = "{\\\"field\\n1\\\":\\\"value\\u008F_1\\\"}";
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(jsonValueNotEscaped);
+        assertEquals(jsonValueNotEscaped, sb.toString());
+        StringBuilders.escapeJson(sb, 0);
+        assertEquals(jsonValueEscaped, sb.toString());
+    }
 }


### PR DESCRIPTION
This PR resolves a memory allocation issue with the escapeJson function.  Rather than compute expansions of the String builder as we encounter them, we compute the total expansion, allocate the memory, and then assign characters as needed.