### PR TITLE
LOG4J2-2025: JUL bridge handler (incl. unit test and site doc)

### DIFF
--- a/log4j-jul/pom.xml
+++ b/log4j-jul/pom.xml
@@ -89,23 +89,52 @@
           </instructions>
         </configuration>
       </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>${surefire.plugin.version}</version>
-            <configuration>
-                <systemPropertyVariables>
-                    <java.awt.headless>true</java.awt.headless>
-                </systemPropertyVariables>
-                <argLine>-Xms256m -Xmx1024m</argLine>
-                <forkCount>1</forkCount>
-                <reuseForks>false</reuseForks>
-                <excludes>
-                    <exclude>${log4j.skip.test1}</exclude>
-                    <exclude>${log4j.skip.test2}</exclude>
-                </excludes>
-            </configuration>
-        </plugin>
+      <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${surefire.plugin.version}</version>
+          <configuration>
+              <systemPropertyVariables>
+                  <java.awt.headless>true</java.awt.headless>
+              </systemPropertyVariables>
+              <argLine>-Xms256m -Xmx1024m</argLine>
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+          </configuration>
+          <executions>
+              <execution>
+                  <id>default-test</id>
+                  <phase>test</phase>
+                  <goals>
+                      <goal>test</goal>
+                  </goals>
+                  <excludes>
+                      <exclude>${log4j.skip.test1}</exclude>
+                      <exclude>${log4j.skip.test2}</exclude>
+                      <exclude>Log4jBridgeHandlerTest.java</exclude>
+                  </excludes>
+              </execution>
+          </executions>
+          <executions>
+              <execution>
+                  <!-- this test needs some special configuration, thus its own run -->
+                  <id>bridgeHandler-test</id>
+                  <phase>test</phase>
+                  <goals>
+                      <goal>test</goal>
+                  </goals>
+                  <includes>
+                      <include>Log4jBridgeHandlerTest.java</include>
+                  </includes>
+                  <configuration>
+                      <systemPropertyVariables>
+                          <java.util.logging.config.file>src/test/resources/logging-test.properties</java.util.logging.config.file>
+                          <log4j2.configurationFile>log4j2-julBridge-test.xml</log4j2.configurationFile>
+                      </systemPropertyVariables>
+                  </configuration>
+              </execution>
+          </executions>
+      </plugin>
     </plugins>
   </build>
   <reporting>

--- a/log4j-jul/pom.xml
+++ b/log4j-jul/pom.xml
@@ -108,14 +108,14 @@
                   <goals>
                       <goal>test</goal>
                   </goals>
-                  <excludes>
-                      <exclude>${log4j.skip.test1}</exclude>
-                      <exclude>${log4j.skip.test2}</exclude>
-                      <exclude>Log4jBridgeHandlerTest.java</exclude>
-                  </excludes>
+                  <configuration>
+                      <excludes>
+                          <exclude>${log4j.skip.test1}</exclude>
+                          <exclude>${log4j.skip.test2}</exclude>
+                          <exclude>Log4jBridgeHandlerTest.java</exclude>
+                      </excludes>
+                  </configuration>
               </execution>
-          </executions>
-          <executions>
               <execution>
                   <!-- this test needs some special configuration, thus its own run -->
                   <id>bridgeHandler-test</id>
@@ -123,10 +123,10 @@
                   <goals>
                       <goal>test</goal>
                   </goals>
-                  <includes>
-                      <include>Log4jBridgeHandlerTest.java</include>
-                  </includes>
                   <configuration>
+                      <includes>
+                          <include>Log4jBridgeHandlerTest.java</include>
+                      </includes>
                       <systemPropertyVariables>
                           <java.util.logging.config.file>src/test/resources/logging-test.properties</java.util.logging.config.file>
                           <log4j2.configurationFile>log4j2-julBridge-test.xml</log4j2.configurationFile>

