### PR TITLE
[LOG4J2-2405] Better handling of %highlight pattern when using jul-bridge	

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/HighlightConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/HighlightConverter.java
@@ -80,9 +80,9 @@ import org.apache.logging.log4j.util.Strings;
 @PerformanceSensitive("allocation")
 public final class HighlightConverter extends LogEventPatternConverter implements AnsiConverter {
 
-    private static final Map<Level, String> DEFAULT_STYLES = new HashMap<>();
+    private static final Map<String, String> DEFAULT_STYLES = new HashMap<>();
 
-    private static final Map<Level, String> LOGBACK_STYLES = new HashMap<>();
+    private static final Map<String, String> LOGBACK_STYLES = new HashMap<>();
 
     private static final String STYLE_KEY = "STYLE";
 
@@ -90,23 +90,23 @@ public final class HighlightConverter extends LogEventPatternConverter implement
 
     private static final String STYLE_KEY_LOGBACK = "LOGBACK";
 
-    private static final Map<String, Map<Level, String>> STYLES = new HashMap<>();
+    private static final Map<String, Map<String, String>> STYLES = new HashMap<>();
 
     static {
         // Default styles:
-        DEFAULT_STYLES.put(Level.FATAL, AnsiEscape.createSequence("BRIGHT", "RED"));
-        DEFAULT_STYLES.put(Level.ERROR, AnsiEscape.createSequence("BRIGHT", "RED"));
-        DEFAULT_STYLES.put(Level.WARN, AnsiEscape.createSequence("YELLOW"));
-        DEFAULT_STYLES.put(Level.INFO, AnsiEscape.createSequence("GREEN"));
-        DEFAULT_STYLES.put(Level.DEBUG, AnsiEscape.createSequence("CYAN"));
-        DEFAULT_STYLES.put(Level.TRACE, AnsiEscape.createSequence("BLACK"));
+        DEFAULT_STYLES.put(Level.FATAL.name(), AnsiEscape.createSequence("BRIGHT", "RED"));
+        DEFAULT_STYLES.put(Level.ERROR.name(), AnsiEscape.createSequence("BRIGHT", "RED"));
+        DEFAULT_STYLES.put(Level.WARN.name(), AnsiEscape.createSequence("YELLOW"));
+        DEFAULT_STYLES.put(Level.INFO.name(), AnsiEscape.createSequence("GREEN"));
+        DEFAULT_STYLES.put(Level.DEBUG.name(), AnsiEscape.createSequence("CYAN"));
+        DEFAULT_STYLES.put(Level.TRACE.name(), AnsiEscape.createSequence("BLACK"));
         // Logback styles:
-        LOGBACK_STYLES.put(Level.FATAL, AnsiEscape.createSequence("BLINK", "BRIGHT", "RED"));
-        LOGBACK_STYLES.put(Level.ERROR, AnsiEscape.createSequence("BRIGHT", "RED"));
-        LOGBACK_STYLES.put(Level.WARN, AnsiEscape.createSequence("RED"));
-        LOGBACK_STYLES.put(Level.INFO, AnsiEscape.createSequence("BLUE"));
-        LOGBACK_STYLES.put(Level.DEBUG, AnsiEscape.createSequence((String[]) null));
-        LOGBACK_STYLES.put(Level.TRACE, AnsiEscape.createSequence((String[]) null));
+        LOGBACK_STYLES.put(Level.FATAL.name(), AnsiEscape.createSequence("BLINK", "BRIGHT", "RED"));
+        LOGBACK_STYLES.put(Level.ERROR.name(), AnsiEscape.createSequence("BRIGHT", "RED"));
+        LOGBACK_STYLES.put(Level.WARN.name(), AnsiEscape.createSequence("RED"));
+        LOGBACK_STYLES.put(Level.INFO.name(), AnsiEscape.createSequence("BLUE"));
+        LOGBACK_STYLES.put(Level.DEBUG.name(), AnsiEscape.createSequence((String[]) null));
+        LOGBACK_STYLES.put(Level.TRACE.name(), AnsiEscape.createSequence((String[]) null));
         // Style map:
         STYLES.put(STYLE_KEY_DEFAULT, DEFAULT_STYLES);
         STYLES.put(STYLE_KEY_LOGBACK, LOGBACK_STYLES);
@@ -140,7 +140,7 @@ public final class HighlightConverter extends LogEventPatternConverter implement
      *        The second slot can optionally contain the style map.
      * @return a new map
      */
-    private static Map<Level, String> createLevelStyleMap(final String[] options) {
+    private static Map<String, String> createLevelStyleMap(final String[] options) {
         if (options.length < 2) {
             return DEFAULT_STYLES;
         }
@@ -150,12 +150,12 @@ public final class HighlightConverter extends LogEventPatternConverter implement
                 .replaceAll(PatternParser.NO_CONSOLE_NO_ANSI + "=(true|false)", Strings.EMPTY);
         //
         final Map<String, String> styles = AnsiEscape.createMap(string, new String[] {STYLE_KEY});
-        final Map<Level, String> levelStyles = new HashMap<>(DEFAULT_STYLES);
+        final Map<String, String> levelStyles = new HashMap<>(DEFAULT_STYLES);
         for (final Map.Entry<String, String> entry : styles.entrySet()) {
             final String key = entry.getKey().toUpperCase(Locale.ENGLISH);
             final String value = entry.getValue();
             if (STYLE_KEY.equalsIgnoreCase(key)) {
-                final Map<Level, String> enumMap = STYLES.get(value.toUpperCase(Locale.ENGLISH));
+                final Map<String, String> enumMap = STYLES.get(value.toUpperCase(Locale.ENGLISH));
                 if (enumMap == null) {
                     LOGGER.error("Unknown level style: " + value + ". Use one of " +
                         Arrays.toString(STYLES.keySet().toArray()));
@@ -165,9 +165,10 @@ public final class HighlightConverter extends LogEventPatternConverter implement
             } else {
                 final Level level = Level.toLevel(key, null);
                 if (level == null) {
-                    LOGGER.error("Unknown level name: {}; use one of {}", key, Arrays.toString(Level.values()));
+                    LOGGER.warn("Setting style for yet unknown level name {}", key);
+                    levelStyles.put(key, value);
                 } else {
-                    levelStyles.put(level, value);
+                    levelStyles.put(level.name(), value);
                 }
             }
         }
@@ -199,7 +200,7 @@ public final class HighlightConverter extends LogEventPatternConverter implement
         return new HighlightConverter(formatters, createLevelStyleMap(options), hideAnsi);
     }
 
-    private final Map<Level, String> levelStyles;
+    private final Map<String, String> levelStyles;
 
     private final List<PatternFormatter> patternFormatters;
 
@@ -215,7 +216,7 @@ public final class HighlightConverter extends LogEventPatternConverter implement
      * @param noAnsi
      *            If true, do not output ANSI escape codes.
      */
-    private HighlightConverter(final List<PatternFormatter> patternFormatters, final Map<Level, String> levelStyles, final boolean noAnsi) {
+    private HighlightConverter(final List<PatternFormatter> patternFormatters, final Map<String, String> levelStyles, final boolean noAnsi) {
         super("style", "style");
         this.patternFormatters = patternFormatters;
         this.levelStyles = levelStyles;
@@ -230,7 +231,7 @@ public final class HighlightConverter extends LogEventPatternConverter implement
     public void format(final LogEvent event, final StringBuilder toAppendTo) {
         int start = 0;
         int end = 0;
-        String levelStyle = levelStyles.get(event.getLevel());
+        String levelStyle = levelStyles.get(event.getLevel().name());
         if (!noAnsi) { // use ANSI: set prefix
             start = toAppendTo.length();
             if (levelStyle != null) {
@@ -256,7 +257,7 @@ public final class HighlightConverter extends LogEventPatternConverter implement
     }
 
     String getLevelStyle(Level level) {
-        return levelStyles.get(level);
+        return levelStyles.get(level.name());
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/HighlightConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/HighlightConverter.java
@@ -230,9 +230,12 @@ public final class HighlightConverter extends LogEventPatternConverter implement
     public void format(final LogEvent event, final StringBuilder toAppendTo) {
         int start = 0;
         int end = 0;
+        String levelStyle = levelStyles.get(event.getLevel());
         if (!noAnsi) { // use ANSI: set prefix
             start = toAppendTo.length();
-            toAppendTo.append(levelStyles.get(event.getLevel()));
+            if (levelStyle != null) {
+              toAppendTo.append(levelStyle);
+            }
             end = toAppendTo.length();
         }
 
@@ -246,7 +249,7 @@ public final class HighlightConverter extends LogEventPatternConverter implement
         if (!noAnsi) {
             if (empty) {
                 toAppendTo.setLength(start); // erase prefix
-            } else {
+            } else if (levelStyle != null) {
                 toAppendTo.append(defaultStyle); // add postfix
             }
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/HighlightConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/HighlightConverter.java
@@ -165,8 +165,7 @@ public final class HighlightConverter extends LogEventPatternConverter implement
             } else {
                 final Level level = Level.toLevel(key, null);
                 if (level == null) {
-                    LOGGER.info("Creating level for unknown level name {} with intValue {}", key, Integer.MAX_VALUE);
-                    levelStyles.put(Level.forName(key, Integer.MAX_VALUE), value);
+                    LOGGER.error("Unknown level name: {}; use one of {}", key, Arrays.toString(Level.values()));
                 } else {
                     levelStyles.put(level, value);
                 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/HighlightConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/HighlightConverter.java
@@ -165,7 +165,8 @@ public final class HighlightConverter extends LogEventPatternConverter implement
             } else {
                 final Level level = Level.toLevel(key, null);
                 if (level == null) {
-                    LOGGER.error("Unknown level name: {}; use one of {}", key, Arrays.toString(Level.values()));
+                    LOGGER.info("Creating level for unknown level name {} with intValue {}", key, Integer.MAX_VALUE);
+                    levelStyles.put(Level.forName(key, Integer.MAX_VALUE), value);
                 } else {
                     levelStyles.put(level, value);
                 }


### PR DESCRIPTION
This patch fixes some glitches with the `%highlight` pattern and therefore fixes the issue [LOG4J2-2405](https://issues.apache.org/jira/browse/LOG4J2-2405).

It provides the following changes:

- do not print out "null" in front of log messages with unknown levels
- allow to specify a style for unknown log levels

The patch contains the actual code changes as well as some tests.

However there is one small problem with this solution. To allow styles for unknown log levels the `HighlightConverter` creates these new log levels itself with an int value of `Integer.MAX_VALUE`. The problem is, when the actual application code tries to register this log level itself, the given int value will be ignored and `Integer.MAX_VALUE` remains. This is due to the implementation of `Level.forName(String, int)`, which specifies that the intValue is ignored when called a second time with the same level name.
(This is actually not a problem when the unknown log level is registered before parsing the log4j2 config file, but we can not enforce this.)

I can think of two solutions to this problem:

1. Rewrite `Level.forName(String, int)` to always _update_ the intValue with the given one.
2. Change the `HighlightConverter` to store the mapping of levels to styles not as `Map<Level, String>`, but instead as `Map<String, String>` where the key is the levels _name_.

I see option 1 as the "more correct" one, since I think when calling `Level.forName(String, intValue)` the user would expect that the last definition wins, not the first one (or at least an Exception should be thrown and there needs to be a ways to override the existing definition of a log level).
However it is also a more intrusive change as it changes one of the base classes of the API and changes the behaviour of a public method.

Option 2 is less intrusive as it only changes some internals of `HighlightConverter`. However I still think that the current behaviour of `Level.forName(String, intValue)` is incorrect and should actually be changed.