### PR TITLE
LOG4J2-2850 Fix ctor used in LocalizedMessageFactory#newMessage().

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessageFactory.java
@@ -70,7 +70,7 @@ public class LocalizedMessageFactory implements MessageFactory, Serializable {
     @Override
     public Message newMessage(final String key) {
         if (resourceBundle == null) {
-            return new LocalizedMessage(baseName,  key);
+            return new LocalizedMessage(baseName,  key, null);
         }
         return new LocalizedMessage(resourceBundle, key);
     }

--- a/log4j-api/src/test/java/org/apache/logging/log4j/message/LocalizedMessageFactoryTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/message/LocalizedMessageFactoryTest.java
@@ -35,4 +35,12 @@ public class LocalizedMessageFactoryTest {
         final Message message = localizedMessageFactory.newMessage("hello_world");
         assertEquals("Hello world.", message.getFormattedMessage());
     }
+	
+	  @Test
+    public void testNewMessageUsingBaseName() {
+        final LocalizedMessageFactory localizedMessageFactory = new LocalizedMessageFactory("MF");
+		final String testMsg = "hello_world";
+        final Message message = localizedMessageFactory.newMessage(testMsg);
+        assertEquals("Hello world.", message.getFormattedMessage());
+    }
 }

--- a/log4j-api/src/test/java/org/apache/logging/log4j/message/LocalizedMessageFactoryTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/message/LocalizedMessageFactoryTest.java
@@ -39,7 +39,7 @@ public class LocalizedMessageFactoryTest {
 	  @Test
     public void testNewMessageUsingBaseName() {
         final LocalizedMessageFactory localizedMessageFactory = new LocalizedMessageFactory("MF");
-		final String testMsg = "hello_world";
+        final String testMsg = "hello_world";
         final Message message = localizedMessageFactory.newMessage(testMsg);
         assertEquals("Hello world.", message.getFormattedMessage());
     }

--- a/log4j-api/src/test/java/org/apache/logging/log4j/message/LocalizedMessageTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/message/LocalizedMessageTest.java
@@ -90,4 +90,11 @@ public class LocalizedMessageTest {
         final String actual = msg.getFormattedMessage();
         assertEquals("Test message abc", actual, "Should use initial param value");
     }
+	
+	@Test
+    public void testMessageUsingBaseName() { // LOG4J2-2850
+        final String testMsg = "hello_world";
+        final LocalizedMessage msg = new LocalizedMessage("MF", testMsg, null);
+        assertEquals("Hello world.", msg.getFormattedMessage());
+    }
 }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -277,6 +277,9 @@
       <action issue="LOG4J2-2954" dev="ckozak" type="fix" due-to="Henry Tung">
         Prevent premature garbage collection of shutdown hooks in DefaultShutdownCallbackRegistry.
       </action>
+	  <action issue="LOG4J2-2850" dev="sandeepbarnwal" type="fix">
+		Fix incorrect constructor call in LocalizedMessageFactory.
+      </action>
     </release>
     <release version="2.13.3" date="2020-05-10" description="GA Release 2.13.3">
       <action issue="LOG4J2-2838" dev="rgoers" type="fix">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -188,6 +188,9 @@
       <action issue="LOG4J2-2844" dev="ggregory" type="fix">
         Null pointer exception when no network interfaces are available.
       </action>
+	  <action issue="LOG4J2-2850" dev="sandeepbarnwal" type="fix">
+		Fixes incorrect constructor call in LocalizedMessageFactory.
+      </action>
     </release>
     <release version="2.14.0" date="2020-MM-DD" description="GA Release 2.14.0">
       <action issue="LOG4J2-2911" dev="rgoers" type="fix">
@@ -276,9 +279,6 @@
       </action>
       <action issue="LOG4J2-2954" dev="ckozak" type="fix" due-to="Henry Tung">
         Prevent premature garbage collection of shutdown hooks in DefaultShutdownCallbackRegistry.
-      </action>
-	  <action issue="LOG4J2-2850" dev="sandeepbarnwal" type="fix">
-		Fix incorrect constructor call in LocalizedMessageFactory.
       </action>
     </release>
     <release version="2.13.3" date="2020-05-10" description="GA Release 2.13.3">


### PR DESCRIPTION
newMessage method in LocalizedMessageFactory uses incorrect constructor. it creates the new message with baseName as messagePattern. I have changed it to point to the appropriate constructor.