### PR TITLE
LOG4J2-2859 - Fix typo that mergeFactory should be mergeStrategy

### DIFF
--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/LegacyPropertiesCompatibilityTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/LegacyPropertiesCompatibilityTest.java
@@ -39,7 +39,7 @@ public class LegacyPropertiesCompatibilityTest {
     public static Object[][] data() {
         return new Object[][]{
             {"log4j2.configurationFile", "log4j.configurationFile"},
-            {"log4j2.mergeFactory", "log4j.mergeFactory"},
+            {"log4j2.mergeStrategy", "log4j.mergeStrategy"},
             {"log4j2.contextSelector", "Log4jContextSelector"},
             {"log4j2.logEventFactory", "Log4jLogEventFactory"},
             {"log4j2.configurationFactory", "log4j.configurationFactory"},

--- a/src/site/asciidoc/manual/configuration.adoc
+++ b/src/site/asciidoc/manual/configuration.adoc
@@ -1701,8 +1701,8 @@ configuration file locations.
 internal logging to the console if system property `log4j2.debug` is
 defined (with any or no value).
 
-|[[mergeFactory]]log4j2.mergeFactory +
-([[log4j.mergeFactory]]log4j.mergeFactory)
+|[[mergeStrategy]]log4j2.mergeStrategy +
+([[log4j.mergeStrategy]]log4j.mergeStrategy)
 |LOG4J_MERGE_FACTORY
 | 
 |The name of the class that implements the MergeStrategy interface. If not


### PR DESCRIPTION
according to https://github.com/apache/logging-log4j2/blob/d304e034dfd3e3e5ca115b6b6e6f22d72d606850/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/CompositeConfiguration.java#L50