### PR TITLE
(doc) Fix Logger documentation formatting error

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -68,7 +68,7 @@ import org.apache.logging.log4j.util.Supplier;
  * </pre>
  *
  * <p>
- * Note that although {@link MessageSupplier} is provided, using {@link Supplier {@code Supplier&lt;Message&gt;}} works just the
+ * Note that although {@link MessageSupplier} is provided, using {@link Supplier Supplier&lt;Message&gt;} works just the
  * same. MessageSupplier was deprecated in 2.6 and un-deprecated in 2.8.1. Anonymous class usage of these APIs
  * should prefer using Supplier instead.
  * </p>


### PR DESCRIPTION
`{@link ...}` already formats the link text as code (unlike `{@linkplain ...}`) and additionally does not support nested Javadoc tags, so currently the HTML output is `{@code Supplier<Message>}`.