### PR TITLE
LOG4J2-2701: update jackson 2.9.9->2.9.10, minor jackson usage cleanup

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/JsonConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/JsonConfiguration.java
@@ -16,8 +16,6 @@
  */
 package org.apache.logging.log4j.core.config.json;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -52,14 +50,12 @@ public class JsonConfiguration extends AbstractConfiguration implements Reconfig
 
     public JsonConfiguration(final LoggerContext loggerContext, final ConfigurationSource configSource) {
         super(loggerContext, configSource);
-        final File configFile = configSource.getFile();
-        byte[] buffer;
         try {
+            final byte[] buffer;
             try (final InputStream configStream = configSource.getInputStream()) {
                 buffer = toByteArray(configStream);
             }
-            final InputStream is = new ByteArrayInputStream(buffer);
-            root = getObjectMapper().readTree(is);
+            root = getObjectMapper().readTree(buffer);
             if (root.size() == 1) {
                 for (final JsonNode node : root) {
                     root = node;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/YamlConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/YamlConfiguration.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.core.config.json.JsonConfiguration;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 
 public class YamlConfiguration extends JsonConfiguration {
 
@@ -35,7 +35,7 @@ public class YamlConfiguration extends JsonConfiguration {
 
     @Override
     protected ObjectMapper getObjectMapper() {
-        return new ObjectMapper(new YAMLFactory()).configure(JsonParser.Feature.ALLOW_COMMENTS, true);
+        return new YAMLMapper().configure(JsonParser.Feature.ALLOW_COMMENTS, true);
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/YamlConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/YamlConfigurationFactory.java
@@ -37,7 +37,7 @@ public class YamlConfigurationFactory extends ConfigurationFactory {
             "com.fasterxml.jackson.databind.ObjectMapper",
             "com.fasterxml.jackson.databind.JsonNode",
             "com.fasterxml.jackson.core.JsonParser",
-            "com.fasterxml.jackson.dataformat.yaml.YAMLFactory"
+            "com.fasterxml.jackson.dataformat.yaml.YAMLMapper"
     };
 
     private final boolean isActive;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/parser/AbstractJacksonLogEventParser.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/parser/AbstractJacksonLogEventParser.java
@@ -28,8 +28,8 @@ public class AbstractJacksonLogEventParser implements TextLogEventParser {
     private final ObjectReader objectReader;
 
     protected AbstractJacksonLogEventParser(final ObjectMapper objectMapper) {
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        this.objectReader = objectMapper.readerFor(Log4jLogEvent.class);
+        this.objectReader = objectMapper.readerFor(Log4jLogEvent.class)
+            .without(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <slf4jVersion>1.7.25</slf4jVersion>
     <logbackVersion>1.2.3</logbackVersion>
     <jackson1Version>1.9.13</jackson1Version>
-    <jackson2Version>2.9.9</jackson2Version>
+    <jackson2Version>2.9.10</jackson2Version>
     <springVersion>3.2.18.RELEASE</springVersion>
     <flumeVersion>1.9.0</flumeVersion>
     <disruptorVersion>3.4.2</disruptorVersion>


### PR DESCRIPTION
Update Jackson patch version (as per Jira issue): also minor simplification for Jackson usage.
I had a look at other usage and everything makes sense; the only thing I was wondering was whether some transient `ObjectMapper` instances could use statically created ones, in case methods are called more than once.
 But not being familiar enough with codebase decided not to try to change those yet.

