### PR TITLE
[LOG4J2-2674] CompositeConfiguration misleading configuration source

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/Configuration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/Configuration.java
@@ -136,7 +136,9 @@ public interface Configuration extends Filterable {
      * Returns the source of this configuration.
      *
      * @return the source of this configuration, never {@code null}, but may be
-     * {@link org.apache.logging.log4j.core.config.ConfigurationSource#NULL_SOURCE}.
+     * {@link org.apache.logging.log4j.core.config.ConfigurationSource#NULL_SOURCE}
+     * or
+     * {@link org.apache.logging.log4j.core.config.ConfigurationSource#COMPOSITE_SOURCE}
      */
     ConfigurationSource getConfigurationSource();
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
@@ -42,11 +42,15 @@ import org.apache.logging.log4j.util.LoaderUtil;
  * Represents the source for the logging configuration.
  */
 public class ConfigurationSource {
-    
+
     /**
      * ConfigurationSource to use with Configurations that do not require a "real" configuration source.
      */
     public static final ConfigurationSource NULL_SOURCE = new ConfigurationSource(new byte[0], null, 0);
+    /**
+     * ConfigurationSource to use with {@link org.apache.logging.log4j.core.config.composite.CompositeConfiguration}.
+     */
+    public static final ConfigurationSource COMPOSITE_SOURCE = new ConfigurationSource(new byte[0], null, 0);
     private static final String HTTPS = "https";
     private static final String HTTP = "http";
 
@@ -284,6 +288,9 @@ public class ConfigurationSource {
         }
         if (this == NULL_SOURCE) {
             return "NULL_SOURCE";
+        }
+        if (this == COMPOSITE_SOURCE) {
+            return "COMPOSITE_SOURCE";
         }
         final int length = data == null ? -1 : data.length;
         return "stream (" + length + " bytes, unknown location)";

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/CompositeConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/CompositeConfiguration.java
@@ -61,7 +61,7 @@ public class CompositeConfiguration extends AbstractConfiguration implements Rec
      * @param configurations The List of Configurations to merge.
      */
     public CompositeConfiguration(final List<? extends AbstractConfiguration> configurations) {
-        super(configurations.get(0).getLoggerContext(), ConfigurationSource.NULL_SOURCE);
+        super(configurations.get(0).getLoggerContext(), ConfigurationSource.COMPOSITE_SOURCE);
         rootNode = configurations.get(0).getRootNode();
         this.configurations = configurations;
         final String mergeStrategyClassName = PropertiesUtil.getProperties().getStringProperty(MERGE_STRATEGY_PROPERTY,

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CompositeConfigurationTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CompositeConfigurationTest.java
@@ -115,6 +115,9 @@ public class CompositeConfigurationTest {
                         appendersMap.size());
                 assertTrue(appendersMap.get("File") instanceof FileAppender);
                 assertTrue(appendersMap.get("STDOUT") instanceof ConsoleAppender);
+
+                assertEquals("Expected COMPOSITE_SOURCE for composite configuration but got " + config.getConfigurationSource(),
+                        config.getConfigurationSource(), ConfigurationSource.COMPOSITE_SOURCE);
             }
         };
         runTest(lcr, test);


### PR DESCRIPTION
Introduced new marker ConfigurationSource.COMPOSITE_SOURCE and used by CompositeConfiguration.