### PR TITLE
LOG4J2-2749 - fix JSON Layout output containing empty values while configured otherwise

### DIFF
--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/JsonLayoutTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/JsonLayoutTest.java
@@ -591,6 +591,19 @@ public class JsonLayoutTest {
         assertFalse(str.endsWith("\0"));
     }
 
+    @Test  // LOG4J2-2749
+    public void testEmptyValuesAreIgnored() {
+        final AbstractJacksonLayout layout = JsonLayout.newBuilder()
+                .setAdditionalFields(new KeyValuePair[] {
+                    new KeyValuePair("empty", "${ctx:empty:-}")
+                })
+                .setConfiguration(ctx.getConfiguration())
+                .build();
+
+        final String str = layout.toSerializable(LogEventFixtures.createLogEvent());
+        assertFalse(str, str.contains("\"empty\""));
+    }
+
     private String toPropertySeparator(final boolean compact) {
         return compact ? ":" : " : ";
     }

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <slf4jVersion>1.7.25</slf4jVersion>
     <logbackVersion>1.2.3</logbackVersion>
     <jackson1Version>1.9.13</jackson1Version>
-    <jackson2Version>2.10.2</jackson2Version>
+    <jackson2Version>2.11.0</jackson2Version>
     <springVersion>3.2.18.RELEASE</springVersion>
     <kubernetes-client.version>4.6.1</kubernetes-client.version>
     <flumeVersion>1.9.0</flumeVersion>


### PR DESCRIPTION
### Description

`Log4jJsonObjectMapper` [has `JsonInclude.Include.NON_EMPTY` enabled](https://github.com/apache/logging-log4j2/blob/log4j-2.13.3/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/Log4jJsonObjectMapper.java#L44) but it is not working at the moment - keys with empty values are still present in output. It is caused by [bug in `jackson-databind`](https://github.com/FasterXML/jackson-databind/pull/2615) which I have fixed. Fix was released as part of `jackson-databind:2.11.x`.

### Why LOG4J2-2749?

I feel this fix will address user request.

### Issue itself

#### `log4j2.xml`

```
<?xml version="1.0" encoding="UTF-8"?>
<Configuration status="WARN">
    <Appenders>
        <Console name="Console" target="SYSTEM_OUT">
            <JsonLayout compact="true" properties="true">
                <KeyValuePair key="empty" value="${ctx:empty:-}"/>
            </JsonLayout>
        </Console>
    </Appenders>
    <Loggers>
        <Root level="DEBUG">
            <AppenderRef ref="Console"/>
        </Root>
    </Loggers>
</Configuration>
```

#### `Main.java`

```
import org.apache.logging.log4j.LogManager;
import org.apache.logging.log4j.Logger;

public class Main {
    private static final Logger logger = LogManager.getLogger();

    public static void main(String[] args) {
        logger.info("info");
    }
}
```

#### Output

```
{"instant":{"epochSecond":1590743485,"nanoOfSecond":93000000},"thread":"main","level":"INFO","loggerName":"org.apache.logging.log4j.core.Main","message":"info","endOfBatch":false,"loggerFqcn":"org.apache.logging.log4j.spi.AbstractLogger","contextMap":{},"threadId":1,"threadPriority":5,"empty":""}
```

### Notes

* I have chosen `release-2.x` while I have actually developed a patch on `2.13.3` tag. I can rebase to any other brach, just let me know which one.