### PR TITLE
avoid initialize 'volatile' fields with default values

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
@@ -26,7 +26,7 @@ import java.util.Stack;
  */
 public final class StackLocatorUtil {
     private static StackLocator stackLocator = null;
-    private static volatile boolean errorLogged = false;
+    private static volatile boolean errorLogged;
 
     static {
         stackLocator = StackLocator.getInstance();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
@@ -87,7 +87,7 @@ public class LoggerContext extends AbstractLifeCycle
 
     private final LoggerRegistry<Logger> loggerRegistry = new LoggerRegistry<>();
     private final CopyOnWriteArrayList<PropertyChangeListener> propertyChangeListeners = new CopyOnWriteArrayList<>();
-    private volatile List<LoggerContextShutdownAware> listeners = null;
+    private volatile List<LoggerContextShutdownAware> listeners;
 
     /**
      * The Configuration is volatile to guarantee that initialization of the Configuration has completed before the

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
@@ -342,7 +342,7 @@ public final class AsyncAppender extends AbstractAppender {
      */
     private class AsyncThread extends Log4jThread {
 
-        private volatile boolean shutdown = false;
+        private volatile boolean shutdown;
         private final List<AppenderControl> appenders;
         private final BlockingQueue<LogEvent> queue;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FailoverAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FailoverAppender.java
@@ -61,7 +61,7 @@ public final class FailoverAppender extends AbstractAppender {
 
     private final long intervalNanos;
 
-    private volatile long nextCheckNanos = 0;
+    private volatile long nextCheckNanos;
 
     private FailoverAppender(final String name, final Filter filter, final String primary, final String[] failovers,
             final int intervalMillis, final Configuration config, final boolean ignoreExceptions,

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
@@ -66,8 +66,8 @@ public class RollingFileManager extends FileManager {
     private final Log4jThreadFactory threadFactory = Log4jThreadFactory.createThreadFactory("RollingFileManager");
     private volatile TriggeringPolicy triggeringPolicy;
     private volatile RolloverStrategy rolloverStrategy;
-    private volatile boolean renameEmptyFiles = false;
-    private volatile boolean initialized = false;
+    private volatile boolean renameEmptyFiles;
+    private volatile boolean initialized;
     private volatile String fileName;
     private final boolean directWrite;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender.java
@@ -415,7 +415,7 @@ public final class RoutingAppender extends AbstractAppender {
 
     private static final class CreatedRouteAppenderControl extends RouteAppenderControl {
 
-        private volatile boolean pendingDeletion = false;
+        private volatile boolean pendingDeletion;
         private final AtomicInteger depth = new AtomicInteger();
 
         CreatedRouteAppenderControl(Appender appender) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigDisruptor.java
@@ -184,7 +184,7 @@ public class AsyncLoggerConfigDisruptor extends AbstractLifeCycle implements Asy
     private long backgroundThreadId; // LOG4J2-471
     private EventFactory<Log4jEventWrapper> factory;
     private EventTranslatorTwoArg<Log4jEventWrapper, LogEvent, AsyncLoggerConfig> translator;
-    private volatile boolean alreadyLoggedWarning = false;
+    private volatile boolean alreadyLoggedWarning;
 
     private final Object queueFullEnqueueLock = new Object();
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
@@ -138,7 +138,7 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
 
     private static final String OVERRIDE_PARAM = "override";
 
-    private static volatile List<ConfigurationFactory> factories = null;
+    private static volatile List<ConfigurationFactory> factories;
 
     private static ConfigurationFactory configFactory = new Factory();
 
@@ -149,7 +149,7 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
     private static final String HTTPS = "https";
     private static final String HTTP = "http";
 
-    private static volatile AuthorizationProvider authorizationProvider = null;
+    private static volatile AuthorizationProvider authorizationProvider;
 
     /**
      * Returns the ConfigurationFactory.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
@@ -59,7 +59,7 @@ public class ConfigurationSource {
     private final String location;
     private final InputStream stream;
     private volatile byte[] data;
-    private volatile Source source = null;
+    private volatile Source source;
     private final long lastModified;
     // Set when the configuration has been updated so reset can use it for the next lastModified timestamp.
     private volatile long modifiedMillis;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LockingReliabilityStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LockingReliabilityStrategy.java
@@ -33,7 +33,7 @@ import org.apache.logging.log4j.util.Supplier;
 public class LockingReliabilityStrategy implements ReliabilityStrategy {
     private final LoggerConfig loggerConfig;
     private final ReadWriteLock reconfigureLock = new ReentrantReadWriteLock();
-    private volatile boolean isStopping = false;
+    private volatile boolean isStopping;
 
     public LockingReliabilityStrategy(final LoggerConfig loggerConfig) {
         this.loggerConfig = Objects.requireNonNull(loggerConfig, "loggerConfig was null");

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/status/StatusConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/status/StatusConfiguration.java
@@ -47,7 +47,7 @@ public class StatusConfiguration {
     private final Collection<String> errorMessages = new LinkedBlockingQueue<String>();
     private final StatusLogger logger = StatusLogger.getLogger();
 
-    private volatile boolean initialized = false;
+    private volatile boolean initialized;
 
     private PrintStream destination = DEFAULT_STREAM;
     private Level status = DEFAULT_STATUS;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/time/internal/format/FixedDateFormat.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/time/internal/format/FixedDateFormat.java
@@ -392,8 +392,8 @@ public class FixedDateFormat {
     private final FixedTimeZoneFormat fixedTimeZoneFormat;
 
 
-    private volatile long midnightToday = 0;
-    private volatile long midnightTomorrow = 0;
+    private volatile long midnightToday;
+    private volatile long midnightTomorrow;
     private final int[] dstOffsets = new int[25];
 
     // cachedDate does not need to be volatile because

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/WatcherFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/WatcherFactory.java
@@ -39,7 +39,7 @@ public class WatcherFactory {
     private static final Logger LOGGER = StatusLogger.getLogger();
     private static final PluginManager pluginManager = new PluginManager(Watcher.CATEGORY);
 
-    private static volatile WatcherFactory factory = null;
+    private static volatile WatcherFactory factory;
 
     private final Map<String, PluginType<?>> plugins;
 

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAppender.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAppender.java
@@ -63,7 +63,7 @@ public final class FlumeAppender extends AbstractAppender implements FlumeEventF
     private final FlumeEventFactory factory;
 
     private final Timer timer = new Timer("FlumeEvent", 5000);
-    private volatile long count = 0;
+    private volatile long count;
 
     /**
      * Which Manager will be used by the appender instance.

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAvroManager.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAvroManager.java
@@ -50,7 +50,7 @@ public class FlumeAvroManager extends AbstractFlumeManager {
 
     private final int current = 0;
 
-    private volatile RpcClient rpcClient = null;
+    private volatile RpcClient rpcClient;
 
     private BatchEvent batchEvent = new BatchEvent();
     private long nextSend = 0;

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumePersistentManager.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumePersistentManager.java
@@ -469,7 +469,7 @@ public class FlumePersistentManager extends FlumeAvroManager {
      * Thread that sends data to Flume and pulls it from Berkeley DB.
      */
     private static class WriterThread extends Log4jThread  {
-        private volatile boolean shutdown = false;
+        private volatile boolean shutdown;
         private final Database database;
         private final Environment environment;
         private final FlumePersistentManager manager;

--- a/log4j-jdbc/src/main/java/org/apache/logging/log4j/jdbc/appender/JdbcDatabaseManager.java
+++ b/log4j-jdbc/src/main/java/org/apache/logging/log4j/jdbc/appender/JdbcDatabaseManager.java
@@ -161,7 +161,7 @@ public final class JdbcDatabaseManager extends AbstractDatabaseManager {
     private final class Reconnector extends Log4jThread {
 
         private final CountDownLatch latch = new CountDownLatch(1);
-        private volatile boolean shutdown = false;
+        private volatile boolean shutdown;
 
         private Reconnector() {
             super("JdbcDatabaseManager-Reconnector");

--- a/log4j-jms/src/main/java/org/apache/logging/log4j/jms/appender/JmsManager.java
+++ b/log4j-jms/src/main/java/org/apache/logging/log4j/jms/appender/JmsManager.java
@@ -141,7 +141,7 @@ public class JmsManager extends AbstractManager {
 
         private final CountDownLatch latch = new CountDownLatch(1);
 
-        private volatile boolean shutdown = false;
+        private volatile boolean shutdown;
 
         private final Object owner;
 

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/ClocksBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/ClocksBenchmark.java
@@ -152,7 +152,7 @@ public class ClocksBenchmark {
         private static volatile OldCachedClock instance;
         private static final Object INSTANCE_LOCK = new Object();
         private volatile long millis = System.currentTimeMillis();
-        private volatile short count = 0;
+        private volatile short count;
 
         private OldCachedClock() {
             final Thread updater = new Thread(new Runnable() {

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/LoggerConfigBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/LoggerConfigBenchmark.java
@@ -53,7 +53,7 @@ import org.openjdk.jmh.infra.Blackhole;
 public class LoggerConfigBenchmark {
 
     private final CopyOnWriteArraySet<AppenderControl> appenderSet = new CopyOnWriteArraySet<>();
-    private volatile Filter filter = null;
+    private volatile Filter filter;
     private final boolean additive = true;
     private final boolean includeLocation = true;
     private LoggerConfig parent;

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/TimeFormatBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/TimeFormatBenchmark.java
@@ -57,8 +57,8 @@ public class TimeFormatBenchmark {
     };
     FastDateFormat fastDateFormat = FastDateFormat.getInstance("HH:mm:ss.SSS");
     FixedDateFormat fixedDateFormat = FixedDateFormat.createIfSupported(new String[]{"ABSOLUTE"});
-    volatile long midnightToday = 0;
-    volatile long midnightTomorrow = 0;
+    volatile long midnightToday;
+    volatile long midnightTomorrow;
 
     @State(Scope.Thread)
     public static class BufferState {

--- a/log4j-samples/log4j-samples-flume-common/src/main/java/org/apache/logging/log4j/samples/app/LoggingController.java
+++ b/log4j-samples/log4j-samples-flume-common/src/main/java/org/apache/logging/log4j/samples/app/LoggingController.java
@@ -45,7 +45,7 @@ public class LoggingController {
      */
     private static Logger logger = LogManager.getLogger(LoggingController.class);
 
-    private volatile boolean generateLog = false;
+    private volatile boolean generateLog;
     private final Random ran = new Random();
 
     private List<AuditEvent> events;


### PR DESCRIPTION
It's known that writing to a  `volatile` field has performance impact.
It's true even if code initializes field with _default_ value.
This PR cleans such redundant initialization and improves startup performance.
 See similar improvement in JDK codebase: https://bugs.openjdk.java.net/browse/JDK-8145680.