### PR TITLE
LOG4J2-2564: PatternParser chooses newInstance methods with known parameters

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
@@ -540,8 +540,10 @@ public final class PatternParser {
         final Method[] methods = converterClass.getDeclaredMethods();
         Method newInstanceMethod = null;
         for (final Method method : methods) {
-            if (Modifier.isStatic(method.getModifiers()) && method.getDeclaringClass().equals(converterClass)
-                    && method.getName().equals("newInstance")) {
+            if (Modifier.isStatic(method.getModifiers())
+                    && method.getDeclaringClass().equals(converterClass)
+                    && method.getName().equals("newInstance")
+                    && areValidNewInstanceParameters(method.getParameterTypes())) {
                 if (newInstanceMethod == null) {
                     newInstanceMethod = method;
                 } else if (method.getReturnType().equals(newInstanceMethod.getReturnType())) {
@@ -593,6 +595,17 @@ public final class PatternParser {
         }
 
         return null;
+    }
+
+    /** LOG4J2-2564: Returns true if all method parameters are valid for injection. */
+    private static boolean areValidNewInstanceParameters(Class<?>[] parameterTypes) {
+        for (Class<?> clazz : parameterTypes) {
+            if (!clazz.isAssignableFrom(Configuration.class)
+                    && !(clazz.isArray() && "[Ljava.lang.String;".equals(clazz.getName()))) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/PatternParserTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/PatternParserTest.java
@@ -33,8 +33,8 @@ import org.apache.logging.log4j.core.config.NullConfiguration;
 import org.apache.logging.log4j.core.impl.ContextDataFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.impl.ThrowableFormatOptions;
-import org.apache.logging.log4j.core.time.internal.DummyNanoClock;
 import org.apache.logging.log4j.core.time.SystemNanoClock;
+import org.apache.logging.log4j.core.time.internal.DummyNanoClock;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.util.StringMap;
 import org.apache.logging.log4j.util.Strings;
@@ -406,4 +406,13 @@ public class PatternParserTest {
         assertEquals("|", options.getSeparator());
     }
 
+    // LOG4J2-2564: Multiple newInstance methods.
+    @Test
+    public void testMapPatternConverter() {
+        final List<PatternFormatter> formatters = parser.parse("%K");
+        assertNotNull(formatters);
+        assertTrue(formatters.size() == 1);
+        PatternFormatter formatter = formatters.get(0);
+        assertTrue("Expected a MapPatternConverter", formatter.getConverter() instanceof MapPatternConverter);
+    }
 }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -388,6 +388,10 @@
       <action issue="LOG4J2-2598" dev="ggregory" type="fix" due-to="Gary Gregory">
         java.lang.StackOverflowError at org.apache.logging.log4j.junit.AbstractExternalFileCleaner.println(AbstractExternalFileCleaner.java:169).
       </action>
+      <action issue="LOG4J2-2564" dev="ckozak" type="fix">
+        MapPatternConverter is properly created from the '%K', '%map', and '%MAP' patterns.
+        PatternConverter instanceOf methods with unknown parameter types no longer elide those with known parameters.
+      </action>
     </release>
     <release version="2.12.0" date="2019-MM-DD" description="GA Release 2.12.0">
       <action issue="LOG4J2-2561" dev="rgoers" type="fix" due-to="Ulrich Enslin">
@@ -428,6 +432,10 @@
       </action>
       <action issue="LOG4J2-2598" dev="ggregory" type="fix" due-to="Gary Gregory">
         java.lang.StackOverflowError at org.apache.logging.log4j.junit.AbstractExternalFileCleaner.println(AbstractExternalFileCleaner.java:169).
+      </action>
+      <action issue="LOG4J2-2564" dev="ckozak" type="fix">
+        MapPatternConverter is properly created from the '%K', '%map', and '%MAP' patterns.
+        PatternConverter instanceOf methods with unknown parameter types no longer elide those with known parameters.
       </action>
     </release>
     <release version="2.11.2" date="2018-MM-DD" description="GA Release 2.11.2">


### PR DESCRIPTION
Fixes MapPatternConverter, which contains two newInstance methods where
only one can be created using the PatternParser factory.