### PR TITLE
Synchronize before looping over synchronized collection

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/status/StatusConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/status/StatusConfiguration.java
@@ -217,9 +217,12 @@ public class StatusConfiguration {
     }
 
     private void migrateSavedLogMessages() {
-        for (final String message : this.errorMessages) {
-            this.logger.error(message);
+        synchronized(this.errorMessages) {
+            for (final String message : this.errorMessages) {
+                this.logger.error(message);
+            }
         }
+
         this.initialized = true;
         this.errorMessages.clear();
     }


### PR DESCRIPTION
In StatusConfiguration.java, `errorMessages = Collections.synchronizedCollection(new LinkedList<String>())` is iterated over without synchronization. According to [Java API](https://docs.oracle.com/javase/6/docs/api/java/util/Collections.html#synchronizedCollection%28java.util.Collection%29), it is recommended that user manually synchronizes each iteration over the synchronized collection to reduce non-determinism.
This pull request improved the condition by synchronizing a loop which loops over the synchronized collection.