### PR TITLE
Allow clients to set the source manually.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,23 @@ JIRA issue in the Pull Request.
 
 ## Building From Source
 
-Log4j requires Apache Maven 3.x. To build from source and install to your local Maven repository, execute the following:
+Log4j requires Apache Maven 3.x. Java 9 needs to be installed and present in your `~/.m2/toolchains.xml`. See the following for an example.
+ 
+ ```$xml
+<toolchains>
+	<toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>9</version>
+    </provides>
+    <configuration>
+      <jdkHome>C:\Program Files\Java\jdk-9.0.1</jdkHome>
+    </configuration>
+	</toolchain>
+</toolchains>
+```
+ 
+ To build from source and install to your local Maven repository, execute the following:
 
 ```sh
 mvn install

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -85,6 +85,15 @@ public interface Logger {
     void catching(Level level, Throwable t);
 
     /**
+     * Logs an exception or error that has been caught to a specific logging level, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param level The logging Level.
+     * @param t The Throwable.
+     */
+    void catching(StackTraceElement source, Level level, Throwable t);
+
+    /**
      * Logs an exception or error that has been caught. Normally, one may wish to provide additional information with an
      * exception while logging it; in these cases, one would not use this method. In other cases where simply logging
      * the fact that an exception was swallowed somewhere (e.g., at the top of the stack trace in a {@code main()}
@@ -93,6 +102,17 @@ public interface Logger {
      * @param t The Throwable.
      */
     void catching(Throwable t);
+
+    /**
+     * Logs an exception or error that has been caught, when the location of the log statement might be known at
+     * compile time.. Normally, one may wish to provide additional information with an exception while logging it; in
+     * these cases, one would not use this method. In other cases where simply logging the fact that an exception was
+     * swallowed somewhere (e.g., at the top of the stack trace in a {@code main()} method), this method is ideal for
+     * it.
+     *
+     * @param t The Throwable.
+     */
+    void catching(StackTraceElement source, Throwable t);
 
     /**
      * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
@@ -2998,6 +3018,21 @@ public interface Logger {
     <T extends Throwable> T throwing(Level level, T t);
 
     /**
+     * Logs an exception or error to be thrown, when the location
+     * of the log statement might be known at compile time. This may be coded as:
+     *
+     * <pre>
+     * throw logger.throwing(source, Level.DEBUG, myException);
+     * </pre>
+     *
+     * @param <T> the Throwable type.
+     * @param level The logging Level.
+     * @param t The Throwable.
+     * @return the Throwable.
+     */
+    <T extends Throwable> T throwing(StackTraceElement source, Level level, T t);
+
+    /**
      * Logs an exception or error to be thrown. This may be coded as:
      *
      * <pre>
@@ -3009,6 +3044,20 @@ public interface Logger {
      * @return the Throwable.
      */
     <T extends Throwable> T throwing(T t);
+
+    /**
+     * Logs an exception or error to be thrown, when the location
+     * of the log statement might be known at compile time. This may be coded as:
+     *
+     * <pre>
+     * throw logger.throwing(source, myException);
+     * </pre>
+     *
+     * @param <T> the Throwable type.
+     * @param t The Throwable.
+     * @return the Throwable.
+     */
+    <T extends Throwable> T throwing(StackTraceElement source, T t);
 
     /**
      * Logs a message with the specific Marker at the {@link Level#TRACE TRACE} level.
@@ -3551,6 +3600,8 @@ public interface Logger {
      */
     EntryMessage traceEntry();
 
+    EntryMessage traceEntry(StackTraceElement source);
+
     /**
      * Logs entry to a method along with its parameters. For example,
      *
@@ -3577,6 +3628,8 @@ public interface Logger {
      */
     EntryMessage traceEntry(String format, Object... params);
 
+    EntryMessage traceEntry(StackTraceElement source, String format, Object... params);
+
     /**
      * Logs entry to a method along with its parameters. For example,
      *
@@ -3595,6 +3648,8 @@ public interface Logger {
      * @since 2.6
      */
     EntryMessage traceEntry(Supplier<?>... paramSuppliers);
+
+    EntryMessage traceEntry(StackTraceElement source, Supplier<?>... paramSuppliers);
 
     /**
      * Logs entry to a method along with its parameters. For example,
@@ -3615,6 +3670,8 @@ public interface Logger {
      * @since 2.6
      */
     EntryMessage traceEntry(String format, Supplier<?>... paramSuppliers);
+
+    EntryMessage traceEntry(StackTraceElement source, String format, Supplier<?>... paramSuppliers);
 
     /**
      * Logs entry to a method using a Message to describe the parameters.
@@ -3639,12 +3696,21 @@ public interface Logger {
      */
     EntryMessage traceEntry(Message message);
 
+    EntryMessage traceEntry(StackTraceElement source, Message message);
+
     /**
      * Logs exit from a method. Used for methods that do not return anything.
      *
      * @since 2.6
      */
     void traceExit();
+
+    /**
+     * Logs exit from a method. Used for methods that do not return anything.
+     *
+     * @since
+     */
+    void traceExit(StackTraceElement source);
 
     /**
      * Logs exiting from a method with the result. This may be coded as:
@@ -3660,6 +3726,8 @@ public interface Logger {
      * @since 2.6
      */
     <R> R traceExit(R result);
+
+    <R> R traceExit(StackTraceElement source, R result);
 
     /**
      * Logs exiting from a method with the result. This may be coded as:
@@ -3677,6 +3745,8 @@ public interface Logger {
      */
     <R> R traceExit(String format, R result);
 
+    <R> R traceExit(StackTraceElement source, String format, R result);
+
     /**
      * Logs exiting from a method with no result. Allows custom formatting of the result. This may be coded as:
      *
@@ -3692,6 +3762,8 @@ public interface Logger {
      * @since 2.6
      */
     void traceExit(EntryMessage message);
+
+    void traceExit(StackTraceElement source, EntryMessage message);
 
     /**
      * Logs exiting from a method with the result. Allows custom formatting of the result. This may be coded as:
@@ -3713,6 +3785,8 @@ public interface Logger {
      */
     <R> R traceExit(EntryMessage message, R result);
 
+    <R> R traceExit(StackTraceElement source, EntryMessage message, R result);
+
     /**
      * Logs exiting from a method with the result. Allows custom formatting of the result. This may be coded as:
      *
@@ -3728,6 +3802,8 @@ public interface Logger {
      * @since 2.6
      */
     <R> R traceExit(Message message, R result);
+
+    <R> R traceExit(StackTraceElement source, Message message, R result);
 
     /**
      * Logs a message with the specific Marker at the {@link Level#WARN WARN} level.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/AbstractMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/AbstractMessageFactory.java
@@ -36,7 +36,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
 
     @Override
     public Message newMessage(final CharSequence message) {
-        return new SimpleMessage(message);
+        return newMessage((StackTraceElement) null, message);
     }
 
     /*
@@ -46,7 +46,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
      */
     @Override
     public Message newMessage(final Object message) {
-        return new ObjectMessage(message);
+        return newMessage((StackTraceElement) null, message);
     }
 
     /*
@@ -56,7 +56,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
      */
     @Override
     public Message newMessage(final String message) {
-        return new SimpleMessage(message);
+        return newMessage((StackTraceElement) null, message);
     }
 
     /**
@@ -64,7 +64,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
      */
     @Override
     public Message newMessage(final String message, final Object p0) {
-        return newMessage(message, new Object[] { p0 });
+        return newMessage((StackTraceElement) null, message, p0);
     }
 
     /**
@@ -72,7 +72,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1) {
-        return newMessage(message, new Object[] { p0, p1 });
+        return newMessage((StackTraceElement) null, message, p0, p1);
     }
 
     /**
@@ -80,7 +80,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2) {
-        return newMessage(message, new Object[] { p0, p1, p2 });
+        return newMessage((StackTraceElement) null, message, p0, p1, p2);
     }
 
     /**
@@ -88,7 +88,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3 });
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3);
     }
 
     /**
@@ -96,7 +96,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4 });
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4);
     }
 
     /**
@@ -104,7 +104,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5 });
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5);
     }
 
     /**
@@ -113,7 +113,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
             final Object p6) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5, p6 });
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     /**
@@ -122,7 +122,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
             final Object p6, final Object p7) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5, p6, p7 });
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     /**
@@ -131,7 +131,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
             final Object p6, final Object p7, final Object p8) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8 });
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     /**
@@ -140,7 +140,117 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
             final Object p6, final Object p7, final Object p8, final Object p9) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9 });
+        return newMessage(null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+
+    @Override
+    public Message newMessage(final StackTraceElement source, final CharSequence message) {
+        return new SimpleMessage(source, message);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.apache.logging.log4j.message.MessageFactory#newMessage(java.lang.StackTraceElement,java.lang.Object)
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final Object message) {
+        return new ObjectMessage(source, message);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.apache.logging.log4j.message.MessageFactory#newMessage(java.lang.StackTraceElement,java.lang.String)
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message) {
+        return new SimpleMessage(source, message);
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0) {
+        return newMessage(source, message, new Object[] { p0 });
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1) {
+        return newMessage(source, message, new Object[] { p0, p1 });
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2) {
+        return newMessage(source, message, new Object[] { p0, p1, p2 });
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+        return newMessage(source, message, new Object[] { p0, p1, p2, p3 });
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+        return newMessage(source, message, new Object[] { p0, p1, p2, p3, p4 });
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+        return newMessage(source, message, new Object[] { p0, p1, p2, p3, p4, p5 });
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+                              final Object p6) {
+        return newMessage(source, message, new Object[] { p0, p1, p2, p3, p4, p5, p6 });
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+                              final Object p6, final Object p7) {
+        return newMessage(source, message, new Object[] { p0, p1, p2, p3, p4, p5, p6, p7 });
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+                              final Object p6, final Object p7, final Object p8) {
+        return newMessage(source, message, new Object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8 });
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+                              final Object p6, final Object p7, final Object p8, final Object p9) {
+        return newMessage(source, message, new Object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9 });
     }
 
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
@@ -53,10 +53,12 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
     private static class AbstractFlowMessage implements FlowMessage {
 
         private static final long serialVersionUID = 1L;
+        private final StackTraceElement source;
         private final Message message;
         private final String text;
 
-        AbstractFlowMessage(final String text, final Message message) {
+        AbstractFlowMessage(final StackTraceElement source, final String text, final Message message) {
+            this.source = source;
             this.message = message;
             this.text = text;
         }
@@ -102,14 +104,19 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
         public String getText() {
             return text;
         }
+
+        @Override
+        public StackTraceElement getSource() {
+            return source;
+        }
     }
 
     private static final class SimpleEntryMessage extends AbstractFlowMessage implements EntryMessage {
 
         private static final long serialVersionUID = 1L;
 
-        SimpleEntryMessage(final String entryText, final Message message) {
-            super(entryText, message);
+        SimpleEntryMessage(final StackTraceElement source, final String entryText, final Message message) {
+            super(source, entryText, message);
         }
 
     }
@@ -121,20 +128,20 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
         private final Object result;
         private final boolean isVoid;
 
-        SimpleExitMessage(final String exitText, final EntryMessage message) {
-            super(exitText, message.getMessage());
+        SimpleExitMessage(final StackTraceElement source, final String exitText, final EntryMessage message) {
+            super(source, exitText, message.getMessage());
             this.result = null;
             isVoid = true;
         }
 
-        SimpleExitMessage(final String exitText, final Object result, final EntryMessage message) {
-            super(exitText, message.getMessage());
+        SimpleExitMessage(final StackTraceElement source, final String exitText, final Object result, final EntryMessage message) {
+            super(source, exitText, message.getMessage());
             this.result = result;
             isVoid = false;
         }
 
-        SimpleExitMessage(final String exitText, final Object result, final Message message) {
-            super(exitText, message);
+        SimpleExitMessage(final StackTraceElement source, final String exitText, final Object result, final Message message) {
+            super(source, exitText, message);
             this.result = result;
             isVoid = false;
         }
@@ -171,15 +178,20 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
      * @see org.apache.logging.log4j.message.MessageFactory#newEntryMessage(org.apache.logging.log4j.message.Message)
      */
     @Override
-    public EntryMessage newEntryMessage(final Message message) {
-        return new SimpleEntryMessage(entryText, makeImmutable(message));
+    public EntryMessage newEntryMessage(final StackTraceElement source, final Message message) {
+        return new SimpleEntryMessage(source, entryText, makeImmutable(message));
+    }
+
+    @Override
+    public EntryMessage newEntryMessage(Message message) {
+        return newEntryMessage(null, message);
     }
 
     private Message makeImmutable(final Message message) {
         if (!(message instanceof ReusableMessage)) {
             return message;
         }
-        return new SimpleMessage(message.getFormattedMessage());
+        return new SimpleMessage(message.getSource(), message.getFormattedMessage());
     }
 
     /*
@@ -188,8 +200,13 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
      * @see org.apache.logging.log4j.message.FlowMessageFactory#newExitMessage(org.apache.logging.log4j.message.EntryMessage)
      */
     @Override
-    public ExitMessage newExitMessage(final EntryMessage message) {
-        return new SimpleExitMessage(exitText, message);
+    public ExitMessage newExitMessage(final StackTraceElement source, final EntryMessage message) {
+        return new SimpleExitMessage(source, exitText, message);
+    }
+
+    @Override
+    public ExitMessage newExitMessage(EntryMessage message) {
+        return newExitMessage(null, message);
     }
 
     /*
@@ -198,8 +215,13 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
      * @see org.apache.logging.log4j.message.FlowMessageFactory#newExitMessage(java.lang.Object, org.apache.logging.log4j.message.EntryMessage)
      */
     @Override
-    public ExitMessage newExitMessage(final Object result, final EntryMessage message) {
-        return new SimpleExitMessage(exitText, result, message);
+    public ExitMessage newExitMessage(final StackTraceElement source, final Object result, final EntryMessage message) {
+        return new SimpleExitMessage(source, exitText, result, message);
+    }
+
+    @Override
+    public ExitMessage newExitMessage(Object result, Message message) {
+        return newExitMessage(null, result, message);
     }
 
     /*
@@ -208,7 +230,12 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
      * @see org.apache.logging.log4j.message.FlowMessageFactory#newExitMessage(java.lang.Object, org.apache.logging.log4j.message.Message)
      */
     @Override
-    public ExitMessage newExitMessage(final Object result, final Message message) {
-        return new SimpleExitMessage(exitText, result, message);
+    public ExitMessage newExitMessage(final StackTraceElement source, final Object result, final Message message) {
+        return new SimpleExitMessage(source, exitText, result, message);
+    }
+
+    @Override
+    public ExitMessage newExitMessage(Object result, EntryMessage message) {
+        return newExitMessage(null, result, message);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/FlowMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/FlowMessageFactory.java
@@ -21,38 +21,51 @@ package org.apache.logging.log4j.message;
  * @since 2.6
  */
 public interface FlowMessageFactory {
-    
+
     /**
      * Creates a new entry message based on an existing message.
      *
+     * @param source the location of the log statement if known at compile time.
      * @param message the original message
      * @return the new entry message
      */
+    EntryMessage newEntryMessage(StackTraceElement source, Message message);
+
     EntryMessage newEntryMessage(Message message);
 
     /**
      * Creates a new exit message based on a return value and an existing message.
      *
+     * @param source the location of the log statement if known at compile time.
      * @param result the return value.
      * @param message the original message
      * @return the new exit message
      */
+    ExitMessage newExitMessage(StackTraceElement source, Object result, Message message);
+
     ExitMessage newExitMessage(Object result, Message message);
 
     /**
      * Creates a new exit message based on no return value and an existing entry message.
      *
+     * @param source the location of the log statement if known at compile time.
      * @param message the original entry message
      * @return the new exit message
      */
+    ExitMessage newExitMessage(StackTraceElement source, EntryMessage message);
+
     ExitMessage newExitMessage(EntryMessage message);
 
     /**
      * Creates a new exit message based on a return value and an existing entry message.
      *
+     * @param source the location of the log statement if known at compile time.
      * @param result the return value.
      * @param message the original entry message
      * @return the new exit message
      */
+    ExitMessage newExitMessage(StackTraceElement source, Object result, EntryMessage message);
+
     ExitMessage newExitMessage(Object result, EntryMessage message);
+
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessage.java
@@ -43,6 +43,7 @@ public class FormattedMessage implements Message {
     private final Throwable throwable;
     private Message message;
     private final Locale locale;
+    private StackTraceElement source;
     
     /**
      * Constructs with a locale, a pattern and a single parameter.
@@ -52,7 +53,18 @@ public class FormattedMessage implements Message {
      * @since 2.6
      */
     public FormattedMessage(final Locale locale, final String messagePattern, final Object arg) {
-        this(locale, messagePattern, new Object[] { arg }, null);
+        this(null, locale, messagePattern, arg, (Throwable) null);
+    }
+
+    /**
+     * Constructs with a locale, a pattern and a single parameter.
+     * @param locale The locale
+     * @param messagePattern The message pattern.
+     * @param arg The parameter.
+     * @since 2.6
+     */
+    public FormattedMessage(final StackTraceElement source, final Locale locale, final String messagePattern, final Object arg) {
+        this(source, locale, messagePattern, source, new Object[] { arg }, null);
     }
 
     /**
@@ -68,6 +80,18 @@ public class FormattedMessage implements Message {
     }
 
     /**
+     * Constructs with a locale, a pattern and two parameters.
+     * @param locale The locale
+     * @param messagePattern The message pattern.
+     * @param arg1 The first parameter.
+     * @param arg2 The second parameter.
+     * @since 2.6
+     */
+    public FormattedMessage(final StackTraceElement source, final Locale locale, final String messagePattern, final Object arg1, final Object arg2) {
+        this(source, locale, messagePattern, new Object[] { arg1, arg2 });
+    }
+
+    /**
      * Constructs with a locale, a pattern and a parameter array.
      * @param locale The locale
      * @param messagePattern The message pattern.
@@ -75,7 +99,18 @@ public class FormattedMessage implements Message {
      * @since 2.6
      */
     public FormattedMessage(final Locale locale, final String messagePattern, final Object... arguments) {
-        this(locale, messagePattern, arguments, null);
+        this(null, locale, messagePattern, arguments, null);
+    }
+
+    /**
+     * Constructs with a locale, a pattern and a parameter array.
+     * @param locale The locale
+     * @param messagePattern The message pattern.
+     * @param arguments The parameter.
+     * @since 2.6
+     */
+    public FormattedMessage(StackTraceElement source, final Locale locale, final String messagePattern, final Object... arguments) {
+        this(source, locale, messagePattern, arguments, (Throwable) null);
     }
 
     /**
@@ -87,6 +122,19 @@ public class FormattedMessage implements Message {
      * @since 2.6
      */
     public FormattedMessage(final Locale locale, final String messagePattern, final Object[] arguments, final Throwable throwable) {
+        this(null, locale, messagePattern, arguments, throwable);
+    }
+
+    /**
+     * Constructs with a locale, a pattern, a parameter array, and a throwable.
+     * @param locale The Locale
+     * @param messagePattern The message pattern.
+     * @param arguments The parameter.
+     * @param throwable The throwable
+     * @since 2.6
+     */
+    public FormattedMessage(final StackTraceElement source, final Locale locale, final String messagePattern, final Object[] arguments, final Throwable throwable) {
+        this.source = source;
         this.locale = locale;
         this.messagePattern = messagePattern;
         this.argArray = arguments;
@@ -99,7 +147,16 @@ public class FormattedMessage implements Message {
      * @param arg The parameter.
      */
     public FormattedMessage(final String messagePattern, final Object arg) {
-        this(messagePattern, new Object[] { arg }, null);
+        this((StackTraceElement) null, messagePattern, new Object[] { arg }, null);
+    }
+
+    /**
+     * Constructs with a pattern and a single parameter.
+     * @param messagePattern The message pattern.
+     * @param arg The parameter.
+     */
+    public FormattedMessage(final StackTraceElement source, final String messagePattern, final Object arg) {
+        this(source, messagePattern, new Object[] { arg }, null);
     }
 
     /**
@@ -113,6 +170,16 @@ public class FormattedMessage implements Message {
     }
 
     /**
+     * Constructs with a pattern and two parameters.
+     * @param messagePattern The message pattern.
+     * @param arg1 The first parameter.
+     * @param arg2 The second parameter.
+     */
+    public FormattedMessage(final StackTraceElement source, final String messagePattern, final Object arg1, final Object arg2) {
+        this(source, messagePattern, new Object[] { arg1, arg2 });
+    }
+
+    /**
      * Constructs with a pattern and a parameter array.
      * @param messagePattern The message pattern.
      * @param arguments The parameter.
@@ -122,18 +189,37 @@ public class FormattedMessage implements Message {
     }
 
     /**
+     * Constructs with a pattern and a parameter array.
+     * @param messagePattern The message pattern.
+     * @param arguments The parameter.
+     */
+    public FormattedMessage(final StackTraceElement source, final String messagePattern, final Object... arguments) {
+        this(source, messagePattern, arguments, null);
+    }
+
+    /**
      * Constructs with a pattern, a parameter array, and a throwable.
      * @param messagePattern The message pattern.
      * @param arguments The parameter.
      * @param throwable The throwable
      */
     public FormattedMessage(final String messagePattern, final Object[] arguments, final Throwable throwable) {
+        this((StackTraceElement) null, messagePattern, arguments, throwable);
+    }
+
+    /**
+     * Constructs with a pattern, a parameter array, and a throwable.
+     * @param messagePattern The message pattern.
+     * @param arguments The parameter.
+     * @param throwable The throwable
+     */
+    public FormattedMessage(final StackTraceElement source, final String messagePattern, final Object[] arguments, final Throwable throwable) {
         this.locale = Locale.getDefault(Locale.Category.FORMAT);
         this.messagePattern = messagePattern;
         this.argArray = arguments;
         this.throwable = throwable;
+        this.source = source;
     }
-
 
     @Override
     public boolean equals(final Object o) {
@@ -150,6 +236,9 @@ public class FormattedMessage implements Message {
             return false;
         }
         if (!Arrays.equals(stringArgs, that.stringArgs)) {
+            return false;
+        }
+        if (source != null ? !source.equals(that.source) : that.source != null) {
             return false;
         }
 
@@ -173,26 +262,26 @@ public class FormattedMessage implements Message {
     public String getFormattedMessage() {
         if (formattedMessage == null) {
             if (message == null) {
-                message = getMessage(messagePattern, argArray, throwable);
+                message = getMessage(source, messagePattern, argArray, throwable);
             }
             formattedMessage = message.getFormattedMessage();
         }
         return formattedMessage;
     }
 
-    protected Message getMessage(final String msgPattern, final Object[] args, final Throwable aThrowable) {
+    protected Message getMessage(final StackTraceElement source, final String msgPattern, final Object[] args, final Throwable aThrowable) {
         try {
             final MessageFormat format = new MessageFormat(msgPattern);
             final Format[] formats = format.getFormats();
             if (formats != null && formats.length > 0) {
-                return new MessageFormatMessage(locale, msgPattern, args);
+                return new MessageFormatMessage(source, locale, msgPattern, args);
             }
         } catch (final Exception ignored) {
             // Obviously, the message is not a proper pattern for MessageFormat.
         }
         try {
             if (MSG_PATTERN.matcher(msgPattern).find()) {
-                return new StringFormattedMessage(locale, msgPattern, args);
+                return new StringFormattedMessage(source, locale, msgPattern, args);
             }
         } catch (final Exception ignored) {
             // Also not properly formatted.
@@ -218,11 +307,15 @@ public class FormattedMessage implements Message {
             return throwable;
         }
         if (message == null) {
-            message = getMessage(messagePattern, argArray, null);
+            message = getMessage(source, messagePattern, argArray, null);
         }
         return message.getThrowable();
     }
 
+    @Override
+    public StackTraceElement getSource() {
+        return source;
+    }
 
     @Override
     public int hashCode() {
@@ -239,6 +332,14 @@ public class FormattedMessage implements Message {
         stringArgs = new String[length];
         for (int i = 0; i < length; ++i) {
             stringArgs[i] = in.readUTF();
+        }
+        boolean hasSource = in.readBoolean();
+        if (hasSource) {
+            String className = in.readUTF();
+            String methodName = in.readUTF();
+            String fileName = MessageFormatMessage.readNullableString(in);
+            int lineNumber = in.readInt();
+            source = new StackTraceElement(className, methodName, fileName, lineNumber);
         }
     }
 
@@ -260,6 +361,14 @@ public class FormattedMessage implements Message {
             stringArgs[i] = string;
             out.writeUTF(string);
             ++i;
+        }
+        boolean hasSource = source != null;
+        out.writeBoolean(hasSource);
+        if (hasSource) {
+            out.writeUTF(source.getClassName());
+            out.writeUTF(source.getMethodName());
+            MessageFormatMessage.writeNullableString(out, source.getFileName());
+            out.writeInt(source.getLineNumber());
         }
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessageFactory.java
@@ -133,4 +133,9 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
             final Object p6, final Object p7, final Object p8, final Object p9) {
         return new FormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object... params) {
+        return new FormattedMessage(source, message, params);
+    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessage.java
@@ -52,6 +52,7 @@ public class LocalizedMessage implements Message, LoggerNameAwareMessage {
     private transient Object[] argArray;
     private String formattedMessage;
     private transient Throwable throwable;
+    private StackTraceElement source;
 
     /**
      * Constructor with message pattern and arguments.
@@ -60,95 +61,187 @@ public class LocalizedMessage implements Message, LoggerNameAwareMessage {
      * @param arguments the argument array to be converted.
      */
     public LocalizedMessage(final String messagePattern, final Object[] arguments) {
-        this((ResourceBundle) null, (Locale) null, messagePattern, arguments);
+        this(null, (ResourceBundle) null, (Locale) null, messagePattern, arguments);
     }
 
     public LocalizedMessage(final String baseName, final String key, final Object[] arguments) {
-        this(baseName, (Locale) null, key, arguments);
+        this(null, baseName, (Locale) null, key, arguments);
     }
 
     public LocalizedMessage(final ResourceBundle bundle, final String key, final Object[] arguments) {
-        this(bundle, (Locale) null, key, arguments);
+        this(null, bundle, (Locale) null, key, arguments);
     }
 
     public LocalizedMessage(final String baseName, final Locale locale, final String key, final Object[] arguments) {
-        this.key = key;
-        this.argArray = arguments;
-        this.throwable = null;
-        this.baseName = baseName;
-        this.resourceBundle = null;
-        this.locale = locale;
+        this(null, baseName, locale, key, arguments);
     }
 
     public LocalizedMessage(final ResourceBundle bundle, final Locale locale, final String key,
             final Object[] arguments) {
-        this.key = key;
-        this.argArray = arguments;
-        this.throwable = null;
-        this.baseName = null;
-        this.resourceBundle = bundle;
-        this.locale = locale;
+        this(null, bundle, locale, key, arguments);
     }
 
     public LocalizedMessage(final Locale locale, final String key, final Object[] arguments) {
-        this((ResourceBundle) null, locale, key, arguments);
+        this(null, (ResourceBundle) null, locale, key, arguments);
     }
 
     public LocalizedMessage(final String messagePattern, final Object arg) {
-        this((ResourceBundle) null, (Locale) null, messagePattern, new Object[] {arg});
+        this(null, (ResourceBundle) null, (Locale) null, messagePattern, new Object[] {arg});
     }
 
     public LocalizedMessage(final String baseName, final String key, final Object arg) {
-        this(baseName, (Locale) null, key, new Object[] {arg});
+        this(null, baseName, (Locale) null, key, new Object[] {arg});
     }
 
     /**
      * @since 2.8
      */
     public LocalizedMessage(final ResourceBundle bundle, final String key) {
-        this(bundle, (Locale) null, key, new Object[] {});
+        this(null, bundle, (Locale) null, key, new Object[] {});
     }
 
     public LocalizedMessage(final ResourceBundle bundle, final String key, final Object arg) {
-        this(bundle, (Locale) null, key, new Object[] {arg});
+        this(null, bundle, (Locale) null, key, new Object[] {arg});
     }
 
     public LocalizedMessage(final String baseName, final Locale locale, final String key, final Object arg) {
-        this(baseName, locale, key, new Object[] {arg});
+        this(null, baseName, locale, key, new Object[] {arg});
     }
 
     public LocalizedMessage(final ResourceBundle bundle, final Locale locale, final String key, final Object arg) {
-        this(bundle, locale, key, new Object[] {arg});
+        this(null, bundle, locale, key, new Object[] {arg});
     }
 
     public LocalizedMessage(final Locale locale, final String key, final Object arg) {
-        this((ResourceBundle) null, locale, key, new Object[] {arg});
+        this(null, (ResourceBundle) null, locale, key, new Object[] {arg});
     }
 
     public LocalizedMessage(final String messagePattern, final Object arg1, final Object arg2) {
-        this((ResourceBundle) null, (Locale) null, messagePattern, new Object[] {arg1, arg2});
+        this(null, (ResourceBundle) null, (Locale) null, messagePattern, new Object[] {arg1, arg2});
     }
 
     public LocalizedMessage(final String baseName, final String key, final Object arg1, final Object arg2) {
-        this(baseName, (Locale) null, key, new Object[] {arg1, arg2});
+        this(null, baseName, (Locale) null, key, new Object[] {arg1, arg2});
     }
 
     public LocalizedMessage(final ResourceBundle bundle, final String key, final Object arg1, final Object arg2) {
-        this(bundle, (Locale) null, key, new Object[] {arg1, arg2});
+        this(null, bundle, (Locale) null, key, new Object[] {arg1, arg2});
     }
 
     public LocalizedMessage(final String baseName, final Locale locale, final String key, final Object arg1,
             final Object arg2) {
-        this(baseName, locale, key, new Object[] {arg1, arg2});
+        this(null, baseName, locale, key, new Object[] {arg1, arg2});
     }
 
     public LocalizedMessage(final ResourceBundle bundle, final Locale locale, final String key, final Object arg1,
             final Object arg2) {
-        this(bundle, locale, key, new Object[] {arg1, arg2});
+        this(null, bundle, locale, key, new Object[] {arg1, arg2});
     }
 
     public LocalizedMessage(final Locale locale, final String key, final Object arg1, final Object arg2) {
-        this((ResourceBundle) null, locale, key, new Object[] {arg1, arg2});
+        this(null, (ResourceBundle) null, locale, key, new Object[] {arg1, arg2});
+    }
+
+    /**
+     * Constructor with message pattern and arguments, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param messagePattern the message pattern that to be checked for placeholders.
+     * @param arguments the argument array to be converted.
+     */
+    public LocalizedMessage(final StackTraceElement source, final String messagePattern, final Object[] arguments) {
+        this(source, (ResourceBundle) null, (Locale) null, messagePattern, arguments);
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final String baseName, final String key, final Object[] arguments) {
+        this(source, baseName, (Locale) null, key, arguments);
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final ResourceBundle bundle, final String key, final Object[] arguments) {
+        this(source, bundle, (Locale) null, key, arguments);
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final String baseName, final Locale locale, final String key, final Object[] arguments) {
+        this.key = key;
+        this.argArray = arguments;
+        this.throwable = null;
+        this.baseName = baseName;
+        this.resourceBundle = null;
+        this.locale = locale;
+        this.source = source;
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final ResourceBundle bundle, final Locale locale, final String key,
+                            final Object[] arguments) {
+        this.key = key;
+        this.argArray = arguments;
+        this.throwable = null;
+        this.baseName = null;
+        this.resourceBundle = bundle;
+        this.locale = locale;
+        this.source = source;
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final Locale locale, final String key, final Object[] arguments) {
+        this(source, (ResourceBundle) null, locale, key, arguments);
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final String messagePattern, final Object arg) {
+        this(source, (ResourceBundle) null, (Locale) null, messagePattern, new Object[] {arg});
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final String baseName, final String key, final Object arg) {
+        this(source, baseName, (Locale) null, key, new Object[] {arg});
+    }
+
+    /**
+     * @since
+     */
+    public LocalizedMessage(final StackTraceElement source, final ResourceBundle bundle, final String key) {
+        this(source, bundle, (Locale) null, key, new Object[] {});
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final ResourceBundle bundle, final String key, final Object arg) {
+        this(source, bundle, (Locale) null, key, new Object[] {arg});
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final String baseName, final Locale locale, final String key, final Object arg) {
+        this(source, baseName, locale, key, new Object[] {arg});
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final ResourceBundle bundle, final Locale locale, final String key, final Object arg) {
+        this(source, bundle, locale, key, new Object[] {arg});
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final Locale locale, final String key, final Object arg) {
+        this(source, (ResourceBundle) null, locale, key, new Object[] {arg});
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final String messagePattern, final Object arg1, final Object arg2) {
+        this(source, (ResourceBundle) null, (Locale) null, messagePattern, new Object[] {arg1, arg2});
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final String baseName, final String key, final Object arg1, final Object arg2) {
+        this(source, baseName, (Locale) null, key, new Object[] {arg1, arg2});
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final ResourceBundle bundle, final String key, final Object arg1, final Object arg2) {
+        this(source, bundle, (Locale) null, key, new Object[] {arg1, arg2});
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final String baseName, final Locale locale, final String key, final Object arg1,
+                            final Object arg2) {
+        this(source, baseName, locale, key, new Object[] {arg1, arg2});
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final ResourceBundle bundle, final Locale locale, final String key, final Object arg1,
+                            final Object arg2) {
+        this(source, bundle, locale, key, new Object[] {arg1, arg2});
+    }
+
+    public LocalizedMessage(final StackTraceElement source, final Locale locale, final String key, final Object arg1, final Object arg2) {
+        this(source, (ResourceBundle) null, locale, key, new Object[] {arg1, arg2});
     }
 
     /**
@@ -214,6 +307,11 @@ public class LocalizedMessage implements Message, LoggerNameAwareMessage {
     @Override
     public Throwable getThrowable() {
         return throwable;
+    }
+
+    @Override
+    public StackTraceElement getSource() {
+        return source;
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessageFactory.java
@@ -73,7 +73,7 @@ public class LocalizedMessageFactory extends AbstractMessageFactory {
         }
         return new LocalizedMessage(resourceBundle, key);
     }
-    
+
     /**
      * Creates {@link LocalizedMessage} instances.
      *
@@ -85,10 +85,25 @@ public class LocalizedMessageFactory extends AbstractMessageFactory {
      */
     @Override
     public Message newMessage(final String key, final Object... params) {
-        if (resourceBundle == null) {
-            return new LocalizedMessage(baseName, key, params);
-        }
-        return new LocalizedMessage(resourceBundle, key, params);
+        return newMessage((StackTraceElement) null, key, params);
     }
 
+    /**
+     * Creates {@link LocalizedMessage} instances, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message The key String, used as a message if the key is absent.
+     * @param params The parameters for the message at the given key.
+     * @return The LocalizedMessage.
+     *
+     * @see org.apache.logging.log4j.message.MessageFactory#newMessage(String, Object...)
+     */
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object... params) {
+        if (resourceBundle == null) {
+            return new LocalizedMessage(source, baseName, message, params);
+        }
+        return new LocalizedMessage(source, resourceBundle, message, params);
+    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
@@ -100,12 +100,19 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     }
 
     private final IndexedStringMap data;
+    private final StackTraceElement source;
 
     /**
      * Constructs a new instance.
      */
     public MapMessage() {
         this.data = new SortedArrayStringMap();
+        source = null;
+    }
+
+    public MapMessage(StackTraceElement source) {
+        this.data = new SortedArrayStringMap();
+        this.source = source;
     }
 
     /**
@@ -114,7 +121,17 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param  initialCapacity the initial capacity.
      */
     public MapMessage(final int initialCapacity) {
+        this(null, initialCapacity);
+    }
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param  initialCapacity the initial capacity.
+     */
+    public MapMessage(final StackTraceElement source, final int initialCapacity) {
         this.data = new SortedArrayStringMap(initialCapacity);
+        this.source = source;
     }
 
     /**
@@ -122,7 +139,16 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param map The Map.
      */
     public MapMessage(final Map<String, V> map) {
+        this(null, map);
+    }
+
+    /**
+     * Constructs a new instance based on an existing Map.
+     * @param map The Map.
+     */
+    public MapMessage(final StackTraceElement source, final Map<String, V> map) {
         this.data = new SortedArrayStringMap(map);
+        this.source = source;
     }
 
     @Override
@@ -164,6 +190,11 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
             result.put(data.getKeyAt(i), (V) data.getValueAt(i));
         }
         return Collections.unmodifiableMap(result);
+    }
+
+    @Override
+    public StackTraceElement getSource() {
+        return source;
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/Message.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/Message.java
@@ -94,4 +94,11 @@ public interface Message extends Serializable {
      * @return the throwable or null.
      */
     Throwable getThrowable();
+
+    /**
+     * A StackTraceElement providing the location of the log statement.
+     * @return a StackTraceElement with the log statement's location, or null.
+     */
+    StackTraceElement getSource();
+
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFactory.java
@@ -34,6 +34,18 @@ public interface MessageFactory {
     Message newMessage(Object message);
 
     /**
+     * Creates a new message based on an Object, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source
+     *            the location of the log statement, or null
+     * @param message
+     *            a message object
+     * @return a new message
+     */
+    Message newMessage(StackTraceElement source, Object message);
+
+    /**
      * Creates a new message based on a String.
      *
      * @param message
@@ -41,6 +53,18 @@ public interface MessageFactory {
      * @return a new message
      */
     Message newMessage(String message);
+
+    /**
+     * Creates a new message based on a String, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source
+     *            the location of the log statement, or null
+     * @param message
+     *            a message String
+     * @return a new message
+     */
+    Message newMessage(StackTraceElement source, String message);
 
     /**
      * Creates a new parameterized message.
@@ -54,4 +78,20 @@ public interface MessageFactory {
      * @see StringFormatterMessageFactory
      */
     Message newMessage(String message, Object... params);
+
+    /**
+     * Creates a new parameterized message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source
+     *            the location of the log statement, or null
+     * @param message
+     *            a message template, the kind of message template depends on the implementation.
+     * @param params
+     *            the message parameters
+     * @return a new message
+     * @see ParameterizedMessageFactory
+     * @see StringFormatterMessageFactory
+     */
+    Message newMessage(StackTraceElement source, String message, Object... params);
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFactory2.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFactory2.java
@@ -178,4 +178,182 @@ public interface MessageFactory2 extends MessageFactory {
      */
     Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
             Object p7, Object p8, Object p9);
+
+
+    /**
+     * Creates a new message for the specified CharSequence, when the location
+     * of the log statement might be known at compile time.
+     * @param source the location of the log statement, or null
+     * @param charSequence the (potentially mutable) CharSequence
+     * @return a new message for the specified CharSequence
+     */
+    Message newMessage(StackTraceElement source, CharSequence charSequence);
+
+    /**
+     * Creates a new parameterized message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message a message template, the kind of message template depends on the implementation.
+     * @param p0 a message parameter
+     * @return a new message
+     * @see ParameterizedMessageFactory
+     */
+    Message newMessage(StackTraceElement source, String message, Object p0);
+
+    /**
+     * Creates a new parameterized message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message a message template, the kind of message template depends on the implementation.
+     * @param p0 a message parameter
+     * @param p1 a message parameter
+     * @return a new message
+     * @see ParameterizedMessageFactory
+     */
+    Message newMessage(StackTraceElement source, String message, Object p0, Object p1);
+
+    /**
+     * Creates a new parameterized message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message a message template, the kind of message template depends on the implementation.
+     * @param p0 a message parameter
+     * @param p1 a message parameter
+     * @param p2 a message parameter
+     * @return a new message
+     * @see ParameterizedMessageFactory
+     */
+    Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2);
+
+    /**
+     * Creates a new parameterized message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message a message template, the kind of message template depends on the implementation.
+     * @param p0 a message parameter
+     * @param p1 a message parameter
+     * @param p2 a message parameter
+     * @param p3 a message parameter
+     * @return a new message
+     * @see ParameterizedMessageFactory
+     */
+    Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3);
+
+    /**
+     * Creates a new parameterized message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message a message template, the kind of message template depends on the implementation.
+     * @param p0 a message parameter
+     * @param p1 a message parameter
+     * @param p2 a message parameter
+     * @param p3 a message parameter
+     * @param p4 a message parameter
+     * @return a new message
+     * @see ParameterizedMessageFactory
+     */
+    Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
+
+    /**
+     * Creates a new parameterized message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message a message template, the kind of message template depends on the implementation.
+     * @param p0 a message parameter
+     * @param p1 a message parameter
+     * @param p2 a message parameter
+     * @param p3 a message parameter
+     * @param p4 a message parameter
+     * @param p5 a message parameter
+     * @return a new message
+     * @see ParameterizedMessageFactory
+     */
+    Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+
+    /**
+     * Creates a new parameterized message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message a message template, the kind of message template depends on the implementation.
+     * @param p0 a message parameter
+     * @param p1 a message parameter
+     * @param p2 a message parameter
+     * @param p3 a message parameter
+     * @param p4 a message parameter
+     * @param p5 a message parameter
+     * @param p6 a message parameter
+     * @return a new message
+     * @see ParameterizedMessageFactory
+     */
+    Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+
+    /**
+     * Creates a new parameterized message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message a message template, the kind of message template depends on the implementation.
+     * @param p0 a message parameter
+     * @param p1 a message parameter
+     * @param p2 a message parameter
+     * @param p3 a message parameter
+     * @param p4 a message parameter
+     * @param p5 a message parameter
+     * @param p6 a message parameter
+     * @param p7 a message parameter
+     * @return a new message
+     * @see ParameterizedMessageFactory
+     */
+    Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+                       Object p7);
+
+    /**
+     * Creates a new parameterized message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message a message template, the kind of message template depends on the implementation.
+     * @param p0 a message parameter
+     * @param p1 a message parameter
+     * @param p2 a message parameter
+     * @param p3 a message parameter
+     * @param p4 a message parameter
+     * @param p5 a message parameter
+     * @param p6 a message parameter
+     * @param p7 a message parameter
+     * @param p8 a message parameter
+     * @return a new message
+     * @see ParameterizedMessageFactory
+     */
+    Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+                       Object p7, Object p8);
+
+    /**
+     * Creates a new parameterized message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message a message template, the kind of message template depends on the implementation.
+     * @param p0 a message parameter
+     * @param p1 a message parameter
+     * @param p2 a message parameter
+     * @param p3 a message parameter
+     * @param p4 a message parameter
+     * @param p5 a message parameter
+     * @param p6 a message parameter
+     * @param p7 a message parameter
+     * @param p8 a message parameter
+     * @param p9 a message parameter
+     * @return a new message
+     * @see ParameterizedMessageFactory
+     */
+    Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+                       Object p7, Object p8, Object p9);
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFormatMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFormatMessageFactory.java
@@ -49,86 +49,19 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
     }
 
     /**
-     * @since 2.6.1
+     * Creates {@link org.apache.logging.log4j.message.StringFormattedMessage} instances, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message The message pattern.
+     * @param params Parameters to the message.
+     * @return The Message.
+     *
+     * @see org.apache.logging.log4j.message.MessageFactory#newMessage(String, Object...)
      */
     @Override
-    public Message newMessage(final String message, final Object p0) {
-        return new MessageFormatMessage(message, p0);
+    public Message newMessage(StackTraceElement source, String message, Object... params) {
+        return new MessageFormatMessage(source, message, params);
     }
 
-    /**
-     * @since 2.6.1
-     */
-    @Override
-    public Message newMessage(final String message, final Object p0, final Object p1) {
-        return new MessageFormatMessage(message, p0, p1);
-    }
-
-    /**
-     * @since 2.6.1
-     */
-    @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2) {
-        return new MessageFormatMessage(message, p0, p1, p2);
-    }
-
-    /**
-     * @since 2.6.1
-     */
-    @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
-        return new MessageFormatMessage(message, p0, p1, p2, p3);
-    }
-
-    /**
-     * @since 2.6.1
-     */
-    @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
-        return new MessageFormatMessage(message, p0, p1, p2, p3, p4);
-    }
-
-    /**
-     * @since 2.6.1
-     */
-    @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
-        return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5);
-    }
-
-    /**
-     * @since 2.6.1
-     */
-    @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6) {
-        return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5, p6);
-    }
-
-    /**
-     * @since 2.6.1
-     */
-    @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
-        return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
-    }
-
-    /**
-     * @since 2.6.1
-     */
-    @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
-        return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
-    }
-
-    /**
-     * @since 2.6.1
-     */
-    @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
-        return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
-    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectArrayMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectArrayMessage.java
@@ -40,6 +40,7 @@ public final class ObjectArrayMessage implements Message {
 
     private transient Object[] array;
     private transient String arrayString;
+    private transient StackTraceElement source;
 
     /**
      * Creates the ObjectMessage.
@@ -48,7 +49,18 @@ public final class ObjectArrayMessage implements Message {
      *            The Object to format.
      */
     public ObjectArrayMessage(final Object... obj) {
+        this(null, obj);
+    }
+
+    /**
+     * Creates the ObjectMessage.
+     *
+     * @param obj
+     *            The Object to format.
+     */
+    public ObjectArrayMessage(final StackTraceElement source, final Object... obj) {
         this.array = obj == null ? EMPTY_OBJECT_ARRAY : obj;
+        this.source = source;
     }
 
     private boolean equalObjectsOrStrings(final Object[] left, final Object[] right) {
@@ -110,6 +122,11 @@ public final class ObjectArrayMessage implements Message {
     @Override
     public Throwable getThrowable() {
         return null;
+    }
+
+    @Override
+    public StackTraceElement getSource() {
+        return source;
     }
 
     @Override

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectMessage.java
@@ -33,6 +33,7 @@ public class ObjectMessage implements Message, StringBuilderFormattable {
 
     private transient Object obj;
     private transient String objectString;
+    private transient StackTraceElement source;
 
     /**
      * Creates the ObjectMessage.
@@ -40,7 +41,17 @@ public class ObjectMessage implements Message, StringBuilderFormattable {
      * @param obj The Object to format.
      */
     public ObjectMessage(final Object obj) {
+        this(null, obj);
+    }
+
+    /**
+     * Creates the ObjectMessage.
+     *
+     * @param obj The Object to format.
+     */
+    public ObjectMessage(final StackTraceElement source, final Object obj) {
         this.obj = obj == null ? "null" : obj;
+        this.source = source;
     }
 
     /**
@@ -145,5 +156,10 @@ public class ObjectMessage implements Message, StringBuilderFormattable {
     @Override
     public Throwable getThrowable() {
         return obj instanceof Throwable ? (Throwable) obj : null;
+    }
+
+    @Override
+    public StackTraceElement getSource() {
+        return source;
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
@@ -78,6 +78,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
     private transient Throwable throwable;
     private int[] indices;
     private int usedCount;
+    private StackTraceElement source;
 
     /**
      * Creates a parameterized message.
@@ -89,9 +90,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      */
     @Deprecated
     public ParameterizedMessage(final String messagePattern, final String[] arguments, final Throwable throwable) {
-        this.argArray = arguments;
-        this.throwable = throwable;
-        init(messagePattern);
+        this(null, messagePattern, arguments, throwable);
     }
 
     /**
@@ -102,6 +101,18 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      * @param throwable A Throwable.
      */
     public ParameterizedMessage(final String messagePattern, final Object[] arguments, final Throwable throwable) {
+        this(null, messagePattern, arguments, throwable);
+    }
+
+    /**
+     * Creates a parameterized message.
+     * @param messagePattern The message "format" string. This will be a String containing "{}" placeholders
+     * where parameters should be substituted.
+     * @param arguments The arguments for substitution.
+     * @param throwable A Throwable.
+     */
+    public ParameterizedMessage(StackTraceElement source, final String messagePattern, final Object[] arguments, final Throwable throwable) {
+        this.source = source;
         this.argArray = arguments;
         this.throwable = throwable;
         init(messagePattern);
@@ -119,8 +130,24 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      * @param arguments      the argument array to be converted.
      */
     public ParameterizedMessage(final String messagePattern, final Object... arguments) {
+        this((StackTraceElement) null, messagePattern, arguments);
+    }
+
+    /**
+     * Constructs a ParameterizedMessage which contains the arguments converted to String as well as an optional
+     * Throwable.
+     *
+     * <p>If the last argument is a Throwable and is NOT used up by a placeholder in the message pattern it is returned
+     * in {@link #getThrowable()} and won't be contained in the created String[].
+     * If it is used up {@link #getThrowable()} will return null even if the last argument was a Throwable!</p>
+     *
+     * @param messagePattern the message pattern that to be checked for placeholders.
+     * @param arguments      the argument array to be converted.
+     */
+    public ParameterizedMessage(final StackTraceElement source, final String messagePattern, final Object... arguments) {
         this.argArray = arguments;
         init(messagePattern);
+        this.source = source;
     }
 
     /**
@@ -129,7 +156,16 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      * @param arg The parameter.
      */
     public ParameterizedMessage(final String messagePattern, final Object arg) {
-        this(messagePattern, new Object[]{arg});
+        this((StackTraceElement) null, messagePattern, new Object[]{arg});
+    }
+
+    /**
+     * Constructor with a pattern and a single parameter.
+     * @param messagePattern The message pattern.
+     * @param arg The parameter.
+     */
+    public ParameterizedMessage(final StackTraceElement source, final String messagePattern, final Object arg) {
+        this(source, messagePattern, new Object[]{arg});
     }
 
     /**
@@ -139,7 +175,17 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      * @param arg1 The second parameter.
      */
     public ParameterizedMessage(final String messagePattern, final Object arg0, final Object arg1) {
-        this(messagePattern, new Object[]{arg0, arg1});
+        this((StackTraceElement) null, messagePattern, new Object[]{arg0, arg1});
+    }
+
+    /**
+     * Constructor with a pattern and two parameters.
+     * @param messagePattern The message pattern.
+     * @param arg0 The first parameter.
+     * @param arg1 The second parameter.
+     */
+    public ParameterizedMessage(final StackTraceElement source, final String messagePattern, final Object arg0, final Object arg1) {
+        this(source, messagePattern, new Object[]{arg0, arg1});
     }
 
     private void init(final String messagePattern) {
@@ -190,6 +236,11 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
     @Override
     public Throwable getThrowable() {
         return throwable;
+    }
+
+    @Override
+    public StackTraceElement getSource() {
+        return source;
     }
 
     /**
@@ -328,7 +379,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
 
     @Override
     public String toString() {
-        return "ParameterizedMessage[messagePattern=" + messagePattern + ", stringArgs=" +
+        return "ParameterizedMessage[source=" + source + ", messagePattern=" + messagePattern + ", stringArgs=" +
                 Arrays.toString(argArray) + ", throwable=" + throwable + ']';
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessageFactory.java
@@ -50,6 +50,106 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
     }
 
     /**
+     * Creates {@link ParameterizedMessage} instances, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message The message pattern.
+     * @param params The message parameters.
+     * @return The Message.
+     *
+     * @see MessageFactory#newMessage(String, Object...)
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object... params) {
+        return new ParameterizedMessage(source, message, params);
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0) {
+        return new ParameterizedMessage(source, message, p0);
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1) {
+        return new ParameterizedMessage(source, message, p0, p1);
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2) {
+        return new ParameterizedMessage(source, message, p0, p1, p2);
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+        return new ParameterizedMessage(source, message, p0, p1, p2, p3);
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+        return new ParameterizedMessage(source, message, p0, p1, p2, p3, p4);
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+        return new ParameterizedMessage(source, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+            final Object p6) {
+        return new ParameterizedMessage(source, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+            final Object p6, final Object p7) {
+        return new ParameterizedMessage(source, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+            final Object p6, final Object p7, final Object p8) {
+        return new ParameterizedMessage(source, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+            final Object p6, final Object p7, final Object p8, final Object p9) {
+        return new ParameterizedMessage(source, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    /**
      * Creates {@link ParameterizedMessage} instances.
      *
      * @param message The message pattern.
@@ -60,7 +160,7 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      */
     @Override
     public Message newMessage(final String message, final Object... params) {
-        return new ParameterizedMessage(message, params);
+        return newMessage((StackTraceElement) null, message, params);
     }
 
     /**
@@ -68,7 +168,7 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      */
     @Override
     public Message newMessage(final String message, final Object p0) {
-        return new ParameterizedMessage(message, p0);
+        return newMessage((StackTraceElement) null, message, p0);
     }
 
     /**
@@ -76,7 +176,7 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1) {
-        return new ParameterizedMessage(message, p0, p1);
+        return newMessage((StackTraceElement) null, message, p0, p1);
     }
 
     /**
@@ -84,7 +184,7 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2) {
-        return new ParameterizedMessage(message, p0, p1, p2);
+        return newMessage((StackTraceElement) null, message, p0, p1, p2);
     }
 
     /**
@@ -92,7 +192,7 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
-        return new ParameterizedMessage(message, p0, p1, p2, p3);
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3);
     }
 
     /**
@@ -100,7 +200,7 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
-        return new ParameterizedMessage(message, p0, p1, p2, p3, p4);
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4);
     }
 
     /**
@@ -108,7 +208,7 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
-        return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5);
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5);
     }
 
     /**
@@ -116,8 +216,8 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6) {
-        return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5, p6);
+                              final Object p6) {
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     /**
@@ -125,8 +225,8 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
-        return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
+                              final Object p6, final Object p7) {
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     /**
@@ -134,8 +234,8 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
-        return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+                              final Object p6, final Object p7, final Object p8) {
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     /**
@@ -143,7 +243,7 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
-        return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+                              final Object p6, final Object p7, final Object p8, final Object p9) {
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedNoReferenceMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedNoReferenceMessageFactory.java
@@ -49,10 +49,16 @@ public final class ParameterizedNoReferenceMessageFactory extends AbstractMessag
         private static final long serialVersionUID = 4199272162767841280L;
         private final String formattedMessage;
         private final Throwable throwable;
+        private final StackTraceElement source;
 
         public StatusMessage(final String formattedMessage, final Throwable throwable) {
+            this(null, formattedMessage, throwable);
+        }
+
+        public StatusMessage(StackTraceElement source,final String formattedMessage, final Throwable throwable) {
             this.formattedMessage = formattedMessage;
             this.throwable = throwable;
+            this.source = source;
         }
 
         @Override
@@ -73,6 +79,11 @@ public final class ParameterizedNoReferenceMessageFactory extends AbstractMessag
         @Override
         public Throwable getThrowable() {
             return throwable;
+        }
+
+        @Override
+        public StackTraceElement getSource() {
+            return source;
         }
     }
 
@@ -99,10 +110,26 @@ public final class ParameterizedNoReferenceMessageFactory extends AbstractMessag
      */
     @Override
     public Message newMessage(final String message, final Object... params) {
+        return newMessage((StackTraceElement) null, message, params);
+    }
+
+    /**
+     * Creates {@link SimpleMessage} instances containing the formatted parameterized message string, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message The message pattern.
+     * @param params The message parameters.
+     * @return The Message.
+     *
+     * @see MessageFactory#newMessage(StackTraceElement, String, Object...)
+     */
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object... params) {
         if (params == null) {
-            return new SimpleMessage(message);
+            return new SimpleMessage(source, message);
         }
-        final ParameterizedMessage msg = new ParameterizedMessage(message, params);
-        return new StatusMessage(msg.getFormattedMessage(), msg.getThrowable());
+        final ParameterizedMessage msg = new ParameterizedMessage(source, message, params);
+        return new StatusMessage(source, msg.getFormattedMessage(), msg.getThrowable());
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessage.java
@@ -52,6 +52,8 @@ public interface ReusableMessage extends Message, StringBuilderFormattable {
      */
     Object[] swapParameters(Object[] emptyReplacement);
 
+    StackTraceElement swapSource(StackTraceElement source);
+
     /**
      * Returns the number of parameters that was used to initialize this reusable message for the current content.
      * <p>

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
@@ -90,10 +90,88 @@ public final class ReusableMessageFactory implements MessageFactory2, Serializab
     }
 
     @Override
-    public Message newMessage(final CharSequence charSequence) {
+    public Message newMessage(final StackTraceElement source, final CharSequence charSequence) {
         final ReusableSimpleMessage result = getSimple();
         result.set(charSequence);
+        result.swapSource(source);
         return result;
+    }
+
+    @Override
+    public Message newMessage(CharSequence charSequence) {
+        return newMessage((StackTraceElement) null, charSequence);
+    }
+
+    /**
+     * Creates {@link ReusableParameterizedMessage} instances, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param message The message pattern.
+     * @param params The message parameters.
+     * @return The Message.
+     *
+     * @see MessageFactory#newMessage(String, Object...)
+     */
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object... params) {
+        return getParameterized().set(source, message, params);
+    }
+
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0) {
+        return getParameterized().set(source, message, p0);
+    }
+
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1) {
+        return getParameterized().set(source, message, p0, p1);
+    }
+
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2) {
+        return getParameterized().set(source, message, p0, p1, p2);
+    }
+
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2,
+            final Object p3) {
+        return getParameterized().set(source, message, p0, p1, p2, p3);
+    }
+
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+            final Object p4) {
+        return getParameterized().set(source, message, p0, p1, p2, p3, p4);
+    }
+
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+            final Object p4, final Object p5) {
+        return getParameterized().set(source, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+            final Object p4, final Object p5, final Object p6) {
+        return getParameterized().set(source, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+            final Object p4, final Object p5, final Object p6, final Object p7) {
+        return getParameterized().set(source, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+        return getParameterized().set(source, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override
+    public Message newMessage(final StackTraceElement source, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
+        return getParameterized().set(source, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
     /**
@@ -107,64 +185,64 @@ public final class ReusableMessageFactory implements MessageFactory2, Serializab
      */
     @Override
     public Message newMessage(final String message, final Object... params) {
-        return getParameterized().set(message, params);
+        return newMessage((StackTraceElement) null, message, params);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0) {
-        return getParameterized().set(message, p0);
+        return newMessage((StackTraceElement) null, message, p0);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1) {
-        return getParameterized().set(message, p0, p1);
+        return newMessage((StackTraceElement) null, message, p0, p1);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2) {
-        return getParameterized().set(message, p0, p1, p2);
+        return newMessage((StackTraceElement) null, message, p0, p1, p2);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3) {
-        return getParameterized().set(message, p0, p1, p2, p3);
+                              final Object p3) {
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4) {
-        return getParameterized().set(message, p0, p1, p2, p3, p4);
+                              final Object p4) {
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
-        return getParameterized().set(message, p0, p1, p2, p3, p4, p5);
+                              final Object p4, final Object p5) {
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
-        return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6);
+                              final Object p4, final Object p5, final Object p6) {
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
-        return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6, p7);
+                              final Object p4, final Object p5, final Object p6, final Object p7) {
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
-        return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+                              final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
-        return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+                              final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
+        return newMessage((StackTraceElement) null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
     /**
@@ -176,12 +254,17 @@ public final class ReusableMessageFactory implements MessageFactory2, Serializab
      * @see MessageFactory#newMessage(String)
      */
     @Override
-    public Message newMessage(final String message) {
+    public Message newMessage(final StackTraceElement source, final String message) {
         final ReusableSimpleMessage result = getSimple();
         result.set(message);
+        result.swapSource(source);
         return result;
     }
 
+    @Override
+    public Message newMessage(String message) {
+        return newMessage((StackTraceElement) null, message);
+    }
 
     /**
      * Creates {@link ReusableObjectMessage} instances.
@@ -192,9 +275,15 @@ public final class ReusableMessageFactory implements MessageFactory2, Serializab
      * @see MessageFactory#newMessage(Object)
      */
     @Override
-    public Message newMessage(final Object message) {
+    public Message newMessage(final StackTraceElement source, final Object message) {
         final ReusableObjectMessage result = getObject();
         result.set(message);
+        result.swapSource(source);
         return result;
+    }
+
+    @Override
+    public Message newMessage(Object message) {
+        return newMessage((StackTraceElement) null, message);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
@@ -28,6 +28,7 @@ public class ReusableObjectMessage implements ReusableMessage, ParameterVisitabl
     private static final long serialVersionUID = 6922476812535519960L;
 
     private transient Object obj;
+    private StackTraceElement source;
 
     public void set(final Object object) {
         this.obj = object;
@@ -112,6 +113,18 @@ public class ReusableObjectMessage implements ReusableMessage, ParameterVisitabl
         return emptyReplacement;
     }
 
+    @Override
+    public StackTraceElement swapSource(StackTraceElement source) {
+        StackTraceElement originalSource = this.source;
+        this.source = source;
+        return originalSource;
+    }
+
+    @Override
+    public StackTraceElement getSource() {
+        return source;
+    }
+
     /**
      * This message has exactly one parameter (the object), so always returns one.
      * @return 1
@@ -134,5 +147,6 @@ public class ReusableObjectMessage implements ReusableMessage, ParameterVisitabl
     @Override
     public void clear() {
         obj = null;
+        source = null;
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
@@ -44,6 +44,7 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
     private transient Object[] varargs;
     private transient Object[] params = new Object[MAX_PARMS];
     private transient Throwable throwable;
+    private transient StackTraceElement source;
     transient boolean reserved = false; // LOG4J2-1583 prevent scrambled logs with nested logging calls
 
     /**
@@ -121,8 +122,9 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return new ParameterizedMessage(messagePattern, getTrimmedParams());
     }
 
-    private void init(final String messagePattern, final int argCount, final Object[] paramArray) {
+    private void init(final StackTraceElement source, final String messagePattern, final int argCount, final Object[] paramArray) {
         this.varargs = null;
+        this.source = source;
         this.messagePattern = messagePattern;
         this.argCount = argCount;
         final int placeholderCount = count(messagePattern, indices);
@@ -147,64 +149,64 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         }
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object... arguments) {
-        init(messagePattern, arguments == null ? 0 : arguments.length, arguments);
+    ReusableParameterizedMessage set(final StackTraceElement source, final String messagePattern, final Object... arguments) {
+        init(source, messagePattern, arguments == null ? 0 : arguments.length, arguments);
         varargs = arguments;
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0) {
+    ReusableParameterizedMessage set(final StackTraceElement source, final String messagePattern, final Object p0) {
         params[0] = p0;
-        init(messagePattern, 1, params);
+        init(source, messagePattern, 1, params);
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1) {
+    ReusableParameterizedMessage set(final StackTraceElement source, final String messagePattern, final Object p0, final Object p1) {
         params[0] = p0;
         params[1] = p1;
-        init(messagePattern, 2, params);
+        init(source, messagePattern, 2, params);
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2) {
+    ReusableParameterizedMessage set(final StackTraceElement source, final String messagePattern, final Object p0, final Object p1, final Object p2) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
-        init(messagePattern, 3, params);
+        init(source, messagePattern, 3, params);
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3) {
+    ReusableParameterizedMessage set(final StackTraceElement source, final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
         params[3] = p3;
-        init(messagePattern, 4, params);
+        init(source, messagePattern, 4, params);
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    ReusableParameterizedMessage set(final StackTraceElement source, final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
         params[3] = p3;
         params[4] = p4;
-        init(messagePattern, 5, params);
+        init(source, messagePattern, 5, params);
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    ReusableParameterizedMessage set(final StackTraceElement source, final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
         params[3] = p3;
         params[4] = p4;
         params[5] = p5;
-        init(messagePattern, 6, params);
+        init(source, messagePattern, 6, params);
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    ReusableParameterizedMessage set(final StackTraceElement source, final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
             final Object p6) {
         params[0] = p0;
         params[1] = p1;
@@ -213,11 +215,11 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         params[4] = p4;
         params[5] = p5;
         params[6] = p6;
-        init(messagePattern, 7, params);
+        init(source, messagePattern, 7, params);
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    ReusableParameterizedMessage set(final StackTraceElement source, final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
             final Object p6, final Object p7) {
         params[0] = p0;
         params[1] = p1;
@@ -227,11 +229,11 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         params[5] = p5;
         params[6] = p6;
         params[7] = p7;
-        init(messagePattern, 8, params);
+        init(source, messagePattern, 8, params);
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    ReusableParameterizedMessage set(final StackTraceElement source, final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
             final Object p6, final Object p7, final Object p8) {
         params[0] = p0;
         params[1] = p1;
@@ -242,11 +244,11 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         params[6] = p6;
         params[7] = p7;
         params[8] = p8;
-        init(messagePattern, 9, params);
+        init(source, messagePattern, 9, params);
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    ReusableParameterizedMessage set(final StackTraceElement source, final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
             final Object p6, final Object p7, final Object p8, final Object p9) {
         params[0] = p0;
         params[1] = p1;
@@ -258,8 +260,68 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         params[7] = p7;
         params[8] = p8;
         params[9] = p9;
-        init(messagePattern, 10, params);
+        init(source, messagePattern, 10, params);
         return this;
+    }
+
+    ReusableParameterizedMessage set(final String messagePattern, final Object... arguments) {
+        return set((StackTraceElement) null, messagePattern, arguments);
+    }
+
+    ReusableParameterizedMessage set(final String messagePattern, final Object p0) {
+        return set((StackTraceElement) null, messagePattern, p0);
+    }
+
+    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1) {
+        return set((StackTraceElement) null, messagePattern, p0, p1);
+    }
+
+    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2) {
+        return set((StackTraceElement) null, messagePattern, p0, p1, p2);
+    }
+
+    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3) {
+        return set((StackTraceElement) null, messagePattern, p0, p1, p2, p3);
+    }
+
+    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+        return set((StackTraceElement) null, messagePattern, p0, p1, p2, p3, p4);
+    }
+
+    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+        return set((StackTraceElement) null, messagePattern, p0, p1, p2, p3, p4, p5);
+    }
+
+    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+                                     final Object p6) {
+        return set((StackTraceElement) null, messagePattern, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+                                     final Object p6, final Object p7) {
+        return set((StackTraceElement) null, messagePattern, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+                                     final Object p6, final Object p7, final Object p8) {
+        return set((StackTraceElement) null, messagePattern, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+                                     final Object p6, final Object p7, final Object p8, final Object p9) {
+        return set((StackTraceElement) null, messagePattern, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override
+    public StackTraceElement getSource() {
+        return source;
+    }
+
+    @Override
+    public StackTraceElement swapSource(StackTraceElement source) {
+        StackTraceElement originalSource = this.source;
+        this.source = source;
+        return originalSource;
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
@@ -27,6 +27,7 @@ public class ReusableSimpleMessage implements ReusableMessage, CharSequence, Par
     private static final long serialVersionUID = -9199974506498249809L;
     private static Object[] EMPTY_PARAMS = new Object[0];
     private CharSequence charSequence;
+    private StackTraceElement source;
 
     public void set(final String message) {
         this.charSequence = message;
@@ -59,6 +60,18 @@ public class ReusableSimpleMessage implements ReusableMessage, CharSequence, Par
     @Override
     public void formatTo(final StringBuilder buffer) {
         buffer.append(charSequence);
+    }
+
+    @Override
+    public StackTraceElement getSource() {
+        return source;
+    }
+
+    @Override
+    public StackTraceElement swapSource(StackTraceElement source) {
+        StackTraceElement originalSource = this.source;
+        this.source = source;
+        return originalSource;
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessage.java
@@ -30,6 +30,7 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
 
     private String message;
     private transient CharSequence charSequence;
+    private StackTraceElement source;
 
     /**
      * Basic constructor.
@@ -43,8 +44,20 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
      * @param message The String message.
      */
     public SimpleMessage(final String message) {
+        this(null, message);
+    }
+
+    /**
+     * Constructor that includes the message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param message The String message.
+     */
+    public SimpleMessage(final StackTraceElement source, final String message) {
         this.message = message;
         this.charSequence = message;
+        this.source = source;
     }
 
     /**
@@ -53,7 +66,20 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
      */
     public SimpleMessage(final CharSequence charSequence) {
         // this.message = String.valueOf(charSequence); // postponed until getFormattedMessage
+        this(null, charSequence);
+    }
+
+    /**
+     * Constructor that includes the message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param charSequence The CharSequence message.
+     */
+    public SimpleMessage(final StackTraceElement source, final CharSequence charSequence) {
+        // this.message = String.valueOf(charSequence); // postponed until getFormattedMessage
         this.charSequence = charSequence;
+        this.source = source;
     }
 
     /**
@@ -149,5 +175,10 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
         charSequence = message;
+    }
+
+    @Override
+    public StackTraceElement getSource() {
+        return source;
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessageFactory.java
@@ -144,4 +144,12 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
             final Object p6, final Object p7, final Object p8, final Object p9) {
         return new SimpleMessage(message);
     }
+
+    /**
+     * @since
+     */
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object... params) {
+        return new SimpleMessage(source, message);
+    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormattedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormattedMessage.java
@@ -22,6 +22,7 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.IllegalFormatException;
 import java.util.Locale;
+import java.util.Objects;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
@@ -49,33 +50,62 @@ public class StringFormattedMessage implements Message {
     private transient String formattedMessage;
     private transient Throwable throwable;
     private final Locale locale;
+    private StackTraceElement source;
     
    /**
-    * Constructs a message.
-    * 
+    * Constructs a message, when the location
+    * of the log statement might be known at compile time.
+    *
+    * @param source the location of the log statement, or null
     * @param locale the locale for this message format
     * @param messagePattern the pattern for this message format
     * @param arguments The objects to format
     * @since 2.6
     */
-    public StringFormattedMessage(final Locale locale, final String messagePattern, final Object... arguments) {
+    public StringFormattedMessage(final StackTraceElement source, final Locale locale, final String messagePattern, final Object... arguments) {
         this.locale = locale;
         this.messagePattern = messagePattern;
         this.argArray = arguments;
         if (arguments != null && arguments.length > 0 && arguments[arguments.length - 1] instanceof Throwable) {
             this.throwable = (Throwable) arguments[arguments.length - 1];
         }
+        this.source = source;
     }
 
     /**
      * Constructs a message.
-     * 
+     *
+     * @param locale the locale for this message format
+     * @param messagePattern the pattern for this message format
+     * @param arguments The objects to format
+     * @since 2.6
+     */
+    public StringFormattedMessage(final Locale locale, final String messagePattern, final Object... arguments) {
+        this(null, locale, messagePattern, arguments);
+    }
+
+    /**
+     * Constructs a message, when the location
+     * of the log statement might be known at compile time.
+     *
+     * @param source the location of the log statement, or null
+     * @param messagePattern the pattern for this message format
+     * @param arguments The objects to format
+     * @since 2.6
+     */
+    public StringFormattedMessage(final StackTraceElement source, final String messagePattern, final Object... arguments) {
+        this(source, Locale.getDefault(Locale.Category.FORMAT), messagePattern, arguments);
+    }
+
+    /**
+     * Constructs a message.
+     *
      * @param messagePattern the pattern for this message format
      * @param arguments The objects to format
      * @since 2.6
      */
     public StringFormattedMessage(final String messagePattern, final Object... arguments) {
-        this(Locale.getDefault(Locale.Category.FORMAT), messagePattern, arguments);
+        this(null, Locale.getDefault(Locale.Category.FORMAT), messagePattern, arguments);
     }
 
     /**
@@ -111,6 +141,11 @@ public class StringFormattedMessage implements Message {
         return stringArgs;
     }
 
+    @Override
+    public StackTraceElement getSource() {
+        return source;
+    }
+
     protected String formatMessage(final String msgPattern, final Object... args) {
         try {
             return String.format(locale, msgPattern, args);
@@ -131,7 +166,7 @@ public class StringFormattedMessage implements Message {
 
         final StringFormattedMessage that = (StringFormattedMessage) o;
 
-        if (messagePattern != null ? !messagePattern.equals(that.messagePattern) : that.messagePattern != null) {
+        if (!Objects.equals(messagePattern, that.messagePattern) || !Objects.equals(source, that.source)) {
             return false;
         }
 
@@ -140,8 +175,9 @@ public class StringFormattedMessage implements Message {
 
     @Override
     public int hashCode() {
-        int result = messagePattern != null ? messagePattern.hashCode() : 0;
+        int result = Objects.hashCode(messagePattern);
         result = HASHVAL * result + (stringArgs != null ? Arrays.hashCode(stringArgs) : 0);
+        result = HASHVAL * result + Objects.hashCode(source);
         return result;
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormatterMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormatterMessageFactory.java
@@ -145,4 +145,9 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
             final Object p6, final Object p7, final Object p8, final Object p9) {
         return new StringFormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object... params) {
+        return new StringFormattedMessage(source, message, params);
+    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StringMapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StringMapMessage.java
@@ -39,6 +39,10 @@ public class StringMapMessage extends MapMessage<StringMapMessage, String> {
         super();
     }
 
+    public StringMapMessage(final StackTraceElement source) {
+        super(source);
+    }
+
     /**
      * Constructs a new instance.
      * 
@@ -46,7 +50,11 @@ public class StringMapMessage extends MapMessage<StringMapMessage, String> {
      *            the initial capacity.
      */
     public StringMapMessage(final int initialCapacity) {
-        super(initialCapacity);
+        this(null, initialCapacity);
+    }
+
+    public StringMapMessage(final StackTraceElement source, final int initialCapacity) {
+        super(source, initialCapacity);
     }
 
     /**
@@ -56,7 +64,11 @@ public class StringMapMessage extends MapMessage<StringMapMessage, String> {
      *            The Map.
      */
     public StringMapMessage(final Map<String, String> map) {
-        super(map);
+        this(null, map);
+    }
+
+    public StringMapMessage(StackTraceElement source, final Map<String, String> map) {
+        super(source, map);
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataCollectionMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataCollectionMessage.java
@@ -99,4 +99,15 @@ public class StructuredDataCollectionMessage implements StringBuilderFormattable
         }
         return null;
     }
+
+    @Override
+    public StackTraceElement getSource() {
+        for (StructuredDataMessage msg : structuredDataMessageList) {
+            StackTraceElement t = msg.getSource();
+            if (t != null) {
+                return t;
+            }
+        }
+        return null;
+    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
@@ -69,6 +69,16 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
     }
 
     /**
+     * Creates a StructuredDataMessage using an ID (max 32 characters), message, and type (max 32 characters).
+     * @param id The String id.
+     * @param msg The message.
+     * @param type The message type.
+     */
+    public StructuredDataMessage(final String id, final String msg, final String type, StackTraceElement source) {
+        this(id, msg, type, MAX_LENGTH, source);
+    }
+
+    /**
      * Creates a StructuredDataMessage using an ID (user specified max characters), message, and type (user specified
      * maximum number of characters).
      * @param id The String id.
@@ -83,7 +93,24 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
         this.type = type;
         this.maxLength = maxLength;
     }
-    
+
+    /**
+     * Creates a StructuredDataMessage using an ID (user specified max characters), message, and type (user specified
+     * maximum number of characters).
+     * @param id The String id.
+     * @param msg The message.
+     * @param type The message type.
+     * @param maxLength The maximum length of keys;
+     * @since 2.9
+     */
+    public StructuredDataMessage(final String id, final String msg, final String type, final int maxLength, final StackTraceElement source) {
+        super(source);
+        this.id = new StructuredDataId(id, null, null, maxLength);
+        this.message = msg;
+        this.type = type;
+        this.maxLength = maxLength;
+    }
+
     /**
      * Creates a StructuredDataMessage using an ID (max 32 characters), message, type (max 32 characters), and an
      * initial map of structured data to include.
@@ -95,6 +122,19 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
     public StructuredDataMessage(final String id, final String msg, final String type,
                                  final Map<String, String> data) {
         this(id, msg, type, data, MAX_LENGTH);
+    }
+
+    /**
+     * Creates a StructuredDataMessage using an ID (max 32 characters), message, type (max 32 characters), and an
+     * initial map of structured data to include.
+     * @param id The String id.
+     * @param msg The message.
+     * @param type The message type.
+     * @param data The StructuredData map.
+     */
+    public StructuredDataMessage(final String id, final String msg, final String type,
+                                 final Map<String, String> data, StackTraceElement source) {
+        this(id, msg, type, data, MAX_LENGTH, source);
     }
 
     /**
@@ -117,6 +157,25 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
     }
 
     /**
+     * Creates a StructuredDataMessage using an (user specified max characters), message, and type (user specified
+     * maximum number of characters, and an initial map of structured data to include.
+     * @param id The String id.
+     * @param msg The message.
+     * @param type The message type.
+     * @param data The StructuredData map.
+     * @param maxLength The maximum length of keys;
+     * @since 2.9
+     */
+    public StructuredDataMessage(final String id, final String msg, final String type,
+                                 final Map<String, String> data, final int maxLength, StackTraceElement source) {
+        super(source, data);
+        this.id = new StructuredDataId(id, null, null, maxLength);
+        this.message = msg;
+        this.type = type;
+        this.maxLength = maxLength;
+    }
+
+    /**
      * Creates a StructuredDataMessage using a StructuredDataId, message, and type (max 32 characters).
      * @param id The StructuredDataId.
      * @param msg The message.
@@ -131,10 +190,36 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param id The StructuredDataId.
      * @param msg The message.
      * @param type The message type.
+     */
+    public StructuredDataMessage(final StructuredDataId id, final String msg, final String type, StackTraceElement source) {
+        this(id, msg, type, MAX_LENGTH, source);
+    }
+
+    /**
+     * Creates a StructuredDataMessage using a StructuredDataId, message, and type (max 32 characters).
+     * @param id The StructuredDataId.
+     * @param msg The message.
+     * @param type The message type.
      * @param maxLength The maximum length of keys;
      * @since 2.9
      */
     public StructuredDataMessage(final StructuredDataId id, final String msg, final String type, final int maxLength) {
+        this.id = id;
+        this.message = msg;
+        this.type = type;
+        this.maxLength = maxLength;
+    }
+
+    /**
+     * Creates a StructuredDataMessage using a StructuredDataId, message, and type (max 32 characters).
+     * @param id The StructuredDataId.
+     * @param msg The message.
+     * @param type The message type.
+     * @param maxLength The maximum length of keys;
+     * @since 2.9
+     */
+    public StructuredDataMessage(final StructuredDataId id, final String msg, final String type, final int maxLength, StackTraceElement source) {
+        super(source);
         this.id = id;
         this.message = msg;
         this.type = type;
@@ -161,12 +246,44 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param msg The message.
      * @param type The message type.
      * @param data The StructuredData map.
+     */
+    public StructuredDataMessage(final StructuredDataId id, final String msg, final String type,
+                                 final Map<String, String> data, StackTraceElement source) {
+        this(id, msg, type, data, MAX_LENGTH, source);
+    }
+
+    /**
+     * Creates a StructuredDataMessage using a StructuredDataId, message, type (max 32 characters), and an initial map
+     * of structured data to include.
+     * @param id The StructuredDataId.
+     * @param msg The message.
+     * @param type The message type.
+     * @param data The StructuredData map.
      * @param maxLength The maximum length of keys;
      * @since 2.9
      */
     public StructuredDataMessage(final StructuredDataId id, final String msg, final String type,
                                  final Map<String, String> data, final int maxLength) {
         super(data);
+        this.id = id;
+        this.message = msg;
+        this.type = type;
+        this.maxLength = maxLength;
+    }
+
+    /**
+     * Creates a StructuredDataMessage using a StructuredDataId, message, type (max 32 characters), and an initial map
+     * of structured data to include.
+     * @param id The StructuredDataId.
+     * @param msg The message.
+     * @param type The message type.
+     * @param data The StructuredData map.
+     * @param maxLength The maximum length of keys;
+     * @since 2.9
+     */
+    public StructuredDataMessage(final StructuredDataId id, final String msg, final String type,
+                                 final Map<String, String> data, final int maxLength, StackTraceElement source) {
+        super(source, data);
         this.id = id;
         this.message = msg;
         this.type = type;
@@ -181,6 +298,19 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      */
     private StructuredDataMessage(final StructuredDataMessage msg, final Map<String, String> map) {
         super(map);
+        this.id = msg.id;
+        this.message = msg.message;
+        this.type = msg.type;
+        this.maxLength = MAX_LENGTH;
+    }
+
+    /**
+     * Constructor based on a StructuredDataMessage.
+     * @param msg The StructuredDataMessage.
+     * @param map The StructuredData map.
+     */
+    private StructuredDataMessage(final StructuredDataMessage msg, final Map<String, String> map, StackTraceElement source) {
+        super(source, map);
         this.id = msg.id;
         this.message = msg.message;
         this.type = msg.type;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadDumpMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadDumpMessage.java
@@ -40,17 +40,28 @@ public class ThreadDumpMessage implements Message, StringBuilderFormattable {
     private volatile Map<ThreadInformation, StackTraceElement[]> threads;
     private final String title;
     private String formattedMessage;
+    private StackTraceElement source;
 
     /**
      * Generate a ThreadDumpMessage with a title.
      * @param title The title.
      */
     public ThreadDumpMessage(final String title) {
+        this((StackTraceElement) null, title);
+    }
+
+    public ThreadDumpMessage(StackTraceElement source, final String title) {
         this.title = title == null ? Strings.EMPTY : title;
         threads = getFactory().createThreadInfo();
+        this.source = source;
     }
 
     private ThreadDumpMessage(final String formattedMsg, final String title) {
+        this(null, formattedMsg, title);
+    }
+
+    private ThreadDumpMessage(StackTraceElement source, final String formattedMsg, final String title) {
+        this.source = source;
         this.formattedMessage = formattedMsg;
         this.title = title == null ? Strings.EMPTY : title;
     }
@@ -191,6 +202,11 @@ public class ThreadDumpMessage implements Message, StringBuilderFormattable {
             }
             return threads;
         }
+    }
+
+    @Override
+    public StackTraceElement getSource() {
+        return source;
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -173,7 +173,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void catching(final Level level, final Throwable t) {
-        catching(FQCN, level, t);
+        catching(null, FQCN, level, t);
+    }
+
+    @Override
+    public void catching(StackTraceElement source, Level level, Throwable t) {
+        catching(source, FQCN, level, t);
     }
 
     /**
@@ -183,21 +188,26 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param level The logging level.
      * @param t The Throwable.
      */
-    protected void catching(final String fqcn, final Level level, final Throwable t) {
+    protected void catching(final StackTraceElement source, final String fqcn, final Level level, final Throwable t) {
         if (isEnabled(level, CATCHING_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, level, CATCHING_MARKER, catchingMsg(t), t);
+            logMessageSafely(fqcn, level, CATCHING_MARKER, catchingMsg(source, t), t);
         }
     }
 
     @Override
     public void catching(final Throwable t) {
+        catching((StackTraceElement) null, t);
+    }
+
+    @Override
+    public void catching(StackTraceElement source, Throwable t) {
         if (isEnabled(Level.ERROR, CATCHING_MARKER, (Object) null, null)) {
-            logMessageSafely(FQCN, Level.ERROR, CATCHING_MARKER, catchingMsg(t), t);
+            logMessageSafely(FQCN, Level.ERROR, CATCHING_MARKER, catchingMsg(source, t), t);
         }
     }
 
-    protected Message catchingMsg(final Throwable t) {
-        return messageFactory.newMessage(CATCHING);
+    protected Message catchingMsg(final StackTraceElement source, final Throwable t) {
+        return messageFactory.newMessage(source, CATCHING);
     }
 
     private static Class<? extends MessageFactory> createClassForProperty(final String property,
@@ -514,10 +524,10 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param format Format String for the parameters.
      * @param paramSuppliers The Suppliers of the parameters.
      */
-    protected EntryMessage enter(final String fqcn, final String format, final Supplier<?>... paramSuppliers) {
+    protected EntryMessage enter(final StackTraceElement source, final String fqcn, final String format, final Supplier<?>... paramSuppliers) {
         EntryMessage entryMsg = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg = entryMsg(format, paramSuppliers), null);
+            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg = entryMsg(source, format, paramSuppliers), null);
         }
         return entryMsg;
     }
@@ -530,10 +540,10 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param paramSuppliers The parameters to the method.
      */
     @Deprecated
-    protected EntryMessage enter(final String fqcn, final String format, final MessageSupplier... paramSuppliers) {
+    protected EntryMessage enter(final StackTraceElement source, final String fqcn, final String format, final MessageSupplier... paramSuppliers) {
         EntryMessage entryMsg = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg = entryMsg(format, paramSuppliers), null);
+            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg = entryMsg(source, format, paramSuppliers), null);
         }
         return entryMsg;
     }
@@ -545,10 +555,10 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param format The format String for the parameters.
      * @param params The parameters to the method.
      */
-    protected EntryMessage enter(final String fqcn, final String format, final Object... params) {
+    protected EntryMessage enter(final StackTraceElement source, final String fqcn, final String format, final Object... params) {
         EntryMessage entryMsg = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg = entryMsg(format, params), null);
+            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg = entryMsg(source, format, params), null);
         }
         return entryMsg;
     }
@@ -563,8 +573,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     protected EntryMessage enter(final String fqcn, final MessageSupplier msgSupplier) {
         EntryMessage message = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, message = flowMessageFactory.newEntryMessage(
-                    msgSupplier.get()), null);
+            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, message = flowMessageFactory.newEntryMessage(null, msgSupplier.get()), null);
         }
         return message;
     }
@@ -578,10 +587,10 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      *            the Message.
      * @since 2.6
      */
-    protected EntryMessage enter(final String fqcn, final Message message) {
+    protected EntryMessage enter(final StackTraceElement source, final String fqcn, final Message message) {
         EntryMessage flowMessage = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, flowMessage = flowMessageFactory.newEntryMessage(message),
+            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, flowMessage = flowMessageFactory.newEntryMessage(source, message),
                     null);
         }
         return flowMessage;
@@ -590,12 +599,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     @Deprecated
     @Override
     public void entry() {
-        entry(FQCN, (Object[]) null);
+        entry(null, FQCN, (Object[]) null);
     }
 
     @Override
     public void entry(final Object... params) {
-        entry(FQCN, params);
+        entry(null, FQCN, params);
     }
 
     /**
@@ -604,26 +613,26 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param fqcn The fully qualified class name of the <b>caller</b>.
      * @param params The parameters to the method.
      */
-    protected void entry(final String fqcn, final Object... params) {
+    protected void entry(final StackTraceElement source, final String fqcn, final Object... params) {
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
             if (params == null) {
-                logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg(null, (Supplier<?>[]) null), null);
+                logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg(source, null, (Supplier<?>[]) null), null);
             } else {
-                logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg(null, params), null);
+                logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg(source, null, params), null);
             }
         }
     }
 
-    protected EntryMessage entryMsg(final String format, final Object... params) {
+    protected EntryMessage entryMsg(final StackTraceElement source, final String format, final Object... params) {
         final int count = params == null ? 0 : params.length;
         if (count == 0) {
             if (Strings.isEmpty(format)) {
-                return flowMessageFactory.newEntryMessage(null);
+                return flowMessageFactory.newEntryMessage(source, null);
             }
-            return flowMessageFactory.newEntryMessage(new SimpleMessage(format));
+            return flowMessageFactory.newEntryMessage(source, new SimpleMessage(format));
         }
         if (format != null) {
-            return flowMessageFactory.newEntryMessage(new ParameterizedMessage(format, params));
+            return flowMessageFactory.newEntryMessage(source, new ParameterizedMessage(format, params));
         }
         final StringBuilder sb = new StringBuilder();
         sb.append("params(");
@@ -635,20 +644,20 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
             sb.append(parm instanceof Message ? ((Message) parm).getFormattedMessage() : String.valueOf(parm));
         }
         sb.append(')');
-        return flowMessageFactory.newEntryMessage(new SimpleMessage(sb));
+        return flowMessageFactory.newEntryMessage(source, new SimpleMessage(sb));
     }
 
-    protected EntryMessage entryMsg(final String format, final MessageSupplier... paramSuppliers) {
+    protected EntryMessage entryMsg(final StackTraceElement source, final String format, final MessageSupplier... paramSuppliers) {
         final int count = paramSuppliers == null ? 0 : paramSuppliers.length;
         final Object[] params = new Object[count];
         for (int i = 0; i < count; i++) {
             params[i] = paramSuppliers[i].get();
             params[i] = params[i] != null ? ((Message) params[i]).getFormattedMessage() : null;
         }
-        return entryMsg(format, params);
+        return entryMsg(source, format, params);
     }
 
-    protected EntryMessage entryMsg(final String format, final Supplier<?>... paramSuppliers) {
+    protected EntryMessage entryMsg(final StackTraceElement source, final String format, final Supplier<?>... paramSuppliers) {
         final int count = paramSuppliers == null ? 0 : paramSuppliers.length;
         final Object[] params = new Object[count];
         for (int i = 0; i < count; i++) {
@@ -657,7 +666,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
                 params[i] = ((Message) params[i]).getFormattedMessage();
             }
         }
-        return entryMsg(format, params);
+        return entryMsg(source, format, params);
     }
 
     @Override
@@ -920,26 +929,27 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     @Deprecated
     @Override
     public void exit() {
-        exit(FQCN, (Object) null);
+        exit(null, FQCN, (Object) null);
     }
 
     @Deprecated
     @Override
     public <R> R exit(final R result) {
-        return exit(FQCN, result);
+        return exit(null, FQCN, result);
     }
 
     /**
      * Logs exiting from a method with the result and location information.
      *
+     * @param source The location of the log statement if known at comile time.
      * @param fqcn The fully qualified class name of the <b>caller</b>.
      * @param <R> The type of the parameter and object being returned.
      * @param result The result being returned from the method call.
      * @return the return value passed to this method.
      */
-    protected <R> R exit(final String fqcn, final R result) {
+    protected <R> R exit(final StackTraceElement source, final String fqcn, final R result) {
         if (isEnabled(Level.TRACE, EXIT_MARKER, (CharSequence) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, EXIT_MARKER, exitMsg(null, result), null);
+            logMessageSafely(fqcn, Level.TRACE, EXIT_MARKER, exitMsg(source, null, result), null);
         }
         return result;
     }
@@ -947,29 +957,30 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     /**
      * Logs exiting from a method with the result and location information.
      *
+     * @param source The location of the log statement if known at comile time.
      * @param fqcn The fully qualified class name of the <b>caller</b>.
      * @param <R> The type of the parameter and object being returned.
      * @param result The result being returned from the method call.
      * @return the return value passed to this method.
      */
-    protected <R> R exit(final String fqcn, final String format, final R result) {
+    protected <R> R exit(final StackTraceElement source, final String fqcn, final String format, final R result) {
         if (isEnabled(Level.TRACE, EXIT_MARKER, (CharSequence) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, EXIT_MARKER, exitMsg(format, result), null);
+            logMessageSafely(fqcn, Level.TRACE, EXIT_MARKER, exitMsg(source, format, result), null);
         }
         return result;
     }
 
-    protected Message exitMsg(final String format, final Object result) {
+    protected Message exitMsg(final StackTraceElement source, final String format, final Object result) {
         if (result == null) {
             if (format == null) {
-                return messageFactory.newMessage("Exit");
+                return messageFactory.newMessage(source, "Exit");
             }
-            return messageFactory.newMessage("Exit: " + format);
+            return messageFactory.newMessage(source, "Exit: " + format);
         }
         if (format == null) {
-            return messageFactory.newMessage("Exit with(" + result + ')');
+            return messageFactory.newMessage(source, "Exit with(" + result + ')');
         }
-        return messageFactory.newMessage("Exit: " + format, result);
+        return messageFactory.newMessage(source, "Exit: " + format, result);
 
     }
 
@@ -2230,12 +2241,22 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public <T extends Throwable> T throwing(final T t) {
-        return throwing(FQCN, Level.ERROR, t);
+        return throwing((StackTraceElement) null, t);
+    }
+
+    @Override
+    public <T extends Throwable> T throwing(StackTraceElement source, T t) {
+        return throwing(source, FQCN, Level.ERROR, t);
     }
 
     @Override
     public <T extends Throwable> T throwing(final Level level, final T t) {
-        return throwing(FQCN, level, t);
+        return throwing((StackTraceElement) null, level, t);
+    }
+
+    @Override
+    public <T extends Throwable> T throwing(StackTraceElement source, Level level, T t) {
+        return throwing(source, FQCN, level, t);
     }
 
     /**
@@ -2247,15 +2268,15 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param t The Throwable.
      * @return the Throwable.
      */
-    protected <T extends Throwable> T throwing(final String fqcn, final Level level, final T t) {
+    protected <T extends Throwable> T throwing(final StackTraceElement source, final String fqcn, final Level level, final T t) {
         if (isEnabled(level, THROWING_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, level, THROWING_MARKER, throwingMsg(t), t);
+            logMessageSafely(fqcn, level, THROWING_MARKER, throwingMsg(source, t), t);
         }
         return t;
     }
 
-    protected Message throwingMsg(final Throwable t) {
-        return messageFactory.newMessage(THROWING);
+    protected Message throwingMsg(final StackTraceElement source, final Throwable t) {
+        return messageFactory.newMessage(source, THROWING);
     }
 
     @Override
@@ -2515,66 +2536,121 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public EntryMessage traceEntry() {
-        return enter(FQCN, null, (Object[]) null);
+        return traceEntry((StackTraceElement) null);
+    }
+
+    @Override
+    public EntryMessage traceEntry(final StackTraceElement source) {
+        return enter(source, FQCN, null, (Object[]) null);
     }
 
     @Override
     public EntryMessage traceEntry(final String format, final Object... params) {
-        return enter(FQCN, format, params);
+        return traceEntry(null, format, params);
+    }
+
+    @Override
+    public EntryMessage traceEntry(final StackTraceElement source, final String format, final Object... params) {
+        return enter(source, FQCN, format, params);
     }
 
     @Override
     public EntryMessage traceEntry(final Supplier<?>... paramSuppliers) {
-        return enter(FQCN, null, paramSuppliers);
+        return traceEntry(null, null, paramSuppliers);
+    }
+
+    @Override
+    public EntryMessage traceEntry(final StackTraceElement source, final Supplier<?>... paramSuppliers) {
+        return enter(source, FQCN, null, paramSuppliers);
     }
 
     @Override
     public EntryMessage traceEntry(final String format, final Supplier<?>... paramSuppliers) {
-        return enter(FQCN, format, paramSuppliers);
+        return traceEntry(null, format, paramSuppliers);
+    }
+
+    @Override
+    public EntryMessage traceEntry(final StackTraceElement source, final String format, final Supplier<?>... paramSuppliers) {
+        return enter(source, FQCN, format, paramSuppliers);
     }
 
     @Override
     public EntryMessage traceEntry(final Message message) {
-        return enter(FQCN, message);
+        return traceEntry(null, message);
+    }
+
+    @Override
+    public EntryMessage traceEntry(final StackTraceElement source, final Message message) {
+        return enter(source, FQCN, message);
     }
 
     @Override
     public void traceExit() {
-        exit(FQCN, null, null);
+        traceExit((StackTraceElement) null);
+    }
+
+    @Override
+    public void traceExit(final StackTraceElement source) {
+        exit(source, FQCN, null, null);
     }
 
     @Override
     public <R> R traceExit(final R result) {
-        return exit(FQCN, null, result);
+        return traceExit((StackTraceElement) null, result);
+    }
+
+    @Override
+    public <R> R traceExit(final StackTraceElement source, final R result) {
+        return exit(source, FQCN, null, result);
     }
 
     @Override
     public <R> R traceExit(final String format, final R result) {
-        return exit(FQCN, format, result);
+        return traceExit(null, format, result);
+    }
+
+    @Override
+    public <R> R traceExit(final StackTraceElement source, final String format, final R result) {
+        return exit(source, FQCN, format, result);
     }
 
     @Override
     public void traceExit(final EntryMessage message) {
+        traceExit((StackTraceElement) null, message);
+    }
+
+    @Override
+    public void traceExit(final StackTraceElement source, final EntryMessage message) {
         // If the message is null, traceEnter returned null because flow logging was disabled, we can optimize out calling isEnabled().
         if (message != null && isEnabled(Level.TRACE, EXIT_MARKER, message, null)) {
-            logMessageSafely(FQCN, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(message), null);
+            logMessageSafely(FQCN, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(source, message), null);
         }
     }
 
     @Override
     public <R> R traceExit(final EntryMessage message, final R result) {
+        return traceExit(null, message, result);
+    }
+
+    @Override
+    public <R> R traceExit(final StackTraceElement source, final EntryMessage message, final R result) {
         // If the message is null, traceEnter returned null because flow logging was disabled, we can optimize out calling isEnabled().
         if (message != null && isEnabled(Level.TRACE, EXIT_MARKER, message, null)) {
-            logMessageSafely(FQCN, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(result, message), null);
+            logMessageSafely(FQCN, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(source, result, message), null);
         }
         return result;
     }
 
     @Override
     public <R> R traceExit(final Message message, final R result) {
+        return traceExit(null, message, result);
+    }
+
+    @Override
+    public <R> R traceExit(final StackTraceElement source, final Message message, final R result) {
         // If the message is null, traceEnter returned null because flow logging was disabled, we can optimize out calling isEnabled().
         if (message != null && isEnabled(Level.TRACE, EXIT_MARKER, message, null)) {
-            logMessageSafely(FQCN, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(result, message), null);
+            logMessageSafely(FQCN, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(source, result, message), null);
         }
         return result;
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/MessageFactory2Adapter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/MessageFactory2Adapter.java
@@ -115,4 +115,74 @@ public class MessageFactory2Adapter implements MessageFactory2 {
     public Message newMessage(final String message, final Object... params) {
         return wrapped.newMessage(message, params);
     }
+
+    @Override
+    public Message newMessage(StackTraceElement source, CharSequence charSequence) {
+        return wrapped.newMessage(source, charSequence);
+    }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object p0) {
+        return wrapped.newMessage(source, message, p0);
+    }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object p0, Object p1) {
+        return wrapped.newMessage(source, message, p0, p1);
+    }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2) {
+        return wrapped.newMessage(source, message, p0, p1, p2);
+    }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3) {
+        return wrapped.newMessage(source, message, p0, p1, p2, p3);
+    }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        return wrapped.newMessage(source, message, p0, p1, p2, p3, p4);
+    }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        return wrapped.newMessage(source, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        return wrapped.newMessage(source, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {
+        return wrapped.newMessage(source, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7, Object p8) {
+        return wrapped.newMessage(source, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7, Object p8, Object p9) {
+        return wrapped.newMessage(source, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override
+    public Message newMessage(StackTraceElement source, Object message) {
+        return wrapped.newMessage(source, message);
+    }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message) {
+        return wrapped.newMessage(source, message);
+    }
+
+    @Override
+    public Message newMessage(StackTraceElement source, String message, Object... params) {
+        return wrapped.newMessage(source, message, params);
+    }
 }

--- a/log4j-api/src/test/java/org/apache/logging/log4j/AbstractLoggerTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/AbstractLoggerTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import org.apache.logging.log4j.message.*;
 import org.apache.logging.log4j.junit.StatusLoggerRule;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ObjectMessage;
@@ -978,6 +979,11 @@ public class AbstractLoggerTest {
         interface FormattedMessageSupplier {
             String getFormattedMessage();
         }
+
+        @Override
+        public StackTraceElement getSource() {
+            return null;
+        }
     }
 
     private static class CountingLogger extends AbstractLogger {
@@ -1347,6 +1353,11 @@ public class AbstractLoggerTest {
         @Override
         public Throwable getThrowable() {
             return throwable;
+        }
+
+        @Override
+        public StackTraceElement getSource() {
+            return null;
         }
     }
 }

--- a/log4j-api/src/test/java/org/apache/logging/log4j/message/JsonMessage.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/message/JsonMessage.java
@@ -28,6 +28,7 @@ public class JsonMessage implements Message {
 
     private static final long serialVersionUID = 1L;
     private static final ObjectMapper mapper = new ObjectMapper();
+    private final StackTraceElement source;
     private final Object object;
 
     /**
@@ -35,7 +36,18 @@ public class JsonMessage implements Message {
      *
      * @param object the Object to serialize.
      */
-    public JsonMessage(final Object object) {
+    public JsonMessage(Object object) {
+        this(null, object);
+    }
+
+    /**
+     * Constructs a JsonMessage.
+     *
+     * @param source the location of the log statement.
+     * @param object the Object to serialize.
+     */
+    public JsonMessage(final StackTraceElement source, final Object object) {
+        this.source = source;
         this.object = object;
     }
 
@@ -62,5 +74,10 @@ public class JsonMessage implements Message {
     @Override
     public Throwable getThrowable() {
         return null;
+    }
+
+    @Override
+    public StackTraceElement getSource() {
+        return source;
     }
 }

--- a/log4j-api/src/test/java/org/apache/logging/log4j/message/StringFormattedMessageTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/message/StringFormattedMessageTest.java
@@ -115,7 +115,7 @@ public class StringFormattedMessageTest {
     }
 
     @Test
-    public void testSerialization() throws IOException, ClassNotFoundException {
+    public void testSerializationWithoutSource() throws IOException, ClassNotFoundException {
         final StringFormattedMessage expected = new StringFormattedMessage("Msg", "a", "b", "c");
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (final ObjectOutputStream out = new ObjectOutputStream(baos)) {
@@ -128,5 +128,24 @@ public class StringFormattedMessageTest {
         Assert.assertEquals(expected.getFormat(), actual.getFormat());
         Assert.assertEquals(expected.getFormattedMessage(), actual.getFormattedMessage());
         Assert.assertArrayEquals(expected.getParameters(), actual.getParameters());
+        Assert.assertEquals(expected.getSource(), actual.getSource());
+    }
+
+    @Test
+    public void testSerializationWithSource() throws IOException, ClassNotFoundException {
+        final StackTraceElement source = new StackTraceElement("class", "method", "file", 55);
+        final StringFormattedMessage expected = new StringFormattedMessage(source, "Msg", "a", "b", "c");
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (final ObjectOutputStream out = new ObjectOutputStream(baos)) {
+            out.writeObject(expected);
+        }
+        final ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        final ObjectInputStream in = new ObjectInputStream(bais);
+        final StringFormattedMessage actual = (StringFormattedMessage) in.readObject();
+        Assert.assertEquals(expected, actual);
+        Assert.assertEquals(expected.getFormat(), actual.getFormat());
+        Assert.assertEquals(expected.getFormattedMessage(), actual.getFormattedMessage());
+        Assert.assertArrayEquals(expected.getParameters(), actual.getParameters());
+        Assert.assertEquals(expected.getSource(), actual.getSource());
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLogger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLogger.java
@@ -286,7 +286,7 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
                 ThreadContext.getImmutableStack(), //
 
                 // location (expensive to calculate)
-                calcLocationIfRequested(fqcn), //
+                calcLocationIfRequested(fqcn, message), //
                 CLOCK, //
                 nanoClock //
         );
@@ -305,11 +305,14 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
      * @param fqcn fully qualified caller name.
      * @return the caller location if requested, {@code null} otherwise.
      */
-    private StackTraceElement calcLocationIfRequested(final String fqcn) {
+    private StackTraceElement calcLocationIfRequested(final String fqcn, final Message message) {
         // location: very expensive operation. LOG4J2-153:
         // Only include if "includeLocation=true" is specified,
         // exclude if not specified or if "false" was specified.
-        return includeLocation ? StackLocatorUtil.calcLocation(fqcn) : null;
+        StackTraceElement messageSource = message.getSource();
+        return messageSource == null ?
+                (includeLocation ? StackLocatorUtil.calcLocation(fqcn) : null) :
+                messageSource;
     }
 
     /**
@@ -341,7 +344,7 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
         // calls the translateTo method on this AsyncLogger
         if (!disruptor.getRingBuffer().tryPublishEvent(this,
                 this, // asyncLogger: 0
-                (location = calcLocationIfRequested(fqcn)), // location: 1
+                (location = calcLocationIfRequested(fqcn, message)), // location: 1
                 fqcn, // 2
                 level, // 3
                 marker, // 4

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
@@ -265,6 +265,13 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
         return result;
     }
 
+    @Override
+    public StackTraceElement swapSource(StackTraceElement source) {
+        StackTraceElement original = this.location;
+        this.location = source;
+        return original;
+    }
+
     /*
      * @see ReusableMessage#getParameterCount
      */
@@ -285,7 +292,7 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
     @Override
     public Message memento() {
         if (message == null) {
-            message = new MementoMessage(String.valueOf(messageText), messageFormat, getParameters());
+            message = new MementoMessage(getSource(), String.valueOf(messageText), messageFormat, getParameters());
         }
         return message;
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
@@ -401,12 +401,12 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
                     String[] sources = parseConfigLocations(configLocationStr);
                     if (sources.length > 1) {
                         final List<AbstractConfiguration> configs = new ArrayList<>();
-                        for (final String sourceLocation : sources) {
-                            final Configuration config = getConfiguration(loggerContext, sourceLocation.trim());
+                        for (final String StackTraceElement : sources) {
+                            final Configuration config = getConfiguration(loggerContext, StackTraceElement.trim());
                             if (config != null && config instanceof AbstractConfiguration) {
                                 configs.add((AbstractConfiguration) config);
                             } else {
-                                LOGGER.error("Failed to created configuration at {}", sourceLocation);
+                                LOGGER.error("Failed to created configuration at {}", StackTraceElement);
                                 return null;
                             }
                         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jLogEvent.java
@@ -562,7 +562,7 @@ public class Log4jLogEvent implements LogEvent {
     }
 
     public void makeMessageImmutable() {
-        message = new MementoMessage(message.getFormattedMessage(), message.getFormat(), message.getParameters());
+        message = new MementoMessage(source, message.getFormattedMessage(), message.getFormat(), message.getParameters());
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MementoMessage.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MementoMessage.java
@@ -35,11 +35,13 @@ public final class MementoMessage implements Message, StringBuilderFormattable {
     private final String formattedMessage;
     private final String format;
     private final Object[] parameters;
+    private final StackTraceElement source;
 
-    public MementoMessage(final String formattedMessage, final String format, final Object[] parameters) {
+    public MementoMessage(final StackTraceElement source, final String formattedMessage, final String format, final Object[] parameters) {
         this.formattedMessage = formattedMessage;
         this.format = format;
         this.parameters = parameters;
+        this.source = source;
     }
 
     @Override
@@ -70,6 +72,11 @@ public final class MementoMessage implements Message, StringBuilderFormattable {
     @Override
     public void formatTo(final StringBuilder buffer) {
         buffer.append(formattedMessage);
+    }
+
+    @Override
+    public StackTraceElement getSource() {
+        return source;
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
@@ -300,7 +300,7 @@ public class MutableLogEvent implements LogEvent, ReusableMessage, ParameterVisi
     @Override
     public Message memento() {
         if (message == null) {
-            message = new MementoMessage(String.valueOf(messageText), messageFormat, getParameters());
+            message = new MementoMessage(source, String.valueOf(messageText), messageFormat, getParameters());
         }
         return message;
     }
@@ -368,6 +368,13 @@ public class MutableLogEvent implements LogEvent, ReusableMessage, ParameterVisi
         }
         source = StackLocatorUtil.calcLocation(loggerFqcn);
         return source;
+    }
+
+    @Override
+    public StackTraceElement swapSource(StackTraceElement source) {
+        StackTraceElement originalSource = this.source;
+        this.source = source;
+        return originalSource;
     }
 
     @SuppressWarnings("unchecked")

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManagerTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManagerTest.java
@@ -228,11 +228,11 @@ public class RollingRandomAccessFileManagerTest {
         // Create the manager.
         final RolloverStrategy rolloverStrategy = DefaultRolloverStrategy
                 .newBuilder()
-                .setMax("7")
-                .setMin("1")
-                .setFileIndex("max")
-                .setStopCustomActionsOnError(false)
-                .setConfig(new DefaultConfiguration())
+                .withMax("7")
+                .withMin("1")
+                .withFileIndex("max")
+                .withStopCustomActionsOnError(false)
+                .withConfig(new DefaultConfiguration())
                 .build();
         final RollingRandomAccessFileManager manager =
                 RollingRandomAccessFileManager.getRollingRandomAccessFileManager(

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigErrorOnFormat.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigErrorOnFormat.java
@@ -97,5 +97,10 @@ public class AsyncLoggerConfigErrorOnFormat {
         public Throwable getThrowable() {
             return null;
         }
+
+        @Override
+        public StackTraceElement getSource() {
+            return null;
+        }
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestArgumentFreedOnError.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestArgumentFreedOnError.java
@@ -105,5 +105,10 @@ public class AsyncLoggerTestArgumentFreedOnError {
         public void formatTo(StringBuilder buffer) {
             throw new Error("Expected");
         }
+
+        @Override
+        public StackTraceElement getSource() {
+            return null;
+        }
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest3.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest3.java
@@ -127,5 +127,10 @@ public class QueueFullAsyncLoggerTest3 extends QueueFullAbstractTest {
             latch.countDown();
             super.finalize();
         }
+
+        @Override
+        public StackTraceElement getSource() {
+            return null;
+        }
     }
 }

--- a/log4j-samples/log4j-samples-loggerProperties/src/main/java/org/apache/logging/log4j/lookup/CustomMapMessage.java
+++ b/log4j-samples/log4j-samples-loggerProperties/src/main/java/org/apache/logging/log4j/lookup/CustomMapMessage.java
@@ -31,7 +31,11 @@ public class CustomMapMessage extends StringMapMessage {
     private final String message;
 
     public CustomMapMessage(final String msg, final Map<String, String> map) {
-        super(map);
+        this(null, msg, map);
+    }
+
+    public CustomMapMessage(final StackTraceElement source, final String msg, final Map<String, String> map) {
+        super(source, map);
         this.message = msg;
     }
 


### PR DESCRIPTION
The purpose of this is to make it possible to improve performance. Getting the StackTraceElement for a message is somewhat expensive. Creating it manually is tedious and no one should do it, but the Scala plugin can provide the source location at compile time. Possibly other tools could do the same thing. This enables that to be possible.