### PR TITLE
LOG4J2-2832: Updated strategy name to existing strategy

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RollingFileAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RollingFileAppender.java
@@ -134,7 +134,7 @@ public final class RollingFileAppender extends AbstractOutputStreamAppender<Roll
                                         .build();
                 }
             } else if (fileName == null && !(strategy instanceof DirectFileRolloverStrategy)) {
-                LOGGER.error("RollingFileAppender '{}': When no file name is provided a DirectFilenameRolloverStrategy must be configured", getName());
+                LOGGER.error("RollingFileAppender '{}': When no file name is provided a {} must be configured", getName(), DirectFileRolloverStrategy.class.getSimpleName());
                 return null;
             }
 


### PR DESCRIPTION
Instead of using a hard coded name the class name of the interface was used which
a) Increases visibility where the interface is referenced
b) Prevents that the message needs to be adjusted when the interface name changes