### PR TITLE
Add logic to detect kafka broker is valid or not

### DIFF
--- a/log4j-kafka/src/main/java/org/apache/logging/log4j/kafka/appender/KafkaManager.java
+++ b/log4j-kafka/src/main/java/org/apache/logging/log4j/kafka/appender/KafkaManager.java
@@ -153,7 +153,10 @@ public class KafkaManager extends AbstractManager {
     }
 
     public void startup() {
-        producer = producerFactory.newKafkaProducer(config);
+        // Avoid kafka thread leak
+        if (producer == null) {
+            producer = producerFactory.newKafkaProducer(config);
+        }
     }
 
     public String getTopic() {

--- a/log4j-kafka/src/main/java/org/apache/logging/log4j/kafka/appender/KafkaManager.java
+++ b/log4j-kafka/src/main/java/org/apache/logging/log4j/kafka/appender/KafkaManager.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;


### PR DESCRIPTION
Add logic to detect kafka broker is valid or not during app startup.
User should be noticed with kafka broker available or not.
Mark kafka appenders as not disabled if kafka broker not available. Then Logevents won't be stored in this appender.
Otherwise, the kafka producer will retry unlimited with lots of log. If user didn't add blocking parameter to asyncappender, all appenders in this logger will be affected.