### PR TITLE
ThrowableProxy pre-warms its cache using the detected stack

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxy.java
@@ -104,8 +104,8 @@ public class ThrowableProxy implements Serializable {
         this.name = throwable.getClass().getName();
         this.message = throwable.getMessage();
         this.localizedMessage = throwable.getLocalizedMessage();
-        final Map<String, ThrowableProxyHelper.CacheEntry> map = new HashMap<>();
         final Stack<Class<?>> stack = StackLocatorUtil.getCurrentStackTrace();
+        final Map<String, ThrowableProxyHelper.CacheEntry> map = ThrowableProxyHelper.createCacheFromStack(stack);
         this.extendedStackTrace = ThrowableProxyHelper.toExtendedStackTrace(this, stack, map, null, throwable.getStackTrace());
         final Throwable throwableCause = throwable.getCause();
         final Set<Throwable> causeVisited = new HashSet<>(1);


### PR DESCRIPTION
This allows us to avoid class loading even when order doesn't match
the stack due to exceptions caught and pased from a slightly different
codepath.
This change also includes a name-based predicate to avoid loading
classes types which are known not to provide location information.
Unfortunately this mostly invalidates our existing benchmarks which are
based on dynamic proxies, but modern java applications use proxies
and lambdas heavily enough that I expect a sizable performance
improvement.

In a future commit we may consider relying exclusively on classes from
the detected stack for location information and entirely avoid
class loading.