### PR TITLE
LOG4J2-2790 Conditionally allocate PluginEntry during PluginCache load

### DIFF
--- a/log4j-plugins/src/main/java/org/apache/logging/log4j/plugins/processor/PluginCache.java
+++ b/log4j-plugins/src/main/java/org/apache/logging/log4j/plugins/processor/PluginCache.java
@@ -76,16 +76,7 @@ public class PluginCache {
                         final String name = in.readUTF();
                         final boolean printable = in.readBoolean();
                         final boolean defer = in.readBoolean();
-                        m.computeIfAbsent(key, k -> {
-                            final PluginEntry entry = new PluginEntry();
-                            entry.setKey(k);
-                            entry.setClassName(className);
-                            entry.setName(name);
-                            entry.setPrintable(printable);
-                            entry.setDefer(defer);
-                            entry.setCategory(category);
-                            return entry;
-                        });
+                        m.computeIfAbsent(key, k -> new PluginEntry(k, className, name, printable, defer, category));
                     }
                 }
             }

--- a/log4j-plugins/src/main/java/org/apache/logging/log4j/plugins/processor/PluginCache.java
+++ b/log4j-plugins/src/main/java/org/apache/logging/log4j/plugins/processor/PluginCache.java
@@ -18,11 +18,8 @@
 package org.apache.logging.log4j.plugins.processor;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.Map;
@@ -53,10 +50,7 @@ public class PluginCache {
      */
     public Map<String, PluginEntry> getCategory(final String category) {
         final String key = category.toLowerCase();
-        if (!categories.containsKey(key)) {
-            categories.put(key, new TreeMap<String, PluginEntry>());
-        }
-        return categories.get(key);
+        return categories.computeIfAbsent(key, ignored -> new TreeMap<>());
     }
 
     /**
@@ -76,16 +70,22 @@ public class PluginCache {
                     final Map<String, PluginEntry> m = getCategory(category);
                     final int entries = in.readInt();
                     for (int j = 0; j < entries; j++) {
-                        final PluginEntry entry = new PluginEntry();
-                        entry.setKey(in.readUTF());
-                        entry.setClassName(in.readUTF());
-                        entry.setName(in.readUTF());
-                        entry.setPrintable(in.readBoolean());
-                        entry.setDefer(in.readBoolean());
-                        entry.setCategory(category);
-                        if (!m.containsKey(entry.getKey())) {
-                            m.put(entry.getKey(), entry);
-                        }
+                        // Must always read all parts of the entry, even if not adding, so that the stream progresses
+                        final String key = in.readUTF();
+                        final String className = in.readUTF();
+                        final String name = in.readUTF();
+                        final boolean printable = in.readBoolean();
+                        final boolean defer = in.readBoolean();
+                        m.computeIfAbsent(key, k -> {
+                            final PluginEntry entry = new PluginEntry();
+                            entry.setKey(k);
+                            entry.setClassName(className);
+                            entry.setName(name);
+                            entry.setPrintable(printable);
+                            entry.setDefer(defer);
+                            entry.setCategory(category);
+                            return entry;
+                        });
                     }
                 }
             }


### PR DESCRIPTION
When populating the PluginCache from resources, only allocate a new PluginEntry if there is not already an existing one.

PR consists of 2 commits to facilitate backporting to 2.x if desirable. The second commit uses the new `PluginEntry` constructor which is not available in `2.x`