### PR TITLE
LOG4J2-2793 - Unable to parse the log LEVEL when it ends with SPACE.

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
@@ -284,7 +284,8 @@ public final class Level implements Comparable<Level>, Serializable {
         if (name == null) {
             return defaultLevel;
         }
-        final Level level = LEVELS.get(toUpperCase(name));
+        String trimmedName = name.trim();
+        final Level level = LEVELS.get(toUpperCase(trimmedName));
         return level == null ? defaultLevel : level;
     }
 
@@ -312,7 +313,8 @@ public final class Level implements Comparable<Level>, Serializable {
      */
     public static Level valueOf(final String name) {
         Objects.requireNonNull(name, "No level name given.");
-        final String levelName = toUpperCase(name);
+        String trimmedName = name.trim();
+        final String levelName = toUpperCase(trimmedName);
         final Level level = LEVELS.get(levelName);
         if (level != null) {
             return level;

--- a/log4j-api/src/test/java/org/apache/logging/log4j/LevelTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/LevelTest.java
@@ -54,6 +54,17 @@ public class LevelTest {
     }
 
     @Test
+    public void testLevelsWithSpaces() {
+        Level level = Level.toLevel(" INFO ");
+        assertNotNull(level);
+        assertEquals(Level.INFO, level);
+
+        level = Level.valueOf(" INFO ");
+        assertNotNull(level);
+        assertEquals(Level.INFO, level);
+    }
+
+    @Test
     public void testIsInRangeErrorToDebug() {
         assertFalse(Level.OFF.isInRange(Level.ERROR, Level.DEBUG));
         assertFalse(Level.FATAL.isInRange(Level.ERROR, Level.DEBUG));


### PR DESCRIPTION
Handled leading & trailing spaces in log LEVEL.