### PR TITLE
LOG4J2-2892 - Add support for newline delimited messages in GelfLayout

### DIFF
--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/GelfLayoutTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/GelfLayoutTest.java
@@ -220,6 +220,14 @@ public class GelfLayoutTest {
         //@formatter:on
         assertJsonEquals(expected, uncompressedString);
         assertJsonEquals(expected, uncompressedString2);
+        if (includeNullDelimiter) {
+            assertEquals(uncompressedString.indexOf('\0'), uncompressedString.length() - 1);
+            assertEquals(uncompressedString2.indexOf('\0'), uncompressedString2.length() - 1);
+        }
+        if (includeNewLineDelimiter) {
+            assertEquals(uncompressedString.indexOf('\n'), uncompressedString.length() - 1);
+            assertEquals(uncompressedString2.indexOf('\n'), uncompressedString2.length() - 1);
+        }
     }
 
     @Test
@@ -259,7 +267,7 @@ public class GelfLayoutTest {
 
     @Test
     public void testLayoutNewLineDelimiter() throws Exception {
-        testCompressedLayout(CompressionType.OFF, false, true, HOSTNAME, false, true);
+        testCompressedLayout(CompressionType.OFF, true, true, HOSTNAME, false, true);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/GelfLayoutTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/GelfLayoutTest.java
@@ -80,7 +80,8 @@ public class GelfLayoutTest {
     Logger root = ctx.getRootLogger();
 
     private void testCompressedLayout(final CompressionType compressionType, final boolean includeStacktrace,
-                                      final boolean includeThreadContext, String host, final boolean includeNullDelimiter) throws IOException {
+                                      final boolean includeThreadContext, String host, final boolean includeNullDelimiter,
+                                      final boolean includeNewLineDelimiter) throws IOException {
         for (final Appender appender : root.getAppenders().values()) {
             root.removeAppender(appender);
         }
@@ -96,6 +97,7 @@ public class GelfLayoutTest {
             .setIncludeStacktrace(includeStacktrace)
             .setIncludeThreadContext(includeThreadContext)
             .setIncludeNullDelimiter(includeNullDelimiter)
+            .setIncludeNewLineDelimiter(includeNewLineDelimiter)
             .build();
         final ListAppender eventAppender = new ListAppender("Events", null, null, true, false);
         final ListAppender rawAppender = new ListAppender("Raw", null, layout, true, true);
@@ -222,37 +224,42 @@ public class GelfLayoutTest {
 
     @Test
     public void testLayoutGzipCompression() throws Exception {
-        testCompressedLayout(CompressionType.GZIP, true, true, HOSTNAME, false);
+        testCompressedLayout(CompressionType.GZIP, true, true, HOSTNAME, false, false);
     }
 
     @Test
     public void testLayoutNoCompression() throws Exception {
-        testCompressedLayout(CompressionType.OFF, true, true, HOSTNAME, false);
+        testCompressedLayout(CompressionType.OFF, true, true, HOSTNAME, false, false);
     }
 
     @Test
     public void testLayoutZlibCompression() throws Exception {
-        testCompressedLayout(CompressionType.ZLIB, true, true, HOSTNAME, false);
+        testCompressedLayout(CompressionType.ZLIB, true, true, HOSTNAME, false, false);
     }
 
     @Test
     public void testLayoutNoStacktrace() throws Exception {
-        testCompressedLayout(CompressionType.OFF, false, true, HOSTNAME, false);
+        testCompressedLayout(CompressionType.OFF, false, true, HOSTNAME, false, false);
     }
 
     @Test
     public void testLayoutNoThreadContext() throws Exception {
-        testCompressedLayout(CompressionType.OFF, true, false, HOSTNAME, false);
+        testCompressedLayout(CompressionType.OFF, true, false, HOSTNAME, false, false);
     }
 
     @Test
     public void testLayoutNoHost() throws Exception {
-        testCompressedLayout(CompressionType.OFF, true, true, null, false);
+        testCompressedLayout(CompressionType.OFF, true, true, null, false, false);
     }
 
     @Test
     public void testLayoutNullDelimiter() throws Exception {
-        testCompressedLayout(CompressionType.OFF, false, true, HOSTNAME, true);
+        testCompressedLayout(CompressionType.OFF, false, true, HOSTNAME, true, false);
+    }
+
+    @Test
+    public void testLayoutNewLineDelimiter() throws Exception {
+        testCompressedLayout(CompressionType.OFF, false, true, HOSTNAME, false, true);
     }
 
     @Test


### PR DESCRIPTION
A pull request for issue [https://issues.apache.org/jira/browse/LOG4J2-2892](https://issues.apache.org/jira/browse/LOG4J2-2892).

This PR adds ability to delimit Graylog Extended Log Format (GELF) messages with a newline. It can be useful when you want to append messages in the Graylog format into a file, or when you have to feed the messages into a consumer which supports only newlines as a delimiter. The documentation of GELF only specifies usage of a NULL delimiter and doesn't discourage from using some other. It also requires that newlines inside the message body must be escaped, so multi-line stack traces shouldn't be an issue.

New optional boolean parameter "includeNewLineDelimiter" is introduced to GelfLayout, nothing changes for current users if they decide not to use it.