### PR TITLE
LOG4J2-2606: Substantially improve async logging performance under heavy load

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLogger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLogger.java
@@ -178,7 +178,7 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
         final EventRoute eventRoute = loggerDisruptor.getEventRoute(translator.level);
         switch (eventRoute) {
             case ENQUEUE:
-                loggerDisruptor.enqueueLogMessageInfo(translator);
+                loggerDisruptor.enqueueLogMessageWhenQueueFull(translator);
                 break;
             case SYNCHRONOUS:
                 logMessageInCurrentThread(translator.fqcn, translator.level, translator.marker, translator.message,
@@ -328,7 +328,7 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
         final EventRoute eventRoute = loggerDisruptor.getEventRoute(level);
         switch (eventRoute) {
             case ENQUEUE:
-                loggerDisruptor.getDisruptor().getRingBuffer().publishEvent(this,
+                loggerDisruptor.enqueueLogMessageWhenQueueFull(this,
                         this, // asyncLogger: 0
                         location, // location: 1
                         fqcn, // 2

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigDelegate.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigDelegate.java
@@ -46,6 +46,11 @@ public interface AsyncLoggerConfigDelegate {
      */
     EventRoute getEventRoute(final Level level);
 
+    /**
+     * Enqueues the {@link LogEvent} on the mixed configuration ringbuffer.
+     * This method must only be used after {@link #tryEnqueue(LogEvent, AsyncLoggerConfig)} returns <code>false</code>
+     * indicating that the ringbuffer is full, otherwise it may incur unnecessary synchronization.
+     */
     void enqueueEvent(LogEvent event, AsyncLoggerConfig asyncLoggerConfig);
 
     boolean tryEnqueue(LogEvent event, AsyncLoggerConfig asyncLoggerConfig);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
@@ -20,7 +20,9 @@ package org.apache.logging.log4j.core.async;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
+import com.lmax.disruptor.EventTranslatorVararg;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.AbstractLifeCycle;
 import org.apache.logging.log4j.core.jmx.RingBufferAdmin;
 import org.apache.logging.log4j.core.util.Log4jThreadFactory;
@@ -32,6 +34,7 @@ import com.lmax.disruptor.TimeoutException;
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
+import org.apache.logging.log4j.message.Message;
 
 /**
  * Helper class for async loggers: AsyncLoggerDisruptor handles the mechanics of working with the LMAX Disruptor, and
@@ -42,6 +45,8 @@ import com.lmax.disruptor.dsl.ProducerType;
 class AsyncLoggerDisruptor extends AbstractLifeCycle {
     private static final int SLEEP_MILLIS_BETWEEN_DRAIN_ATTEMPTS = 50;
     private static final int MAX_DRAIN_ATTEMPTS_BEFORE_SHUTDOWN = 200;
+
+    private final Object queueFullEnqueueLock = new Object();
 
     private volatile Disruptor<RingBufferLogEvent> disruptor;
     private String contextName;
@@ -202,30 +207,92 @@ class AsyncLoggerDisruptor extends AbstractLifeCycle {
         return false;
     }
 
-    public boolean tryPublish(final RingBufferLogEventTranslator translator) {
-        try {
-            return disruptor.getRingBuffer().tryPublishEvent(translator);
-        } catch (final NullPointerException npe) {
-            // LOG4J2-639: catch NPE if disruptor field was set to null in stop()
-            LOGGER.warn("[{}] Ignoring log event after log4j was shut down: {} [{}] {}", contextName,
-                    translator.level, translator.loggerName, translator.message.getFormattedMessage()
-                            + (translator.thrown == null ? "" : Throwables.toStringList(translator.thrown)));
-            return false;
-        }
-    }
-
-    void enqueueLogMessageInfo(final RingBufferLogEventTranslator translator) {
+    boolean tryPublish(final RingBufferLogEventTranslator translator) {
         try {
             // Note: we deliberately access the volatile disruptor field afresh here.
             // Avoiding this and using an older reference could result in adding a log event to the disruptor after it
             // was shut down, which could cause the publishEvent method to hang and never return.
-            disruptor.publishEvent(translator);
+            return disruptor.getRingBuffer().tryPublishEvent(translator);
         } catch (final NullPointerException npe) {
             // LOG4J2-639: catch NPE if disruptor field was set to null in stop()
-            LOGGER.warn("[{}] Ignoring log event after log4j was shut down: {} [{}] {}", contextName,
-                    translator.level, translator.loggerName, translator.message.getFormattedMessage()
-                            + (translator.thrown == null ? "" : Throwables.toStringList(translator.thrown)));
+            logWarningOnNpeFromDisruptorPublish(translator);
+            return false;
         }
+    }
+
+    void enqueueLogMessageWhenQueueFull(final RingBufferLogEventTranslator translator) {
+        try {
+            // Note: we deliberately access the volatile disruptor field afresh here.
+            // Avoiding this and using an older reference could result in adding a log event to the disruptor after it
+            // was shut down, which could cause the publishEvent method to hang and never return.
+            if (synchronizeEnqueueWhenQueueFull()) {
+                synchronized (queueFullEnqueueLock) {
+                    disruptor.publishEvent(translator);
+                }
+            } else {
+                disruptor.publishEvent(translator);
+            }
+        } catch (final NullPointerException npe) {
+            // LOG4J2-639: catch NPE if disruptor field was set to null in stop()
+            logWarningOnNpeFromDisruptorPublish(translator);
+        }
+    }
+
+    void enqueueLogMessageWhenQueueFull(
+            final EventTranslatorVararg<RingBufferLogEvent> translator,
+            final AsyncLogger asyncLogger,
+            final StackTraceElement location,
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Message msg,
+            final Throwable thrown) {
+        try {
+            // Note: we deliberately access the volatile disruptor field afresh here.
+            // Avoiding this and using an older reference could result in adding a log event to the disruptor after it
+            // was shut down, which could cause the publishEvent method to hang and never return.
+            if (synchronizeEnqueueWhenQueueFull()) {
+                synchronized (queueFullEnqueueLock) {
+                    disruptor.getRingBuffer().publishEvent(translator,
+                            asyncLogger, // asyncLogger: 0
+                            location, // location: 1
+                            fqcn, // 2
+                            level, // 3
+                            marker, // 4
+                            msg, // 5
+                            thrown); // 6
+                }
+            } else {
+                disruptor.getRingBuffer().publishEvent(translator,
+                        asyncLogger, // asyncLogger: 0
+                        location, // location: 1
+                        fqcn, // 2
+                        level, // 3
+                        marker, // 4
+                        msg, // 5
+                        thrown); // 6
+            }
+        } catch (final NullPointerException npe) {
+            // LOG4J2-639: catch NPE if disruptor field was set to null in stop()
+            logWarningOnNpeFromDisruptorPublish(level, fqcn, msg, thrown);
+        }
+    }
+
+    private boolean synchronizeEnqueueWhenQueueFull() {
+        return DisruptorUtil.ASYNC_LOGGER_SYNCHRONIZE_ENQUEUE_WHEN_QUEUE_FULL
+                // Background thread must never block
+                && backgroundThreadId != Thread.currentThread().getId();
+    }
+
+    private void logWarningOnNpeFromDisruptorPublish(final RingBufferLogEventTranslator translator) {
+        logWarningOnNpeFromDisruptorPublish(
+                translator.level, translator.loggerName, translator.message, translator.thrown);
+    }
+
+    private void logWarningOnNpeFromDisruptorPublish(
+            final Level level, final String fqcn, final Message msg, final Throwable thrown) {
+        LOGGER.warn("[{}] Ignoring log event after log4j was shut down: {} [{}] {}{}", contextName,
+                level, fqcn, msg.getFormattedMessage(), thrown == null ? "" : Throwables.toStringList(thrown));
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
@@ -46,6 +46,17 @@ final class DisruptorUtil {
     private static final int RINGBUFFER_DEFAULT_SIZE = 256 * 1024;
     private static final int RINGBUFFER_NO_GC_DEFAULT_SIZE = 4 * 1024;
 
+    /**
+     * LOG4J2-2606: Users encountered excessive CPU utilization with Disruptor v3.4.2 when the application
+     * was logging more than the underlying appender could keep up with and the ringbuffer became full,
+     * especially when the number of application threads vastly outnumbered the number of cores.
+     * CPU utilization is significantly reduced by restricting access to the enqueue operation.
+     */
+    static final boolean ASYNC_LOGGER_SYNCHRONIZE_ENQUEUE_WHEN_QUEUE_FULL = PropertiesUtil.getProperties()
+            .getBooleanProperty("AsyncLogger.SynchronizeEnqueueWhenQueueFull", true);
+    static final boolean ASYNC_CONFIG_SYNCHRONIZE_ENQUEUE_WHEN_QUEUE_FULL = PropertiesUtil.getProperties()
+            .getBooleanProperty("AsyncLoggerConfig.SynchronizeEnqueueWhenQueueFull", true);
+
     private DisruptorUtil() {
     }
 

--- a/log4j-perf/src/main/resources/ConcurrentAsyncLoggerToFileBenchmark-asyncConfig.xml
+++ b/log4j-perf/src/main/resources/ConcurrentAsyncLoggerToFileBenchmark-asyncConfig.xml
@@ -22,8 +22,8 @@
     </RandomAccessFile>
   </Appenders>
   <Loggers>
-    <Root level="info" includeLocation="false">
+    <AsyncRoot level="info" includeLocation="false">
       <appender-ref ref="RandomAccessFile"/>
-    </Root>
+    </AsyncRoot>
   </Loggers>
 </Configuration>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -212,6 +212,9 @@
         Fix a race allowing events not to be recorded when a RoutingAppender purge policy attempts to delete an idle
         appender at exactly the same time as a new event is recorded.
       </action>
+      <action issue="LOG4J2-2606" dev="ckozak" type="fix">
+        Asynchronous logging when the queue is full no longer results in heavy CPU utilization and low throughput.
+      </action>
     </release>
     <release version="2.11.2" date="2018-MM-DD" description="GA Release 2.11.2">
       <action issue="LOG4J2-2500" dev="rgoers" type="fix">

--- a/src/site/asciidoc/manual/async.adoc
+++ b/src/site/asciidoc/manual/async.adoc
@@ -232,6 +232,15 @@ events after an initially spinning. Yield is a good compromise between
 performance and CPU resource, but may use more CPU than Sleep in order
 to get the message logged to disk sooner.
 
+|AsyncLogger.SynchronizeEnqueueWhenQueueFull
+|`true`
+|Synchronizes access to the Disruptor ring buffer for blocking enqueue operations when the queue is full.
+Users encountered excessive CPU utilization with Disruptor v3.4.2 when the application
+was logging more than the underlying appender could keep up with and the ring buffer became full,
+especially when the number of application threads vastly outnumbered the number of cores.
+CPU utilization is significantly reduced by restricting access to the enqueue operation. Setting this value
+to `false` may lead to very high CPU utilization when the async logging queue is full.
+
 |log4j2.asyncLoggerThreadNameStrategy
 |`CACHED`
 |Valid values: CACHED, UNCACHED.
@@ -388,6 +397,16 @@ latency for actually getting the message logged. +
 events after an initially spinning. Yield is a good compromise between
 performance and CPU resource, but may use more CPU than Sleep in order
 to get the message logged to disk sooner.
+
+|AsyncLoggerConfig.SynchronizeEnqueueWhenQueueFull
+|`true`
+|Synchronizes access to the Disruptor ring buffer for blocking enqueue operations when the queue is full.
+Users encountered excessive CPU utilization with Disruptor v3.4.2 when the application
+was logging more than the underlying appender could keep up with and the ring buffer became full,
+especially when the number of application threads vastly outnumbered the number of cores.
+CPU utilization is significantly reduced by restricting access to the enqueue operation. Setting this value
+to `false` may lead to very high CPU utilization when the async logging queue is full.
+
 |===
 
 There are also a few system properties that can be used to maintain

--- a/src/site/asciidoc/manual/configuration.adoc
+++ b/src/site/asciidoc/manual/configuration.adoc
@@ -2034,6 +2034,13 @@ details.
 link:async.html#SysPropsAllAsync[Async Logger System Properties] for
 details.
 
+|[[AsyncLogger.SynchronizeEnqueueWhenQueueFull]]AsyncLogger.SynchronizeEnqueueWhenQueueFull
+|ASYNC_LOGGER_SYNCHRONIZE_ENQUEUE_WHEN_QUEUE_FULL
+|true
+|See
+link:async.html#SysPropsAllAsync[Async Logger System Properties] for
+details.
+
 |[[asyncLoggerThreadNameStrategy]]log4j2.asyncLoggerThreadNameStrategy +
 ([[AsyncLogger.ThreadNameStrategy]]AsyncLogger.ThreadNameStrategy)
 |LOG4J_ASYNC_LOGGER_THREAD_NAME_STRATEGY
@@ -2062,6 +2069,13 @@ System Properties] for details.
 ([[AsyncLoggerConfig.WaitStrategy]]AsyncLoggerConfig.WaitStrategy)
 |LOG4J_ASYNC_LOGGER_CONFIG_WAIT_STRATEGY
 |Timeout
+|See
+link:async.html#SysPropsMixedSync-Async[Mixed Async/Synchronous Logger
+System Properties] for details.
+
+|[[AsyncLoggerConfig.SynchronizeEnqueueWhenQueueFull]]AsyncLoggerConfig.SynchronizeEnqueueWhenQueueFull
+|ASYNC_LOGGER_CONFIG_SYNCHRONIZE_ENQUEUE_WHEN_QUEUE_FULL
+|true
 |See
 link:async.html#SysPropsMixedSync-Async[Mixed Async/Synchronous Logger
 System Properties] for details.


### PR DESCRIPTION
This change applies synchronization to AsyncLoggerDisruptor blocking enqueue
operations when the asynchronous logging queue is completely full.
This new behavior may be disabled using the boolean property
`AsyncLogger.SynchronizeEnqueueWhenQueueFull` (default true).

Alternatives tested:
* All available lmax disruptor `WaitStrategy` implementations.
  None of the available implementations provided a substantial
  difference in throughput or CPU utilization. In all cases
  my processor was stuck at or near 100% across all six cores.
* Based on feedback from https://github.com/LMAX-Exchange/disruptor/issues/266
  I attempted avoiding the blocking enqueue entirely in favor of
  `LockSupport.parkNanos` with values ranging from 1,000 through
  1,000,000. 1,000,000 provided the most throughput among parkNanos
  values tested, but is too long for most scenarios.
* Semaphore instead of synchronized. Testing with permits
  equivalent to the available processor count yielded higher
  CPU utilization and lower throughput than a semaphore
  with a single permit. Given that most work occurs on
  the (single) background thread, there's not much reason
  to allow multiple enqueues simultaneously.

Updated benchmarks adding "ENQUEUE_UNSYNCHRONIZED" following
the old unsynchronized path, where "ENQUEUE" shows an improvement.
Also added benchmarks for mixed asynchronous logging.

```
Benchmark                                                      (asyncLoggerType)       (queueFullPolicy)   Mode  Cnt        Score         Error  Units
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads      ASYNC_CONTEXT                 ENQUEUE  thrpt    3  1196852.082 ±  656921.903  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads      ASYNC_CONTEXT  ENQUEUE_UNSYNCHRONIZED  thrpt    3   299829.995 ±  672293.830  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads      ASYNC_CONTEXT             SYNCHRONOUS  thrpt    3  1119699.755 ±  985194.962  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads       ASYNC_CONFIG                 ENQUEUE  thrpt    3  1255978.339 ±  208596.091  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads       ASYNC_CONFIG  ENQUEUE_UNSYNCHRONIZED  thrpt    3   252966.661 ±   31303.171  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads       ASYNC_CONFIG             SYNCHRONOUS  thrpt    3  1050306.069 ± 1564741.862  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread           ASYNC_CONTEXT                 ENQUEUE  thrpt    3  1256681.352 ± 1858635.191  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread           ASYNC_CONTEXT  ENQUEUE_UNSYNCHRONIZED  thrpt    3  1357446.702 ±  825753.509  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread           ASYNC_CONTEXT             SYNCHRONOUS  thrpt    3  1240065.456 ±  832767.348  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread            ASYNC_CONFIG                 ENQUEUE  thrpt    3  1376691.658 ±  614955.853  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread            ASYNC_CONFIG  ENQUEUE_UNSYNCHRONIZED  thrpt    3  1403978.404 ±  776352.491  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread            ASYNC_CONFIG             SYNCHRONOUS  thrpt    3  1347219.410 ± 2608889.236  ops/s
```