### PR TITLE
Fixed log message in RollingFileAppender

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RollingFileAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RollingFileAppender.java
@@ -134,7 +134,7 @@ public final class RollingFileAppender extends AbstractOutputStreamAppender<Roll
                                         .build();
                 }
             } else if (fileName == null && !(strategy instanceof DirectFileRolloverStrategy)) {
-                LOGGER.error("RollingFileAppender '{}': When no file name is provided a DirectFilenameRolloverStrategy must be configured");
+                LOGGER.error("RollingFileAppender '{}': When no file name is provided a DirectFilenameRolloverStrategy must be configured", getName());
                 return null;
             }
 


### PR DESCRIPTION
An error message in RollingFileAppender uses a placeholder for the name but does not specify the name argument in the logging call. This PR adds the missing argument.