### PR TITLE
Strings.toRootUpperCase  add static

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -143,7 +143,7 @@ public final class Strings {
      * @return a new string
      * @see String#toLowerCase(Locale)
      */
-    public String toRootUpperCase(final String str) {
+    public static String toRootUpperCase(final String str) {
         return str.toUpperCase(Locale.ROOT);
     }
     


### PR DESCRIPTION
because Strings() is private
and there is no getInstance  in this class.
the others function are static, so I want to add 'static' for toRootUpperCase.

sorry, my english is poor.
thanks.