### PR TITLE
DOCUMENTATION fix. Adding target to Console appender in YAML config

### DIFF
--- a/src/site/asciidoc/manual/configuration.adoc
+++ b/src/site/asciidoc/manual/configuration.adoc
@@ -734,6 +734,7 @@ Configuration:
   appenders:
     Console:
       name: STDOUT
+      target: SYSTEM_OUT
       PatternLayout:
         Pattern: "%m%n"
     File:


### PR DESCRIPTION
Console appender requires target property in order to work for YAML configuration