### PR TITLE
[LOG4J2-2403] Allow zero padding of integer values

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PaddingSpec.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PaddingSpec.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.pattern;
+
+
+/**
+ *
+ * Encapsulates the data needed for padding strings.
+ */
+class PaddingSpec {
+
+  /** The char to use for padding */
+  private final char paddingchar;
+
+  /** The length to which to pad the string */
+  private final int length;
+
+
+  /**
+   * Creates a new PaddingSpec with the given values.
+   *
+   * @param paddingchar the char to use for padding
+   * @param length the length to which to pad the string
+   */
+  public PaddingSpec(final char paddingchar, final int length) {
+    this.paddingchar = paddingchar;
+    this.length = length;
+  }
+
+
+  public char getPaddingchar() {
+    return paddingchar;
+  }
+
+
+  public int getLength() {
+    return length;
+  }
+
+
+  /**
+   * Applies this padding to an integer value.
+   *
+   * @param i the integer value to pad
+   * @return a padded string for the given integer value
+   */
+  public String apply(final int i) {
+    //FIXME: This is currently very inefficient and should be reworked.
+    return this.apply(String.valueOf(i));
+  }
+
+
+  /**
+   * Applies this padding to a string value.
+   *
+   * @param s the string value to pad
+   * @return a padded string for the given string value
+   */
+  public String apply(final String s) {
+    //FIXME: This is currently very inefficient and should be reworked.
+    if (s.length() >= length) {
+        return s;
+    }
+    final StringBuilder sb = new StringBuilder();
+    while (sb.length() < length - s.length()) {
+        sb.append('0');
+    }
+    sb.append(s);
+
+    return sb.toString();
+  }
+
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/RolloverWithPaddingTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/RolloverWithPaddingTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.appender.rolling;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+/**
+ * Tests that zero-padding in rolled files works correctly.
+ */
+public class RolloverWithPaddingTest {
+  private static final String CONFIG = "log4j-rolling-with-padding.xml";
+  private static final String DIR = "target/rolling-with-padding";
+
+  private final LoggerContextRule loggerContextRule = LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
+
+  @Rule
+  public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+
+  @Test
+  public void testAppender() throws Exception {
+    final Logger logger = loggerContextRule.getLogger();
+    for (int i = 0; i < 10; ++i) {
+      // 30 chars per message: each message triggers a rollover
+      logger.fatal("This is a test message number " + i); // 30 chars:
+    }
+    Thread.sleep(100); // Allow time for rollover to complete
+
+    final File dir = new File(DIR);
+    assertTrue("Dir " + DIR + " should exist", dir.exists());
+    assertTrue("Dir " + DIR + " should contain 6 files", dir.listFiles().length == 6);
+
+    final File[] files = dir.listFiles();
+    final List<String> expected = Arrays.asList("rollingtest.log", "test-001.log", "test-002.log", "test-003.log", "test-004.log", "test-005.log");
+    assertEquals("Unexpected number of files", expected.size(), files.length);
+    for (final File file : files) {
+      if (!expected.contains(file.getName())) {
+        fail("unexpected file" + file);
+      }
+    }
+  }
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/IntegerPatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/IntegerPatternConverterTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.pattern;
+
+import java.util.regex.Matcher;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test padding of Integer patterns
+ */
+public class IntegerPatternConverterTest {
+
+    @Test
+    public void testWithSpacePadding() throws Exception {
+      final Matcher matcher = IntegerPatternConverter.PATTERN_OPTIONS.matcher("3");
+      assertTrue(matcher.matches());
+      assertNull(matcher.group("PADDING"));
+      assertEquals("3", matcher.group("LENGTH"));
+    }
+
+    @Test
+    public void testWithZeroPadding() throws Exception {
+      final Matcher matcher = IntegerPatternConverter.PATTERN_OPTIONS.matcher("03");
+      assertTrue(matcher.matches());
+      assertEquals("0", matcher.group("PADDING"));
+      assertEquals("3", matcher.group("LENGTH"));
+    }
+
+    @Test
+    public void testUnmatched() throws Exception {
+      final Matcher matcher = IntegerPatternConverter.PATTERN_OPTIONS.matcher("0");
+      assertFalse(matcher.matches());
+    }
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/PaddingSpecTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/PaddingSpecTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.pattern;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+
+/**
+ *
+ */
+public class PaddingSpecTest {
+
+
+  @Test
+  public void testApply_Integer() {
+    assertEquals("00001", new PaddingSpec('0', 5).apply(1));
+    assertEquals("00164", new PaddingSpec('0', 5).apply(164));
+  }
+
+
+  @Test
+  public void testApply_String() {
+    assertEquals("00001", new PaddingSpec('0', 5).apply("1"));
+    assertEquals("00164", new PaddingSpec('0', 5).apply("164"));
+  }
+
+
+  @Test
+  public void testApply_ValueLongerThanPadding() {
+    assertEquals("164356", new PaddingSpec('0', 5).apply(164356));
+    assertEquals("164356", new PaddingSpec('0', 5).apply("164356"));
+  }
+
+}

--- a/log4j-core/src/test/resources/log4j-rolling-with-padding.xml
+++ b/log4j-core/src/test/resources/log4j-rolling-with-padding.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration status="WARN" name="RollingWithPadding">
+  <Properties>
+    <Property name="base">target/rolling-with-padding/</Property>
+  </Properties>
+
+  <Appenders>
+    <RollingFile name="RollingFile" fileName="${base}/rollingtest.log" filePattern="${base}/test-%i{03}.log">
+      <PatternLayout>
+        <Pattern>%d %p %c{1.} [%t] %m%n</Pattern>
+      </PatternLayout>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="30" />
+      </Policies>
+      <DefaultRolloverStrategy max="5" />
+    </RollingFile>
+  </Appenders>
+
+  <Loggers>
+    <Root level="trace">
+      <AppenderRef ref="RollingFile" />
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/src/site/asciidoc/manual/appenders.adoc
+++ b/src/site/asciidoc/manual/appenders.adoc
@@ -2546,7 +2546,10 @@ file. The format of the pattern is dependent on the RolloverPolicy that
 is used. The DefaultRolloverPolicy will accept both a date/time pattern
 compatible with
 https://download.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html[`SimpleDateFormat`]
-and/or a %i which represents an integer counter. The pattern also
+and/or a %i which represents an integer counter. The integer counter
+allows specifying a padding, like %i{3} for zero-padding the counter to
+3 digits or (rather unusual) %i{_3} for underscore-padding the counter to
+3 digits. The pattern also
 supports interpolation at runtime so any of the Lookups (such as the
 link:./lookups.html#DateLookup[DateLookup]) can be included in the
 pattern.


### PR DESCRIPTION
Alternative to https://github.com/apache/logging-log4j2/pull/224 with less impact on other files.

This alternative uses the the form `%i{03}` to specify the padding instead of `%03i` used in the orginal PR. 
However this imposes an inconsistency with the justification that can already be specified and always uses spaces for padding as described in the [PatternLayout section of the Layout manual](https://logging.apache.org/log4j/2.x/manual/layouts.html#PatternLayout).
