### PR TITLE
LOG4J2-2725 - Added try/finally around event.execute() for RingBufferLogEventHandler

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler.java
@@ -42,12 +42,16 @@ public class RingBufferLogEventHandler implements
     @Override
     public void onEvent(final RingBufferLogEvent event, final long sequence,
             final boolean endOfBatch) throws Exception {
-        event.execute(endOfBatch);
-        event.clear();
-        // notify the BatchEventProcessor that the sequence has progressed.
-        // Without this callback the sequence would not be progressed
-        // until the batch has completely finished.
-        notifyCallback(sequence);
+        try {
+            event.execute(endOfBatch);
+        }
+        finally {
+            event.clear();
+            // notify the BatchEventProcessor that the sequence has progressed.
+            // Without this callback the sequence would not be progressed
+            // until the batch has completely finished.
+            notifyCallback(sequence);
+        }
     }
 
     private void notifyCallback(long sequence) {


### PR DESCRIPTION
Added try/finally around event.execute() for RingBufferLogEventHandler to clear memory correctly in case of exception/error