### PR TITLE
workaround flaky "Operation not permitted" failures in mongo tests

### DIFF
--- a/log4j-mongodb2/pom.xml
+++ b/log4j-mongodb2/pom.xml
@@ -89,6 +89,14 @@
           </instructions>
         </configuration>
       </plugin>
+      <!-- workaround flaky "Operation not permitted" failures when running tests in parallel -->
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <reporting>

--- a/log4j-mongodb3/pom.xml
+++ b/log4j-mongodb3/pom.xml
@@ -93,6 +93,14 @@
           </instructions>
         </configuration>
       </plugin>
+      <!-- workaround flaky "Operation not permitted" failures when running tests in parallel -->
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <reporting>


### PR DESCRIPTION
mongo tests intermittenly fail with an "Operation not permitted"
IOException when trying to execute the mongod extracted by
de.flapdoodle.embed.process; this seems to be related to surefire
running tests in parallel. Work around that here by forcing serial
execution of the mongo tests.