### PR TITLE
Proposed fix for LOG4J2-2610 rollover issue:

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
@@ -344,7 +344,12 @@ public class RollingFileManager extends FileManager {
     }
 
     protected void createFileAfterRollover() throws IOException  {
-        setOutputStream(createOutputStream());
+        try {
+            Thread.sleep(1L);  // Windows requires delay to prevent log message loss during rapid rollover.
+        } catch (InterruptedException iex) {
+            // Don't care
+        }
+        setOutputStream(createOutputStream(initialTime));
     }
 
     /**


### PR DESCRIPTION
Proposed fix for LOG4J2-2610 rollover issue:
- Fix for Windows Filesystem Tunneling issue, rapid rollover issue.
- Added FileUtils.updateFileCreationTime() method.
- Updated FileManager and RollingFileManager to allow the file creationTime attribute to be updated on rollover (when it doesn't  match initialTime).
- RollingAppenderSizeWithTimeTest.testAppender() was failing on Windows before any changes.  Rapid log rollover was causing overwrite of data in some cases (instead of writing to a new log file), resulting in lost logging messages.  Mitigation was to apply a 1ms sleep in RollingFileManager.createFileAfterRollover().