### PR TITLE
LOG4J2-2882: Add support for JUL filters

### DIFF
--- a/log4j-jul/src/main/java/org/apache/logging/log4j/jul/ApiLogger.java
+++ b/log4j-jul/src/main/java/org/apache/logging/log4j/jul/ApiLogger.java
@@ -119,22 +119,38 @@ public class ApiLogger extends Logger {
 
     @Override
     public void log(final Level level, final String msg) {
-        logger.log(LevelTranslator.toLevel(level), msg);
+        if (getFilter() == null) {
+            logger.log(LevelTranslator.toLevel(level), msg);
+        } else {
+            super.log(level, msg);
+        }
     }
 
     @Override
     public void log(final Level level, final String msg, final Object param1) {
-        logger.log(LevelTranslator.toLevel(level), msg, param1);
+        if (getFilter() == null) {
+            logger.log(LevelTranslator.toLevel(level), msg, param1);
+        } else {
+            super.log(level, msg, param1);
+        }
     }
 
     @Override
     public void log(final Level level, final String msg, final Object[] params) {
-        logger.log(LevelTranslator.toLevel(level), msg, params);
+        if (getFilter() == null) {
+            logger.log(LevelTranslator.toLevel(level), msg, params);
+        } else {
+            super.log(level, msg, params);
+        }
     }
 
     @Override
     public void log(final Level level, final String msg, final Throwable thrown) {
-        logger.log(LevelTranslator.toLevel(level), msg, thrown);
+        if (getFilter() == null) {
+            logger.log(LevelTranslator.toLevel(level), msg, thrown);
+        } else {
+            super.log(level, msg, thrown);
+        }
     }
 
     @Override
@@ -216,36 +232,64 @@ public class ApiLogger extends Logger {
 
     @Override
     public void severe(final String msg) {
-        logger.logIfEnabled(FQCN, org.apache.logging.log4j.Level.ERROR, null, msg);
+        if (getFilter() == null) {
+            logger.logIfEnabled(FQCN, org.apache.logging.log4j.Level.ERROR, null, msg);
+        } else {
+            super.severe(msg);
+        }
     }
 
     @Override
     public void warning(final String msg) {
-        logger.logIfEnabled(FQCN, org.apache.logging.log4j.Level.WARN, null, msg);
+        if (getFilter() == null) {
+            logger.logIfEnabled(FQCN, org.apache.logging.log4j.Level.WARN, null, msg);
+        } else {
+            super.warning(msg);
+        }
     }
 
     @Override
     public void info(final String msg) {
-        logger.logIfEnabled(FQCN, org.apache.logging.log4j.Level.INFO, null, msg);
+        if (getFilter() == null) {
+            logger.logIfEnabled(FQCN, org.apache.logging.log4j.Level.INFO, null, msg);
+        } else {
+            super.info(msg);
+        }
     }
 
     @Override
     public void config(final String msg) {
-        logger.logIfEnabled(FQCN, LevelTranslator.CONFIG, null, msg);
+        if (getFilter() == null) {
+            logger.logIfEnabled(FQCN, LevelTranslator.CONFIG, null, msg);
+        } else {
+            super.config(msg);
+        }
     }
 
     @Override
     public void fine(final String msg) {
-        logger.logIfEnabled(FQCN, org.apache.logging.log4j.Level.DEBUG, null, msg);
+        if (getFilter() == null) {
+            logger.logIfEnabled(FQCN, org.apache.logging.log4j.Level.DEBUG, null, msg);
+        } else {
+            super.fine(msg);
+        }
     }
 
     @Override
     public void finer(final String msg) {
-        logger.logIfEnabled(FQCN, org.apache.logging.log4j.Level.TRACE, null, msg);
+        if (getFilter() == null) {
+            logger.logIfEnabled(FQCN, org.apache.logging.log4j.Level.TRACE, null, msg);
+        } else {
+            super.finer(msg);
+        }
     }
 
     @Override
     public void finest(final String msg) {
-        logger.logIfEnabled(FQCN, LevelTranslator.FINEST, null, msg);
+        if (getFilter() == null) {
+            logger.logIfEnabled(FQCN, LevelTranslator.FINEST, null, msg);
+        } else {
+            super.finest(msg);
+        }
     }
 }

--- a/log4j-jul/src/test/java/org/apache/logging/log4j/jul/AbstractLoggerTest.java
+++ b/log4j-jul/src/test/java/org/apache/logging/log4j/jul/AbstractLoggerTest.java
@@ -85,6 +85,34 @@ public abstract class AbstractLoggerTest {
     }
 
     @Test
+    public void testLogFilter() throws Exception {
+        logger.setFilter(record -> false);
+        logger.severe("Informative message here.");
+        logger.warning("Informative message here.");
+        logger.info("Informative message here.");
+        logger.config("Informative message here.");
+        logger.fine("Informative message here.");
+        logger.finer("Informative message here.");
+        logger.finest("Informative message here.");
+        final List<LogEvent> events = eventAppender.getEvents();
+        assertThat(events, hasSize(0));
+    }
+
+    @Test
+    public void testAlteringLogFilter() throws Exception {
+        logger.setFilter(record -> { record.setMessage("This is not the message you are looking for."); return true; });
+        logger.info("Informative message here.");
+        final List<LogEvent> events = eventAppender.getEvents();
+        assertThat(events, hasSize(1));
+        final LogEvent event = events.get(0);
+        assertThat(event, instanceOf(Log4jLogEvent.class));
+        assertEquals(Level.INFO, event.getLevel());
+        assertEquals(LOGGER_NAME, event.getLoggerName());
+        assertEquals("This is not the message you are looking for.", event.getMessage().getFormattedMessage());
+        assertEquals(ApiLogger.class.getName(), event.getLoggerFqcn());
+    }
+
+    @Test
     public void testLogParamMarkers() {
         final Logger flowLogger = Logger.getLogger("TestFlow");
         flowLogger.logp(java.util.logging.Level.FINER, "sourceClass", "sourceMethod", "ENTER {0}", "params");

--- a/log4j-jul/src/test/java/org/apache/logging/log4j/jul/ApiLoggerTest.java
+++ b/log4j-jul/src/test/java/org/apache/logging/log4j/jul/ApiLoggerTest.java
@@ -48,6 +48,7 @@ public class ApiLoggerTest extends AbstractLoggerTest {
     @Before
     public void setUp() throws Exception {
         logger = Logger.getLogger(LOGGER_NAME);
+        logger.setFilter(null);
         assertThat(logger.getLevel(), equalTo(java.util.logging.Level.FINE));
         eventAppender = ListAppender.getListAppender("TestAppender");
         flowAppender = ListAppender.getListAppender("FlowAppender");

--- a/log4j-jul/src/test/java/org/apache/logging/log4j/jul/CoreLoggerTest.java
+++ b/log4j-jul/src/test/java/org/apache/logging/log4j/jul/CoreLoggerTest.java
@@ -48,6 +48,7 @@ public class CoreLoggerTest extends AbstractLoggerTest {
     @Before
     public void setUp() throws Exception {
         logger = Logger.getLogger(LOGGER_NAME);
+        logger.setFilter(null);
         assertThat(logger.getLevel(), equalTo(Level.FINE));
         eventAppender = ListAppender.getListAppender("TestAppender");
         flowAppender = ListAppender.getListAppender("FlowAppender");


### PR DESCRIPTION
This implements basic support for JUL filters as described in [LOG4J2-2882](https://issues.apache.org/jira/browse/LOG4J2-2882). The log calls are delegated to the super class only when a filter is configured, I hope this preserves the performance in the general case. I left out the tracing methods because I wasn't sure delegating to the super class would generate a message with the right semantic.