### PR TITLE
LOG4J2-2677: Rollover and Deletion handle file deletions gracefully

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/SortingVisitor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/SortingVisitor.java
@@ -17,8 +17,12 @@
 
 package org.apache.logging.log4j.core.appender.rolling.action;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.status.StatusLogger;
+
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -32,6 +36,7 @@ import java.util.Objects;
  */
 public class SortingVisitor extends SimpleFileVisitor<Path> {
 
+    private static final Logger LOGGER = StatusLogger.getLogger();
     private final PathSorter sorter;
     private final List<PathWithAttributes> collected = new ArrayList<>();
 
@@ -49,6 +54,18 @@ public class SortingVisitor extends SimpleFileVisitor<Path> {
     public FileVisitResult visitFile(final Path path, final BasicFileAttributes attrs) throws IOException {
         collected.add(new PathWithAttributes(path, attrs));
         return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFileFailed(Path file, IOException ioException) throws IOException {
+        // LOG4J2-2677: Appenders may rollover and purge in parallel. SimpleVisitor rethrows exceptions from
+        // failed attempts to load file attributes.
+        if (ioException instanceof NoSuchFileException) {
+            LOGGER.info("File {} could not be accessed, it has likely already been deleted", file, ioException);
+            return FileVisitResult.CONTINUE;
+        } else {
+            return super.visitFileFailed(file, ioException);
+        }
     }
     
     public List<PathWithAttributes> getSortedPaths() {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/DeletingVisitorTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/DeletingVisitorTest.java
@@ -18,11 +18,14 @@
 package org.apache.logging.log4j.core.appender.rolling.action;
 
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
@@ -131,5 +134,27 @@ public class DeletingVisitorTest {
 
         final Path child = Paths.get("/a/b/c/relative");
         visitor.visitFile(child, null);
+    }
+
+    @Test
+    public void testNoSuchFileFailure() throws IOException {
+        final DeletingVisitorHelper visitor =
+                new DeletingVisitorHelper(Paths.get("/a/b/c"), Collections.emptyList(), true);
+        assertEquals(
+                FileVisitResult.CONTINUE,
+                visitor.visitFileFailed(Paths.get("doesNotExist"), new NoSuchFileException("doesNotExist")));
+    }
+
+    @Test
+    public void testIOException() {
+        final DeletingVisitorHelper visitor =
+                new DeletingVisitorHelper(Paths.get("/a/b/c"), Collections.emptyList(), true);
+        IOException exception = new IOException();
+        try {
+            visitor.visitFileFailed(Paths.get("doesNotExist"), exception);
+            fail();
+        } catch (IOException e) {
+            assertSame(exception, e);
+        }
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/SortingVisitorTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/SortingVisitorTest.java
@@ -17,9 +17,13 @@
 
 package org.apache.logging.log4j.core.appender.rolling.action;
 
+import java.io.IOException;
 import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.FileTime;
 import java.util.Collections;
@@ -90,5 +94,25 @@ public class SortingVisitorTest {
         assertEquals("1st: oldest first; sorted=" + found, aaa, found.get(0).getPath());
         assertEquals("2nd; sorted=" + found, bbb, found.get(1).getPath());
         assertEquals("3rd: most recent sorted; list=" + found, ccc, found.get(2).getPath());
+    }
+
+    @Test
+    public void testNoSuchFileFailure() throws IOException {
+        SortingVisitor visitor = new SortingVisitor(new PathSortByModificationTime(false));
+        assertEquals(
+                FileVisitResult.CONTINUE,
+                visitor.visitFileFailed(Paths.get("doesNotExist"), new NoSuchFileException("doesNotExist")));
+    }
+
+    @Test
+    public void testIOException() {
+        SortingVisitor visitor = new SortingVisitor(new PathSortByModificationTime(false));
+        IOException exception = new IOException();
+        try {
+            visitor.visitFileFailed(Paths.get("doesNotExist"), exception);
+            fail();
+        } catch (IOException e) {
+            assertSame(exception, e);
+        }
     }
 }


### PR DESCRIPTION
It's common for multiple appenders to write (and roll) log files
into a single directory. When these appenders are also responsible
for cleaning up after themselves, they must also search that
directory for files to delete. These searches are executed in
parallel by multiple appenders and have a chance to delete files
the other is checking before the file can be checked against
a regex or glob.
Missing files can safely be assumed to have been deleted.