### PR TITLE
LOG4J2-1103 remove used nodes when child is of list type

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginElementVisitor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginElementVisitor.java
@@ -63,6 +63,7 @@ public class PluginElementVisitor extends AbstractPluginVisitor<PluginElement> {
                     }
                     if (childObject.getClass().isArray()) {
                         log.append(Arrays.toString((Object[]) childObject)).append('}');
+                        node.getChildren().removeAll(used);
                         return childObject;
                     }
                     log.append(child.toString());

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidatingPluginWithFailoverTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidatingPluginWithFailoverTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.config.plugins.validation.validators;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Core;
+import org.apache.logging.log4j.core.appender.FailoverAppender;
+import org.apache.logging.log4j.core.appender.FailoversPlugin;
+import org.apache.logging.log4j.core.config.AppenderRef;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.NullConfiguration;
+import org.apache.logging.log4j.core.config.plugins.util.PluginBuilder;
+import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
+import org.apache.logging.log4j.core.config.plugins.util.PluginType;
+import org.apache.logging.log4j.status.StatusData;
+import org.apache.logging.log4j.status.StatusListener;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.junit.Assert.*;
+
+public class ValidatingPluginWithFailoverTest {
+
+    private PluginType<FailoverAppender> plugin;
+    private Node node;
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() throws Exception {
+        final PluginManager manager = new PluginManager(Core.CATEGORY_NAME);
+        manager.collectPlugins();
+        plugin = (PluginType<FailoverAppender>) manager.getPluginType("failover");
+        assertNotNull("Rebuild this module to make sure annotation processing kicks in.", plugin);
+
+        AppenderRef appenderRef = AppenderRef.createAppenderRef("List", Level.ALL, null);
+        node = new Node(null, "failover", plugin);
+        Node failoversNode = new Node(node, "Failovers", manager.getPluginType("Failovers"));
+        Node appenderRefNode  = new Node(failoversNode, "appenderRef", manager.getPluginType("appenderRef"));
+        appenderRefNode.getAttributes().put("ref", "file");
+        appenderRefNode.setObject(appenderRef);
+        failoversNode.getChildren().add(appenderRefNode);
+        failoversNode.setObject(FailoversPlugin.createFailovers(appenderRef));
+        node.getAttributes().put("primary", "CONSOLE");
+        node.getAttributes().put("name", "Failover");
+        node.getChildren().add(failoversNode);
+    }
+
+    @Test
+    public void testDoesNotLog_NoParameterThatMatchesElement_message() {
+        final StoringStatusListener listener = new StoringStatusListener();
+        // @formatter:off
+        final PluginBuilder builder = new PluginBuilder(plugin).
+                withConfiguration(new NullConfiguration()).
+                withConfigurationNode(node);
+        // @formatter:on
+        StatusLogger.getLogger().registerListener(listener);
+
+        final FailoverAppender failoverAppender = (FailoverAppender) builder.build();
+
+        assertThat(listener.logs, emptyCollectionOf(StatusData.class));
+        assertNotNull(failoverAppender);
+        assertEquals("Failover", failoverAppender.getName());
+    }
+
+    private static class StoringStatusListener implements StatusListener {
+        private final List<StatusData> logs = new ArrayList<>();
+        @Override
+        public void log(StatusData data) {
+            logs.add(data);
+        }
+
+        @Override
+        public Level getStatusLevel() {
+            return Level.WARN;
+        }
+
+        @Override
+        public void close() {}
+    }
+}


### PR DESCRIPTION
Fix a bug that caused "ERROR appender Failover has no parameter that matches element Failovers" to be printed when using a correctly configured failover appender.