### PR TITLE
[LOG4J2-2561] JEP223 version detection fix for JDK 9 and up (release-…

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
@@ -89,7 +89,10 @@ public final class Constants {
     }
 
     private static int getMajorVersion() {
-        final String version = System.getProperty("java.version");
+        return getMajorVersion(System.getProperty("java.version"));
+    }
+
+    static int getMajorVersion(final String version) {
         final String[] parts = version.split("-|\\.");
         boolean isJEP223;
         try {

--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/ConstantsTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/ConstantsTest.java
@@ -1,0 +1,17 @@
+package org.apache.logging.log4j.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ConstantsTest {
+
+    @Test
+    public void testJdkVersionDetection() {
+        assertEquals(1, Constants.getMajorVersion("1.1.2"));
+        assertEquals(8, Constants.getMajorVersion("1.8.2"));
+        assertEquals(9, Constants.getMajorVersion("9.1.1"));
+        assertEquals(11, Constants.getMajorVersion("11.1.1"));
+    }
+
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/AbstractStringLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/AbstractStringLayout.java
@@ -131,14 +131,7 @@ public abstract class AbstractStringLayout extends AbstractLayout<String> implem
 
     // LOG4J2-1151: If the built-in JDK 8 encoders are available we should use them.
     private static boolean isPreJava8() {
-        final String version = System.getProperty("java.version");
-        final String[] parts = version.split("\\.");
-        try {
-            final int major = Integer.parseInt(parts[1]);
-            return major < 8;
-        } catch (final Exception ex) {
-            return true;
-        }
+        return org.apache.logging.log4j.util.Constants.JAVA_MAJOR_VERSION < 8;
     }
 
     private static int size(final String property, final int defaultValue) {


### PR DESCRIPTION
…2.x)

Same as previous PR, but now on release-2.x : https://github.com/apache/logging-log4j2/pull/260

Fix version detection for JDK 9 and up

