### PR TITLE
[LOG4J2-2399] support for async formatting on reusable messages

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageContentFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageContentFormatter.java
@@ -1,0 +1,5 @@
+package org.apache.logging.log4j.message;
+
+public interface MessageContentFormatter {
+    void formatTo(String formatString, Object[] parameters, int parameterCount, final StringBuilder buffer);
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageContentFormatterProvider.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageContentFormatterProvider.java
@@ -1,0 +1,5 @@
+package org.apache.logging.log4j.message;
+
+public interface MessageContentFormatterProvider {
+    MessageContentFormatter getMessageContentFormatter();
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.util.StringBuilders;
  * @since 2.6
  */
 @PerformanceSensitive("allocation")
-public class ReusableObjectMessage implements ReusableMessage, ParameterVisitable, Clearable {
+public class ReusableObjectMessage implements ReusableMessage, ParameterVisitable, Clearable, MessageContentFormatterProvider {
     private static final long serialVersionUID = 6922476812535519960L;
 
     private transient Object obj;
@@ -126,4 +126,16 @@ public class ReusableObjectMessage implements ReusableMessage, ParameterVisitabl
     public void clear() {
         obj = null;
     }
+
+    @Override
+    public MessageContentFormatter getMessageContentFormatter() {
+        return formatter;
+    }
+
+    private static final MessageContentFormatter formatter = new MessageContentFormatter() {
+        @Override
+        public void formatTo(String formatString, Object[] parameters, int parameterCount, StringBuilder buffer) {
+            StringBuilders.appendValue(buffer, parameters[0]);
+        }
+    };
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/BackgroundFormattingRingBufferLogEventTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/BackgroundFormattingRingBufferLogEventTest.java
@@ -1,0 +1,74 @@
+package org.apache.logging.log4j.core.async;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.ThreadContext.ContextStack;
+import org.apache.logging.log4j.categories.AsyncLoggers;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.time.internal.DummyNanoClock;
+import org.apache.logging.log4j.core.time.internal.FixedPreciseClock;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.MessageContentFormatter;
+import org.apache.logging.log4j.message.ReusableMessageFactory;
+import org.apache.logging.log4j.message.ReusableObjectMessage;
+import org.apache.logging.log4j.util.StringBuilders;
+import org.apache.logging.log4j.util.StringMap;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Tests the RingBufferLogEvent class when background message formatting is enabled.
+ */
+@Category(AsyncLoggers.class)
+public class BackgroundFormattingRingBufferLogEventTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        System.setProperty("log4j.format.msg.async", "true");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("log4j.format.msg.async");
+    }
+
+    private class TestReusableMessage extends ReusableObjectMessage {
+        @Override
+        public MessageContentFormatter getMessageContentFormatter() {
+            return (formatString, parameters, parameterCount, buffer) -> StringBuilders.appendValue(buffer, "foo");
+        }
+    }
+
+    @Test
+    public void testMessageContentFormatters() {
+        RingBufferLogEvent evt = RingBufferLogEvent.FACTORY.newInstance();
+        final String loggerName = null;
+        final Marker marker = null;
+        final String fqcn = null;
+        final Level level = null;
+        final Message data = new TestReusableMessage();
+        final Throwable t = null;
+        final ContextStack contextStack = null;
+        final String threadName = null;
+        final StackTraceElement location = null;
+        evt.setValues(null, loggerName, marker, fqcn, level, data, t, (StringMap) evt.getContextData(),
+                contextStack, -1, threadName, -1, location, new FixedPreciseClock(), new DummyNanoClock(1));
+        assertNotNull(evt.getMessage());
+        assertEquals(evt, evt.getMessage());
+        assertEquals("foo", evt.getFormattedMessage());
+
+        final Message data2 = ReusableMessageFactory.INSTANCE.newMessage("test");
+        RingBufferLogEvent evt2 = RingBufferLogEvent.FACTORY.newInstance();
+        evt2.setValues(null, loggerName, marker, fqcn, level, data2, t, (StringMap) evt.getContextData(),
+                contextStack, -1, threadName, -1, location, new FixedPreciseClock(), new DummyNanoClock(1));
+        assertNotNull(evt2.getMessage());
+        assertEquals(evt2, evt2.getMessage());
+        assertEquals("test", evt2.getFormattedMessage());
+    }
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/BackgroundFormattingMutableLogEventTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/BackgroundFormattingMutableLogEventTest.java
@@ -1,0 +1,85 @@
+package org.apache.logging.log4j.core.impl;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.MarkerManager;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.MessageContentFormatter;
+import org.apache.logging.log4j.message.ReusableMessageFactory;
+import org.apache.logging.log4j.message.ReusableObjectMessage;
+import org.apache.logging.log4j.util.StringBuilders;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests the MutableLogEvent class when background message formatting is enabled.
+ */
+public class BackgroundFormattingMutableLogEventTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        System.setProperty("log4j.format.msg.async", "true");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("log4j.format.msg.async");
+    }
+
+    private class TestReusableMessage extends ReusableObjectMessage {
+        @Override
+        public MessageContentFormatter getMessageContentFormatter() {
+            return (formatString, parameters, parameterCount, buffer) -> StringBuilders.appendValue(buffer, "foo");
+        }
+    }
+
+    @Test
+    public void testWithMessageContentFormatter() {
+        TestReusableMessage message = new TestReusableMessage();
+        final Log4jLogEvent source = Log4jLogEvent.newBuilder()
+                .setEndOfBatch(true) //
+                .setIncludeLocation(true) //
+                .setLevel(Level.FATAL) //
+                .setLoggerFqcn("a.b.c.d.e") //
+                .setLoggerName("my name is Logger") //
+                .setMarker(MarkerManager.getMarker("on your marks")) //
+                .setMessage(message) //
+                .setNanoTime(1234567) //
+                .setSource(new StackTraceElement("myclass", "mymethod", "myfile", 123)) //
+                .setThreadId(100).setThreadName("threadname").setThreadPriority(10) //
+                .setThrown(new RuntimeException("run")) //
+                .setTimeMillis(987654321)
+                .build();
+        final MutableLogEvent mutable = new MutableLogEvent();
+        mutable.initFrom(source);
+        // does not format message in setMessage, so this should be null
+        assertNull(mutable.getFormat());
+        assertEquals("foo", mutable.getFormattedMessage());
+    }
+
+    @Test
+    public void testWithoutMessageContentFormatter() {
+        Message message = ReusableMessageFactory.INSTANCE.newMessage("test");
+        final Log4jLogEvent source = Log4jLogEvent.newBuilder()
+                .setEndOfBatch(true) //
+                .setIncludeLocation(true) //
+                .setLevel(Level.FATAL) //
+                .setLoggerFqcn("a.b.c.d.e") //
+                .setLoggerName("my name is Logger") //
+                .setMarker(MarkerManager.getMarker("on your marks")) //
+                .setMessage(message) //
+                .setNanoTime(1234567) //
+                .setSource(new StackTraceElement("myclass", "mymethod", "myfile", 123)) //
+                .setThreadId(100).setThreadName("threadname").setThreadPriority(10) //
+                .setThrown(new RuntimeException("run")) //
+                .setTimeMillis(987654321)
+                .build();
+        final MutableLogEvent mutable = new MutableLogEvent();
+        mutable.initFrom(source);
+        assertEquals("test", mutable.getFormat());
+        assertEquals("test", mutable.getFormattedMessage());
+    }
+}


### PR DESCRIPTION
Adds support for deferring message content formatting on certain
ReusableMessage implementations to a background thread when async
logging is enabled. This change adds the ability for log events to
retain an instance of a formatter for a message so that the message
content can be formatted later, after the message has already been
recycled.

This is an effort to optimize performance for use cases where formatting
on the logging thread is unnecessary or undesired.