### PR TITLE
[proposal] Add "log4j2.enable.throwable.proxy" to disable ThrowableProxy

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
@@ -330,10 +330,8 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
     @Override
     public ThrowableProxy getThrownProxy() {
         // lazily instantiate the (expensive) ThrowableProxy
-        if (thrownProxy == null) {
-            if (thrown != null) {
-                thrownProxy = new ThrowableProxy(thrown);
-            }
+        if (thrownProxy == null && thrown != null && Constants.ENABLE_THROWABLE_PROXY) {
+            thrownProxy = new ThrowableProxy(thrown);
         }
         return this.thrownProxy;
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jLogEvent.java
@@ -32,6 +32,7 @@ import org.apache.logging.log4j.core.ContextDataInjector;
 import org.apache.logging.log4j.core.time.*;
 import org.apache.logging.log4j.core.time.ClockFactory;
 import org.apache.logging.log4j.core.time.internal.DummyNanoClock;
+import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.async.RingBufferLogEvent;
@@ -601,12 +602,11 @@ public class Log4jLogEvent implements LogEvent {
      */
     @Override
     public ThrowableProxy getThrownProxy() {
-        if (thrownProxy == null && thrown != null) {
+        if (thrownProxy == null && thrown != null && Constants.ENABLE_THROWABLE_PROXY) {
             thrownProxy = new ThrowableProxy(thrown);
         }
         return thrownProxy;
     }
-
 
     /**
      * Returns the Marker associated with the event, or null.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
@@ -349,7 +349,7 @@ public class MutableLogEvent implements LogEvent, ReusableMessage, ParameterVisi
      */
     @Override
     public ThrowableProxy getThrownProxy() {
-        if (thrownProxy == null && thrown != null) {
+        if (thrownProxy == null && thrown != null && Constants.ENABLE_THROWABLE_PROXY) {
             thrownProxy = new ThrowableProxy(thrown);
         }
         return thrownProxy;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
@@ -135,6 +135,17 @@ public final class Constants {
      */
     public static final int ENCODER_BYTE_BUFFER_SIZE = size("log4j.encoder.byteBufferSize", 8 * 1024);
 
+    /**
+     * Kill switch for <code>ThrowableProxy</code> object creation. ThrowableProxy instances provide additional
+     * packaging information about each stack trace element, however in some cases they can be expensive to
+     * create.
+     * Initialization requires a stack trace to be created, as well as several classloader class lookups.
+     *
+     * @see <a href="https://issues.apache.org/jira/browse/LOG4J2-2391">LOG4J2-2391</a>
+     * @since 2.11.2
+     */
+    public static final boolean ENABLE_THROWABLE_PROXY = PropertiesUtil.getProperties().getBooleanProperty(
+            "log4j2.enable.throwable.proxy", true);
 
     private static int size(final String property, final int defaultValue) {
         return PropertiesUtil.getProperties().getIntegerProperty(property, defaultValue);


### PR DESCRIPTION
This is not expected to be compatible with java serialized
objects or the jackson layout, both of which require a
ThrowableProxy.