### PR TITLE
LOG4J2-2760: Fixes RollingFileAppender with DirectWriteRolloverStrategy and HtmlLayout

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/OutputStreamManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/OutputStreamManager.java
@@ -164,6 +164,7 @@ public class OutputStreamManager extends AbstractManager implements ByteBufferDe
     protected OutputStream getOutputStream() throws IOException {
         if (outputStream == null) {
             outputStream = createOutputStream();
+            setOutputStream(outputStream); // Needed so the header will be written
         }
         return outputStream;
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
@@ -96,7 +96,7 @@ public class RollingFileManager extends FileManager {
             final String filePermissions, final String fileOwner, final String fileGroup,
             final boolean writeHeader, final ByteBuffer buffer) {
         super(loggerContext, fileName != null ? fileName : pattern, os, append, false, createOnDemand,
-			advertiseURI, layout, filePermissions, fileOwner, fileGroup, writeHeader, buffer);
+			advertiseURI, layout, filePermissions, fileOwner, fileGroup, false, buffer);
         this.size = size;
         this.initialTime = initialTime;
         this.triggeringPolicy = triggeringPolicy;

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithHtmlLayoutTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectWriteWithHtmlLayoutTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.appender.rolling;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.core.layout.HtmlLayout;
+import org.apache.logging.log4j.core.util.IOUtils;
+import org.apache.logging.log4j.junit.CleanFolders;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.GZIPInputStream;
+
+import static org.apache.logging.log4j.hamcrest.Descriptors.that;
+import static org.apache.logging.log4j.hamcrest.FileMatchers.hasName;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for LOG4J2-2760
+ */
+public class RollingAppenderDirectWriteWithHtmlLayoutTest {
+
+    private static final String DIR = "target/rolling-direct-htmlLayout";
+
+    public static LoggerContextRule loggerContextRule = new LoggerContextRule();
+
+    @Rule
+    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+
+
+    @Test
+    public void testRollingFileAppenderWithHtmlLayout() throws Exception {
+        checkAppenderWithHtmlLayout(true);
+    }
+
+    @Test
+    public void testRollingFileAppenderWithHtmlLayoutNoAppend() throws Exception {
+        checkAppenderWithHtmlLayout(false);
+    }
+
+    private void checkAppenderWithHtmlLayout(boolean append) throws InterruptedException, IOException {
+        String prefix = "testHtml_" + (append ? "append_" : "noAppend_");
+        Configuration config = loggerContextRule.getConfiguration();
+        RollingFileAppender appender = RollingFileAppender.newBuilder()
+                .setName("RollingHtml")
+                .setFilePattern(DIR + "/" + prefix + "_-%d{MM-dd-yy-HH-mm}-%i.html")
+                .setPolicy(new SizeBasedTriggeringPolicy(500))
+                .setStrategy(DirectWriteRolloverStrategy.newBuilder()
+                        .setConfig(config)
+                        .build())
+                .setLayout(HtmlLayout.createDefaultLayout())
+                .setAppend(append)
+                .build();
+        boolean stopped = false;
+        try {
+            int count = 100;
+            for (int i = 0; i < count; ++i) {
+                appender.append(Log4jLogEvent.newBuilder()
+                        .setMessage(new SimpleMessage("This is test message number " + i))
+                        .build()
+                );
+            }
+            appender.getManager().flush();
+            appender.stop();
+            stopped = true;
+            Thread.sleep(50);
+            final File dir = new File(DIR);
+            assertTrue("Directory not created", dir.exists());
+            final File[] files = dir.listFiles();
+            assertNotNull(files);
+            assertThat(files, hasItemInArray(that(hasName(that(endsWith(".html"))))));
+
+            int foundEvents = 0;
+            final Pattern eventMatcher = Pattern.compile("title=\"Message\"");
+            for (File file : files) {
+                if (!file.getName().startsWith(prefix))
+                    continue;
+                try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+                    String data = IOUtils.toString(reader).trim();
+                    // check that every file starts with the header
+                    assertThat("header in file " + file, data, Matchers.startsWith("<!DOCTYPE"));
+                    assertThat("footer in file " + file, data, Matchers.endsWith("</html>"));
+                    final Matcher matcher = eventMatcher.matcher(data);
+                    while (matcher.find()) {
+                        foundEvents++;
+                    }
+                }
+            }
+            assertEquals("Incorrect number of events read.", count, foundEvents);
+        } finally {
+            if (!stopped) {
+                appender.stop();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR consist of a regression test showcasing the problem(s) and a fix.

See https://issues.apache.org/jira/browse/LOG4J2-2760