### PR TITLE
[LOG4J2-2652] JSON output wrong when using additonal fields

### DIFF
--- a/log4j-layout-jackson-json/src/main/java/org/apache/logging/log4j/jackson/json/layout/JsonLayout.java
+++ b/log4j-layout-jackson-json/src/main/java/org/apache/logging/log4j/jackson/json/layout/JsonLayout.java
@@ -19,6 +19,7 @@ package org.apache.logging.log4j.jackson.json.layout;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
@@ -135,7 +136,7 @@ public final class JsonLayout extends AbstractJacksonLayout {
     @JsonRootName(XmlConstants.ELT_EVENT)
     public static class JsonLogEventWithAdditionalFields extends LogEventWithAdditionalFields {
 
-        public JsonLogEventWithAdditionalFields(final Object logEvent, final Map<String, String> additionalFields) {
+        public JsonLogEventWithAdditionalFields(final LogEvent logEvent, final Map<String, String> additionalFields) {
             super(logEvent, additionalFields);
         }
 
@@ -147,7 +148,8 @@ public final class JsonLayout extends AbstractJacksonLayout {
 
         @Override
         @JsonUnwrapped
-        public Object getLogEvent() {
+        @JsonSerialize(as = LogEvent.class)
+        public LogEvent getLogEvent() {
             return super.getLogEvent();
         }
     }

--- a/log4j-layout-jackson-json/src/test/java/org/apache/logging/log4j/jackson/json/layout/JsonLayoutTest.java
+++ b/log4j-layout-jackson-json/src/test/java/org/apache/logging/log4j/jackson/json/layout/JsonLayoutTest.java
@@ -199,6 +199,29 @@ public class JsonLayoutTest {
         assertTrue(str, str.contains("\"KEY2\":\"" + new JavaLookup().getRuntime() + "\""));
     }
 
+    @Test
+    public void testMutableLogEvent() throws Exception {
+        final AbstractJacksonLayout layout = JsonLayout.newBuilder()
+                .setLocationInfo(false)
+                .setProperties(false)
+                .setComplete(false)
+                .setCompact(true)
+                .setEventEol(false)
+                .setIncludeStacktrace(false)
+                .setAdditionalFields(new KeyValuePair[] {
+                        new KeyValuePair("KEY1", "VALUE1"),
+                        new KeyValuePair("KEY2", "${java:runtime}"), })
+                .setCharset(StandardCharsets.UTF_8)
+                .setConfiguration(ctx.getConfiguration())
+                .build();
+        Log4jLogEvent logEvent = LogEventFixtures.createLogEvent();
+        final MutableLogEvent mutableEvent = new MutableLogEvent();
+        mutableEvent.initFrom(logEvent);
+        final String strLogEvent = layout.toSerializable(logEvent);
+        final String strMutableEvent = layout.toSerializable(mutableEvent);
+        assertEquals(strMutableEvent, strLogEvent, strMutableEvent);
+    }
+
     private void testAllFeatures(final boolean locationInfo, final boolean compact, final boolean eventEol,
             final String endOfLine, final boolean includeContext, final boolean contextMapAslist, final boolean includeStacktrace)
             throws Exception {

--- a/log4j-layout-jackson-xml/src/main/java/org/apache/logging/log4j/jackson/xml/layout/XmlLayout.java
+++ b/log4j-layout-jackson-xml/src/main/java/org/apache/logging/log4j/jackson/xml/layout/XmlLayout.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.jackson.xml.layout;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
@@ -84,8 +85,15 @@ public final class XmlLayout extends AbstractJacksonLayout {
     @JacksonXmlRootElement(namespace = XmlConstants.XML_NAMESPACE, localName = XmlConstants.ELT_EVENT)
     public static class XmlLogEventWithAdditionalFields extends LogEventWithAdditionalFields {
 
-        public XmlLogEventWithAdditionalFields(final Object logEvent, final Map<String, String> additionalFields) {
+        public XmlLogEventWithAdditionalFields(final LogEvent logEvent, final Map<String, String> additionalFields) {
             super(logEvent, additionalFields);
+
+        }
+
+        @Override
+        @JsonSerialize(as = LogEvent.class)
+        public LogEvent getLogEvent() {
+            return super.getLogEvent();
         }
 
     }

--- a/log4j-layout-jackson-xml/src/test/java/org/apache/logging/log4j/jackson/xml/layout/XmlLayoutTest.java
+++ b/log4j-layout-jackson-xml/src/test/java/org/apache/logging/log4j/jackson/xml/layout/XmlLayoutTest.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.core.impl.MutableLogEvent;
 import org.apache.logging.log4j.core.layout.LogEventFixtures;
 import org.apache.logging.log4j.core.lookup.JavaLookup;
 import org.apache.logging.log4j.core.util.KeyValuePair;
@@ -197,6 +198,20 @@ public class XmlLayoutTest {
         assertTrue(str, str.contains("<KEY2>" + new JavaLookup().getRuntime() + "</KEY2>"));
     }
 
+    @Test
+    public void testMutableLogEvent() throws Exception {
+        final AbstractJacksonLayout layout = XmlLayout.newBuilder().setLocationInfo(false).setProperties(false)
+                .setIncludeStacktrace(false)
+                .setAdditionalFields(new KeyValuePair[] { new KeyValuePair("KEY1", "VALUE1"),
+                        new KeyValuePair("KEY2", "${java:runtime}"), })
+                .setCharset(StandardCharsets.UTF_8).setConfiguration(ctx.getConfiguration()).build();
+        Log4jLogEvent logEvent = LogEventFixtures.createLogEvent();
+        final MutableLogEvent mutableEvent = new MutableLogEvent();
+        mutableEvent.initFrom(logEvent);
+        final String strLogEvent = layout.toSerializable(logEvent);
+        final String strMutableEvent = layout.toSerializable(mutableEvent);
+        assertEquals(strMutableEvent, strLogEvent, strMutableEvent);
+    }
     /**
      * @param includeLocationInfo
      *            TODO

--- a/log4j-layout-jackson-yaml/src/main/java/org/apache/logging/log4j/jackson/yaml/layout/YamlLayout.java
+++ b/log4j-layout-jackson-yaml/src/main/java/org/apache/logging/log4j/jackson/yaml/layout/YamlLayout.java
@@ -20,6 +20,7 @@ package org.apache.logging.log4j.jackson.yaml.layout;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
@@ -76,7 +77,7 @@ public final class YamlLayout extends AbstractJacksonLayout {
     @JsonRootName(YamlConstants.EVENT)
     public static class YamlLogEventWithAdditionalFields extends LogEventWithAdditionalFields {
 
-        public YamlLogEventWithAdditionalFields(final Object logEvent, final Map<String, String> additionalFields) {
+        public YamlLogEventWithAdditionalFields(final LogEvent logEvent, final Map<String, String> additionalFields) {
             super(logEvent, additionalFields);
         }
 
@@ -88,7 +89,8 @@ public final class YamlLayout extends AbstractJacksonLayout {
 
         @Override
         @JsonUnwrapped
-        public Object getLogEvent() {
+        @JsonSerialize(as = LogEvent.class)
+        public LogEvent getLogEvent() {
             return super.getLogEvent();
         }
 

--- a/log4j-layout-jackson-yaml/src/test/java/org/apache/logging/log4j/jackson/yaml/layout/YamlLayoutTest.java
+++ b/log4j-layout-jackson-yaml/src/test/java/org/apache/logging/log4j/jackson/yaml/layout/YamlLayoutTest.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.core.impl.MutableLogEvent;
 import org.apache.logging.log4j.core.layout.LogEventFixtures;
 import org.apache.logging.log4j.core.lookup.JavaLookup;
 import org.apache.logging.log4j.core.util.KeyValuePair;
@@ -139,6 +140,26 @@ public class YamlLayoutTest {
         final String str = layout.toSerializable(LogEventFixtures.createLogEvent());
         assertThat(str, containsString("KEY1: \"VALUE1\""));
         assertThat(str, containsString("KEY2: \"" + new JavaLookup().getRuntime() + "\""));
+    }
+
+    @Test
+    public void testMutableLogEvent() throws Exception {
+        final AbstractJacksonLayout layout = YamlLayout.newBuilder()
+                .setLocationInfo(false)
+                .setProperties(false)
+                .setIncludeStacktrace(false)
+                .setAdditionalFields(new KeyValuePair[] {
+                        new KeyValuePair("KEY1", "VALUE1"),
+                        new KeyValuePair("KEY2", "${java:runtime}"), })
+                .setCharset(StandardCharsets.UTF_8)
+                .setConfiguration(ctx.getConfiguration())
+                .build();
+        Log4jLogEvent logEvent = LogEventFixtures.createLogEvent();
+        final MutableLogEvent mutableEvent = new MutableLogEvent();
+        mutableEvent.initFrom(logEvent);
+        final String strLogEvent = layout.toSerializable(logEvent);
+        final String strMutableEvent = layout.toSerializable(mutableEvent);
+        assertEquals(strMutableEvent, strLogEvent, strMutableEvent);
     }
 
     private void testAllFeatures(final boolean includeSource, final boolean compact, final boolean eventEol,

--- a/log4j-layout-jackson/src/main/java/org/apache/logging/log4j/jackson/AbstractJacksonLayout.java
+++ b/log4j-layout-jackson/src/main/java/org/apache/logging/log4j/jackson/AbstractJacksonLayout.java
@@ -202,10 +202,10 @@ public abstract class AbstractJacksonLayout extends AbstractStringLayout {
      */
     public static class LogEventWithAdditionalFields {
 
-        private final Object logEvent;
+        private final LogEvent logEvent;
         private final Map<String, String> additionalFields;
 
-        public LogEventWithAdditionalFields(final Object logEvent, final Map<String, String> additionalFields) {
+        public LogEventWithAdditionalFields(final LogEvent logEvent, final Map<String, String> additionalFields) {
             this.logEvent = logEvent;
             this.additionalFields = additionalFields;
         }
@@ -214,7 +214,7 @@ public abstract class AbstractJacksonLayout extends AbstractStringLayout {
             return additionalFields;
         }
 
-        public Object getLogEvent() {
+        public LogEvent getLogEvent() {
             return logEvent;
         }
     }


### PR DESCRIPTION
Fix and tests for the issue https://issues.apache.org/jira/projects/LOG4J2/issues/LOG4J2-2652 

The cause of the issue is: 
1. Jackson is configured with custom serializer for Message added through setSerializer https://github.com/apache/logging-log4j2/blob/33009e1163227a20b526ac04b9af79b90d439bf5/log4j-layout-jackson/src/main/java/org/apache/logging/log4j/jackson/SimpleModuleInitializer.java#L24 
2. Annotations for LogEvent is mixed through mix-in mechanism 
3. MutableLogEvent implements both interfaces LogEvent and Message.

When Jackson looking for an appropriate serializer for MutableLogEvent, it selects MessageSerializer and not UnwrappingBeanSerializer because MutableLogEvent implements Message.

The bug report notes that the problem is not reproduced in 2,10 version. There was converting of MutableLogEvent to Log4jEvent and Log4jEvent implements single LogEvent interface,
https://github.com/apache/logging-log4j2/blob/6275d8aac4e392eacd81d942a1b97856c92b698f/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/AbstractJacksonLayout.java#L306

As the fix I added JsonSerialize annotation with parameter "as" on the getter method in order to tell Jackson that the field must be serialized as LogEvent. Jackson will not consider MessageSerializer if actual type of this LogEvent is MutableLogEvent.