### PR TITLE
LOG4J-2676: Backport use of javax.annotation.processing.Messager to release-2.x.

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessor.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Messager;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.SourceVersion;
@@ -67,16 +68,17 @@ public class PluginProcessor extends AbstractProcessor {
 
     @Override
     public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
-        System.out.println("Processing annotations");
+        Messager messager = processingEnv.getMessager();
+        messager.printMessage(Kind.NOTE, "Processing Log4j annotations");
         try {
             final Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(Plugin.class);
             if (elements.isEmpty()) {
-                System.out.println("No elements to process");
+                messager.printMessage(Kind.NOTE, "No elements to process");
                 return false;
             }
             collectPlugins(elements);
             writeCacheFile(elements.toArray(new Element[elements.size()]));
-            System.out.println("Annotations processed");
+            messager.printMessage(Kind.NOTE, "Annotations processed");
             return true;
         } catch (final IOException e) {
             e.printStackTrace();

--- a/misc/bazel-test/BUILD.bazel
+++ b/misc/bazel-test/BUILD.bazel
@@ -1,0 +1,50 @@
+java_import(
+    name = "logging_log4j2_api_jar",
+    jars = [
+        "jars/log4j-api-2.13.0-SNAPSHOT.jar",
+    ],
+)
+
+java_import(
+    name = "logging_log4j2_core_jar",
+    jars = [
+        "jars/log4j-core-2.13.0-SNAPSHOT.jar",
+    ],
+)
+
+java_library(
+    name = "log4j_api",
+    visibility = [
+        "//visibility:public",
+    ],
+    exports = [
+        ":logging_log4j2_api_jar",
+    ],
+)
+
+java_library(
+    name = "log4j_core",
+    exported_plugins = [
+        ":log4j_core_plugin",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+    exports = [
+        ":log4j_api",
+        ":logging_log4j2_core_jar",
+    ],
+)
+
+java_plugin(
+    name = "log4j_core_plugin",
+    generates_api = False,
+    processor_class = "org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor",
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        ":log4j_api",
+        ":logging_log4j2_core_jar",
+    ],
+)

--- a/misc/bazel-test/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/BUILD.bazel
+++ b/misc/bazel-test/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/BUILD.bazel
@@ -1,0 +1,5 @@
+java_library(
+    name = "processor",
+    srcs = ["BazelTestPlugin.java"],
+    deps = ["//:log4j_core"],
+)

--- a/misc/bazel-test/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/BazelTestPlugin.java
+++ b/misc/bazel-test/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/BazelTestPlugin.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.core.config.plugins.processor;
+
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAliases;
+
+/**
+ * Test plugin class for unit tests.
+ */
+@Plugin(name = "BazelTest", category = "Test")
+@PluginAliases({"BazelTest", "BazelTestPlugin"})
+public class BazelTestPlugin {
+
+  @Plugin(name = "Nested", category = "Test")
+  public static class Nested {
+  }
+}

--- a/misc/bazel-test/test.sh
+++ b/misc/bazel-test/test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Test Bazel support in log4j2.
+#   Run this script after `mvn clean package`.
+
+set -o errexit
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "${DIR}"
+
+mkdir -p "${DIR}/jars"
+cp "${DIR}/../../log4j-api/target/log4j-api-2.13.0-SNAPSHOT.jar" jars/
+cp "${DIR}/../../log4j-core/target/log4j-core-2.13.0-SNAPSHOT.jar" jars/
+bazel build //...
+


### PR DESCRIPTION
Add a test for Bazel support for the PluginProcessor, which does not work on 2.12.1 due to System.out calls, but works with this PR.