### PR TITLE
LOG4J2-2609: Implement Synchronous AsyncQueueFullPolicy

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactory.java
@@ -47,6 +47,7 @@ public class AsyncQueueFullPolicyFactory {
     static final String PROPERTY_VALUE_DEFAULT_ASYNC_EVENT_ROUTER = "Default";
     static final String PROPERTY_VALUE_DISCARDING_ASYNC_EVENT_ROUTER = "Discard";
     static final String PROPERTY_NAME_DISCARDING_THRESHOLD_LEVEL = "log4j2.DiscardThreshold";
+    static final String PROPERTY_VALUE_SYNCHRONOUS_ASYNC_EVENT_ROUTER = "Synchronous";
 
     private static final Logger LOGGER = StatusLogger.getLogger();
 
@@ -66,17 +67,28 @@ public class AsyncQueueFullPolicyFactory {
      */
     public static AsyncQueueFullPolicy create() {
         final String router = PropertiesUtil.getProperties().getStringProperty(PROPERTY_NAME_ASYNC_EVENT_ROUTER);
-        if (router == null || PROPERTY_VALUE_DEFAULT_ASYNC_EVENT_ROUTER.equals(router)
-                || DefaultAsyncQueueFullPolicy.class.getSimpleName().equals(router)
-                || DefaultAsyncQueueFullPolicy.class.getName().equals(router)) {
+        if (router == null || isRouterSelected(
+                router, DefaultAsyncQueueFullPolicy.class, PROPERTY_VALUE_DEFAULT_ASYNC_EVENT_ROUTER)) {
             return new DefaultAsyncQueueFullPolicy();
         }
-        if (PROPERTY_VALUE_DISCARDING_ASYNC_EVENT_ROUTER.equals(router)
-                || DiscardingAsyncQueueFullPolicy.class.getSimpleName().equals(router)
-                || DiscardingAsyncQueueFullPolicy.class.getName().equals(router)) {
+        if (isRouterSelected(
+                router, DiscardingAsyncQueueFullPolicy.class, PROPERTY_VALUE_DISCARDING_ASYNC_EVENT_ROUTER)) {
             return createDiscardingAsyncQueueFullPolicy();
         }
+        if (isRouterSelected(
+                router, SynchronousAsyncQueueFullPolicy.class, PROPERTY_VALUE_SYNCHRONOUS_ASYNC_EVENT_ROUTER)) {
+            return new SynchronousAsyncQueueFullPolicy();
+        }
         return createCustomRouter(router);
+    }
+
+    private static boolean isRouterSelected(
+            String propertyValue,
+            Class<? extends AsyncQueueFullPolicy> policy,
+            String shortPropertyValue) {
+        return propertyValue != null && (shortPropertyValue.equalsIgnoreCase(propertyValue)
+                || policy.getName().equals(propertyValue)
+                || policy.getSimpleName().equals(propertyValue));
     }
 
     private static AsyncQueueFullPolicy createCustomRouter(final String router) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/EventRoute.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/EventRoute.java
@@ -53,6 +53,8 @@ public enum EventRoute {
     },
     /**
      * Logs the event synchronously: sends the event directly to the appender (in the current thread).
+     * WARNING: This may result in lines logged out of order as synchronous events may be persisted before
+     * earlier events, even from the same thread, which wait in the queue.
      */
     SYNCHRONOUS {
         @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/SynchronousAsyncQueueFullPolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/SynchronousAsyncQueueFullPolicy.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.async;
+
+import org.apache.logging.log4j.Level;
+
+/**
+ * {@link EventRoute#SYNCHRONOUS Synchronous} policy which logs using the non-asynchronous
+ * code path when the asynchronous logging queue is full.
+ * WARNING: This results in lines logged out of order as synchronous events may be persisted before earlier
+ * events, even from the same thread, which wait in the queue.
+ *
+ * @since 2.12.0
+ */
+public final class SynchronousAsyncQueueFullPolicy implements AsyncQueueFullPolicy {
+    @Override
+    public EventRoute getRoute(final long backgroundThreadId, final Level level) {
+        return EventRoute.SYNCHRONOUS;
+    }
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactoryTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactoryTest.java
@@ -19,9 +19,12 @@ package org.apache.logging.log4j.core.async;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.categories.AsyncLoggers;
 import org.apache.logging.log4j.util.PropertiesUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.util.Locale;
 
 import static org.junit.Assert.*;
 
@@ -32,7 +35,8 @@ import static org.junit.Assert.*;
 public class AsyncQueueFullPolicyFactoryTest {
 
     @Before
-    public void setUp() throws Exception {
+    @After
+    public void resetProperties() throws Exception {
         System.clearProperty(AsyncQueueFullPolicyFactory.PROPERTY_NAME_ASYNC_EVENT_ROUTER);
         System.clearProperty(AsyncQueueFullPolicyFactory.PROPERTY_NAME_DISCARDING_THRESHOLD_LEVEL);
         PropertiesUtil.getProperties().reload();
@@ -105,5 +109,19 @@ public class AsyncQueueFullPolicyFactoryTest {
         System.setProperty(AsyncQueueFullPolicyFactory.PROPERTY_NAME_ASYNC_EVENT_ROUTER,
                 DoesNotImplementInterface.class.getName());
         assertEquals(DefaultAsyncQueueFullPolicy.class, AsyncQueueFullPolicyFactory.create().getClass());
+    }
+
+    @Test
+    public void testCreateSynchronousRouter() {
+        System.setProperty(AsyncQueueFullPolicyFactory.PROPERTY_NAME_ASYNC_EVENT_ROUTER,
+                AsyncQueueFullPolicyFactory.PROPERTY_VALUE_SYNCHRONOUS_ASYNC_EVENT_ROUTER);
+        assertTrue(AsyncQueueFullPolicyFactory.create() instanceof SynchronousAsyncQueueFullPolicy);
+    }
+
+    @Test
+    public void testCreateSynchronousRouterCaseInsensitive() {
+        System.setProperty(AsyncQueueFullPolicyFactory.PROPERTY_NAME_ASYNC_EVENT_ROUTER,
+                AsyncQueueFullPolicyFactory.PROPERTY_VALUE_SYNCHRONOUS_ASYNC_EVENT_ROUTER.toLowerCase(Locale.ENGLISH));
+        assertTrue(AsyncQueueFullPolicyFactory.create() instanceof SynchronousAsyncQueueFullPolicy);
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/SynchronousAsyncQueueFullPolicyTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/SynchronousAsyncQueueFullPolicyTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.async;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.categories.AsyncLoggers;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests the {@link SynchronousAsyncQueueFullPolicy}.
+ */
+@Category(AsyncLoggers.class)
+public class SynchronousAsyncQueueFullPolicyTest {
+
+    private static long currentThreadId() {
+        return Thread.currentThread().getId();
+    }
+
+    private static long otherThreadId() {
+        return -1;
+    }
+
+    @Test
+    public void testGetRouteSynchronous() {
+        final AsyncQueueFullPolicy router = new SynchronousAsyncQueueFullPolicy();
+        assertEquals(EventRoute.SYNCHRONOUS, router.getRoute(otherThreadId(), Level.ALL));
+        assertEquals(EventRoute.SYNCHRONOUS, router.getRoute(otherThreadId(), Level.OFF));
+    }
+
+    @Test
+    public void testGetRouteSynchronousIfCalledFromSameThread() {
+        final AsyncQueueFullPolicy router = new SynchronousAsyncQueueFullPolicy();
+        assertEquals(EventRoute.SYNCHRONOUS, router.getRoute(currentThreadId(), Level.ALL));
+        assertEquals(EventRoute.SYNCHRONOUS, router.getRoute(currentThreadId(), Level.OFF));
+    }
+}

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/ConcurrentAsyncLoggerToFileBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/ConcurrentAsyncLoggerToFileBenchmark.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.perf.jmh;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LifeCycle;
+import org.apache.logging.log4j.perf.util.BenchmarkMessageParams;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests Log4j2 Async Loggers performance with many threads producing events quickly while the background
+ * thread persists events to disk.
+ * @see <a href="https://issues.apache.org/jira/browse/LOG4J2-2606">LOG4J2-2606</a>
+ */
+@Fork(1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 1, time = 3)
+@Measurement(iterations = 3, time = 15)
+public class ConcurrentAsyncLoggerToFileBenchmark {
+
+    @Benchmark
+    @Threads(32)
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void concurrentLoggingThreads(BenchmarkState state) {
+        state.logger.info(BenchmarkMessageParams.TEST);
+    }
+
+    @Benchmark
+    @Threads(1)
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void singleLoggingThread(BenchmarkState state) {
+        state.logger.info(BenchmarkMessageParams.TEST);
+    }
+
+    @State(Scope.Benchmark)
+    public static class BenchmarkState {
+
+        @Param({"ENQUEUE", "SYNCHRONOUS"})
+        private QueueFullPolicy queueFullPolicy;
+
+        private Logger logger;
+
+        @Setup
+        public final void before() {
+            new File("target/testRandomlog4j2.log").delete();
+            System.setProperty("log4j.configurationFile", "ConcurrentAsyncLoggerToFileBenchmark.xml");
+            System.setProperty("Log4jContextSelector", "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector");
+            System.setProperty("log4j2.is.webapp", "false");
+            queueFullPolicy.setProperties();
+            logger = LogManager.getLogger(ConcurrentAsyncLoggerToFileBenchmark.class);
+        }
+
+        @TearDown
+        public final void after() {
+            ((LifeCycle) LogManager.getContext(false)).stop();
+            new File("target/testRandomlog4j2.log").delete();
+            logger = null;
+        }
+
+        @SuppressWarnings("unused") // Used by JMH
+        public enum QueueFullPolicy {
+            ENQUEUE("Default"),
+            SYNCHRONOUS("Synchronous");
+
+            private final String queueFullPolicy;
+
+            QueueFullPolicy(String queueFullPolicy) {
+                this.queueFullPolicy = queueFullPolicy;
+            }
+
+            void setProperties() {
+                System.setProperty("log4j2.AsyncQueueFullPolicy", queueFullPolicy);
+            }
+        }
+    }
+}

--- a/log4j-perf/src/main/resources/ConcurrentAsyncLoggerToFileBenchmark.xml
+++ b/log4j-perf/src/main/resources/ConcurrentAsyncLoggerToFileBenchmark.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache license, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the license for the specific language governing permissions and
+  limitations under the license.
+  -->
+<Configuration status="OFF">
+  <Appenders>
+    <RandomAccessFile name="RandomAccessFile" fileName="target/testRandomlog4j2.log" immediateFlush="false">
+      <PatternLayout pattern="%d %p [%t] %c{1} %X{transactionId} - %m%n"/>
+    </RandomAccessFile>
+  </Appenders>
+  <Loggers>
+    <Root level="info" includeLocation="false">
+      <appender-ref ref="RandomAccessFile"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -433,6 +433,9 @@
         MapPatternConverter is properly created from the '%K', '%map', and '%MAP' patterns.
         PatternConverter instanceOf methods with unknown parameter types no longer elide those with known parameters.
       </action>
+      <action issue="LOG4J2-2609" dev="ckozak" type="add">
+        Implement "Synchronous" AsyncQueueFullPolicy. AsyncQueueFullPolicy short values are case insensitive.
+      </action>
     </release>
     <release version="2.11.2" date="2018-MM-DD" description="GA Release 2.11.2">
       <action issue="LOG4J2-2500" dev="rgoers" type="fix">

--- a/src/site/asciidoc/manual/configuration.adoc
+++ b/src/site/asciidoc/manual/configuration.adoc
@@ -2101,6 +2101,14 @@ to the queue.
 Specify `Discard` to drop events whose level is equal or less than the
 threshold level (INFO by default) when the queue is full.
 
+Specify `Synchronous` to block until events can be logged on the
+calling thread, avoiding the asynchronous logging queue entirely.
+This results in lines logged out of order as synchronous events may
+be persisted before earlier events, even from the same thread,
+which wait in the queue. When many threads are concurrently logging
+this policy will result in lower CPU utilization than the default
+policy.
+
 |[[discardThreshold]]log4j2.discardThreshold +
 ([[log4j2.DiscardThreshold]]log4j2.DiscardThreshold)
 |LOG4J_DISCARD_THRESHOLD


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LOG4J2-2609

* Implement "Synchronous" AsyncQueueFullPolicy
* AsyncQueueFullPolicy short values are case insensitive

Benchmarks for [LOG4J2-2606](https://issues.apache.org/jira/browse/LOG4J2-2606):
```
Benchmark                                                      (queueFullPolicy)   Mode  Cnt        Score         Error  Units
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads            ENQUEUE  thrpt    3   369559.791 ± 1307230.236  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads        SYNCHRONOUS  thrpt    3  1059713.811 ± 1910806.587  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread                 ENQUEUE  thrpt    3  1451843.607 ±  355606.050  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread             SYNCHRONOUS  thrpt    3  1393328.851 ±  589759.385  ops/s
```