--- a/log4j-jul/src/main/java/org/apache/logging/log4j/jul/Log4jBridgeHandler.java
+++ b/log4j-jul/src/main/java/org/apache/logging/log4j/jul/Log4jBridgeHandler.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.jul;
+
+// note: NO import of Logger, LogManager etc. to prevent conflicts JUL/log4j
+import java.util.logging.LogRecord;
+
+import org.apache.logging.log4j.spi.ExtendedLogger;
+import org.apache.logging.log4j.status.StatusLogger;
+
+
+/**
+ * Bridge from JUL to log4j2.
+ * This is an alternative to log4j.jul.LogManager (running as complete JUL replacement),
+ * especially useful for webapps running on a container for which the LogManager can or
+ * should not be used.
+ *
+ * Installation/usage:
+ * - programmatically by calling install() method,
+ *    e.g. inside ServletContextListener static-class-init. or contextInitialized()
+ * - declaratively inside JUL's logging.properties:
+ *    handlers = org.apache.logging.log4j.jul.Log4jBridgeHandler
+ *    (note: in a webapp running on Tomcat, you may create a WEB-INF/classes/logging.properties
+ *     file to configure JUL for this webapp only)
+ *
+ * Configuration (in logging.properties):
+ * - Log4jBridgeHandler.suffixToAppend
+ *        String, suffix to append to JUL logger names, to easily recognize bridged log messages.
+ *        A dot "." is automatically prepended, so configuration for the basis logger is used
+ *        Example:  suffixToAppend = _JUL
+ * - Log4jBridgeHandler.propagateLevels  boolean, "true" to automatically propagate log4j log levels to JUL.
+ * - Log4jBridgeHandler.sysoutDebug  boolean
+ *
+ * Restrictions:
+ * - Manually given source/location info in JUL (e.g. entering(), exiting(), throwing(), logp(), logrb() )
+ *    will NOT be considered, i.e. gets lost in log4j logging.
+ *
+ * TODO: performance note; log level propagation
+ *
+ * @author Thies Wellpott (twapache@online.de)
+ * @author authors of original org.slf4j.bridge.SLF4JBridgeHandler (ideas and some basis from there)
+ * @author authors of original ch.qos.logback.classic.jul.LevelChangePropagator (ideas and some basis from there)
+ */
+public class Log4jBridgeHandler extends java.util.logging.Handler {
+    private static final org.apache.logging.log4j.Logger SLOGGER = StatusLogger.getLogger();
+
+    // the caller of the logging is java.util.logging.Logger (for location info)
+    private static final String FQCN = java.util.logging.Logger.class.getName();
+    private static final String UNKNOWN_LOGGER_NAME = "unknown.jul.logger";
+    private static final java.util.logging.Formatter julFormatter = new java.util.logging.SimpleFormatter();
+
+    private boolean debugOutput = false;
+    private String suffixToAppend = null;
+    private boolean installAsLevelPropagator = false;
+
+
+    /**
+     * Adds a Log4jBridgeHandler instance to JUL's root logger.
+     * This is a programmatic alternative to specify "handlers = org.apache.logging.log4j.jul.Log4jBridgeHandler"
+     * in logging.properties.
+     * This handler will redirect JUL logging to log4j2.
+     * However, only logs enabled in JUL will be redirected. For example, if a log
+     * statement invoking a JUL logger is disabled, then the corresponding non-event
+     * will <em>not</em> reach Log4jBridgeHandler and cannot be redirected.
+     *
+     * @param removeHandlersForRootLogger  remove all other installed handlers on JUL root level
+     */
+    public static void install(boolean removeHandlersForRootLogger) {
+        java.util.logging.Logger rootLogger = getJulRootLogger();
+        if (removeHandlersForRootLogger) {
+            for (java.util.logging.Handler hdl : rootLogger.getHandlers()) {
+                rootLogger.removeHandler(hdl);
+            }
+        }
+        rootLogger.addHandler(new Log4jBridgeHandler());
+        // note: filter-level of Handler defaults to ALL, so nothing to do here
+    }
+
+    private static java.util.logging.Logger getJulRootLogger() {
+        return java.util.logging.LogManager.getLogManager().getLogger("");
+    }
+
+
+    /**
+     * Initialize this handler. Read out configuration.
+     */
+    public Log4jBridgeHandler() {
+        final java.util.logging.LogManager julLogMgr = java.util.logging.LogManager.getLogManager();
+        String className = this.getClass().getName();
+        debugOutput = Boolean.parseBoolean(julLogMgr.getProperty(className + ".sysoutDebug"));
+        if (debugOutput) {
+            new Exception("DIAGNOSTIC ONLY (sysout):  Log4jBridgeHandler instance created (" + this + ")")
+                    .printStackTrace(System.out);		// is no error thus no syserr
+        }
+
+        suffixToAppend = julLogMgr.getProperty(className + ".appendSuffix");
+        if (suffixToAppend != null) {
+            suffixToAppend = suffixToAppend.trim();		// remove spaces
+            if (suffixToAppend.isEmpty()) {
+                suffixToAppend = null;
+            } else if (suffixToAppend.charAt(0) != '.') {		// always make it a sub-logger
+                suffixToAppend = '.' + suffixToAppend;
+            }
+        }
+        installAsLevelPropagator = Boolean.parseBoolean(julLogMgr.getProperty(className + ".propagateLevels"));
+        // TODO really do install
+        if (installAsLevelPropagator) {
+        	SLOGGER.warn("Log4jBridgeHandler.propagateLevels is currently NOT implemented. Call Log4jBridgeHandler.initJulLogLevels() !");
+        }
+
+        SLOGGER.debug("Log4jBridgeHandler init. with: suffix='{}', lP={}",
+        		suffixToAppend, installAsLevelPropagator);
+    }
+
+
+    @Override
+    public void close() {
+        if (debugOutput) {
+            System.out.println("sysout:  Log4jBridgeHandler close(): " + this);
+        }
+    }
+
+
+    @Override
+    public void publish(LogRecord record) {
+        // silently ignore null records
+        if (record == null) {
+            return;
+        }
+
+        org.apache.logging.log4j.Logger log4jLogger = getLog4jLogger(record);
+        String msg = julFormatter.formatMessage(record);		// use JUL's implementation to get real msg
+        /* log4j allows nulls:
+        if (msg == null) {
+            // this is a check to avoid calling the underlying logging system
+            // with a null message. While it is legitimate to invoke JUL with
+            // a null message, other logging frameworks do not support this.
+            msg = "<null log msg>";
+        } */
+        org.apache.logging.log4j.Level log4jLevel = LevelTranslator.toLevel(record.getLevel());
+        Throwable thrown = record.getThrown();
+        if (log4jLogger instanceof ExtendedLogger) {
+            // relevant for location information
+            try {
+                ((ExtendedLogger) log4jLogger).logIfEnabled(FQCN, log4jLevel, null, msg, thrown);
+            } catch (NoClassDefFoundError e) {
+                // sometimes there are problems with log4j.ExtendedStackTraceElement, so try a workaround
+                log4jLogger.warn("Log4jBridgeHandler: ignored exception when calling 'ExtendedLogger': {}", e.toString());
+                log4jLogger.log(log4jLevel, msg, thrown);
+            }
+        } else {
+            log4jLogger.log(log4jLevel, msg, thrown);
+        }
+    }
+
+
+    @Override
+    public void flush() {
+        // nothing to do
+    }
+
+
+    /**
+     * Return the Logger instance that will be used for logging.
+     * Handles null name case and appends configured suffix.
+     */
+    protected org.apache.logging.log4j.Logger getLog4jLogger(LogRecord record) {
+        String name = record.getLoggerName();
+        if (name == null) {
+            name = UNKNOWN_LOGGER_NAME;
+        } else if (suffixToAppend != null) {
+            name += suffixToAppend;
+        }
+        return org.apache.logging.log4j.LogManager.getLogger(name);
+    }
+
+}

