### PR TITLE
Prevent test flakes

### DIFF
--- a/log4j-api-java9/pom.xml
+++ b/log4j-api-java9/pom.xml
@@ -111,8 +111,6 @@
           <systemPropertyVariables>
             <java.awt.headless>true</java.awt.headless>
           </systemPropertyVariables>
-          <forkCount>2C</forkCount>
-          <reuseForks>true</reuseForks>
           <includes>
             <include>**/Test*.java</include>
             <include>**/*Test.java</include>

--- a/log4j-api/pom.xml
+++ b/log4j-api/pom.xml
@@ -150,14 +150,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkCount>2C</forkCount>
-          <reuseForks>true</reuseForks>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>

--- a/log4j-api/src/test/java/org/apache/logging/log4j/ThreadContextInheritanceTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/ThreadContextInheritanceTest.java
@@ -21,15 +21,20 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.logging.log4j.junit.ThreadContextRule;
 import org.apache.logging.log4j.spi.DefaultThreadContextMap;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * Tests {@link ThreadContext}.
  */
 public class ThreadContextInheritanceTest {
+
+    @Rule
+    public ThreadContextRule threadContextRule = new ThreadContextRule();
 
     @BeforeClass
     public static void setupClass() {

--- a/log4j-api/src/test/java/org/apache/logging/log4j/ThreadContextTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/ThreadContextTest.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.logging.log4j.junit.ThreadContextRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -31,6 +33,9 @@ public class ThreadContextTest {
     public static void reinitThreadContext() {
         ThreadContext.init();
     }
+
+    @Rule
+    public ThreadContextRule threadContextRule = new ThreadContextRule();
 
     @Test
     public void testPush() {
@@ -45,7 +50,6 @@ public class ThreadContextTest {
 
     @Test
     public void testInheritanceSwitchedOffByDefault() throws Exception {
-        ThreadContext.clearMap();
         ThreadContext.put("Greeting", "Hello");
         StringBuilder sb = new StringBuilder();
         TestThread thread = new TestThread(sb);
@@ -105,8 +109,6 @@ public class ThreadContextTest {
 
     @Test
     public void testPutAll() {
-        ThreadContext.clearMap();
-        //
         assertTrue(ThreadContext.isEmpty());
         assertFalse(ThreadContext.containsKey("key"));
         final int mapSize = 10;
@@ -124,7 +126,6 @@ public class ThreadContextTest {
 
     @Test
     public void testRemove() {
-        ThreadContext.clearMap();
         assertNull(ThreadContext.get("testKey"));
         ThreadContext.put("testKey", "testValue");
         assertEquals("testValue", ThreadContext.get("testKey"));
@@ -136,7 +137,6 @@ public class ThreadContextTest {
 
     @Test
     public void testRemoveAll() {
-        ThreadContext.clearMap();
         ThreadContext.put("testKey1", "testValue1");
         ThreadContext.put("testKey2", "testValue2");
         assertEquals("testValue1", ThreadContext.get("testKey1"));
@@ -151,7 +151,6 @@ public class ThreadContextTest {
 
     @Test
     public void testContainsKey() {
-        ThreadContext.clearMap();
         assertFalse(ThreadContext.containsKey("testKey"));
         ThreadContext.put("testKey", "testValue");
         assertTrue(ThreadContext.containsKey("testKey"));

--- a/log4j-core-java9/pom.xml
+++ b/log4j-core-java9/pom.xml
@@ -108,8 +108,6 @@
           <systemPropertyVariables>
             <java.awt.headless>true</java.awt.headless>
           </systemPropertyVariables>
-          <forkCount>2C</forkCount>
-          <reuseForks>true</reuseForks>
           <includes>
             <include>**/Test*.java</include>
             <include>**/*Test.java</include>

--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -381,8 +381,6 @@
           <excludedGroups>
             org.apache.logging.log4j.categories.PerformanceTests
           </excludedGroups>
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
           <systemPropertyVariables>
             <org.apache.activemq.SERIALIZABLE_PACKAGES>*</org.apache.activemq.SERIALIZABLE_PACKAGES>
           </systemPropertyVariables>

--- a/log4j-osgi/pom.xml
+++ b/log4j-osgi/pom.xml
@@ -70,14 +70,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkCount>2C</forkCount>
-          <reuseForks>true</reuseForks>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1102,8 +1102,8 @@
           <systemPropertyVariables>
             <java.awt.headless>true</java.awt.headless>
           </systemPropertyVariables>
-          <forkCount>2C</forkCount>
-          <reuseForks>true</reuseForks>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
           <excludes>
             <exclude>${log4j.skip.test1}</exclude>
             <exclude>${log4j.skip.test2}</exclude>


### PR DESCRIPTION
* Apply ThreadContextRule to ThreadContext tests
* Standardize surefire forkCount on 1, rather than 2*CORES.