### PR TITLE
LOG4J2-2598: GzCompressAction supports configurable compression levels

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/FileExtension.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/FileExtension.java
@@ -39,7 +39,7 @@ public enum FileExtension {
         @Override
         Action createCompressAction(final String renameTo, final String compressedName, final boolean deleteSource,
                                     final int compressionLevel) {
-            return new GzCompressAction(source(renameTo), target(compressedName), deleteSource);
+            return new GzCompressAction(source(renameTo), target(compressedName), deleteSource, compressionLevel);
         }
     },
     BZIP2(".bz2") {

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -382,6 +382,9 @@
       <action issue="LOG4J2-2337" dev="ggregory" type="add" due-to="Arvind Sahare, Patrice Ferrot">
         Allow custom end-of-line with JsonLayout.
       </action>
+      <action issue="LOG4J2-2598" dev="ckozak" type="add" due-to="Carter Kozak">
+        GZIP compression on rollover supports configurable compression levels.
+      </action>
     </release>
     <release version="2.12.0" date="2019-MM-DD" description="GA Release 2.12.0">
       <action issue="LOG4J2-2586" dev="rgoers" type="add">
@@ -401,6 +404,9 @@
       </action>
       <action issue="LOG4J2-2337" dev="ggregory" type="add" due-to="Arvind Sahare, Patrice Ferrot">
         Allow custom end-of-line with JsonLayout.
+      </action>
+      <action issue="LOG4J2-2598" dev="ckozak" type="add" due-to="Carter Kozak">
+        GZIP compression on rollover supports configurable compression levels.
       </action>
     </release>
     <release version="2.11.2" date="2018-MM-DD" description="GA Release 2.11.2">


### PR DESCRIPTION
Updated the implementation to use the BUF_SIZE constant for the
GZIPOutputStream output buffer as well.