### PR TITLE
Reproducer JMH benchmark for LOG4J2-2965

### DIFF
--- a/log4j-perf/pom.xml
+++ b/log4j-perf/pom.xml
@@ -72,6 +72,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jul</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-layout-template-json</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/JulReproBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/JulReproBenchmark.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.perf.jmh;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.message.ThreadDumpMessage;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
+/**
+ * Reproducer for LOG4J2-2965
+ */
+@State(Scope.Benchmark)
+@Fork(100)
+@Threads(1)
+@Warmup(iterations = 0)
+@Measurement(iterations = 1)
+public class JulReproBenchmark {
+
+    @Setup
+    public void up() {
+        System.setProperty("java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
+        System.setProperty("log4j.configurationFile", "log4j2-perf2.xml");
+        System.setProperty("Log4jContextSelector", "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector");
+        System.setProperty("log4j2.enable.threadlocals", "true");
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void reproducer() throws Exception {
+        CountDownLatch threadsWaitingLatch = new CountDownLatch(2);
+        CountDownLatch latch = new CountDownLatch(1);
+        Thread t1 = startedThread("jul-logger", () -> {
+            threadsWaitingLatch.countDown();
+            try {
+                latch.await();
+                java.util.logging.Logger.getLogger("jul-repro-jul").log(Level.SEVERE, "test");
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+        });
+        Thread t2 = startedThread("log4j2-logger", () -> {
+            threadsWaitingLatch.countDown();
+            try {
+                latch.await();
+                LogManager.getLogger("jul-repro-log4j").error("test");
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+        });
+
+        threadsWaitingLatch.await();
+        latch.countDown();
+        t1.join(2000);
+        t2.join(2000);
+        if (t1.isAlive() && t2.isAlive()) {
+            System.err.println(new ThreadDumpMessage("Deadlock detected").getFormattedMessage());
+            t1.join();
+            t2.join();
+        }
+    }
+
+    private static Thread startedThread(String name, Runnable task) {
+        Thread thread = new Thread(task);
+        thread.setName(name);
+        thread.setDaemon(true);
+        thread.start();
+        return thread;
+    }
+}


### PR DESCRIPTION
```
"jul-logger" Id=23 RUNNABLE
	at app//com.lmax.disruptor.dsl.ExceptionHandlerWrapper.<init>(ExceptionHandlerWrapper.java:8)
	at app//com.lmax.disruptor.dsl.Disruptor.<init>(Disruptor.java:65)
	at app//com.lmax.disruptor.dsl.Disruptor.<init>(Disruptor.java:136)
	at app//org.apache.logging.log4j.core.async.AsyncLoggerDisruptor.start(AsyncLoggerDisruptor.java:114)
	-  locked <1905048555> (a org.apache.logging.log4j.core.async.AsyncLoggerDisruptor)
	at app//org.apache.logging.log4j.core.async.AsyncLoggerContext.start(AsyncLoggerContext.java:75)
	at app//org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:155)
	at app//org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:47)
	at app//org.apache.logging.log4j.LogManager.getContext(LogManager.java:194)
	at app//org.apache.logging.log4j.spi.AbstractLoggerAdapter.getContext(AbstractLoggerAdapter.java:137)
	at app//org.apache.logging.log4j.jul.AbstractLoggerAdapter.getContext(AbstractLoggerAdapter.java:34)
	at app//org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:47)
	at app//org.apache.logging.log4j.jul.LogManager.getLogger(LogManager.java:95)
	at java.logging@11.0.9.1/java.util.logging.LogManager.demandLogger(LogManager.java:519)
	at java.logging@11.0.9.1/java.util.logging.LogManager.demandLogger(LogManager.java:515)
	at java.logging@11.0.9.1/java.util.logging.Logger.demandLogger(Logger.java:654)
	at java.logging@11.0.9.1/java.util.logging.Logger.getLogger(Logger.java:717)
	at java.logging@11.0.9.1/java.util.logging.Logger.getLogger(Logger.java:701)
	at app//org.apache.logging.log4j.perf.jmh.JulReproBenchmark.lambda$reproducer$0(JulReproBenchmark.java:82)
	at app//org.apache.logging.log4j.perf.jmh.JulReproBenchmark$$Lambda$33/0x000000084007e840.run(Unknown Source)
	at java.base@11.0.9.1/java.lang.Thread.run(Thread.java:834)

"log4j2-logger" Id=24 BLOCKED (on object monitor owned by "jul-logger" Id=23)
	at app//org.apache.logging.log4j.core.async.AsyncLoggerDisruptor.start(AsyncLoggerDisruptor.java:89)
	-  blocked on <1905048555> (a org.apache.logging.log4j.core.async.AsyncLoggerDisruptor)
	at app//org.apache.logging.log4j.core.async.AsyncLoggerContext.start(AsyncLoggerContext.java:75)
	at app//org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:155)
	at app//org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:47)
	at app//org.apache.logging.log4j.LogManager.getContext(LogManager.java:194)
	at app//org.apache.logging.log4j.spi.AbstractLoggerAdapter.getContext(AbstractLoggerAdapter.java:137)
	at app//org.apache.logging.log4j.jul.AbstractLoggerAdapter.getContext(AbstractLoggerAdapter.java:34)
	at app//org.apache.logging.log4j.spi.AbstractLoggerAdapter.getLogger(AbstractLoggerAdapter.java:47)
	at app//org.apache.logging.log4j.jul.LogManager.getLogger(LogManager.java:95)
	at java.logging@11.0.9.1/java.util.logging.LogManager.demandLogger(LogManager.java:519)
	at java.logging@11.0.9.1/java.util.logging.LogManager.demandLogger(LogManager.java:515)
	at java.logging@11.0.9.1/java.util.logging.Logger.demandLogger(Logger.java:654)
	at java.logging@11.0.9.1/java.util.logging.Logger.getLogger(Logger.java:717)
	at java.logging@11.0.9.1/java.util.logging.Logger.getLogger(Logger.java:701)
	at app//com.lmax.disruptor.FatalExceptionHandler.<clinit>(FatalExceptionHandler.java:27)
	at app//com.lmax.disruptor.dsl.ExceptionHandlerWrapper.<init>(ExceptionHandlerWrapper.java:8)
	at app//com.lmax.disruptor.dsl.Disruptor.<init>(Disruptor.java:65)
	at app//com.lmax.disruptor.dsl.Disruptor.<init>(Disruptor.java:136)
	at app//org.apache.logging.log4j.core.async.AsyncLoggerDisruptor.start(AsyncLoggerDisruptor.java:114)
	-  locked <666034025> (a org.apache.logging.log4j.core.async.AsyncLoggerDisruptor)
	at app//org.apache.logging.log4j.core.async.AsyncLoggerContext.start(AsyncLoggerContext.java:75)
	at app//org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:245)
	at app//org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:47)
	at app//org.apache.logging.log4j.LogManager.getContext(LogManager.java:174)
	at app//org.apache.logging.log4j.LogManager.getLogger(LogManager.java:664)
	at app//org.apache.logging.log4j.perf.jmh.JulReproBenchmark.lambda$reproducer$1(JulReproBenchmark.java:91)
	at app//org.apache.logging.log4j.perf.jmh.JulReproBenchmark$$Lambda$34/0x000000084007ec40.run(Unknown Source)
	at java.base@11.0.9.1/java.lang.Thread.run(Thread.java:834)
```