### PR TITLE
Fix LOG4J2-2388 / Blocking thread when logging message in an interrup…

### DIFF
--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumePersistentManager.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumePersistentManager.java
@@ -196,17 +196,12 @@ public class FlumePersistentManager extends FlumeAvroManager {
             }
             final Future<Integer> future = threadPool.submit(new BDBWriter(keyData, eventData, environment, database,
                 gate, dbCount, getBatchSize(), lockTimeoutRetryCount));
-            boolean interrupted = false;
-            int ieCount = 0;
-            do {
-                try {
-                    future.get();
-                } catch (final InterruptedException ie) {
-                    interrupted = true;
-                    ++ieCount;
-                }
-            } while (interrupted && ieCount <= 1);
-
+            try {
+            	future.get();
+            } catch (final InterruptedException ie) {
+            	// preserve interruption status
+            	Thread.currentThread().interrupt();
+            }
         } catch (final Exception ex) {
             throw new LoggingException("Exception occurred writing log event", ex);
         }

--- a/log4j-flume-ng/src/test/java/org/apache/logging/log4j/flume/appender/FlumePersistentAppenderTest.java
+++ b/log4j-flume-ng/src/test/java/org/apache/logging/log4j/flume/appender/FlumePersistentAppenderTest.java
@@ -27,6 +27,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
@@ -343,6 +345,19 @@ public class FlumePersistentAppenderTest {
 
             }
         }
+    }
+    
+    @Test
+    public void testLogInterrupted() {
+    	ExecutorService executor = Executors.newSingleThreadExecutor();
+        executor.execute(() -> {
+        	executor.shutdownNow();
+        	final Logger logger = LogManager.getLogger("EventLogger");
+            final Marker marker = MarkerManager.getMarker("EVENT");
+            logger.info(marker, "This is a test message");
+            Assert.assertTrue("Interruption status not preserved",
+            		Thread.currentThread().isInterrupted());
+        });
     }
 
     /*


### PR DESCRIPTION
…ted thread

- Fix unfinite loop in org.apache.logging.log4j.flume.appender.FlumePersistentManager.send when the thread is interrupted (Note : The loop has been completely removed since it does not seems to serve any purpose)
- Preserve Thread interruption status on InterruptedException
- Add unit test for this case