### PR TITLE
[LOG4J2-2391] Lazily initialize ThrowableProxy data

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
@@ -258,7 +258,7 @@ public final class LoaderUtil {
         return newCheckedInstanceOf(className, clazz);
     }
 
-    private static boolean isIgnoreTccl() {
+    public static boolean isIgnoreTccl() {
         // we need to lazily initialize this, but concurrent access is not an issue
         if (ignoreTCCL == null) {
             final String ignoreTccl = PropertiesUtil.getProperties().getStringProperty(IGNORE_TCCL_PROPERTY, null);

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/ThrowableProxyTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/ThrowableProxyTest.java
@@ -367,7 +367,7 @@ public class ThrowableProxyTest {
         final Throwable throwable = new IllegalStateException("This is a test");
         final ThrowableProxy proxy = new ThrowableProxy(throwable);
         final ExtendedStackTraceElement[] callerPackageData = proxy.toExtendedStackTrace(stack, map, null,
-                throwable.getStackTrace());
+                throwable.getStackTrace(), null);
         assertNotNull("No package data returned", callerPackageData);
     }
 
@@ -389,7 +389,7 @@ public class ThrowableProxyTest {
         final Throwable throwable = (Throwable) in.readObject();
         final ThrowableProxy subject = new ThrowableProxy(throwable);
 
-        subject.toExtendedStackTrace(stack, map, null, throwable.getStackTrace());
+        subject.toExtendedStackTrace(stack, map, null, throwable.getStackTrace(), null);
     }
 
     /**


### PR DESCRIPTION
Goal is to avoid the most expensive components until render
time, allowing patterns using non-extended traces to avoid
the cost of class loading.

This implementation is fairly naive in that initialization
will deeply initialize all causes and suppressed causes
when any action requires initialization, rather than
lazily initializing only what is required.

Benchmarking results with this change show that the
"complexLog4j2ThrowableAsync" performance matches
"complexLog4j2Throwable" due to avoiding ThrowableProxy
initialization.

```
Benchmark                                                            Mode  Cnt       Score       Error  Units
FileAppenderThrowableBenchmark.complexLog4j1                        thrpt    3    8537.030 ±  5312.479  ops/s
FileAppenderThrowableBenchmark.complexLog4j2ExtendedThrowable       thrpt    3    2534.330 ±   600.769  ops/s
FileAppenderThrowableBenchmark.complexLog4j2ExtendedThrowableAsync  thrpt    3    2488.063 ±   838.325  ops/s
FileAppenderThrowableBenchmark.complexLog4j2Throwable               thrpt    3   13206.010 ±   320.408  ops/s
FileAppenderThrowableBenchmark.complexLog4j2ThrowableAsync          thrpt    3   12795.284 ±  2677.436  ops/s
FileAppenderThrowableBenchmark.complexLogbackFile                   thrpt    3   11377.932 ± 25787.767  ops/s
FileAppenderThrowableBenchmark.julFile                              thrpt    3   54271.234 ± 42052.793  ops/s
FileAppenderThrowableBenchmark.log4j1                               thrpt    3   75694.883 ± 13310.643  ops/s
FileAppenderThrowableBenchmark.log4j2ExtendedThrowable              thrpt    3   46216.007 ±  1046.523  ops/s
FileAppenderThrowableBenchmark.log4j2Throwable                      thrpt    3  110604.119 ± 33981.960  ops/s
FileAppenderThrowableBenchmark.logbackFile                          thrpt    3  112429.311 ± 95759.913  ops/s
```