### PR TITLE
Log4j 2LOG4J2-2770 Fix NPE in JMX reconfiguration

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
@@ -141,7 +141,7 @@ public class ConfigurationSource {
     }
 
     private ConfigurationSource(final byte[] data, final URL url, long lastModified) {
-        Objects.requireNonNull(data, "data is null");
+        this.data = Objects.requireNonNull(data, "data is null");
         this.stream = new ByteArrayInputStream(data);
         this.file = null;
         this.url = url;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
@@ -141,12 +141,15 @@ public class ConfigurationSource {
     }
 
     private ConfigurationSource(final byte[] data, final URL url, long lastModified) {
-        this.data = Objects.requireNonNull(data, "data is null");
+        Objects.requireNonNull(data, "data is null");
         this.stream = new ByteArrayInputStream(data);
         this.file = null;
         this.url = url;
         this.location = null;
         this.lastModified = lastModified;
+        if ( url == null ) {
+        	this.data = data;
+        }
     }
 
     /**


### PR DESCRIPTION
I think this needs to store the data so that resetInputStream() works.
The jmx function LoggerContextAdmin::getConfigText throws a NPE if you have previously called LoggerContextAdmin::setConfigText