### PR TITLE
[LOG4J2-2906] - Fix Log4j2 cloud logging system config loading

### DIFF
--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-client/src/main/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2CloudConfigLoggingSystem.java
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-client/src/main/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2CloudConfigLoggingSystem.java
@@ -86,7 +86,7 @@ public class Log4j2CloudConfigLoggingSystem extends Log4J2LoggingSystem {
         PropertiesUtil props = new PropertiesUtil(new Properties());
         String location = props.getStringProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
         if (location != null) {
-            List<String> list = Arrays.asList(super.getStandardConfigLocations());
+            List<String> list = new ArrayList<>(Arrays.asList(super.getStandardConfigLocations()));
             list.add(location);
             locations = list.toArray(new String[0]);
         }

--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-client/src/test/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2CloudConfigLoggingSystemTest.java
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-client/src/test/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2CloudConfigLoggingSystemTest.java
@@ -1,0 +1,22 @@
+package org.apache.logging.log4j.spring.cloud.config.client;
+
+import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class Log4j2CloudConfigLoggingSystemTest {
+
+    @Test
+    public void getStandardConfigLocations() {
+        String customLog4j2Location = "classpath:my_custom_log4j2.properties";
+        System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, customLog4j2Location);
+        Log4j2CloudConfigLoggingSystem cloudLoggingSystem = new Log4j2CloudConfigLoggingSystem(this.getClass().getClassLoader());
+        List<String> standardConfigLocations = Arrays.asList(cloudLoggingSystem.getStandardConfigLocations());
+        assertTrue(standardConfigLocations.contains(customLog4j2Location));
+
+    }
+}


### PR DESCRIPTION
Wrap the list coming from the getStandardConfigLocations in a list that can be added to.