### PR TITLE
LOG4J-2735 - make PluginCache output reproducible

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginCache.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginCache.java
@@ -25,15 +25,15 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
 import java.util.Enumeration;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  *
  */
 public class PluginCache {
     private final Map<String, Map<String, PluginEntry>> categories =
-        new LinkedHashMap<>();
+        new TreeMap<>();
 
     /**
      * Returns all categories of plugins in this cache.
@@ -54,7 +54,7 @@ public class PluginCache {
     public Map<String, PluginEntry> getCategory(final String category) {
         final String key = category.toLowerCase();
         if (!categories.containsKey(key)) {
-            categories.put(key, new LinkedHashMap<String, PluginEntry>());
+            categories.put(key, new TreeMap<String, PluginEntry>());
         }
         return categories.get(key);
     }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginCacheTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginCacheTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.core.config.plugins.processor;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class PluginCacheTest {
+
+    @Test
+    public void testOutputIsReproducibleWhenInputOrderingChanges() throws IOException {
+        PluginCache cacheA = new PluginCache();
+        createCategory(cacheA, "one", Arrays.asList("bravo", "alpha", "charlie"));
+        createCategory(cacheA, "two", Arrays.asList("alpha", "charlie", "bravo"));
+        assertEquals(cacheA.getAllCategories().size(), 2);
+        assertEquals(cacheA.getAllCategories().get("one").size(), 3);
+        assertEquals(cacheA.getAllCategories().get("two").size(), 3);
+        PluginCache cacheB = new PluginCache();
+        createCategory(cacheB, "two", Arrays.asList("bravo", "alpha", "charlie"));
+        createCategory(cacheB, "one", Arrays.asList("alpha", "charlie", "bravo"));
+        assertEquals(cacheB.getAllCategories().size(), 2);
+        assertEquals(cacheB.getAllCategories().get("one").size(), 3);
+        assertEquals(cacheB.getAllCategories().get("two").size(), 3);
+        assertArrayEquals(cacheData(cacheA), cacheData(cacheB));
+    }
+
+    private void createCategory(PluginCache cache, String categoryName, List<String> entryNames) {
+        Map<String, PluginEntry> category = cache.getCategory(categoryName);
+        for (String entryName: entryNames) {
+            PluginEntry entry = new PluginEntry();
+            entry.setKey(entryName);
+            entry.setClassName("com.example.Plugin");
+            entry.setName("name");
+            entry.setCategory(categoryName);
+            category.put(entryName, entry);
+        }
+    }
+
+    private byte[] cacheData(PluginCache cache) throws IOException {
+        ByteArrayOutputStream outputB = new ByteArrayOutputStream();
+        cache.writeCache(outputB);
+        return outputB.toByteArray();
+    }
+
+}


### PR DESCRIPTION
As discussed, here's a pull request for [LOG4J-2735](https://issues.apache.org/jira/browse/LOG4J2-2735). The commit message contains some details about the change and its motivation. I wasn't sure which base branch to use for a 2.x change. Please let me know if a change needs to be made there.