### PR TITLE
Fix LOG4J2-2510 NullPointerException during shutdown

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
@@ -156,7 +156,9 @@ public class RollingRandomAccessFileManager extends RollingFileManager {
         flush();
         if (randomAccessFile != null) {
             try {
-                randomAccessFile.close();
+                if (randomAccessFile != null) {
+                    randomAccessFile.close();
+                }
                 return true;
             } catch (final IOException e) {
                 logError("Unable to close RandomAccessFile", e);


### PR DESCRIPTION
This should fix LOG4J2-2510

NullPointerEception gets thrown while executing shutdown hook in configuration with RollingRandomAccessFile appender and DirectWriteRolloverStrategy strategy. It happens when no messages logged during the session and thus no log file created.