### PR TITLE
LOG4J2-2741 - Fix race condition in computation of prevFireTime in Cr…

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/CronTriggeringPolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/CronTriggeringPolicy.java
@@ -146,7 +146,7 @@ public final class CronTriggeringPolicy extends AbstractTriggeringPolicy {
     }
 
     private void rollover() {
-    	manager.rollover(cronExpression.getPrevFireTime(new Date()), lastRollDate);
+    	manager.rollover(cronExpression.getPrevFireTime(lastRollDate), lastRollDate);
         if (future != null) {
             lastRollDate = future.getFireTime();
         }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronFireTimeTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderCronFireTimeTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.appender.rolling;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.apache.logging.log4j.hamcrest.Descriptors.that;
+import static org.apache.logging.log4j.hamcrest.FileMatchers.hasName;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.junit.Assert.*;
+
+/**
+ * LOG4J2-2741.
+ * Log files must not be overwritten when using {@link CronTriggeringPolicy} with only a date pattern in the filePattern
+ * and without {@code %i}.
+ */
+public class RollingAppenderCronFireTimeTest {
+
+    private static final String CONFIG = "log4j-rolling-cron-firetime.xml";
+
+    private static final String DIR = "target/rolling-cron-firetime";
+
+    public static LoggerContextRule loggerContextRule = LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
+
+    @Rule
+    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+
+    private Logger logger;
+
+    @Before
+    public void setUp() throws Exception {
+        this.logger = loggerContextRule.getLogger(RollingAppenderCronFireTimeTest.class.getName());
+    }
+
+    @Test
+    public void testAppender() throws Exception {
+        final String testMessagePrefix = "This is test message number ";
+        int totalLogMessagesWritten = 0;
+        Random rand = new Random();
+        for (int j=0; j < 100; ++j) {
+            totalLogMessagesWritten++;
+            logger.debug(testMessagePrefix + totalLogMessagesWritten);
+            Thread.sleep(rand.nextInt(200));
+        }
+
+        final File dir = new File(DIR);
+        assertTrue("Directory not created", dir.exists() && dir.listFiles().length > 0);
+        final File[] files = dir.listFiles();
+        Arrays.sort(files);
+        assertNotNull(files);
+        Assert.assertEquals("number of log messages written vs number of log messages in log files",
+                totalLogMessagesWritten, countLines(files));
+    }
+
+    private int countLines(File... files) throws IOException {
+        int totalLines = 0;
+        for(File file : files){
+            totalLines += Files.lines(file.toPath()).count();
+        }
+        return totalLines;
+    }
+}

--- a/log4j-core/src/test/resources/log4j-rolling-cron-firetime.xml
+++ b/log4j-core/src/test/resources/log4j-rolling-cron-firetime.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration status="ERROR" name="RollingAppenderCronFireTimeTest">
+    <Properties>
+        <Property name="filename">target/rolling-cron-firetime/rollingtest-firetime.log</Property>
+        <Property name="DIR">target/rolling-cron-firetime</Property>
+    </Properties>
+    <Filters>
+        <ThresholdFilter level="debug"/>
+    </Filters>
+
+    <Appenders>
+        <Console name="STDOUT">
+            <PatternLayout pattern="%m%n"/>
+        </Console>
+        <RollingFile name="RollingFile" fileName="${filename}" filePattern="${DIR}/rollingfile_%d{yyyy-MM-dd-HH-mm-ss}.log">
+            <PatternLayout pattern="%d{yyyy-MM-dd-HH-mm-ss,SSS} [%level] [%c] %msg%n"/>
+            <Policies>
+                <CronTriggeringPolicy schedule="* * * * * ?"/>
+            </Policies>
+        </RollingFile>
+        <List name="List">
+            <Filters>
+                <ThresholdFilter level="error"/>
+            </Filters>
+        </List>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.apache.logging.log4j.core.appender.rolling" level="debug" additivity="false">
+            <AppenderRef ref="RollingFile"/>
+        </Logger>
+
+        <Root level="error">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+
+</Configuration>


### PR DESCRIPTION
…onTriggeringPolicy

There was a race condition in the computation of prevFireTime - which is used as time
for the file pattern - could be wrong which lead to the possibility of overwriting files,
because a file name could be generated twice. The cause was CronExpression.getPrevFireTime()
needs a Date in the interval (prevFireTime, currentFireTime], but the Date provided was
created at or after the currentFireTime.
Fixed by using the exact currentFireTime as provided by the scheduler.