### PR TITLE
Fixed message length with TLS and Syslog // fixes LOG4J2-2532

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/TlsSyslogFrame.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/TlsSyslogFrame.java
@@ -41,7 +41,7 @@ public class TlsSyslogFrame {
 
     @Override
     public String toString() {
-        return Integer.toString(byteLength) + Chars.SPACE + message;
+        return message;
     }
 
     @Override


### PR DESCRIPTION
LOG4J2-2532

Length must not be part of syslog message.