### PR TITLE
[LOG4J2-2919] Call ReliabilityStrategy's beforeStopAppenders() method before stopping AsyncAppender

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
@@ -370,6 +370,12 @@ public abstract class AbstractConfiguration extends AbstractFilterable implement
             asyncLoggerConfigDisruptor.stop(timeout, timeUnit);
         }
 
+        LOGGER.trace("{} notifying ReliabilityStrategies that appenders will be stopped.", cls);
+        for (final LoggerConfig loggerConfig : loggerConfigs.values()) {
+            loggerConfig.getReliabilityStrategy().beforeStopAppenders();
+        }
+        root.getReliabilityStrategy().beforeStopAppenders();
+
         // Stop the appenders in reverse order in case they still have activity.
         final Appender[] array = appenders.values().toArray(new Appender[appenders.size()]);
         final List<Appender> async = getAsyncAppenders(array);
@@ -380,12 +386,6 @@ public abstract class AbstractConfiguration extends AbstractFilterable implement
                 ((LifeCycle) appender).stop(timeout, timeUnit);
             }
         }
-
-        LOGGER.trace("{} notifying ReliabilityStrategies that appenders will be stopped.", cls);
-        for (final LoggerConfig loggerConfig : loggerConfigs.values()) {
-            loggerConfig.getReliabilityStrategy().beforeStopAppenders();
-        }
-        root.getReliabilityStrategy().beforeStopAppenders();
 
         LOGGER.trace("{} stopping remaining Appenders.", cls);
         int appenderCount = 0;

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/MockReliabilityStrategy.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/MockReliabilityStrategy.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.core.config;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LifeCycle;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.util.Supplier;
+import org.opentest4j.MultipleFailuresError;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Mock object for validating the behavior of a configuration interacting with ReliabilityStrategy.
+ */
+public class MockReliabilityStrategy implements ReliabilityStrategy {
+
+    private final LoggerConfig config;
+    private final List<AssertionError> errors = Collections.synchronizedList(new ArrayList<>());
+
+    public MockReliabilityStrategy(final LoggerConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public void log(
+            final Supplier<LoggerConfig> reconfigured, final String loggerName, final String fqcn, final Marker marker,
+            final Level level, final Message data, final Throwable t) {
+        config.log(loggerName, fqcn, marker, level, data, t);
+    }
+
+    @Override
+    public void log(
+            final Supplier<LoggerConfig> reconfigured, final String loggerName, final String fqcn,
+            final StackTraceElement location, final Marker marker, final Level level, final Message data, final Throwable t) {
+        config.log(loggerName, fqcn, location, marker, level, data, t);
+    }
+
+    @Override
+    public void log(final Supplier<LoggerConfig> reconfigured, final LogEvent event) {
+        config.log(event);
+    }
+
+    @Override
+    public LoggerConfig getActiveLoggerConfig(final Supplier<LoggerConfig> next) {
+        return config;
+    }
+
+    @Override
+    public void afterLogEvent() {
+        // no-op
+    }
+
+    @Override
+    public void beforeStopAppenders() {
+        checkState(LifeCycle.State.STOPPED, config);
+        for (final Appender appender : config.getAppenders().values()) {
+            checkState(LifeCycle.State.STARTED, appender);
+        }
+    }
+
+    @Override
+    public void beforeStopConfiguration(final Configuration configuration) {
+        checkState(LifeCycle.State.STOPPING, configuration);
+        checkState(LifeCycle.State.STARTED, config);
+    }
+
+    void rethrowAssertionErrors() {
+        synchronized (errors) {
+            if (!errors.isEmpty()) {
+                throw new MultipleFailuresError(null, errors);
+            }
+        }
+    }
+
+    private void checkState(final LifeCycle.State expected, final LifeCycle object) {
+        try {
+            assertSame(expected, object.getState(), () -> "Expected state " + expected + " for LifeCycle object " + object);
+        } catch (final AssertionError e) {
+            errors.add(e);
+        }
+    }
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/ReliabilityStrategyTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/ReliabilityStrategyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.core.config;
+
+import org.apache.logging.log4j.core.appender.AsyncAppender;
+import org.apache.logging.log4j.junit.LoggerContextSource;
+import org.apache.logging.log4j.junit.Named;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReliabilityStrategyTest {
+
+    @BeforeAll
+    static void setUp() {
+        System.setProperty("log4j2.reliabilityStrategy", MockReliabilityStrategy.class.getName());
+    }
+
+    @AfterAll
+    static void tearDown() {
+        System.clearProperty("log4j2.reliabilityStrategy");
+    }
+
+    @Test
+    @LoggerContextSource("ReliabilityStrategyTest.xml")
+    void beforeStopAppendersCalledBeforeAsyncAppendersStopped(@Named final AsyncAppender async, final Configuration config) {
+        assertTrue(async.isStarted());
+        final MockReliabilityStrategy reliabilityStrategy =
+                (MockReliabilityStrategy) config.getRootLogger().getReliabilityStrategy();
+        config.stop();
+        assertTrue(async.isStopped());
+        reliabilityStrategy.rethrowAssertionErrors();
+    }
+}

--- a/log4j-core/src/test/resources/ReliabilityStrategyTest.xml
+++ b/log4j-core/src/test/resources/ReliabilityStrategyTest.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache license, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the license for the specific language governing permissions and
+  ~ limitations under the license.
+  -->
+<Configuration name="ReliabilityStrategyTest" status="OFF">
+  <Appenders>
+    <List name="list">
+      <PatternLayout pattern="%m"/>
+    </List>
+    <Async name="async">
+      <AppenderRef ref="list"/>
+    </Async>
+  </Appenders>
+  <Loggers>
+    <Root level="DEBUG">
+      <AppenderRef ref="async"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
Call ReliabilityStrategy's beforeStopAppenders() method before stopping AsyncAppender
to avoid errors caused by logging with AsyncAppender  while system is reconfiguring
Submitted by: gengyuanzhe <gengyuanzhe@gmail.com>