### PR TITLE
[LOG4J2-2363] pass object parameter to reusable events

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
@@ -94,22 +94,31 @@ public class ReusableObjectMessage implements ReusableMessage, ParameterVisitabl
     }
 
     /**
-     * This message does not have any parameters, so this method returns the specified array.
+     * This message has exactly one parameter (the object), so returns it as the first parameter in the array.
      * @param emptyReplacement the parameter array to return
      * @return the specified array
      */
     @Override
     public Object[] swapParameters(final Object[] emptyReplacement) {
+        // it's unlikely that emptyReplacement is of length 0, but if it is,
+        // go ahead and allocate the memory now;
+        // this saves an allocation in the future when this buffer is re-used
+        if (emptyReplacement.length == 0) {
+            Object[] params = new Object[10]; // Default reusable parameter buffer size
+            params[0] = obj;
+            return params;
+        }
+        emptyReplacement[0] = obj;
         return emptyReplacement;
     }
 
     /**
-     * This message does not have any parameters so this method always returns zero.
-     * @return 0 (zero)
+     * This message has exactly one parameter (the object), so always returns one.
+     * @return 1
      */
     @Override
     public short getParameterCount() {
-        return 0;
+        return 1;
     }
 
     @Override


### PR DESCRIPTION
make ReusableObjectMessage always pass its object as the first parameter