### PR TITLE
Fix MapMessage -> StringMapMessage API breaks

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MapPatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MapPatternConverter.java
@@ -18,8 +18,7 @@ package org.apache.logging.log4j.core.pattern;
 
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
-import org.apache.logging.log4j.message.StringMapMessage;
-import org.apache.logging.log4j.util.IndexedReadOnlyStringMap;
+import org.apache.logging.log4j.message.MapMessage;
 
 /**
  * Able to handle the contents of the LogEvent's MapMessage and either
@@ -30,6 +29,9 @@ import org.apache.logging.log4j.util.IndexedReadOnlyStringMap;
 @Plugin(name = "MapPatternConverter", category = PatternConverter.CATEGORY)
 @ConverterKeys({ "K", "map", "MAP" })
 public final class MapPatternConverter extends LogEventPatternConverter {
+
+    private static final String[] JAVA_FORMAT = new String[]{MapMessage.MapFormat.JAVA.name()};
+
     /**
      * Name of property to output.
      */
@@ -60,31 +62,19 @@ public final class MapPatternConverter extends LogEventPatternConverter {
      */
     @Override
     public void format(final LogEvent event, final StringBuilder toAppendTo) {
-        StringMapMessage msg;
-        if (event.getMessage() instanceof StringMapMessage) {
-            msg = (StringMapMessage) event.getMessage();
+        MapMessage<?, ?> msg;
+        if (event.getMessage() instanceof MapMessage) {
+            msg = (MapMessage) event.getMessage();
         } else {
             return;
         }
-        final IndexedReadOnlyStringMap sortedMap = msg.getIndexedReadOnlyStringMap();
         // if there is no additional options, we output every single
         // Key/Value pair for the Map in a similar format to Hashtable.toString()
         if (key == null) {
-            if (sortedMap.isEmpty()) {
-                toAppendTo.append("{}");
-                return;
-            }
-            toAppendTo.append("{");
-            for (int i = 0; i < sortedMap.size(); i++) {
-                if (i > 0) {
-                    toAppendTo.append(", ");
-                }
-                toAppendTo.append(sortedMap.getKeyAt(i)).append('=').append((String)sortedMap.getValueAt(i));
-            }
-            toAppendTo.append('}');
+            msg.formatTo(JAVA_FORMAT, toAppendTo);
         } else {
             // otherwise they just want a single key output
-            final String val = sortedMap.getValue(key);
+            final String val = msg.get(key);
 
             if (val != null) {
                 toAppendTo.append(val);

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/MapPatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/MapPatternConverterTest.java
@@ -31,7 +31,6 @@ public class MapPatternConverterTest {
 
     @Test
     public void testConverter() {
-
         final StringMapMessage msg = new StringMapMessage();
         msg.put("subject", "I");
         msg.put("verb", "love");
@@ -45,14 +44,14 @@ public class MapPatternConverterTest {
         final StringBuilder sb = new StringBuilder();
         converter.format(event, sb);
         final String str = sb.toString();
-        String expected = "subject=I";
+        String expected = "subject=\"I\"";
         assertTrue("Missing or incorrect subject. Expected " + expected + ", actual " + str, str.contains(expected));
-        expected = "verb=love";
+        expected = "verb=\"love\"";
         assertTrue("Missing or incorrect verb", str.contains(expected));
-        expected = "object=Log4j";
+        expected = "object=\"Log4j\"";
         assertTrue("Missing or incorrect object", str.contains(expected));
 
-        assertEquals("{object=Log4j, subject=I, verb=love}", str);
+        assertEquals("{object=\"Log4j\", subject=\"I\", verb=\"love\"}", str);
     }
 
     @Test

--- a/log4j-samples/log4j-samples-loggerProperties/src/main/java/org/apache/logging/log4j/lookup/MapMessageLookup.java
+++ b/log4j-samples/log4j-samples-loggerProperties/src/main/java/org/apache/logging/log4j/lookup/MapMessageLookup.java
@@ -23,9 +23,11 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.lookup.AbstractLookup;
 import org.apache.logging.log4j.core.lookup.StrLookup;
+import org.apache.logging.log4j.message.MapMessage;
 import org.apache.logging.log4j.message.StringMapMessage;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.IndexedReadOnlyStringMap;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,26 +54,13 @@ public class MapMessageLookup extends AbstractLookup {
     @Override
     public String lookup(final LogEvent event, final String key) {
         final Message msg = event.getMessage();
-        if (msg instanceof StringMapMessage) {
+        if (msg instanceof MapMessage) {
+            MapMessage<?, ?> mapMessage = (MapMessage) msg;
             try {
-                final Map<String, String> properties = ((StringMapMessage) msg).getData();
-                if (properties == null) {
-                    return "";
-                }
                 if (key == null || key.length() == 0 || key.equals("*")) {
-                    final StringBuilder sb = new StringBuilder("{");
-                    boolean first = true;
-                    for (final Map.Entry<String, String> entry : properties.entrySet()) {
-                        if (!first) {
-                            sb.append(", ");
-                        }
-                        sb.append(entry.getKey()).append("=").append(entry.getValue());
-                        first = false;
-                    }
-                    sb.append("}");
-                    return sb.toString();
+                    return mapMessage.asString(MapMessage.MapFormat.JAVA.name());
                 }
-                return properties.get(key);
+                return mapMessage.get(key);
             } catch (final Exception ex) {
                 LOGGER.warn(LOOKUP, "Error while getting property [{}].", key, ex);
                 return null;


### PR DESCRIPTION
Note: This updates MapPatternConverter and MapMessageLookup to use
MapMessage JAVA format, which is slightly different from the original
output because map values are quoted.