### PR TITLE
[LOG4J2-2391] Benchmarks for logging to disk with a Throwable

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -46,7 +46,7 @@ import java.util.Stack;
  */
 public final class StackLocator {
 
-    private static PrivateSecurityManager SECURITY_MANAGER;
+    private static final PrivateSecurityManager SECURITY_MANAGER;
 
     // Checkstyle Suppress: the lower-case 'u' ticks off CheckStyle...
     // CHECKSTYLE:OFF
@@ -81,6 +81,19 @@ public final class StackLocator {
             getCallerClass = null;
             java7u25CompensationOffset = -1;
         }
+
+        PrivateSecurityManager psm;
+        try {
+            final SecurityManager sm = System.getSecurityManager();
+            if (sm != null) {
+                sm.checkPermission(new RuntimePermission("createSecurityManager"));
+            }
+            psm = new PrivateSecurityManager();
+        } catch (final SecurityException ignored) {
+            psm = null;
+        }
+
+        SECURITY_MANAGER = psm;
 
         GET_CALLER_CLASS = getCallerClass;
         JDK_7u25_OFFSET = java7u25CompensationOffset;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxy.java
@@ -505,6 +505,20 @@ public class ThrowableProxy implements Serializable {
      */
     public String getExtendedStackTraceAsString(final List<String> ignorePackages, final TextRenderer textRenderer, final String suffix, final String lineSeparator) {
         final StringBuilder sb = new StringBuilder(1024);
+        formatExtendedStackTraceTo(sb, ignorePackages, textRenderer, suffix, lineSeparator);
+        return sb.toString();
+    }
+
+    /**
+     * Formats the stack trace including packaging information.
+     *
+     * @param sb Destination.
+     * @param ignorePackages List of packages to be ignored in the trace.
+     * @param textRenderer The message renderer.
+     * @param suffix Append this to the end of each stack frame.
+     * @param lineSeparator The end-of-line separator.
+     */
+    public void formatExtendedStackTraceTo(final StringBuilder sb, final List<String> ignorePackages, final TextRenderer textRenderer, final String suffix, final String lineSeparator) {
         textRenderer.render(name, sb, "Name");
         textRenderer.render(": ", sb, "NameMessageSeparator");
         textRenderer.render(this.message, sb, "Message");
@@ -514,7 +528,6 @@ public class ThrowableProxy implements Serializable {
         this.formatElements(sb, Strings.EMPTY, 0, causedTrace, this.extendedStackTrace, ignorePackages, textRenderer, suffix, lineSeparator);
         this.formatSuppressed(sb, TAB, this.suppressedProxies, ignorePackages, textRenderer, suffix, lineSeparator);
         this.formatCause(sb, Strings.EMPTY, this.causeProxy, ignorePackages, textRenderer, suffix, lineSeparator);
-        return sb.toString();
     }
 
     public String getLocalizedMessage() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ExtendedThrowablePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ExtendedThrowablePatternConverter.java
@@ -20,7 +20,6 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.impl.ThrowableProxy;
-import org.apache.logging.log4j.util.Strings;
 
 /**
  * Outputs the Throwable portion of the LoggingEvent as a full stack trace
@@ -68,13 +67,12 @@ public final class ExtendedThrowablePatternConverter extends ThrowablePatternCon
                 super.format(event, toAppendTo);
                 return;
             }
-            final String extStackTrace = proxy.getExtendedStackTraceAsString(options.getIgnorePackages(),
-                    options.getTextRenderer(), getSuffix(event), options.getSeparator());
             final int len = toAppendTo.length();
             if (len > 0 && !Character.isWhitespace(toAppendTo.charAt(len - 1))) {
                 toAppendTo.append(' ');
             }
-            toAppendTo.append(extStackTrace);
+            proxy.formatExtendedStackTraceTo(toAppendTo, options.getIgnorePackages(),
+                    options.getTextRenderer(), getSuffix(event), options.getSeparator());
         }
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverter.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.impl.ThrowableFormatOptions;
 import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.core.util.StringBuilderWriter;
 import org.apache.logging.log4j.util.Strings;
 
 
@@ -44,6 +45,8 @@ public class ThrowablePatternConverter extends LogEventPatternConverter {
      */
     protected final List<PatternFormatter> formatters;
     private String rawOption;
+    private final boolean subShortOption;
+    private final boolean nonStandardLineSeparator;
 
     /**
      * Options.
@@ -87,7 +90,13 @@ public class ThrowablePatternConverter extends LogEventPatternConverter {
         } else {
             this.formatters = Collections.emptyList();
         }
-
+        subShortOption = ThrowableFormatOptions.MESSAGE.equalsIgnoreCase(rawOption) ||
+                ThrowableFormatOptions.LOCALIZED_MESSAGE.equalsIgnoreCase(rawOption) ||
+                ThrowableFormatOptions.FILE_NAME.equalsIgnoreCase(rawOption) ||
+                ThrowableFormatOptions.LINE_NUMBER.equalsIgnoreCase(rawOption) ||
+                ThrowableFormatOptions.METHOD_NAME.equalsIgnoreCase(rawOption) ||
+                ThrowableFormatOptions.CLASS_NAME.equalsIgnoreCase(rawOption);
+        nonStandardLineSeparator = !Strings.LINE_SEPARATOR.equals(this.options.getSeparator());
     }
 
     /**
@@ -109,21 +118,12 @@ public class ThrowablePatternConverter extends LogEventPatternConverter {
     public void format(final LogEvent event, final StringBuilder buffer) {
         final Throwable t = event.getThrown();
 
-        if (isSubShortOption()) {
+        if (subShortOption) {
             formatSubShortOption(t, getSuffix(event), buffer);
         }
         else if (t != null && options.anyLines()) {
             formatOption(t, getSuffix(event), buffer);
         }
-    }
-
-    private boolean isSubShortOption() {
-        return ThrowableFormatOptions.MESSAGE.equalsIgnoreCase(rawOption) ||
-                ThrowableFormatOptions.LOCALIZED_MESSAGE.equalsIgnoreCase(rawOption) ||
-                ThrowableFormatOptions.FILE_NAME.equalsIgnoreCase(rawOption) ||
-                ThrowableFormatOptions.LINE_NUMBER.equalsIgnoreCase(rawOption) ||
-                ThrowableFormatOptions.METHOD_NAME.equalsIgnoreCase(rawOption) ||
-                ThrowableFormatOptions.CLASS_NAME.equalsIgnoreCase(rawOption);
     }
 
     private void formatSubShortOption(final Throwable t, final String suffix, final StringBuilder buffer) {
@@ -174,32 +174,29 @@ public class ThrowablePatternConverter extends LogEventPatternConverter {
     }
 
     private void formatOption(final Throwable throwable, final String suffix, final StringBuilder buffer) {
-        final StringWriter w = new StringWriter();
-
-        throwable.printStackTrace(new PrintWriter(w));
         final int len = buffer.length();
         if (len > 0 && !Character.isWhitespace(buffer.charAt(len - 1))) {
             buffer.append(' ');
         }
-        if (!options.allLines() || !Strings.LINE_SEPARATOR.equals(options.getSeparator()) || Strings.isNotBlank(suffix)) {
-            final StringBuilder sb = new StringBuilder();
+        if (!options.allLines() || nonStandardLineSeparator || Strings.isNotBlank(suffix)) {
+            final StringWriter w = new StringWriter();
+            throwable.printStackTrace(new PrintWriter(w));
+
             final String[] array = w.toString().split(Strings.LINE_SEPARATOR);
             final int limit = options.minLines(array.length) - 1;
             final boolean suffixNotBlank = Strings.isNotBlank(suffix);
             for (int i = 0; i <= limit; ++i) {
-                sb.append(array[i]);
+                buffer.append(array[i]);
                 if (suffixNotBlank) {
-                    sb.append(' ');
-                    sb.append(suffix);
+                    buffer.append(' ');
+                    buffer.append(suffix);
                 }
                 if (i < limit) {
-                    sb.append(options.getSeparator());
+                    buffer.append(options.getSeparator());
                 }
             }
-            buffer.append(sb.toString());
-
         } else {
-            buffer.append(w.toString());
+            throwable.printStackTrace(new PrintWriter(new StringBuilderWriter(buffer)));
         }
     }
 
@@ -214,6 +211,9 @@ public class ThrowablePatternConverter extends LogEventPatternConverter {
     }
 
     protected String getSuffix(final LogEvent event) {
+        if (formatters.isEmpty()) {
+            return Strings.EMPTY;
+        }
         //noinspection ForLoopReplaceableByForEach
         final StringBuilder toAppendTo = new StringBuilder();
         for (int i = 0, size = formatters.size(); i <  size; i++) {

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/FileAppenderThrowableBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/FileAppenderThrowableBenchmark.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.perf.jmh;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+
+/**
+ * Benchmarks Log4j 2, Log4j 1, Logback and JUL using the ERROR level which is enabled for this test.
+ * The configuration for each writes to disk.
+ */
+// HOW TO RUN THIS TEST
+// java -jar target/benchmarks.jar ".*FileAppenderThrowableBenchmark.*" -f 1 -i 10 -wi 20 -bm sample -tu ns
+@State(Scope.Thread)
+@Threads(1)
+@Fork(1)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 3, time = 3)
+public class FileAppenderThrowableBenchmark {
+
+    private static final Throwable THROWABLE = getThrowable();
+
+    private static Throwable getThrowable() {
+        return new IllegalStateException("Test Throwable");
+    }
+
+    private FileHandler julFileHandler;
+    Logger log4j2ExtendedThrowable;
+    Logger log4j2SimpleThrowable;
+    org.slf4j.Logger slf4jLogger;
+    org.apache.log4j.Logger log4j1Logger;
+    java.util.logging.Logger julLogger;
+
+    @Setup
+    public void setUp() throws Exception {
+        deleteLogFiles();
+        System.setProperty("log4j2.is.webapp", "false");
+        System.setProperty("log4j.configurationFile", "log4j2-perf-file-throwable.xml");
+        System.setProperty("log4j.configuration", "log4j12-perf-file-throwable.xml");
+        System.setProperty("logback.configurationFile", "logback-perf-file-throwable.xml");
+
+        log4j2ExtendedThrowable = LogManager.getLogger("RAFExtendedException");
+        log4j2SimpleThrowable = LogManager.getLogger("RAFSimpleException");
+        slf4jLogger = LoggerFactory.getLogger(getClass());
+        log4j1Logger = org.apache.log4j.Logger.getLogger(getClass());
+
+        julFileHandler = new FileHandler("target/testJulLog.log");
+        julLogger = java.util.logging.Logger.getLogger(getClass().getName());
+        julLogger.setUseParentHandlers(false);
+        julLogger.addHandler(julFileHandler);
+        julLogger.setLevel(Level.ALL);
+    }
+
+    @TearDown
+    public void tearDown() {
+        System.clearProperty("log4j2.is.webapp");
+        System.clearProperty("log4j.configurationFile");
+        System.clearProperty("log4j.configuration");
+        System.clearProperty("logback.configurationFile");
+        deleteLogFiles();
+    }
+
+    private void deleteLogFiles() {
+        final File logbackFile = new File("target/testlogback.log");
+        logbackFile.delete();
+        final File log4jFile = new File ("target/testlog4j.log");
+        log4jFile.delete();
+        final File log4jRandomFile = new File ("target/extended-exception.log");
+        log4jRandomFile.delete();
+        final File log4j2File = new File ("target/simple-exception.log");
+        log4j2File.delete();
+        final File julFile = new File("target/testJulLog.log");
+        julFile.delete();
+    }
+
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Benchmark
+    public void log4j1() {
+        log4j1Logger.error("Caught an exception", THROWABLE);
+    }
+
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Benchmark
+    public void log4j2SimpleThrowable() {
+        log4j2SimpleThrowable.error("Caught an exception", THROWABLE);
+    }
+
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Benchmark
+    public void log4j2ExtendedThrowable() {
+        log4j2ExtendedThrowable.error("Caught an exception", THROWABLE);
+    }
+
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Benchmark
+    public void logbackFile() {
+        slf4jLogger.error("Caught an exception", THROWABLE);
+    }
+
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Benchmark
+    public void julFile() {
+        // must specify sourceClass or JUL will look it up by walking the stack trace!
+        julLogger.logp(Level.SEVERE, getClass().getName(), "param1JulFile", "Caught an exception", THROWABLE);
+    }
+}

--- a/log4j-perf/src/main/resources/log4j12-perf-file-throwable.xml
+++ b/log4j-perf/src/main/resources/log4j12-perf-file-throwable.xml
@@ -1,0 +1,31 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+    <appender name="TestLogfile" class="org.apache.log4j.FileAppender">
+        <param name="File" value="target/testlog4j.log"/>
+        <param name="immediateFlush" value="false"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%m%n"/>
+        </layout>
+    </appender>
+    <root>
+        <level value="debug"/>
+        <appender-ref ref="TestLogfile"/>
+    </root>
+</log4j:configuration>

--- a/log4j-perf/src/main/resources/log4j2-perf-file-throwable.xml
+++ b/log4j-perf/src/main/resources/log4j2-perf-file-throwable.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration name="FileAppenderThrowableBenchmark" status="error">
+    <Appenders>
+        <RandomAccessFile name="RAFExtendedException" fileName="target/extended-exception.log" immediateFlush="false">
+            <PatternLayout>
+                <Pattern>%m%xEx</Pattern>
+            </PatternLayout>
+        </RandomAccessFile>
+        <RandomAccessFile name="RAFSimpleException" fileName="target/simple-exception.log" immediateFlush="false">
+            <PatternLayout>
+                <Pattern>%m%ex</Pattern>
+            </PatternLayout>
+        </RandomAccessFile>
+    </Appenders>
+    <Loggers>
+        <Logger name="RAFExtendedException" level="debug" additivity="false">
+            <AppenderRef ref="RAFExtendedException"/>
+        </Logger>
+        <Logger name="RAFSimpleException" level="debug" additivity="false">
+            <AppenderRef ref="RAFSimpleException"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/log4j-perf/src/main/resources/logback-perf-file-throwable.xml
+++ b/log4j-perf/src/main/resources/logback-perf-file-throwable.xml
@@ -1,0 +1,30 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<configuration>
+    <appender name="TestLogfile" class="ch.qos.logback.core.FileAppender">
+        <file>target/testlogback.log</file>
+        <immediateFlush>false</immediateFlush>
+        <encoder>
+            <Pattern>%m%n</Pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="TestLogfile" />
+    </root>
+</configuration>


### PR DESCRIPTION
Initial results (re-ordered fastest to slowest):

```
Benchmark                                                Mode  Cnt       Score       Error  Units
FileAppenderThrowableBenchmark.logbackFile              thrpt    3  135260.838 ± 15790.010  ops/s
FileAppenderThrowableBenchmark.log4j2SimpleThrowable    thrpt    3   87385.712 ±  8082.803  ops/s
FileAppenderThrowableBenchmark.log4j1                   thrpt    3   60359.485 ± 10122.858  ops/s
FileAppenderThrowableBenchmark.julFile                  thrpt    3   52134.431 ±  1302.365  ops/s
FileAppenderThrowableBenchmark.log4j2ExtendedThrowable  thrpt    3   15348.378 ±  1301.501  ops/s
```