--- a/log4j-jul/src/main/java/org/apache/logging/log4j/jul/Log4jBridgeHandler.java
+++ b/log4j-jul/src/main/java/org/apache/logging/log4j/jul/Log4jBridgeHandler.java
@@ -24,37 +24,44 @@ import org.apache.logging.log4j.status.StatusLogger;
 
 
 /**
- * Bridge from JUL to log4j2.
+ * Bridge from JUL to log4j2.<br>
  * This is an alternative to log4j.jul.LogManager (running as complete JUL replacement),
- * especially useful for webapps running on a container for which the LogManager can or
- * should not be used.
+ * especially useful for webapps running on a container for which the LogManager cannot or
+ * should not be used.<br><br>
  *
- * Installation/usage:
- * - programmatically by calling install() method,
- *    e.g. inside ServletContextListener static-class-init. or contextInitialized()
- * - declaratively inside JUL's logging.properties:
- *    handlers = org.apache.logging.log4j.jul.Log4jBridgeHandler
- *    (note: in a webapp running on Tomcat, you may create a WEB-INF/classes/logging.properties
+ * Installation/usage:<ul>
+ * <li> declaratively inside JUL's logging.properties:<br>
+ *    <code>handlers = org.apache.logging.log4j.jul.Log4jBridgeHandler</code><br>
+ *    (note: in a webapp running on Tomcat, you may create a <code>WEB-INF/classes/logging.properties</code>
  *     file to configure JUL for this webapp only)
- *
- * Configuration (in logging.properties):
- * - Log4jBridgeHandler.suffixToAppend
+ * <li> programmatically by calling install() method,
+ *    e.g. inside ServletContextListener static-class-init. or contextInitialized()
+ * </ul>
+ * Configuration (in JUL's <code>logging.properties</code>):<ul>
+ * <li> Log4jBridgeHandler.suffixToAppend<br>
  *        String, suffix to append to JUL logger names, to easily recognize bridged log messages.
  *        A dot "." is automatically prepended, so configuration for the basis logger is used
  *        Example:  suffixToAppend = _JUL
- * - Log4jBridgeHandler.propagateLevels  boolean, "true" to automatically propagate log4j log levels to JUL.
- * - Log4jBridgeHandler.sysoutDebug  boolean
+ * <li> Log4jBridgeHandler.propagateLevels   (this is TODO!) boolean, "true" to automatically propagate log4j log levels to JUL.
+ * <li> Log4jBridgeHandler.sysoutDebug   boolean, perform some (developer) debug output to sysout
+ * </ul>
  *
- * Restrictions:
- * - Manually given source/location info in JUL (e.g. entering(), exiting(), throwing(), logp(), logrb() )
+ * Restrictions:<ul>
+ * <li> Manually given source/location info in JUL (e.g. entering(), exiting(), throwing(), logp(), logrb() )
  *    will NOT be considered, i.e. gets lost in log4j logging.
- *
- * TODO: performance note; log level propagation
+ * <li> Log levels of JUL have to be manually adjusted according to log4j log levels (until "propagateLevels" is implemented).
+ *      I.e. logging.properties and log4j2.xml have some redundancies.
+ * <li> Only JUL log events that are allowed according to the JUL log level get to this handler and thus to log4j.
+ *      If you set <code>.level = SEVERE</code> only error logs will be seen by this handler and thus log4j
+ *      - even if the corresponding log4j log level is ALL.<br>
+ *      On the other side, you should NOT set <code>.level = FINER  or  FINEST</code> if the log4j level is higher.
+ *      In this case a lot of JUL log events would be generated, sent via this bridge to log4j and thrown away by the latter.
+ * </ul>
  *
  * @author Thies Wellpott (twapache@online.de)
  * @author authors of original org.slf4j.bridge.SLF4JBridgeHandler (ideas and some basis from there)
- * @author authors of original ch.qos.logback.classic.jul.LevelChangePropagator (ideas and some basis from there)
  */
