### PR TITLE
LOG4J2-2389 fix the CacheEntry map in ThrowableProxy#toExtendedStackTrace to be put and gotten with same key

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxy.java
@@ -738,7 +738,7 @@ public class ThrowableProxy implements Serializable {
                     final CacheEntry entry = this.toCacheEntry(stackTraceElement,
                         this.loadClass(lastLoader, className), false);
                     extClassInfo = entry.element;
-                    map.put(stackTraceElement.toString(), entry);
+                    map.put(className, entry);
                     if (entry.loader != null) {
                         lastLoader = entry.loader;
                     }


### PR DESCRIPTION
- fix the CacheEntry map in method `toExtendedStackTrace` to be put and gotten with same key 
  - `stackTraceElement.toString()` returns a string representation of this stack trace element, just as `MyClass.mash(MyClass.java)`, which is not equal to `className`
- benchmark result:
  - https://github.com/liuwenchn/log4j2-throwableproxy-benchmark/ 
