### PR TITLE
(doc) fix method name in configuration doc

### DIFF
--- a/src/site/asciidoc/manual/configuration.adoc
+++ b/src/site/asciidoc/manual/configuration.adoc
@@ -1587,7 +1587,7 @@ public class AwesomeTest {
 
     @Test
     public void testSomeAwesomeFeature() {
-        final LoggerContext ctx = init.getContext();
+        final LoggerContext ctx = init.getLoggerContext();
         final Logger logger = init.getLogger("org.apache.logging.log4j.my.awesome.test.logger");
         final Configuration cfg = init.getConfiguration();
         final ListAppender app = init.getListAppender("List");


### PR DESCRIPTION
Configuration doc uses the wrong method name `LoggerContextRule#getContext`, which was changed in https://github.com/apache/logging-log4j2/commit/9152a8201a47b4ac2f16488d2f25a0ee895ac8e5 to `LoggerContextRule#getLoggerContext`