+// TODO: @author authors of original ch.qos.logback.classic.jul.LevelChangePropagator (ideas and some basis from there)
 public class Log4jBridgeHandler extends java.util.logging.Handler {
     private static final org.apache.logging.log4j.Logger SLOGGER = StatusLogger.getLogger();
 
@@ -119,7 +126,7 @@ public class Log4jBridgeHandler extends java.util.logging.Handler {
         installAsLevelPropagator = Boolean.parseBoolean(julLogMgr.getProperty(className + ".propagateLevels"));
         // TODO really do install
         if (installAsLevelPropagator) {
-        	SLOGGER.warn("Log4jBridgeHandler.propagateLevels is currently NOT implemented. Call Log4jBridgeHandler.initJulLogLevels() !");
+        	SLOGGER.warn("Log4jBridgeHandler.propagateLevels is currently NOT implemented."); // Call Log4jBridgeHandler.initJulLogLevels() !");
         }
 
         SLOGGER.debug("Log4jBridgeHandler init. with: suffix='{}', lP={}",

--- a/log4j-jul/src/site/markdown/index.md
+++ b/log4j-jul/src/site/markdown/index.md
@@ -78,11 +78,12 @@ Java Level | Log4j Level
 
 # Log4j JDK Logging Bridge
 
-The LogManager is not always useable because you have to set a JVM wide effective system property
-- e.g. in web servers this is not always possible.
+The LogManager is not always useable because you have to set a JVM wide effective system
+property - e.g. in web servers this is not possible if you are not the administrator.
 
-The [`Log4jBridgeHandler`](apidocs/org/apache/logging/log4j/jul/Log4jBridgeHandler.html) is a (less performant)
+The [`Log4jBridgeHandler`](apidocs/org/apache/logging/log4j/jul/Log4jBridgeHandler.html) is an
 alternative that can be declaratively used via `logging.properties`.
+It is less performant than the LogManager but still okay to use.
 
 ## Usage
 
@@ -93,7 +94,7 @@ and JUL logs go to log4j2.
 In a webapp on Tomcat (and maybe other servers, too), you may simply create a
 `WEB-INF/classes/logging.properties` file with above content.
 The bridge and the log levels defined in this file are only valid for your webapp and
-does NOT have any impact on the other webapps on the same Tomcat instance.
+do NOT have any impact on the other webapps on the same Tomcat instance.
 
 Alternatively you may call `Log4jBridgeHandler.install()` inside your webapps initialization,
 e.g. inside `ServletContextListener` static-class-init. or `contextInitialized()`.

--- a/log4j-jul/src/site/markdown/index.md
+++ b/log4j-jul/src/site/markdown/index.md
@@ -99,20 +99,21 @@ LogManager.
 
 ## Usage
 
-The JUL configuration file `logging.properties` needs the line
-`handlers = org.apache.logging.log4j.jul.Log4jBridgeHandler`
-and JUL logs go to log4j2.
+The JUL configuration file `logging.properties` needs the line<br>
+`handlers = org.apache.logging.log4j.jul.Log4jBridgeHandler`<br>
+and JUL logs go to log4j2. Additionally, you typically want to use to following:<br>
+`org.apache.logging.log4j.jul.Log4jBridgeHandler.propagateLevels = true`
 
 In a webapp on Tomcat (and maybe other servers, too), you may simply create a
 `WEB-INF/classes/logging.properties` file with above content.
 The bridge and the log levels defined in this file are only valid for your webapp and
-do NOT have any impact on the other webapps on the same Tomcat instance.
+do *not* have any impact on the other webapps on the same Tomcat instance.
 
-Alternatively you may call `Log4jBridgeHandler.install()` inside your webapps initialization,
-e.g. inside `ServletContextListener` static-class-init. or `contextInitialized()`.
+Alternatively you may call `Log4jBridgeHandler.install()` inside your webapp's initialization code,
+e.g. inside `ServletContextListener` or a `ServletFilter` static-class-init. or `contextInitialized()`.
 
-**Important:** Currently, you have to manually adjust JDK and log4j logging levels, i.e. `logging.properties`
-must contain the redundant logger level configuration as log4j, but for the really used JDK loggers only.
+**Important:** Log levels of JDK should match the ones of log4j. You may do this manually or use the
+automatic level propagation via `Log4jBridgeHandler.propagateLevels = true`.
 
 Please, read the [JavaDoc](apidocs/org/apache/logging/log4j/jul/Log4jBridgeHandler.html) for detailed
 configuration and limitation information!

--- a/log4j-jul/src/site/markdown/index.md
+++ b/log4j-jul/src/site/markdown/index.md
@@ -16,6 +16,11 @@
     limitations under the License.
 -->
 
+There are two possibilities:
+- Logging Adapter as complete replacement (preferred, but requires JVM start option)
+- Bridge Handler, transfering JDK output to log4j, e.g. useful for webapps
+
+
 # Log4j JDK Logging Adapter
 
 The JDK Logging Adapter is a custom implementation of
@@ -76,14 +81,21 @@ Java Level | Log4j Level
 [`ALL`](http://docs.oracle.com/javase/6/docs/api/java/util/logging/Level.html#ALL) | `ALL`
 
 
-# Log4j JDK Logging Bridge
+# Log4j JDK Logging Bridge Handler
 
 The LogManager is not always useable because you have to set a JVM wide effective system
 property - e.g. in web servers this is not possible if you are not the administrator.
 
 The [`Log4jBridgeHandler`](apidocs/org/apache/logging/log4j/jul/Log4jBridgeHandler.html) is an
 alternative that can be declaratively used via `logging.properties`.
-It is less performant than the LogManager but still okay to use.
+
+It is less performant than the LogManager but still okay to use: the LogManager replaces the JDK
+implementation, so your logging code (using JDK syntax) effectively directly uses log4j.
+When using the BridgeHandler the original JDK implementation along with its configuration
+(e.g. log levels) is still fully working but the log events are "written" via this handler to log4j
+as if you would have called log4j.Logger.debug() etc.; it is like a FileHandler but instead of
+writing to a file, it "writes" to log4j Loggers - thus there is some overhead compared to using
+LogManager.
 
 ## Usage
 
@@ -99,4 +111,8 @@ do NOT have any impact on the other webapps on the same Tomcat instance.
 Alternatively you may call `Log4jBridgeHandler.install()` inside your webapps initialization,
 e.g. inside `ServletContextListener` static-class-init. or `contextInitialized()`.
 
-Please, read the [JavaDoc](apidocs/org/apache/logging/log4j/jul/Log4jBridgeHandler.html) for configuration and limitations!
+**Important:** Currently, you have to manually adjust JDK and log4j logging levels, i.e. `logging.properties`
+must contain the redundant logger level configuration as log4j, but for the really used JDK loggers only.
+
+Please, read the [JavaDoc](apidocs/org/apache/logging/log4j/jul/Log4jBridgeHandler.html) for detailed
+configuration and limitation information!

--- a/log4j-jul/src/site/markdown/index.md
+++ b/log4j-jul/src/site/markdown/index.md
@@ -74,3 +74,28 @@ Java Level | Log4j Level
 [`FINER`](http://docs.oracle.com/javase/6/docs/api/java/util/logging/Level.html#FINER) | `TRACE`
 [`FINEST`](http://docs.oracle.com/javase/6/docs/api/java/util/logging/Level.html#FINEST) | [`FINEST`](apidocs/org/apache/logging/log4j/jul/LevelTranslator.html#FINEST)
 [`ALL`](http://docs.oracle.com/javase/6/docs/api/java/util/logging/Level.html#ALL) | `ALL`
+
+
+# Log4j JDK Logging Bridge
+
+The LogManager is not always useable because you have to set a JVM wide effective system property
+- e.g. in web servers this is not always possible.
+
+The [`Log4jBridgeHandler`](apidocs/org/apache/logging/log4j/jul/Log4jBridgeHandler.html) is a (less performant)
+alternative that can be declaratively used via `logging.properties`.
+
+## Usage
+
+The JUL configuration file `logging.properties` needs the line
+`handlers = org.apache.logging.log4j.jul.Log4jBridgeHandler`
+and JUL logs go to log4j2.
+
+In a webapp on Tomcat (and maybe other servers, too), you may simply create a
+`WEB-INF/classes/logging.properties` file with above content.
+The bridge and the log levels defined in this file are only valid for your webapp and
+does NOT have any impact on the other webapps on the same Tomcat instance.
+
+Alternatively you may call `Log4jBridgeHandler.install()` inside your webapps initialization,
+e.g. inside `ServletContextListener` static-class-init. or `contextInitialized()`.
+
+Please, read the [JavaDoc](apidocs/org/apache/logging/log4j/jul/Log4jBridgeHandler.html) for configuration and limitations!

--- a/log4j-jul/src/test/java/org/apache/logging/log4j/jul/Log4jBridgeHandlerTest.java
+++ b/log4j-jul/src/test/java/org/apache/logging/log4j/jul/Log4jBridgeHandlerTest.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.jul;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.logging.Level;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+
+
+/**
+ * Test the Log4jBridgeHandler.
+ * Requires some configurations in the log-config-files, for format/layout
+ * see also jul() and log4j():
+ * - JUL-config ("logging-test.properties", must be set on JVM-start via "-D..."):
+ *   + handlers = org.apache.logging.log4j.jul.Log4jBridgeHandler, java.util.logging.ConsoleHandler
+ *   + org.apache.logging.log4j.jul.Log4jBridgeHandler.appendSuffix = _JUL
+ *   + java.util.logging.ConsoleHandler.level = ALL
+ *   + java.util.logging.SimpleFormatter.format = JUL:  %1$tT.%1$tL %4$s [%3$s: %2$s]  -  %5$s%6$s%n
+ *   + .level = FINER
+ * - log4j2-config ("log4j2-test.xml"):
+ *   + <Root level="TRACE">
+ *   + <Appenders> <Console> with target="SYSTEM_ERR", follow="true",
+ *      <PatternLayout> "log4j2:  %d{HH:mm:ss.SSS} %5level - [%thread][%logger: %class/%method/%line]  -  %message%n"
+ *
+ * @author Thies Wellpott (twapache@online.de)
+ */
+@FixMethodOrder(org.junit.runners.MethodSorters.NAME_ASCENDING)		// is nicer for manually checking console output
+public class Log4jBridgeHandlerTest {
+    /** Do output the captured logger-output to stdout? */
+    private static final boolean OUTPUT_CAPTURED = Boolean.parseBoolean(
+            System.getProperty("log4j.Log4jBridgeHandlerTest.outputCaptured"));
+
+    /** This classes' simple name = relevant part of logger name. */
+    private static final String CSNAME = Log4jBridgeHandlerTest.class.getSimpleName();
+    // loggers used in many tests
+    private static final java.util.logging.Logger julLog = java.util.logging.Logger.getLogger(Log4jBridgeHandlerTest.class.getName());
+    private static final org.apache.logging.log4j.Logger log4jLog = org.apache.logging.log4j.LogManager.getLogger();
+
+    // capture sysout/syserr
+    //@Rule  public final SystemErrRule systemOutRule = new SystemErrRule().enableLog();
+    private static final ByteArrayOutputStream sysoutBytes = new ByteArrayOutputStream(1024);
+    private static PrintStream prevSysErrStream;
+
+
+    @BeforeClass
+    public static void beforeClass() {
+        // debug output to easily recognize misconfig.:
+        //System.out.println("sys-props:\n" + System.getProperties());
+        System.out.println("sysout:  logging-cfg-file:  " + System.getProperty("java.util.logging.config.file"));
+
+        // JUL does not like setting stderr inbetween, so set it once and reset collecting stream
+        // for each method; (thus com.github.stefanbirkner:system-rules:SystemErrRule cannot be used)
+        System.err.println("vvv--- BEGIN capturing output to stderr ---vvv"
+                + "   (do output of captured text to orig. stderr: " + OUTPUT_CAPTURED + ")");
+        prevSysErrStream = System.err;
+        System.setErr(new PrintStream(sysoutBytes, true));
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        // reset sysout/err to original value
+        System.setErr(prevSysErrStream);
+        System.err.println("^^^--- END capturing output of stderr ---^^^");
+    }
+
+
+    @Before
+    public void beforeTest() {
+        // reset sysout collector
+        sysoutBytes.reset();
+    }
+
+
+
+    /** Assert that sysout matches given regexp (any text may follow afterwards). */
+    private void assertSysoutMatches(String regex) {
+        //String logOutput = systemOutRule.getLogWithNormalizedLineSeparator();
+        String logOutput = sysoutBytes.toString();
+        if (OUTPUT_CAPTURED)  prevSysErrStream.print(logOutput);
+        logOutput = logOutput.replace("\r\n", "\n");
+        regex = regex + "(.|\\n)*";			// allow any text with NL afterwards
+        assertTrue("Unmatching output:\n" + logOutput + "\n-- vs: --\n" + regex + "\n----", logOutput.matches(regex));
+    }
+
+    /** Get regex for a JUL console output. Must match JUL-Console-Formatter! */
+    private String jul(java.util.logging.Level lvl, String locationPartRE,
+            String msgPartRE, String exceptionClassAndMsgRE) {
+        return "JUL:.*" + lvl.getLocalizedName() + ".*" + CSNAME
+                + ".*" + locationPartRE + ".*" + msgPartRE + ".*\n"	// use real \n at end here for better error output
+                + (exceptionClassAndMsgRE == null  ?  ""
+                        :  ".*" + exceptionClassAndMsgRE + ".*\\n(\tat .*\\n)*\\n?");
+    }
+
+    /** Get regex for a log4j console output. Must match log4j2-Console-Layout! */
+    private String log4j(org.apache.logging.log4j.Level lvl, boolean julBridged,
+            String methodPartRE, String msgPartRE, String exceptionClassAndMsgRE) {
+        return "log4j2:.*" + lvl.name() + ".*" + CSNAME + (julBridged ? "\\._JUL" : "")
+                + ".*" + CSNAME + "/\\w*" + methodPartRE + "\\w*/.*"
+                + msgPartRE + ".*\n"		// use real \n at end here for better error output
+                + (exceptionClassAndMsgRE == null  ?  ""
+                    :  ".*" + exceptionClassAndMsgRE + ".*\\n(\tat .*\\n)*\\n?");
+    }
+
+
+
+    @Test
+    public void test1SimpleLoggings1Jul() {
+        julLog.info("Test-'Info'-Log with JUL");
+        julLog.fine("Test-'Fine'-Log with JUL");
+        julLog.finest("Test-'Finest'-Log with JUL");		// should not be logged because JUL-level is FINER
+        julLog.warning("Test-'Warn'-Log with JUL");		// thus add another log afterwards to allow checking
+        String methodRE = "SimpleLoggings";
+        assertSysoutMatches(
+                log4j(org.apache.logging.log4j.Level.INFO, true, methodRE, "'Info'-Log with JUL", null)
+                + jul(java.util.logging.Level.INFO, methodRE, "'Info'-Log with JUL", null)
+                + log4j(org.apache.logging.log4j.Level.DEBUG, true, methodRE, "'Fine'-Log with JUL", null)
+                + jul(java.util.logging.Level.FINE, methodRE, "'Fine'-Log with JUL", null)
+                // no finest/trace
+                + log4j(org.apache.logging.log4j.Level.WARN, true, methodRE, "'Warn'-Log with JUL", null)
+                + jul(java.util.logging.Level.WARNING, methodRE, "'Warn'-Log with JUL", null)
+                );
+    }
+
+    @Test
+    public void test1SimpleLoggings2Log4jDirect() {
+        log4jLog.info("Test-'Info'-Log with log4j2");
+        log4jLog.debug("Test-'Debug'-Log with log4j2");
+        log4jLog.trace("Test-'Trace'-Log with log4j2");
+        String methodRE = "SimpleLoggings";
+        assertSysoutMatches(
+                log4j(org.apache.logging.log4j.Level.INFO, false, methodRE, "'Info'-Log with log4j2", null)
+                + log4j(org.apache.logging.log4j.Level.DEBUG, false, methodRE, "'Debug'-Log with log4j2", null)
+                + log4j(org.apache.logging.log4j.Level.TRACE, false, methodRE, "'Trace'-Log with log4j2", null)
+                );
+    }
+
+
+    @Test
+    public void test2SubMethod() {
+        subMethodWithLogs();					// location info is sub method now
+        String methodRE = "subMethodWithLogs";
+        assertSysoutMatches(
+                log4j(org.apache.logging.log4j.Level.DEBUG, true, methodRE, "'Fine'-Log with JUL in subMethod", null)
+                + jul(java.util.logging.Level.FINE, methodRE, "'Fine'-Log with JUL in subMethod", null)
+                + log4j(org.apache.logging.log4j.Level.INFO, false, methodRE, "'Info'-Log with log4j2 in subMethod", null)
+                );
+    }
+    private void subMethodWithLogs() {
+        julLog.fine("Test-'Fine'-Log with JUL in subMethod");
+        log4jLog.info("Test-'Info'-Log with log4j2 in subMethod");
+    }
+
+
+    @Test
+    public void test3JulFlow1() {
+        // note: manually given source information get lost in log4j!
+        julLog.entering("enteringExampleClassParam", "enteringExampleMethodParam");
+        String methodRE = "JulFlow";
+        assertSysoutMatches(
+                log4j(org.apache.logging.log4j.Level.TRACE, true, methodRE, "ENTRY", null)
+                + jul(java.util.logging.Level.FINER, "enteringExampleClassParam enteringExampleMethodParam", "ENTRY", null)
+                );
+    }
+
+    @Test
+    public void test3JulFlow2() {
+        // note: manually given source information get lost in log4j!
+        julLog.entering("enteringExampleClassParam", "enteringExampleMethodParam_withParams",
+                new Object[] {"with some", "parameters", 42} );
+        String methodRE = "JulFlow";
+        assertSysoutMatches(
+                log4j(org.apache.logging.log4j.Level.TRACE, true, methodRE,
+                        "ENTRY.*with some.*param.*42", null)
+                + jul(java.util.logging.Level.FINER, "enteringExampleClassParam enteringExampleMethodParam_withParams",
+                        "ENTRY.*with some.*param.*42", null)
+                );
+    }
+
+    @Test
+    public void test3JulFlow3() {
+        // note: manually given source information get lost in log4j!
+        julLog.exiting("exitingExampleClassParam", "exitingExampleMethodParam",
+                Arrays.asList("array of Strings", "that are the exit", "result"));
+        String methodRE = "JulFlow";
+        assertSysoutMatches(
+                log4j(org.apache.logging.log4j.Level.TRACE, true, methodRE,
+                        "RETURN.*array of Str.*that are.*result", null)
+                + jul(java.util.logging.Level.FINER, "exitingExampleClassParam exitingExampleMethodParam",
+                        "RETURN.*array of Str.*that are.*result", null)
+                );
+    }
+
+    @Test
+    public void test3JulFlow4() {
+        // note: manually given source information get lost in log4j!
+        julLog.throwing("throwingExampleClassParam", "throwingExampleMethodParam",
+                new IllegalStateException("ONLY TEST for JUL-throwing()"));
+        String methodRE = "JulFlow";
+        assertSysoutMatches(
+                log4j(org.apache.logging.log4j.Level.TRACE, true, methodRE,
+                        "THROW",  "IllegalStateException.*ONLY TEST for JUL-throwing")
+                + jul(java.util.logging.Level.FINER, "throwingExampleClassParam throwingExampleMethodParam",
+                        "THROW",  "IllegalStateException.*ONLY TEST for JUL-throwing")
+                );
+    }
+
+
+
+    @Test
+    public void test4JulSpecials1() {
+        julLog.log(Level.WARNING, "JUL-Test via log() as warning with exception",
+                new java.util.zip.DataFormatException("ONLY TEST for JUL.log()"));
+        String methodRE = "JulSpecials";
+        assertSysoutMatches(
+                log4j(org.apache.logging.log4j.Level.WARN, true, methodRE,
+                        "JUL-Test via log\\(\\) as warning",  "DataFormatException.*ONLY TEST for JUL")
+                + jul(java.util.logging.Level.WARNING, methodRE, "JUL-Test via log\\(\\) as warning",
+                        "DataFormatException.*ONLY TEST for JUL")
+                );
+    }
+
+    @Test
+    public void test4JulSpecials2() {
+        // test with MessageFormat
+        julLog.log(Level.INFO, "JUL-Test via log() with parameters (0={0}, 1={1}, 2={2,number,##000.0})",
+                new Object[] {"a", "b", 42} );
+        String methodRE = "JulSpecials";
+        assertSysoutMatches(
+                log4j(org.apache.logging.log4j.Level.INFO, true, methodRE,
+                        "JUL-Test via log\\(\\) with parameters \\(0=a, 1=b, 2=042.0\\)", null)
+                + jul(java.util.logging.Level.INFO, methodRE,
+                        "JUL-Test via log\\(\\) with parameters \\(0=a, 1=b, 2=042.0\\)", null)
+                );
+    }
+
+    // no test for logrb(ResourceBundle)-case as this is very specific and seldom used (in
+    // my opinion); and it does not add any real thing to test here
+
+}

--- a/log4j-jul/src/test/java/org/apache/logging/log4j/jul/Log4jBridgeHandlerTest.java
+++ b/log4j-jul/src/test/java/org/apache/logging/log4j/jul/Log4jBridgeHandlerTest.java
@@ -44,8 +44,8 @@ import org.junit.Test;
  *   + <Root level="TRACE">
  *   + <Appenders> <Console> with target="SYSTEM_ERR", follow="true",
  *      <PatternLayout> "log4j2:  %d{HH:mm:ss.SSS} %5level - [%thread][%logger: %class/%method/%line]  -  %message%n"
- *
- * @author Thies Wellpott (twapache@online.de)
+ * This test needs to capture syserr because it uses java.util.logging.ConsoleHandler.
+ * Also, it performs some outputs to console (sysout and syserr); see also field OUTPUT_CAPTURED.
  */
 @FixMethodOrder(org.junit.runners.MethodSorters.NAME_ASCENDING)		// is nicer for manually checking console output
 public class Log4jBridgeHandlerTest {

--- a/log4j-jul/src/test/resources/log4j2-julBridge-test.xml
+++ b/log4j-jul/src/test/resources/log4j2-julBridge-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Log4jBridgeHandlerTest TEST execution config -->
+<Configuration status="info">
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_ERR" follow="true">    <!-- syserr + follow !! -->
+            <PatternLayout pattern="log4j2:  %d{HH:mm:ss.SSS} %5level - [%thread][%logger: %class/%method/%line]  -  %message%n" />
+        </Console>
+    </Appenders>
+
+    <Loggers>
+        <Root level="TRACE">
+            <AppenderRef ref="STDOUT" />
+        </Root>
+    </Loggers>
+</Configuration>

--- a/log4j-jul/src/test/resources/log4j2-julBridge-test.xml
+++ b/log4j-jul/src/test/resources/log4j2-julBridge-test.xml
@@ -8,8 +8,17 @@
     </Appenders>
 
     <Loggers>
-        <Root level="TRACE">
+        <Root level="DEBUG">
             <AppenderRef ref="STDOUT" />
         </Root>
+
+        <!-- needs to be set to a lower level: -->
+        <Logger name="org.apache.logging.log4j.jul.Log4jBridgeHandlerTest" level="TRACE" />
+        <!-- some test configs: -->
+        <Logger name="log4j.Log4jBridgeHandlerTest.propagate1" level="DEBUG" />
+        <Logger name="log4j.Log4jBridgeHandlerTest.propagate1.nested1" level="TRACE" />
+        <Logger name="log4j.Log4jBridgeHandlerTest.propagate1.nested2.deeplyNested" level="WARN" />
+        <Logger name="log4j.Log4jBridgeHandlerTest.propagate2" level="ALL" />
+        <Logger name="log4j.Log4jBridgeHandlerTest.propagate2.nested.deeplyNested" level="INFO" />
     </Loggers>
 </Configuration>

--- a/log4j-jul/src/test/resources/logging-test.properties
+++ b/log4j-jul/src/test/resources/logging-test.properties
@@ -1,0 +1,22 @@
+### JUL configuration for log4j-extras test
+# JVM must be started with to use this file:  -Djava.util.logging.config.file=path_to_this_file
+
+
+# install bridge but also also output JUL-logs to console (order of handler matters!):
+handlers = org.apache.logging.log4j.jul.Log4jBridgeHandler, java.util.logging.ConsoleHandler
+
+#org.apache.logging.log4j.jul.Log4jBridgeHandler.sysoutDebug = true
+# append given suffix to logger names (e.g. "_JUL"); a dot is prepended automatically
+org.apache.logging.log4j.jul.Log4jBridgeHandler.appendSuffix = _JUL
+org.apache.logging.log4j.jul.Log4jBridgeHandler.propagateLevels = true
+
+java.util.logging.ConsoleHandler.level = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format = JUL:  %1$tT.%1$tL %4$s [%3$s: %2$s]  -  %5$s%6$s%n
+
+
+# set default JUL logging level (FINER for entering, exiting etc.)
+.level = FINE
+org.apache.logging.log4j.jul.Log4jBridgeHandlerTest.level = FINER
+# do not log mail-init. because this would init. JUL before setErr() happend.
+javax.mail.level = WARNING

--- a/log4j-jul/src/test/resources/logging-test.properties
+++ b/log4j-jul/src/test/resources/logging-test.properties
@@ -1,8 +1,8 @@
-### JUL configuration for log4j-extras test
+### JUL configuration for Log4jBridgeHandler test
 # JVM must be started with to use this file:  -Djava.util.logging.config.file=path_to_this_file
 
 
-# install bridge but also also output JUL-logs to console (order of handler matters!):
+# install bridge but also output JUL-logs to console (order of handler matters!):
 handlers = org.apache.logging.log4j.jul.Log4jBridgeHandler, java.util.logging.ConsoleHandler
 
 #org.apache.logging.log4j.jul.Log4jBridgeHandler.sysoutDebug = true
@@ -10,13 +10,22 @@ handlers = org.apache.logging.log4j.jul.Log4jBridgeHandler, java.util.logging.Co
 org.apache.logging.log4j.jul.Log4jBridgeHandler.appendSuffix = _JUL
 org.apache.logging.log4j.jul.Log4jBridgeHandler.propagateLevels = true
 
+# ConsoleHandler defaults to INFO filtering, but we need all here
 java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 java.util.logging.SimpleFormatter.format = JUL:  %1$tT.%1$tL %4$s [%3$s: %2$s]  -  %5$s%6$s%n
 
 
-# set default JUL logging level (FINER for entering, exiting etc.)
-.level = FINE
+# note: JUL levels are  SEVERE, WARNING, INFO, FINE, FINER, FINEST, ALL
+
+# set default JUL logging level (FINER is for entering, exiting etc.)
+# out-comment to use default of "INFO" - will be set by level propagation to DEBUG=FINE again
+#.level = FINE
 org.apache.logging.log4j.jul.Log4jBridgeHandlerTest.level = FINER
-# do not log mail-init. because this would init. JUL before setErr() happend.
+# do not log mail-init. (is done on INFO-level) because this would init. JUL before setErr() happens
 javax.mail.level = WARNING
+
+# configure (initial) JUL levels differently to log4j-config (and use high levels here)
+log4j.Log4jBridgeHandlerTest.propagate1.nested1.level = SEVERE
+# this is a logger not directly available in log4j, but the level above and below is defined in log4j:
+log4j.Log4jBridgeHandlerTest.propagate2.nested.level = WARNING


### PR DESCRIPTION
Solution for LOG4J2-2025 (as alternative to JUL-LogManager).
Rest see JavaDoc and site-doc (index.md)

This runs with log4j 2.11, so maybe can be even release with 2.11.2 (and not 3.0).