### PR TITLE
make variableResolverPrefix/variableResolverSuffix/variableResolverEscape configable

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/BuiltConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/BuiltConfiguration.java
@@ -52,7 +52,7 @@ public class BuiltConfiguration extends AbstractConfiguration {
     private String contentType = "text";
 
     public BuiltConfiguration(final LoggerContext loggerContext, final ConfigurationSource source, final Component rootComponent) {
-        super(loggerContext, source);
+        super(loggerContext, source, rootComponent.getAttributes());
         statusConfig = new StatusConfiguration().setVerboseClasses(VERBOSE_CLASSES).setStatus(getDefaultStatus());
         for (final Component component : rootComponent.getComponents()) {
             switch (component.getPluginType()) {
@@ -82,6 +82,7 @@ public class BuiltConfiguration extends AbstractConfiguration {
                 }
             }
         }
+        
         this.rootComponent = rootComponent;
     }
 


### PR DESCRIPTION
so that `logStdoutPattern:-%d{yyyyMMdd HH:mm:ss} %-5p %c{20}:%L - %m%n` will be ok
by change variableResolverPrefix/variableResolverSuffix to "$(" and ")"
ie:
```log4j2.properties
variableResolverPrefix=$(
variableResolverSuffix=)
appender.console.layout.pattern=$(logStdoutPattern:-%d{yyyyMMdd HH:mm:ss} %-5p %c{20}:%L - %m%n)
```