### PR TITLE
LOG4J2-2750: Extended throwable class loading can be disabled

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxy.java
@@ -27,7 +27,6 @@ import java.util.Stack;
 
 import org.apache.logging.log4j.core.pattern.PlainTextRenderer;
 import org.apache.logging.log4j.core.pattern.TextRenderer;
-import org.apache.logging.log4j.util.StackLocatorUtil;
 import org.apache.logging.log4j.util.Strings;
 
 /**
@@ -105,7 +104,7 @@ public class ThrowableProxy implements Serializable {
         this.message = throwable.getMessage();
         this.localizedMessage = throwable.getLocalizedMessage();
         final Map<String, ThrowableProxyHelper.CacheEntry> map = new HashMap<>();
-        final Stack<Class<?>> stack = StackLocatorUtil.getCurrentStackTrace();
+        final Stack<Class<?>> stack = ThrowableProxyHelper.getCurrentStackTrace();
         this.extendedStackTrace = ThrowableProxyHelper.toExtendedStackTrace(this, stack, map, null, throwable.getStackTrace());
         final Throwable throwableCause = throwable.getCause();
         final Set<Throwable> causeVisited = new HashSet<>(1);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
@@ -141,6 +141,17 @@ public final class Constants {
     }
 
     /**
+     * Controls whether or not ThrowableProxy creation may load classes in order to discover extended stack frame
+     * information. This is enabled by default and used by the ExtendedThrowablePatternConverter but comes at a
+     * high cost as class loading incurs a great deal of work and synchronization.
+     * See <a href="https://issues.apache.org/jira/browse/LOG4J2-2391">LOG4J2-2391</a> for more information.
+     *
+     * @since 2.13.1
+     */
+    public static final boolean ENABLE_EXTENDED_THROWABLE_CLASS_LOADING = PropertiesUtil.getProperties().
+            getBooleanProperty("log4j2.enable.extended.throwable.class.loading", true);
+
+    /**
      * Prevent class instantiation.
      */
     private Constants() {


### PR DESCRIPTION
Implemented a new `log4j2.enable.extended.throwable.class.loading`
flag which may be set to `false` in order to safely avoid performance
pitfalls of class loading.