### PR TITLE
broken link on https://logging.apache.org/log4j/2.x/manual/thread-con…

### DIFF
--- a/src/site/asciidoc/manual/thread-context.adoc
+++ b/src/site/asciidoc/manual/thread-context.adoc
@@ -205,7 +205,7 @@ class are static.
 === Including the ThreadContext when writing logs
 
 The
-link:../log4j-api/apidocs/org/apache/logging/log4j/core/PatternLayout.html[`PatternLayout`]
+link:https://logging.apache.org/log4j/2.x/manual/layouts.html[`PatternLayout`]
 provides mechanisms to print the contents of the
 link:../log4j-api/apidocs/org/apache/logging/log4j/ThreadContext.html[`ThreadContext`]
 Map and Stack.


### PR DESCRIPTION
https://logging.apache.org/log4j/2.x/manual/thread-context.html's ```Including the ThreadContext when writing logs``` has a broken link on PatternLayout.
<img width="655" alt="Screen Shot 2019-09-15 at 12 40 02 am" src="https://user-images.githubusercontent.com/5586453/64909570-634fae80-d751-11e9-9d98-60ab468a58cf.png">
The class isn't in API, linking to the layout page seems most reasonable.