### PR TITLE
[LOG4J2-2337] Allow custom end-of-line with JsonLayout (master branch)

### DIFF
--- a/log4j-layout-jackson-json/src/main/java/org/apache/logging/log4j/jackson/json/layout/JsonLayout.java
+++ b/log4j-layout-jackson-json/src/main/java/org/apache/logging/log4j/jackson/json/layout/JsonLayout.java
@@ -98,7 +98,7 @@ public final class JsonLayout extends AbstractJacksonLayout {
             final String headerPattern = toStringOrNull(getHeader());
             final String footerPattern = toStringOrNull(getFooter());
             return new JsonLayout(getConfiguration(), isLocationInfo(), isProperties(), encodeThreadContextAsList,
-                    isComplete(), isCompact(), getEventEol(), headerPattern, footerPattern, getCharset(),
+                    isComplete(), isCompact(), getEventEol(), getEndOfLine(), headerPattern, footerPattern, getCharset(),
                     isIncludeStacktrace(), isStacktraceAsString(), isIncludeNullDelimiter(),
                     getAdditionalFields(), getObjectMessageAsJsonObject());
         }
@@ -166,7 +166,7 @@ public final class JsonLayout extends AbstractJacksonLayout {
      * @return A JSON Layout.
      */
     public static JsonLayout createDefaultLayout() {
-        return new JsonLayout(new DefaultConfiguration(), false, false, false, false, false, false,
+        return new JsonLayout(new DefaultConfiguration(), false, false, false, false, false, false, null,
                 DEFAULT_HEADER, DEFAULT_FOOTER, StandardCharsets.UTF_8, true, false, false, null, false);
     }
 
@@ -177,14 +177,14 @@ public final class JsonLayout extends AbstractJacksonLayout {
 
     private JsonLayout(final Configuration config, final boolean locationInfo, final boolean properties,
                        final boolean encodeThreadContextAsList,
-                       final boolean complete, final boolean compact, final boolean eventEol,
+                       final boolean complete, final boolean compact, final boolean eventEol, final String endOfLine,
                        final String headerPattern, final String footerPattern, final Charset charset,
                        final boolean includeStacktrace, final boolean stacktraceAsString,
                        final boolean includeNullDelimiter,
                        final KeyValuePair[] additionalFields, final boolean objectMessageAsJsonObject) {
         super(config, new JsonJacksonFactory(encodeThreadContextAsList, includeStacktrace, stacktraceAsString, objectMessageAsJsonObject).newWriter(
                 locationInfo, properties, compact),
-                charset, compact, complete, eventEol,
+                charset, compact, complete, eventEol, endOfLine,
                 PatternLayout.newSerializerBuilder().setConfiguration(config).setPattern(headerPattern).setDefaultPattern(DEFAULT_HEADER).build(),
                 PatternLayout.newSerializerBuilder().setConfiguration(config).setPattern(footerPattern).setDefaultPattern(DEFAULT_FOOTER).build(),
                 includeNullDelimiter,

--- a/log4j-layout-jackson-json/src/test/java/org/apache/logging/log4j/jackson/json/layout/JsonLayoutTest.java
+++ b/log4j-layout-jackson-json/src/test/java/org/apache/logging/log4j/jackson/json/layout/JsonLayoutTest.java
@@ -200,7 +200,7 @@ public class JsonLayoutTest {
     }
 
     private void testAllFeatures(final boolean locationInfo, final boolean compact, final boolean eventEol,
-            final boolean includeContext, final boolean contextMapAslist, final boolean includeStacktrace)
+            final String endOfLine, final boolean includeContext, final boolean contextMapAslist, final boolean includeStacktrace)
             throws Exception {
         final Log4jLogEvent expected = LogEventFixtures.createLogEvent();
         // @formatter:off
@@ -211,14 +211,21 @@ public class JsonLayoutTest {
                 .setComplete(false)
                 .setCompact(compact)
                 .setEventEol(eventEol)
+                .setEndOfLine(endOfLine)
                 .setCharset(StandardCharsets.UTF_8)
                 .setIncludeStacktrace(includeStacktrace)
                 .build();
         // @formatter:off
         final String str = layout.toSerializable(expected);
         this.toPropertySeparator(compact);
-        // Just check for \n since \r might or might not be there.
-        assertEquals(str, !compact || eventEol, str.contains("\n"));
+        if (endOfLine == null) {
+            // Just check for \n since \r might or might not be there.
+            assertEquals(str, !compact || eventEol, str.contains("\n"));
+        }
+        else {
+            assertEquals(str, !compact || eventEol, str.contains(endOfLine));
+            assertEquals(str, compact && eventEol, str.endsWith(endOfLine));
+        }
         assertEquals(str, locationInfo, str.contains("source"));
         assertEquals(str, includeContext, str.contains("contextMap"));
         final Log4jLogEvent actual = new Log4jJsonObjectMapper(contextMapAslist, includeStacktrace, false, false).readValue(str, Log4jLogEvent.class);
@@ -332,7 +339,12 @@ public class JsonLayoutTest {
 
     @Test
     public void testExcludeStacktrace() throws Exception {
-        this.testAllFeatures(false, false, false, false, false, false);
+        this.testAllFeatures(false, false, false, null, false, false, false);
+    }
+
+    @Test
+    public void testLocationOnCustomEndOfLine() throws Exception {
+        this.testAllFeatures(true, true, true, "CUSTOM_END_OF_LINE", true, false, true);
     }
 
     @Test
@@ -552,22 +564,22 @@ public class JsonLayoutTest {
 
     @Test
     public void testLocationOffCompactOffMdcOff() throws Exception {
-        this.testAllFeatures(false, false, false, false, false, true);
+        this.testAllFeatures(false, false, false, null, false, false, true);
     }
 
     @Test
     public void testLocationOnCompactOnEventEolOnMdcOn() throws Exception {
-        this.testAllFeatures(true, true, true, true, false, true);
+        this.testAllFeatures(true, true, true, null, true, false, true);
     }
 
     @Test
     public void testLocationOnCompactOnEventEolOnMdcOnMdcAsList() throws Exception {
-        this.testAllFeatures(true, true, true, true, true, true);
+        this.testAllFeatures(true, true, true, null, true, true, true);
     }
 
     @Test
     public void testLocationOnCompactOnMdcOn() throws Exception {
-        this.testAllFeatures(true, true, false, true, false, true);
+        this.testAllFeatures(true, true, false, null, true, false, true);
     }
 
     @Test

--- a/log4j-layout-jackson/src/main/java/org/apache/logging/log4j/jackson/AbstractJacksonLayout.java
+++ b/log4j-layout-jackson/src/main/java/org/apache/logging/log4j/jackson/AbstractJacksonLayout.java
@@ -43,6 +43,9 @@ public abstract class AbstractJacksonLayout extends AbstractStringLayout {
         private boolean eventEol;
 
         @PluginBuilderAttribute
+        private String endOfLine;
+
+        @PluginBuilderAttribute
         private boolean compact;
 
         @PluginBuilderAttribute
@@ -72,6 +75,10 @@ public abstract class AbstractJacksonLayout extends AbstractStringLayout {
 
         public boolean getEventEol() {
             return eventEol;
+        }
+
+        public String getEndOfLine() {
+            return endOfLine;
         }
 
         public boolean isCompact() {
@@ -129,6 +136,11 @@ public abstract class AbstractJacksonLayout extends AbstractStringLayout {
 
         public B setEventEol(final boolean eventEol) {
             this.eventEol = eventEol;
+            return asBuilder();
+        }
+
+        public B setEndOfLine(final String endOfLine) {
+            this.endOfLine = endOfLine;
             return asBuilder();
         }
 
@@ -262,11 +274,19 @@ public abstract class AbstractJacksonLayout extends AbstractStringLayout {
             final boolean compact, final boolean complete, final boolean eventEol, final Serializer headerSerializer,
             final Serializer footerSerializer, final boolean includeNullDelimiter,
             final KeyValuePair[] additionalFields) {
+        this(config, objectWriter, charset, compact, complete, eventEol, null, headerSerializer, footerSerializer,
+                includeNullDelimiter, additionalFields);
+    }
+
+    protected AbstractJacksonLayout(final Configuration config, final ObjectWriter objectWriter, final Charset charset,
+            final boolean compact, final boolean complete, final boolean eventEol, final String endOfLine,
+            final Serializer headerSerializer, final Serializer footerSerializer, final boolean includeNullDelimiter,
+            final KeyValuePair[] additionalFields) {
         super(config, charset, headerSerializer, footerSerializer);
         this.objectWriter = objectWriter;
         this.compact = compact;
         this.complete = complete;
-        this.eol = compact && !eventEol ? COMPACT_EOL : DEFAULT_EOL;
+        this.eol = endOfLine != null ? endOfLine : compact && !eventEol ? COMPACT_EOL : DEFAULT_EOL;
         this.includeNullDelimiter = includeNullDelimiter;
         this.additionalFields = prepareAdditionalFields(config, additionalFields);
     }

--- a/log4j-layout-jackson/src/main/java/org/apache/logging/log4j/jackson/layout/AbstractJacksonLayout.java
+++ b/log4j-layout-jackson/src/main/java/org/apache/logging/log4j/jackson/layout/AbstractJacksonLayout.java
@@ -67,6 +67,9 @@ abstract class AbstractJacksonLayout extends AbstractStringLayout {
         private boolean eventEol;
 
         @PluginBuilderAttribute
+        private String endOfLine;
+
+        @PluginBuilderAttribute
         private boolean compact;
 
         @PluginBuilderAttribute
@@ -96,6 +99,10 @@ abstract class AbstractJacksonLayout extends AbstractStringLayout {
 
         public boolean getEventEol() {
             return eventEol;
+        }
+
+        public String getEndOfLine() {
+            return endOfLine;
         }
 
         public boolean isCompact() {
@@ -153,6 +160,11 @@ abstract class AbstractJacksonLayout extends AbstractStringLayout {
 
         public B setEventEol(final boolean eventEol) {
             this.eventEol = eventEol;
+            return asBuilder();
+        }
+
+        public B setEndOfLine(final String endOfLine) {
+            this.endOfLine = endOfLine;
             return asBuilder();
         }
 
@@ -287,11 +299,20 @@ abstract class AbstractJacksonLayout extends AbstractStringLayout {
             final boolean compact, final boolean complete, final boolean eventEol, final Serializer headerSerializer,
             final Serializer footerSerializer, final boolean includeNullDelimiter,
             final KeyValuePair[] additionalFields) {
+        this(config, objectWriter, charset, compact, complete, eventEol, null,
+                headerSerializer, footerSerializer, includeNullDelimiter, additionalFields);
+    }
+    
+
+    protected AbstractJacksonLayout(final Configuration config, final ObjectWriter objectWriter, final Charset charset,
+            final boolean compact, final boolean complete, final boolean eventEol, String endOfLine,
+            final Serializer headerSerializer, final Serializer footerSerializer, final boolean includeNullDelimiter,
+            final KeyValuePair[] additionalFields) {
         super(config, charset, headerSerializer, footerSerializer);
         this.objectWriter = objectWriter;
         this.compact = compact;
         this.complete = complete;
-        this.eol = compact && !eventEol ? COMPACT_EOL : DEFAULT_EOL;
+        this.eol = endOfLine != null ? endOfLine : compact && !eventEol ? COMPACT_EOL : DEFAULT_EOL;
         this.includeNullDelimiter = includeNullDelimiter;
         this.additionalFields = prepareAdditionalFields(config, additionalFields);
     }

--- a/src/site/asciidoc/manual/layouts.adoc
+++ b/src/site/asciidoc/manual/layouts.adoc
@@ -396,6 +396,10 @@ indentation. Defaults to false.
 each record. Defaults to false. Use with eventEol=true and compact=true
 to get one record per line.
 
+|endOfLine
+|String
+|If set, overrides the default end-of-line string. E.g. set it to "\n" and use with eventEol=true and compact=true to have one record per line separated by "\n" instead of "\r\n". Defaults to null (i.e. not set).
+
 |complete
 |boolean
 |If true, the appender includes the JSON header and


### PR DESCRIPTION
This PR introduces the ability to specify a custom end-of-line string for the JSON layout, which therefore addresses the issue reported here: https://jira.apache.org/jira/browse/LOG4J2-2337

This PR is for the `master` branch. The equivalent for the `release-2.x` branch is available here: https://github.com/apache/logging-log4j2/pull/264