### PR TITLE
Remove garbage creation introduced by LOG4J2-2301

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
@@ -72,7 +72,7 @@ import org.apache.logging.log4j.util.Strings;
 @Plugin(name = "asyncLogger", category = Node.CATEGORY, printObject = true)
 public class AsyncLoggerConfig extends LoggerConfig {
 
-    private static final ThreadLocal<Boolean> ASYNC_LOGGER_ENTERED = new ThreadLocal<>();
+    private static final ThreadLocal<Boolean> ASYNC_LOGGER_ENTERED = ThreadLocal.withInitial(() -> Boolean.FALSE);
     private final AsyncLoggerConfigDelegate delegate;
 
     protected AsyncLoggerConfig(final String name,
@@ -89,7 +89,7 @@ public class AsyncLoggerConfig extends LoggerConfig {
     protected void log(final LogEvent event, final LoggerConfigPredicate predicate) {
         // See LOG4J2-2301
         if (predicate == LoggerConfigPredicate.ALL &&
-                ASYNC_LOGGER_ENTERED.get() == null &&
+                ASYNC_LOGGER_ENTERED.get() == Boolean.FALSE &&
                 // Optimization: AsyncLoggerConfig is identical to LoggerConfig
                 // when no appenders are present. Avoid splitting for synchronous
                 // and asynchronous execution paths until encountering an
@@ -108,7 +108,7 @@ public class AsyncLoggerConfig extends LoggerConfig {
                 // from reusable messages.
                 logToAsyncDelegate(event);
             } finally {
-                ASYNC_LOGGER_ENTERED.remove();
+                ASYNC_LOGGER_ENTERED.set(Boolean.FALSE);
             }
         } else {
             super.log(event, predicate);


### PR DESCRIPTION
After upgrading to 2.11.1 we have started seeing garbage being generated here:

Stack Trace	TLABs	Total TLAB Size(bytes)	Pressure(%)
java.lang.ThreadLocal$ThreadLocalMap.set(ThreadLocal, Object) line: 481	10	3,638,864	56.192
   java.lang.ThreadLocal$ThreadLocalMap.access$100(ThreadLocal$ThreadLocalMap, ThreadLocal, Object) line: 298	10	3,638,864	56.192
      java.lang.ThreadLocal.setInitialValue() line: 184	10	3,638,864	56.192
         java.lang.ThreadLocal.get() line: 170	10	3,638,864	56.192
            org.apache.logging.log4j.core.async.AsyncLoggerConfig.log(LogEvent, LoggerConfig$LoggerConfigPredicate) line: 91	10	3,638,864	56.192

The purpose of this patch is to fix this.