### PR TITLE
LOG4J2-2768 Add log(String, ...) overloads to LogBuilder

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
@@ -65,4 +65,162 @@ public interface LogBuilder {
     default void log(Object message) {
 
     }
+
+    /**
+     * Logs a message with parameters.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     *
+     * @see org.apache.logging.log4j.util.Unbox
+     */
+    default void log(String message, Object p0) {
+    }
+
+    /**
+     * Logs a message with parameters.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     *
+     * @see org.apache.logging.log4j.util.Unbox
+     */
+    default void log(String message, Object p0, Object p1) {
+    }
+
+    /**
+     * Logs a message with parameters.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     *
+     * @see org.apache.logging.log4j.util.Unbox
+     */
+    default void log(String message, Object p0, Object p1, Object p2) {
+    }
+
+    /**
+     * Logs a message with parameters.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     *
+     * @see org.apache.logging.log4j.util.Unbox
+     */
+    default void log(String message, Object p0, Object p1, Object p2, Object p3) {
+    }
+
+    /**
+     * Logs a message with parameters.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     *
+     * @see org.apache.logging.log4j.util.Unbox
+     */
+    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+    }
+
+    /**
+     * Logs a message with parameters.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     *
+     * @see org.apache.logging.log4j.util.Unbox
+     */
+    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+    }
+
+    /**
+     * Logs a message with parameters.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @param p6 parameter to the message.
+     *
+     * @see org.apache.logging.log4j.util.Unbox
+     */
+    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+    }
+
+    /**
+     * Logs a message with parameters.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @param p6 parameter to the message.
+     * @param p7 parameter to the message.
+     *
+     * @see org.apache.logging.log4j.util.Unbox
+     */
+    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+            Object p7) {
+    }
+
+    /**
+     * Logs a message with parameters.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @param p6 parameter to the message.
+     * @param p7 parameter to the message.
+     * @param p8 parameter to the message.
+     *
+     * @see org.apache.logging.log4j.util.Unbox
+     */
+    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+            Object p7, Object p8) {
+    }
+
+    /**
+     * Logs a message with parameters.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0 parameter to the message.
+     * @param p1 parameter to the message.
+     * @param p2 parameter to the message.
+     * @param p3 parameter to the message.
+     * @param p4 parameter to the message.
+     * @param p5 parameter to the message.
+     * @param p6 parameter to the message.
+     * @param p7 parameter to the message.
+     * @param p8 parameter to the message.
+     * @param p9 parameter to the message.
+     *
+     * @see org.apache.logging.log4j.util.Unbox
+     */
+    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+            Object p7, Object p8, Object p9) {
+    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
@@ -50,6 +50,14 @@ public interface LogBuilder {
     default void log(String message) {
     }
 
+    /**
+     * Logs a message with parameters.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param params parameters to the message.
+     *
+     * @see org.apache.logging.log4j.util.Unbox
+     */
     default void log(String message, Object... params) {
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
@@ -144,6 +144,79 @@ public class DefaultLogBuilder implements LogBuilder {
         }
     }
 
+    @Override
+    public void log(String message, Object p0) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+            Object p7) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+            Object p7, Object p8) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+            Object p7, Object p8, Object p9) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9));
+        }
+    }
+
     private void logMessage(Message message) {
         try {
             logger.logMessage(level, marker, FQCN, location, message, throwable);


### PR DESCRIPTION
The overloaded methods behave similarly to log(String, Object[]), but reduce the need for an Object[] allocation in certain code paths. The added methods and their Javadoc come from the Logger class. The Javadoc have been modified with the additional of the @see reference to the Unbox class. The Unbox class did not exist when the Logger Javadoc were originally written, and it seems pertinent to make users aware of the performance benefit when using these methods.