### PR TITLE
[LOG4J2-2391] Improve ThrowableProxy performace on java 9+

### DIFF
--- a/log4j-api-java9/src/assembly/java9.xml
+++ b/log4j-api-java9/src/assembly/java9.xml
@@ -35,6 +35,7 @@
         <exclude>**/Dummy.class</exclude>
         <exclude>**/spi/Provider.class</exclude>
         <exclude>**/util/PropertySource.class</exclude>
+        <exclude>**/util/PrivateSecurityManagerStackTraceUtil.class</exclude>
         <exclude>**/message/ThreadDumpMessage.class</exclude>
         <exclude>**/message/ThreadDumpMessage$ThreadInfoFactory.class</exclude>
       </excludes>

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/PrivateSecurityManagerStackTraceUtil.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/PrivateSecurityManagerStackTraceUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.util;
+
+import java.util.Stack;
+
+/**
+ * This is a dummy class and is only here to allow this module to compile. It will not
+ * be copied into the log4j-api module.
+ */
+final class PrivateSecurityManagerStackTraceUtil {
+
+    static boolean isEnabled() {
+        return false;
+    }
+
+    static Stack<Class<?>> getCurrentStackTrace() {
+        return null;
+    }
+}

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -61,6 +61,10 @@ public class StackLocator {
     }
 
     public Stack<Class<?>> getCurrentStackTrace() {
+        // benchmarks show that using the SecurityManager is much faster than looping through getCallerClass(int)
+        if (PrivateSecurityManagerStackTraceUtil.isEnabled()) {
+            return PrivateSecurityManagerStackTraceUtil.getCurrentStackTrace();
+        }
         Stack<Class<?>> stack = new Stack<Class<?>>();
         List<Class<?>> classes = walker.walk(s -> s.map(f -> f.getDeclaringClass()).collect(Collectors.toList()));
         stack.addAll(classes);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PrivateSecurityManagerStackTraceUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PrivateSecurityManagerStackTraceUtil.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.util;
+
+import java.util.Stack;
+
+/**
+ * Internal utility to share a fast implementation of {@link #getCurrentStackTrace()}
+ * with the java 9 implementation of {@link StackLocator}.
+ */
+final class PrivateSecurityManagerStackTraceUtil {
+
+    private static final PrivateSecurityManager SECURITY_MANAGER;
+
+    static {
+        PrivateSecurityManager psm;
+        try {
+            final SecurityManager sm = System.getSecurityManager();
+            if (sm != null) {
+                sm.checkPermission(new RuntimePermission("createSecurityManager"));
+            }
+            psm = new PrivateSecurityManager();
+        } catch (final SecurityException ignored) {
+            psm = null;
+        }
+
+        SECURITY_MANAGER = psm;
+    }
+
+    private PrivateSecurityManagerStackTraceUtil() {
+        // Utility Class
+    }
+
+    static boolean isEnabled() {
+        return SECURITY_MANAGER != null;
+    }
+
+    // benchmarks show that using the SecurityManager is much faster than looping through getCallerClass(int)
+    static Stack<Class<?>> getCurrentStackTrace() {
+        final Class<?>[] array = SECURITY_MANAGER.getClassContext();
+        final Stack<Class<?>> classes = new Stack<>();
+        classes.ensureCapacity(array.length);
+        for (final Class<?> clazz : array) {
+            classes.push(clazz);
+        }
+        return classes;
+    }
+
+    private static final class PrivateSecurityManager extends SecurityManager {
+
+        @Override
+        protected Class<?>[] getClassContext() {
+            return super.getClassContext();
+        }
+
+    }
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -46,8 +46,6 @@ import java.util.Stack;
  */
 public final class StackLocator {
 
-    private static final PrivateSecurityManager SECURITY_MANAGER;
-
     // Checkstyle Suppress: the lower-case 'u' ticks off CheckStyle...
     // CHECKSTYLE:OFF
     static final int JDK_7u25_OFFSET;
@@ -81,19 +79,6 @@ public final class StackLocator {
             getCallerClass = null;
             java7u25CompensationOffset = -1;
         }
-
-        PrivateSecurityManager psm;
-        try {
-            final SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkPermission(new RuntimePermission("createSecurityManager"));
-            }
-            psm = new PrivateSecurityManager();
-        } catch (final SecurityException ignored) {
-            psm = null;
-        }
-
-        SECURITY_MANAGER = psm;
 
         GET_CALLER_CLASS = getCallerClass;
         JDK_7u25_OFFSET = java7u25CompensationOffset;
@@ -167,14 +152,8 @@ public final class StackLocator {
     @PerformanceSensitive
     public Stack<Class<?>> getCurrentStackTrace() {
         // benchmarks show that using the SecurityManager is much faster than looping through getCallerClass(int)
-        if (getSecurityManager() != null) {
-            final Class<?>[] array = getSecurityManager().getClassContext();
-            final Stack<Class<?>> classes = new Stack<>();
-            classes.ensureCapacity(array.length);
-            for (final Class<?> clazz : array) {
-                classes.push(clazz);
-            }
-            return classes;
+        if (PrivateSecurityManagerStackTraceUtil.isEnabled()) {
+            return PrivateSecurityManagerStackTraceUtil.getCurrentStackTrace();
         }
         // slower version using getCallerClass where we cannot use a SecurityManager
         final Stack<Class<?>> classes = new Stack<>();
@@ -250,18 +229,5 @@ public final class StackLocator {
         }
         // any others?
         return true;
-    }
-
-    protected PrivateSecurityManager getSecurityManager() {
-        return SECURITY_MANAGER;
-    }
-
-    private static final class PrivateSecurityManager extends SecurityManager {
-
-        @Override
-        protected Class<?>[] getClassContext() {
-            return super.getClassContext();
-        }
-
     }
 }


### PR DESCRIPTION
Share the SecurityManager implementation of getCurrentStackTrace
with the java 9 implementation.