### PR TITLE
LOG4J2-2631: RoutingAppender PurgePolicy implementations don't remove …

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/IdlePurgePolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/IdlePurgePolicy.java
@@ -74,7 +74,7 @@ public class IdlePurgePolicy extends AbstractLifeCycle implements PurgePolicy, R
         final long createTime = System.currentTimeMillis() - timeToLive;
         for (final Entry<String, Long> entry : appendersUsage.entrySet()) {
             if (entry.getValue() < createTime) {
-                LOGGER.debug("Removing appender " + entry.getKey());
+                LOGGER.debug("Removing appender {}", entry.getKey());
                 if (appendersUsage.remove(entry.getKey(), entry.getValue())) {
                     routingAppender.deleteAppender(entry.getKey());
                 }

--- a/log4j-core/src/test/resources/log4j-routing-purge.xml
+++ b/log4j-core/src/test/resources/log4j-routing-purge.xml
@@ -30,6 +30,7 @@
     <List name="List">
       <ThresholdFilter level="debug"/>
     </List>
+    <List name="ReferencedList"/>
     <Routing name="RoutingPurgeIdle">
       <Routes pattern="$${sd:id}">
         <Route>
@@ -39,15 +40,17 @@
             </PatternLayout>
           </File>
         </Route>
+        <Route ref="ReferencedList" key="2"/>
       </Routes>
       <IdlePurgePolicy timeToLive="2" timeUnit="seconds" />
     </Routing>
-    
+
     <Routing name="RoutingPurgeIdleWithHangingAppender">
       <Routes pattern="$${sd:id}">
         <Route>
           <Hanging name="Routing-${sd:id}" shutdownDelay="10000"/>
         </Route>
+        <Route ref="ReferencedList" key="2"/>
       </Routes>
       <IdlePurgePolicy timeToLive="2" timeUnit="seconds" />
     </Routing>
@@ -61,6 +64,7 @@
             </PatternLayout>
           </File>
         </Route>
+        <Route ref="ReferencedList" key="2"/>
       </Routes>
     </Routing>
   </Appenders>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -201,6 +201,11 @@
       <action issue="LOG4J2-2619" dev="ggregory" type="update">
         Update Jackson from 2.9.8 to 2.9.9.
       </action>
+      <action issue="LOG4J2-2631" dev="ckozak" type="fix">
+        RoutingAppender PurgePolicy implementations no longer stop appenders referenced from the logger configuration,
+        only those that have been created by the RoutingAppender. Note that RoutingAppender.getAppenders no longer
+        includes entries for referenced appenders, only those which it has created.
+      </action>
     </release>
     <release version="2.11.2" date="2018-MM-DD" description="GA Release 2.11.2">
       <action issue="LOG4J2-2500" dev="rgoers" type="fix">


### PR DESCRIPTION
Note that this makes a behavior change to RoutingAppender.getAppenders
where Routes based on appender references are no longer included.
PurgePolicy implementations should be entirely unaware of the
existance of reference based routes because those appenders may
be used elsewhere in the configuration.