### PR TITLE
use 'final' modifier for fields where possible

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/Category.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/Category.java
@@ -44,7 +44,7 @@ import org.apache.logging.log4j.util.Strings;
  */
 public class Category {
 
-    private static PrivateAdapter adapter = new PrivateAdapter();
+    private static final PrivateAdapter adapter = new PrivateAdapter();
 
     private static final Map<LoggerContext, ConcurrentMap<String, Logger>> CONTEXT_MAP =
         new WeakHashMap<>();

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/MDC.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/MDC.java
@@ -29,7 +29,7 @@ import org.apache.logging.log4j.ThreadContext;
 public final class MDC {
 
 
-    private static ThreadLocal<Map<String, Object>> localMap =
+    private static final ThreadLocal<Map<String, Object>> localMap =
         new InheritableThreadLocal<Map<String, Object>>() {
             @Override
             protected Map<String, Object> initialValue() {

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/LayoutAdapter.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/LayoutAdapter.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * Class Description goes here.
  */
 public class LayoutAdapter implements org.apache.logging.log4j.core.Layout<String> {
-    private Layout layout;
+    private final Layout layout;
 
     public LayoutAdapter(Layout layout) {
         this.layout = layout;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
@@ -35,7 +35,7 @@ import java.util.Properties;
  */
 public abstract class AbstractBuilder {
 
-    private static Logger LOGGER = StatusLogger.getLogger();
+    private static final Logger LOGGER = StatusLogger.getLogger();
     protected static final String FILE_PARAM = "File";
     protected static final String APPEND_PARAM = "Append";
     protected static final String BUFFERED_IO_PARAM = "BufferedIO";

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
@@ -46,7 +46,7 @@ public class BuilderManager {
     public static final String CATEGORY = "Log4j Builder";
     private static final Logger LOGGER = StatusLogger.getLogger();
     private final Map<String, PluginType<?>> plugins;
-    private static Class<?>[] constructorParams = new Class[] { String.class, Properties.class};
+    private static final Class<?>[] constructorParams = new Class[] { String.class, Properties.class};
 
     public BuilderManager() {
         final PluginManager manager = new PluginManager(CATEGORY);

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/SyslogAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/SyslogAppenderBuilder.java
@@ -56,7 +56,7 @@ public class SyslogAppenderBuilder extends AbstractBuilder implements AppenderBu
     private static final Logger LOGGER = StatusLogger.getLogger();
     private static final String FACILITY_PARAM = "Facility";
     private static final String SYSLOG_HOST_PARAM = "SyslogHost";
-    private static int SYSLOG_PORT = 512;
+    private static final int SYSLOG_PORT = 512;
 
     public SyslogAppenderBuilder() {
     }

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/PropertySetter.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/PropertySetter.java
@@ -56,7 +56,7 @@ import java.util.Properties;
  * Otherwise an {@link IntrospectionException} are thrown.
  */
 public class PropertySetter {
-    private static Logger LOGGER = StatusLogger.getLogger();
+    private static final Logger LOGGER = StatusLogger.getLogger();
     protected Object obj;
     protected PropertyDescriptor[] props;
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/pattern/Log4j1MdcPatternConverter.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/pattern/Log4j1MdcPatternConverter.java
@@ -79,7 +79,7 @@ public final class Log4j1MdcPatternConverter extends LogEventPatternConverter {
         }
     }
 
-    private static TriConsumer<String, Object, StringBuilder> APPEND_EACH = new TriConsumer<String, Object, StringBuilder>() {
+    private static final TriConsumer<String, Object, StringBuilder> APPEND_EACH = new TriConsumer<String, Object, StringBuilder>() {
         @Override
         public void accept(final String key, final Object value, final StringBuilder toAppendTo) {
             toAppendTo.append('{').append(key).append(',').append(value).append('}');

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/spi/ThrowableInformation.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/spi/ThrowableInformation.java
@@ -30,7 +30,7 @@ public class ThrowableInformation implements java.io.Serializable {
     static final long serialVersionUID = -4748765566864322735L;
 
     private transient Throwable throwable;
-    private Method toStringList;
+    private final Method toStringList;
 
     @SuppressWarnings("unchecked")
     public

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfiguration.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfiguration.java
@@ -100,9 +100,9 @@ public class XmlConfiguration extends Log4j1Configuration {
     protected static final String DEFAULT_PREFIX = "log4j";
 
     // key: appenderName, value: appender
-    private Map<String, Appender> appenderMap;
+    private final Map<String, Appender> appenderMap;
 
-    private Properties props = null;
+    private final Properties props = null;
 
     public XmlConfiguration(final LoggerContext loggerContext, final ConfigurationSource source,
             int monitorIntervalSeconds) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
@@ -34,7 +34,6 @@ import org.apache.logging.log4j.util.Supplier;
 public class DefaultLogBuilder implements LogBuilder {
 
     private static final long serialVersionUID = 8851553895299192531L;
-    private static Message EMPTY_MESSAGE = new SimpleMessage("");
     private static final String FQCN = DefaultLogBuilder.class.getName();
     private static final Logger LOGGER = StatusLogger.getLogger();
 
@@ -44,7 +43,7 @@ public class DefaultLogBuilder implements LogBuilder {
     private Throwable throwable;
     private StackTraceElement location;
     private volatile boolean inUse;
-    private long threadId;
+    private final long threadId;
 
     public DefaultLogBuilder(Logger logger, Level level) {
         this.logger = logger;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -16,9 +16,6 @@
  */
 package org.apache.logging.log4j.message;
 
-import java.text.SimpleDateFormat;
-import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
@@ -65,8 +62,6 @@ final class ParameterFormatter {
     private static final char ESCAPE_CHAR = '\\';
     private static final DateTimeFormatter FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").withZone(ZoneId.systemDefault());
-
-    private static ThreadLocal<SimpleDateFormat> threadLocalSimpleDateFormat = new ThreadLocal<>();
 
     private ParameterFormatter() {
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
@@ -69,7 +69,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
     private static final int HASHVAL = 31;
 
     // storing JDK classes in ThreadLocals does not cause memory leaks in web apps, so this is okay
-    private static ThreadLocal<StringBuilder> threadLocalStringBuilder = new ThreadLocal<>();
+    private static final ThreadLocal<StringBuilder> threadLocalStringBuilder = new ThreadLocal<>();
 
     private String messagePattern;
     private transient Object[] argArray;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
@@ -38,9 +38,9 @@ public final class ReusableMessageFactory implements MessageFactory, Serializabl
     public static final ReusableMessageFactory INSTANCE = new ReusableMessageFactory();
 
     private static final long serialVersionUID = -8970940216592525651L;
-    private static ThreadLocal<ReusableParameterizedMessage> threadLocalParameterized = new ThreadLocal<>();
-    private static ThreadLocal<ReusableSimpleMessage> threadLocalSimpleMessage = new ThreadLocal<>();
-    private static ThreadLocal<ReusableObjectMessage> threadLocalObjectMessage = new ThreadLocal<>();
+    private static final ThreadLocal<ReusableParameterizedMessage> threadLocalParameterized = new ThreadLocal<>();
+    private static final ThreadLocal<ReusableSimpleMessage> threadLocalSimpleMessage = new ThreadLocal<>();
+    private static final ThreadLocal<ReusableObjectMessage> threadLocalObjectMessage = new ThreadLocal<>();
 
     /**
      * Constructs a message factory.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.util.PerformanceSensitive;
 @PerformanceSensitive("allocation")
 public class ReusableSimpleMessage implements ReusableMessage, CharSequence, ParameterVisitable, Clearable {
     private static final long serialVersionUID = -9199974506498249809L;
-    private static Object[] EMPTY_PARAMS = new Object[0];
+    private static final Object[] EMPTY_PARAMS = new Object[0];
     private CharSequence charSequence;
 
     public void set(final String message) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataCollectionMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataCollectionMessage.java
@@ -29,7 +29,7 @@ public class StructuredDataCollectionMessage implements StringBuilderFormattable
         MessageCollectionMessage<StructuredDataMessage> {
     private static final long serialVersionUID = 5725337076388822924L;
 
-    private List<StructuredDataMessage> structuredDataMessageList;
+    private final List<StructuredDataMessage> structuredDataMessageList;
 
     public StructuredDataCollectionMessage(List<StructuredDataMessage> messages) {
         this.structuredDataMessageList = messages;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContextFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContextFactory.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.spi.LoggerContextFactory;
  */
 public class SimpleLoggerContextFactory implements LoggerContextFactory {
 
-    private static LoggerContext context = new SimpleLoggerContext();
+    private static final LoggerContext context = new SimpleLoggerContext();
 
     @Override
     public LoggerContext getContext(final String fqcn, final ClassLoader loader, final Object externalContext,

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -109,7 +109,7 @@ public abstract class AbstractLogger implements ExtendedLogger, Serializable {
     protected final String name;
     private final MessageFactory messageFactory;
     private final FlowMessageFactory flowMessageFactory;
-    private static ThreadLocal<int[]> recursionDepthHolder = new ThreadLocal<>(); // LOG4J2-1518, LOG4J2-2031
+    private static final ThreadLocal<int[]> recursionDepthHolder = new ThreadLocal<>(); // LOG4J2-1518, LOG4J2-2031
     protected final transient ThreadLocal<DefaultLogBuilder> logBuilder;
 
 
@@ -2864,7 +2864,7 @@ public abstract class AbstractLogger implements ExtendedLogger, Serializable {
     }
 
     private class LocalLogBuilder extends ThreadLocal<DefaultLogBuilder> {
-        private AbstractLogger logger;
+        private final AbstractLogger logger;
         LocalLogBuilder(AbstractLogger logger) {
             this.logger = logger;
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -50,7 +50,6 @@ public final class PropertiesUtil {
 
     private static final String LOG4J_PROPERTIES_FILE_NAME = "log4j2.component.properties";
     private static final String LOG4J_SYSTEM_PROPERTIES_FILE_NAME = "log4j2.system.properties";
-    private static final String SYSTEM = "system:";
     private static final PropertiesUtil LOG4J_PROPERTIES = new PropertiesUtil(LOG4J_PROPERTIES_FILE_NAME);
 
     private final Environment environment;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Timer.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Timer.java
@@ -35,10 +35,10 @@ public class Timer implements Serializable, StringBuilderFormattable
     private Status status; // The timer's status
     private long elapsedTime;         // The elapsed time
     private final int iterations;
-    private static long NANO_PER_SECOND = 1000000000L;
-    private static long NANO_PER_MINUTE = NANO_PER_SECOND * 60;
-    private static long NANO_PER_HOUR = NANO_PER_MINUTE * 60;
-    private ThreadLocal<Long> startTime = new ThreadLocal<Long>() {
+    private static final long NANO_PER_SECOND = 1000000000L;
+    private static final long NANO_PER_MINUTE = NANO_PER_SECOND * 60;
+    private static final long NANO_PER_HOUR = NANO_PER_MINUTE * 60;
+    private final ThreadLocal<Long> startTime = new ThreadLocal<Long>() {
             @Override protected Long initialValue() {
                 return 0L;
             }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
@@ -120,8 +120,8 @@ public class Unbox {
             return false;
         }
     }
-    private static ThreadLocal<State> threadLocalState = new ThreadLocal<>();
-    private static WebSafeState webSafeState = new WebSafeState();
+    private static final ThreadLocal<State> threadLocalState = new ThreadLocal<>();
+    private static final WebSafeState webSafeState = new WebSafeState();
 
     private Unbox() {
         // this is a utility

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
@@ -95,7 +95,7 @@ public class LoggerContext extends AbstractLifeCycle
      */
     private volatile Configuration configuration = new DefaultConfiguration();
     private static final String EXTERNAL_CONTEXT_KEY = "__EXTERNAL_CONTEXT_KEY__";
-    private ConcurrentMap<String, Object> externalMap = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Object> externalMap = new ConcurrentHashMap<>();
     private String contextName;
     private volatile URI configLocation;
     private Cancellable shutdownCallback;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
@@ -57,7 +57,7 @@ public final class ConsoleAppender extends AbstractOutputStreamAppender<OutputSt
 
     public static final String PLUGIN_NAME = "Console";
     private static final String JANSI_CLASS = "org.fusesource.jansi.WindowsAnsiOutputStream";
-    private static ConsoleManagerFactory factory = new ConsoleManagerFactory();
+    private static final ConsoleManagerFactory factory = new ConsoleManagerFactory();
     private static final Target DEFAULT_TARGET = Target.SYSTEM_OUT;
     private static final AtomicInteger COUNT = new AtomicInteger();
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FileAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FileAppender.java
@@ -183,8 +183,6 @@ public final class FileAppender extends AbstractOutputStreamAppender<FileManager
 
     }
     
-    private static final int DEFAULT_BUFFER_SIZE = 8192;
-    
     @PluginFactory
     public static <B extends Builder<B>> B newBuilder() {
         return new Builder<B>().asBuilder();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/OutputStreamAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/OutputStreamAppender.java
@@ -50,7 +50,7 @@ public final class OutputStreamAppender extends AbstractOutputStreamAppender<Out
 
         private boolean follow = false;
 
-        private Layout<? extends Serializable> layout = PatternLayout.createDefaultLayout();
+        private final Layout<? extends Serializable> layout = PatternLayout.createDefaultLayout();
 
         private OutputStream target;
 
@@ -115,7 +115,7 @@ public final class OutputStreamAppender extends AbstractOutputStreamAppender<Out
         }
     }
 
-    private static OutputStreamManagerFactory factory = new OutputStreamManagerFactory();
+    private static final OutputStreamManagerFactory factory = new OutputStreamManagerFactory();
 
     /**
      * Creates an OutputStream Appender.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RollingFileAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RollingFileAppender.java
@@ -262,8 +262,6 @@ public final class RollingFileAppender extends AbstractOutputStreamAppender<Roll
 
     }
     
-    private static final int DEFAULT_BUFFER_SIZE = 8192;
-
     private final String fileName;
     private final String filePattern;
     private Object advertisement;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/WriterAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/WriterAppender.java
@@ -104,7 +104,7 @@ public final class WriterAppender extends AbstractWriterAppender<WriterManager> 
         }
     }
 
-    private static WriterManagerFactory factory = new WriterManagerFactory();
+    private static final WriterManagerFactory factory = new WriterManagerFactory();
 
     /**
      * Creates a WriterAppender.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DirectWriteRolloverStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DirectWriteRolloverStrategy.java
@@ -204,7 +204,6 @@ public class DirectWriteRolloverStrategy extends AbstractRolloverStrategy implem
     private volatile String currentFileName;
     private int nextIndex = -1;
     private final PatternProcessor tempCompressedFilePattern;
-    private volatile boolean usePrevTime = false;
 
     /**
      * Constructs a new instance.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
@@ -54,7 +54,7 @@ import org.apache.logging.log4j.core.util.Log4jThreadFactory;
  */
 public class RollingFileManager extends FileManager {
 
-    private static RollingFileManagerFactory factory = new RollingFileManagerFactory();
+    private static final RollingFileManagerFactory factory = new RollingFileManagerFactory();
     private static final int MAX_TRIES = 3;
     private static final int MIN_DURATION = 100;
     private static final FileTime EPOCH = FileTime.fromMillis(0);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/ScriptCondition.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/ScriptCondition.java
@@ -43,7 +43,7 @@ import org.apache.logging.log4j.status.StatusLogger;
  */
 @Plugin(name = "ScriptCondition", category = Core.CATEGORY_NAME, printObject = true)
 public class ScriptCondition {
-    private static Logger LOGGER = StatusLogger.getLogger();
+    private static final Logger LOGGER = StatusLogger.getLogger();
 
     private final AbstractScript script;
     private final Configuration configuration;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender.java
@@ -153,7 +153,7 @@ public final class RoutingAppender extends AbstractAppender {
     private final PurgePolicy purgePolicy;
     private final AbstractScript defaultRouteScript;
     private final ConcurrentMap<Object, Object> scriptStaticVariables = new ConcurrentHashMap<>();
-    private Boolean requiresLocation;
+    private final Boolean requiresLocation;
 
     private RoutingAppender(final String name, final Filter filter, final boolean ignoreExceptions, final Routes routes,
             final RewritePolicy rewritePolicy, final Configuration configuration, final PurgePolicy purgePolicy,

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
@@ -66,7 +66,7 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
 
     private int threadPriority;
     private long threadId;
-    private MutableInstant instant = new MutableInstant();
+    private final MutableInstant instant = new MutableInstant();
     private long nanoTime;
     private short parameterCount;
     private boolean includeLocation;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/HttpWatcher.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/HttpWatcher.java
@@ -42,9 +42,9 @@ import org.apache.logging.log4j.status.StatusLogger;
 @PluginAliases("https")
 public class HttpWatcher extends AbstractWatcher {
 
-    private Logger LOGGER = StatusLogger.getLogger();
+    private final Logger LOGGER = StatusLogger.getLogger();
 
-    private SslConfiguration sslConfiguration;
+    private final SslConfiguration sslConfiguration;
     private URL url;
     private volatile long lastModifiedMillis;
     private static final int NOT_MODIFIED = 304;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultConfigurationBuilder.java
@@ -60,12 +60,12 @@ public class DefaultConfigurationBuilder<T extends BuiltConfiguration> implement
     private static final String EOL = System.lineSeparator();
     
     private final Component root = new Component();
-    private Component loggers;
-    private Component appenders;
-    private Component filters;
-    private Component properties;
-    private Component customLevels;
-    private Component scripts;
+    private final Component loggers;
+    private final Component appenders;
+    private final Component filters;
+    private final Component properties;
+    private final Component customLevels;
+    private final Component scripts;
     private final Class<T> clazz;
     private ConfigurationSource source;
     private int monitorInterval;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/PluginBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/PluginBuilder.java
@@ -63,7 +63,7 @@ public class PluginBuilder implements Builder<Object> {
     private Node node;
     private LogEvent event;
     private Substitutor substitutor;
-    private ConcurrentMap<String, Boolean> aliases = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Boolean> aliases = new ConcurrentHashMap<>();
 
     /**
      * Constructs a PluginBuilder for a given PluginType.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/ScriptFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/ScriptFilter.java
@@ -43,7 +43,7 @@ import org.apache.logging.log4j.status.StatusLogger;
 @Plugin(name = "ScriptFilter", category = Node.CATEGORY, elementType = Filter.ELEMENT_TYPE, printObject = true)
 public final class ScriptFilter extends AbstractFilter {
 
-    private static org.apache.logging.log4j.Logger logger = StatusLogger.getLogger();
+    private static final org.apache.logging.log4j.Logger logger = StatusLogger.getLogger();
 
     private final AbstractScript script;
     private final Configuration configuration;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/StructuredDataFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/StructuredDataFilter.java
@@ -46,7 +46,7 @@ import org.apache.logging.log4j.util.StringBuilders;
 public final class StructuredDataFilter extends MapFilter {
 
     private static final int MAX_BUFFER_SIZE = 2048;
-    private static ThreadLocal<StringBuilder> threadLocalStringBuilder = new ThreadLocal<>();
+    private static final ThreadLocal<StringBuilder> threadLocalStringBuilder = new ThreadLocal<>();
 
     private StructuredDataFilter(final Map<String, List<String>> map, final boolean oper, final Result onMatch,
                                  final Result onMismatch) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMap.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMap.java
@@ -143,7 +143,7 @@ class JdkMapAdapterStringMap implements StringMap {
         sortedKeys = null;
     }
 
-    private static TriConsumer<String, String, Map<String, String>> PUT_ALL = new TriConsumer<String, String, Map<String, String>>() {
+    private static final TriConsumer<String, String, Map<String, String>> PUT_ALL = new TriConsumer<String, String, Map<String, String>>() {
         @Override
         public void accept(final String key, final String value, final Map<String, String> stringStringMap) {
             stringStringMap.put(key, value);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jLogEvent.java
@@ -85,7 +85,7 @@ public class Log4jLogEvent implements LogEvent {
         private String loggerName;
         private Message message;
         private Throwable thrown;
-        private MutableInstant instant = new MutableInstant();
+        private final MutableInstant instant = new MutableInstant();
         private ThrowableProxy thrownProxy;
         private StringMap contextData = createContextData((List<Property>) null);
         private ThreadContext.ContextStack contextStack = ThreadContext.getImmutableStack();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
@@ -47,7 +47,7 @@ public class MutableLogEvent implements LogEvent, ReusableMessage, ParameterVisi
 
     private int threadPriority;
     private long threadId;
-    private MutableInstant instant = new MutableInstant();
+    private final MutableInstant instant = new MutableInstant();
     private long nanoTime;
     private short parameterCount;
     private boolean includeLocation;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ReusableLogEventFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ReusableLogEventFactory.java
@@ -38,7 +38,7 @@ public class ReusableLogEventFactory implements LogEventFactory {
     private static final ThreadNameCachingStrategy THREAD_NAME_CACHING_STRATEGY = ThreadNameCachingStrategy.create();
     private static final Clock CLOCK = ClockFactory.getClock();
 
-    private static ThreadLocal<MutableLogEvent> mutableLogEventThreadLocal = new ThreadLocal<>();
+    private static final ThreadLocal<MutableLogEvent> mutableLogEventThreadLocal = new ThreadLocal<>();
     private final ContextDataInjector injector = ContextDataInjectorFactory.createInjector();
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/LevelPatternSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/LevelPatternSelector.java
@@ -116,7 +116,7 @@ public class LevelPatternSelector implements PatternSelector{
 
     private final String defaultPattern;
 
-    private static Logger LOGGER = StatusLogger.getLogger();
+    private static final Logger LOGGER = StatusLogger.getLogger();
 
     private final boolean requiresLocation;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/MarkerPatternSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/MarkerPatternSelector.java
@@ -116,7 +116,7 @@ public class MarkerPatternSelector implements PatternSelector {
 
     private final String defaultPattern;
 
-    private static Logger LOGGER = StatusLogger.getLogger();
+    private static final Logger LOGGER = StatusLogger.getLogger();
 
     private final boolean requiresLocation;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/ScriptPatternSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/ScriptPatternSelector.java
@@ -139,7 +139,7 @@ public class ScriptPatternSelector implements PatternSelector {
 
     private final String defaultPattern;
 
-    private static Logger LOGGER = StatusLogger.getLogger();
+    private static final Logger LOGGER = StatusLogger.getLogger();
     private final AbstractScript script;
     private final Configuration configuration;
     private final boolean requiresLocation;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/MulticastDnsAdvertiser.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/MulticastDnsAdvertiser.java
@@ -46,7 +46,7 @@ public class MulticastDnsAdvertiser implements Advertiser {
     private static final int MAX_LENGTH = 255;
     private static final int DEFAULT_PORT = 4555;
 
-    private static Object jmDNS = initializeJmDns();
+    private static final Object jmDNS = initializeJmDns();
     private static Class<?> jmDNSClass;
     private static Class<?> serviceInfoClass;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/UrlConnectionFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/UrlConnectionFactory.java
@@ -33,9 +33,9 @@ import org.apache.logging.log4j.core.util.AuthorizationProvider;
  */
 public class UrlConnectionFactory {
 
-    private static int DEFAULT_TIMEOUT = 60000;
-    private static int connectTimeoutMillis = DEFAULT_TIMEOUT;
-    private static int readTimeoutMillis = DEFAULT_TIMEOUT;
+    private static final int DEFAULT_TIMEOUT = 60000;
+    private static final int connectTimeoutMillis = DEFAULT_TIMEOUT;
+    private static final int readTimeoutMillis = DEFAULT_TIMEOUT;
     private static final String JSON = "application/json";
     private static final String XML = "application/xml";
     private static final String PROPERTIES = "text/x-java-properties";

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/picocli/CommandLine.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/picocli/CommandLine.java
@@ -139,11 +139,11 @@ public class CommandLine {
     private String commandName = Help.DEFAULT_COMMAND_NAME;
     private boolean overwrittenOptionsAllowed = false;
     private boolean unmatchedArgumentsAllowed = false;
-    private List<String> unmatchedArguments = new ArrayList<String>();
+    private final List<String> unmatchedArguments = new ArrayList<String>();
     private CommandLine parent;
     private boolean usageHelpRequested;
     private boolean versionHelpRequested;
-    private List<String> versionLines = new ArrayList<String>();
+    private final List<String> versionLines = new ArrayList<String>();
 
     /**
      * Constructs a new {@code CommandLine} interpreter with the specified annotated object.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/BasicAuthorizationProvider.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/BasicAuthorizationProvider.java
@@ -36,7 +36,7 @@ public class BasicAuthorizationProvider implements AuthorizationProvider {
     public static final String CONFIG_PASSWORD = "log4j2.configurationPassword";
     public static final String PASSWORD_DECRYPTOR = "log4j2.passwordDecryptor";
 
-    private static Logger LOGGER = StatusLogger.getLogger();
+    private static final Logger LOGGER = StatusLogger.getLogger();
     private static final Base64.Encoder encoder = Base64.getEncoder();
 
     private String authString = null;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/WatchManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/WatchManager.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class WatchManager extends AbstractLifeCycle {
 
-    private static Logger logger = StatusLogger.getLogger();
+    private static final Logger logger = StatusLogger.getLogger();
     private final ConcurrentMap<Source, ConfigurationMonitor> watchers = new ConcurrentHashMap<>();
     private int intervalSeconds = 0;
     private ScheduledFuture<?> future;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/WatcherFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/WatcherFactory.java
@@ -36,8 +36,8 @@ import org.apache.logging.log4j.status.StatusLogger;
  */
 public class WatcherFactory {
 
-    private static Logger LOGGER = StatusLogger.getLogger();
-    private static PluginManager pluginManager = new PluginManager(Watcher.CATEGORY);
+    private static final Logger LOGGER = StatusLogger.getLogger();
+    private static final PluginManager pluginManager = new PluginManager(Watcher.CATEGORY);
 
     private static volatile WatcherFactory factory = null;
 

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAppender.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAppender.java
@@ -62,7 +62,7 @@ public final class FlumeAppender extends AbstractAppender implements FlumeEventF
 
     private final FlumeEventFactory factory;
 
-    private Timer timer = new Timer("FlumeEvent", 5000);
+    private final Timer timer = new Timer("FlumeEvent", 5000);
     private volatile long count = 0;
 
     /**

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAvroManager.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAvroManager.java
@@ -33,7 +33,7 @@ public class FlumeAvroManager extends AbstractFlumeManager {
     private static final int MAX_RECONNECTS = 3;
     private static final int MINIMUM_TIMEOUT = 1000;
 
-    private static AvroManagerFactory factory = new AvroManagerFactory();
+    private static final AvroManagerFactory factory = new AvroManagerFactory();
 
     private final Agent[] agents;
 

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeEmbeddedManager.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeEmbeddedManager.java
@@ -41,7 +41,7 @@ public class FlumeEmbeddedManager extends AbstractFlumeManager {
 
     private static final String IN_MEMORY = "InMemory";
 
-    private static FlumeManagerFactory factory = new FlumeManagerFactory();
+    private static final FlumeManagerFactory factory = new FlumeManagerFactory();
 
     private final EmbeddedAgent agent;
 

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumePersistentManager.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumePersistentManager.java
@@ -76,7 +76,7 @@ public class FlumePersistentManager extends FlumeAvroManager {
 
     private static final long LOCK_TIMEOUT_SLEEP_MILLIS = 500;
 
-    private static BDBManagerFactory factory = new BDBManagerFactory();
+    private static final BDBManagerFactory factory = new BDBManagerFactory();
 
     private final Database database;
 

--- a/log4j-jms/src/main/java/org/apache/logging/log4j/jms/appender/JmsAppender.java
+++ b/log4j-jms/src/main/java/org/apache/logging/log4j/jms/appender/JmsAppender.java
@@ -201,7 +201,7 @@ public class JmsAppender extends AbstractAppender {
         return new Builder();
     }
 
-    private volatile JmsManager manager;
+    private final JmsManager manager;
 
     /**
      * @param name The Appender's name.

--- a/log4j-kubernetes/src/main/java/org/apache/logging/log4j/kubernetes/KubernetesClientProperties.java
+++ b/log4j-kubernetes/src/main/java/org/apache/logging/log4j/kubernetes/KubernetesClientProperties.java
@@ -54,7 +54,7 @@ public class KubernetesClientProperties {
     private static final String WATCH_RECONNECT_INTERVAL = "watchReconnectInterval";
     private static final String WATCH_RECONNECT_LIMIT = "watchReconnectLimit";
 
-    private PropertiesUtil props = PropertiesUtil.getProperties();
+    private final PropertiesUtil props = PropertiesUtil.getProperties();
     private final Config base;
 
     public KubernetesClientProperties(Config base) {

--- a/log4j-kubernetes/src/main/java/org/apache/logging/log4j/kubernetes/KubernetesLookup.java
+++ b/log4j-kubernetes/src/main/java/org/apache/logging/log4j/kubernetes/KubernetesLookup.java
@@ -54,8 +54,8 @@ public class KubernetesLookup extends AbstractLookup {
     private static final String SPRING_ENVIRONMENT_KEY = "SpringEnvironment";
 
     private static volatile KubernetesInfo kubernetesInfo;
-    private static Lock initLock = new ReentrantLock();
-    private static boolean isSpringIncluded =
+    private static final Lock initLock = new ReentrantLock();
+    private static final boolean isSpringIncluded =
             LoaderUtil.isClassAvailable("org.apache.logging.log4j.spring.cloud.config.client.SpringEnvironmentHolder");
 
     private boolean initialize() {

--- a/log4j-plugins-java9/pom.xml
+++ b/log4j-plugins-java9/pom.xml
@@ -26,7 +26,7 @@
   <artifactId>log4j-plugins-java9</artifactId>
   <packaging>pom</packaging>
   <name>Apache Log4j Plugins Module support</name>
-  <description>Apache Log4j Plugin Moduels Support</description>
+  <description>Apache Log4j Plugin Modules Support</description>
   <properties>
     <log4jParentDir>${basedir}/..</log4jParentDir>
     <docLabel>Log4j Plugins Documentation</docLabel>

--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-client/src/main/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2EventListener.java
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-client/src/main/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2EventListener.java
@@ -32,7 +32,7 @@ import org.springframework.stereotype.Component;
 @EnableBinding(SpringCloudBusClient.class)
 @ConditionalOnProperty(value = "spring.cloud.config.watch.enabled")
 public class Log4j2EventListener {
-    private static Logger LOGGER = LogManager.getLogger(Log4j2EventListener.class);
+    private static final Logger LOGGER = LogManager.getLogger(Log4j2EventListener.class);
 
     @EventListener(classes = RemoteApplicationEvent.class)
     public void acceptLocal(RemoteApplicationEvent event) {

--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-client/src/main/java/org/apache/logging/log4j/spring/cloud/config/client/SpringEnvironmentHolder.java
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-client/src/main/java/org/apache/logging/log4j/spring/cloud/config/client/SpringEnvironmentHolder.java
@@ -28,7 +28,7 @@ import java.util.concurrent.locks.ReentrantLock;
 public class SpringEnvironmentHolder {
 
     private volatile Environment environment;
-    private Lock lock = new ReentrantLock();
+    private final Lock lock = new ReentrantLock();
 
 
     protected Environment getEnvironment() {

--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLoggerContextFactory.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLoggerContextFactory.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.util.LoaderUtil;
  */
 public class SLF4JLoggerContextFactory implements LoggerContextFactory {
     private static final StatusLogger LOGGER = StatusLogger.getLogger();
-    private static LoggerContext context = new SLF4JLoggerContext();
+    private static final LoggerContext context = new SLF4JLoggerContext();
 
     public SLF4JLoggerContextFactory() {
         // LOG4J2-230, LOG4J2-204 (improve error reporting when misconfigured)


### PR DESCRIPTION
Also removed unused fields which my IDEA highlights as possible `final`, but fields were unused (leftovers after refactoring):
1. `DefaultLogBuilder.EMPTY_MESSAGE`
2. `DirectWriteRolloverStrategy.usePrevTime`
3. `ParameterFormatter.threadLocalSimpleDateFormat`
4. `PropertiesUtil.SYSTEM`
5. `FileAppender.DEFAULT_BUFFER_SIZE`
6. `RollingFileAppender.DEFAULT_BUFFER_SIZE`
