### PR TITLE
[LOG4J2-1571] Fixed Appenders section in Extending Log4j

### DIFF
--- a/src/site/asciidoc/manual/extending.adoc
+++ b/src/site/asciidoc/manual/extending.adoc
@@ -354,10 +354,14 @@ pause while the reconfiguration takes place.
 [source,java]
 ----
 @Plugin(name = "Stub", category = "Core", elementType = "appender", printObject = true)
-public final class StubAppender extends OutputStreamAppender {
+public final class StubAppender extends AbstractOutputStreamAppender<StubManager> {
 
-    private StubAppender(String name, Layout layout, Filter filter, StubManager manager,
-                         boolean ignoreExceptions) {
+    private StubAppender(String name,
+                         Layout<? extends Serializable> layout,
+                         Filter filter,
+                         boolean ignoreExceptions,
+                         StubManager  manager) {
+        super(name, layout, filter, ignoreExceptions, true, manager);
     }
 
     @PluginFactory
@@ -378,7 +382,7 @@ public final class StubAppender extends OutputStreamAppender {
         if (layout == null) {
             layout = PatternLayout.createDefaultLayout();
         }
-        return new StubAppender(name, layout, filter, manager, ignoreExceptions);
+        return new StubAppender(name, layout, filter, ignoreExceptions, manager);
     }
 }
 ----


### PR DESCRIPTION
In the example the class inherited from a class declared as final. The example was changed, so that the class inherits from AbstractOutputStreamAppender, like other Appenders in the code.