### PR TITLE
LOG4J2-2867: RingBufferLogEventTranslator uses a static ContextDataInjector

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventTranslator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventTranslator.java
@@ -37,7 +37,7 @@ import com.lmax.disruptor.EventTranslator;
 public class RingBufferLogEventTranslator implements
         EventTranslator<RingBufferLogEvent> {
 
-    private final ContextDataInjector injector = ContextDataInjectorFactory.createInjector();
+    private static final ContextDataInjector INJECTOR = ContextDataInjectorFactory.createInjector();
     private AsyncLogger asyncLogger;
     String loggerName;
     protected Marker marker;
@@ -60,7 +60,7 @@ public class RingBufferLogEventTranslator implements
         event.setValues(asyncLogger, loggerName, marker, fqcn, level, message, thrown,
                 // config properties are taken care of in the EventHandler thread
                 // in the AsyncLogger#actualAsyncLog method
-                injector.injectContextData(null, (StringMap) event.getContextData()), contextStack,
+                INJECTOR.injectContextData(null, (StringMap) event.getContextData()), contextStack,
                 threadId, threadName, threadPriority, location, clock, nanoClock);
 
         clear(); // clear the translator


### PR DESCRIPTION
Previously a new instance was created for each translator, which
occurred on every thread. Some applications do not reuse threads
efficiently, and shouldn't be over-penalized.