### PR TITLE
Fix LOG4J2-2680: Not compressing after rolling a file using copy and …

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/FileRenameAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/FileRenameAction.java
@@ -139,6 +139,7 @@ public class FileRenameAction extends AbstractAction {
                                         exDelete.getClass().getName(), exDelete.getMessage());
                                 try {
                                     new PrintWriter(source.getAbsolutePath()).close();
+                                    result = true;
                                     LOGGER.trace("Renamed file {} to {} with copy and truncation",
                                             source.getAbsolutePath(), destination.getAbsolutePath());
                                 } catch (final IOException exOwerwrite) {


### PR DESCRIPTION
…truncation

This fix set to true the return value of "execute" method in "FileRenameAction" class, after successfully apply copy and truncation method. Doing this, the rolled file can continue to be compressed as expected.