### PR TITLE
[draft/proof of concept] JTL memory optimizations

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -424,6 +424,51 @@ final class ParameterFormatter {
         return str.toString();
     }
 
+    static void deepToString(final Object o, final StringBuilder buf) {
+        if (o == null) {
+            // Unclear if this is ideal
+            buf.append("null");
+            return;
+        }
+        // Check special types to avoid unnecessary StringBuilder usage
+        if (o instanceof String) {
+            buf.append((String) o);
+            return;
+        }
+        if (o instanceof Integer) {
+            buf.append((int) o);
+            return;
+        }
+        if (o instanceof Long) {
+            buf.append((long) o);
+            return;
+        }
+        if (o instanceof Double) {
+            buf.append((double) o);
+        }
+        if (o instanceof Boolean) {
+            buf.append((boolean) o);
+            return;
+        }
+        if (o instanceof Character) {
+            buf.append((char) o);
+            return;
+        }
+        if (o instanceof Short) {
+            buf.append((short) o);
+            return;
+        }
+        if (o instanceof Float) {
+            buf.append((float) o);
+            return;
+        }
+        if (o instanceof Byte) {
+            buf.append((byte) o);
+            return;
+        }
+        recursiveDeepToString(o, buf, null);
+    }
+
     /**
      * This method performs a deep toString of the given Object.
      * Primitive arrays are converted using their respective Arrays.toString methods while

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
@@ -302,6 +302,10 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
         return ParameterFormatter.deepToString(o);
     }
 
+    public static void deepToString(final Object o, final StringBuilder buf) {
+        ParameterFormatter.deepToString(o, buf);
+    }
+
     /**
      * This method returns the same as if Object.toString() would not have been
      * overridden in obj.

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/MessageParameterResolver.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/MessageParameterResolver.java
@@ -22,7 +22,6 @@ import org.apache.logging.log4j.layout.template.json.util.Recycler;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ParameterConsumer;
 import org.apache.logging.log4j.message.ParameterVisitable;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 
 /**
  * {@link Message} parameter (i.e., {@link Message#getParameters()}) resolver.
@@ -125,9 +124,7 @@ final class MessageParameterResolver implements EventResolver {
                 }
                 final Object parameter = parameters[i];
                 if (stringified) {
-                    final String stringifiedParameter =
-                            ParameterizedMessage.deepToString(parameter);
-                    jsonWriter.writeString(stringifiedParameter);
+                    jsonWriter.writeAsString(parameter);
                 } else {
                     jsonWriter.writeValue(parameter);
                 }
@@ -139,9 +136,7 @@ final class MessageParameterResolver implements EventResolver {
         else {
             final Object parameter = parameters[index];
             if (stringified) {
-                final String stringifiedParameter =
-                        ParameterizedMessage.deepToString(parameter);
-                jsonWriter.writeString(stringifiedParameter);
+                jsonWriter.writeAsString(parameter);
             } else {
                 jsonWriter.writeValue(parameter);
             }
@@ -196,9 +191,7 @@ final class MessageParameterResolver implements EventResolver {
                 // Write the value.
                 if (arrayNeeded || state.resolver.index == index) {
                     if (state.resolver.stringified) {
-                        final String stringifiedParameter =
-                                ParameterizedMessage.deepToString(parameter);
-                        state.jsonWriter.writeString(stringifiedParameter);
+                        state.jsonWriter.writeAsString(parameter);
                     } else {
                         state.jsonWriter.writeValue(parameter);
                     }

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/ReadOnlyStringMapResolver.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/ReadOnlyStringMapResolver.java
@@ -202,9 +202,7 @@ class ReadOnlyStringMapResolver implements EventResolver {
                 final ReadOnlyStringMap map = mapAccessor.apply(logEvent);
                 final Object value = map == null ? null : map.getValue(key);
                 if (stringified) {
-                    final String valueString =
-                            ParameterizedMessage.deepToString(value);
-                    jsonWriter.writeString(valueString);
+                    jsonWriter.writeAsString(value);
                 } else {
                     jsonWriter.writeValue(value);
                 }

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/JsonWriter.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/JsonWriter.java
@@ -84,6 +84,9 @@ public final class JsonWriter implements AutoCloseable, Cloneable {
         ESC_CODES = table;
     }
 
+    private static final BiConsumer<StringBuilder, Object> STRING_PARAMETER_EMITTER = (sb, par) ->
+            ParameterizedMessage.deepToString(par, sb);
+
     private final char[] quoteBuffer;
 
     private final StringBuilder stringBuilder;
@@ -211,13 +214,11 @@ public final class JsonWriter implements AutoCloseable, Cloneable {
             final Object[] values = (Object[]) value;
             writeArray(values);
         }
-
         // string
-        else {
-            final String stringValue = value instanceof String
-                    ? (String) value
-                    : ParameterizedMessage.deepToString(value);
-            writeString(stringValue);
+        else if (value instanceof String) {
+            writeString((String) value);
+        } else {
+            writeAsString(value);
         }
 
     }
@@ -570,6 +571,10 @@ public final class JsonWriter implements AutoCloseable, Cloneable {
         }
         stringBuilder.append('"');
 
+    }
+
+    public void writeAsString(Object object) {
+        writeString(STRING_PARAMETER_EMITTER, object);
     }
 
     /**


### PR DESCRIPTION
09e1bae: Avoids allocating new string objects when parameters are formatted, preferring to use the existing StringBuilder instance.

38b9650: Remove JsonWriter.formattableBuffer in favor of using the existing JsonWriter.stringBuilder field.

from the commit message:
```    
    JsonWriter avoids an additional StringBuilder for formatting in
    favor of escaping in places.
    It's worth some benchmarks to compare and contrast. In the ideal
    case, strings don't contain characters that must be escaped, and no
    memory copying is necessary. When escaping does occur, contents are
    localized to an array and cache hits are likely. We may not need
    to reach into main memory as frequently, unless we've escaped enough
    characters to fill a cache line.
    
    This commit is a proof of concept, it's not ideal that we're combining
    two separate json string escaping implementations in JsonWriter:
    `StringBuilders.escapeJson` and `JsonWriter.quoteString`
```