### PR TITLE
LOG4J2-2478 Return the computed variables on each benchmark to avoid DCE

### DIFF
--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/AbstractStringLayoutStringEncodingBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/AbstractStringLayoutStringEncodingBenchmark.java
@@ -123,15 +123,15 @@ public class AbstractStringLayoutStringEncodingBenchmark {
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     @Benchmark
-    public void baseline() {
-        consume(bytes);
+    public long baseline() {
+        return consume(bytes);
     }
 
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     @Benchmark
-    public void usAsciiGetBytes() {
-        consume(usAsciiGetBytesLayout.toByteArray(logEvent));
+    public long usAsciiGetBytes() {
+        return consume(usAsciiGetBytesLayout.toByteArray(logEvent));
     }
 
     @BenchmarkMode(Mode.Throughput)
@@ -145,8 +145,8 @@ public class AbstractStringLayoutStringEncodingBenchmark {
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     @Benchmark
-    public void iso8859_1GetBytes() {
-        consume(iso8859_1GetBytesLayout.toByteArray(logEvent));
+    public long iso8859_1GetBytes() {
+        return consume(iso8859_1GetBytesLayout.toByteArray(logEvent));
     }
 
     @BenchmarkMode(Mode.Throughput)
@@ -160,8 +160,8 @@ public class AbstractStringLayoutStringEncodingBenchmark {
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     @Benchmark
-    public void utf8GetBytes() {
-        consume(utf8GetBytesLayout.toByteArray(logEvent));
+    public long utf8GetBytes() {
+        return consume(utf8GetBytesLayout.toByteArray(logEvent));
     }
 
     @BenchmarkMode(Mode.Throughput)
@@ -175,8 +175,8 @@ public class AbstractStringLayoutStringEncodingBenchmark {
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     @Benchmark
-    public void utf16GetBytes() {
-        consume(utf16GetBytesLayout.toByteArray(logEvent));
+    public long utf16GetBytes() {
+        return consume(utf16GetBytesLayout.toByteArray(logEvent));
     }
 
     @BenchmarkMode(Mode.Throughput)


### PR DESCRIPTION
As mentioned in [JIRA](https://issues.apache.org/jira/browse/LOG4J2-2478), this patch simply returns the computation on every benchmark that uses the static _consume_ method. We do that to prevent dead-code elimination, which is only partially addressed in the current implementation.

Another patch that could simplify the benchmark code, and get considerably faster throughputs, would be to simply rely on _Blackhole.consume_ methods to sink the computation. We then, would not need the _consume_ method we have in the class.
