### PR TITLE
Remove unbound return type from Logger.getMessageFactory()

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -1681,10 +1681,9 @@ public interface Logger {
     /**
      * Gets the message factory used to convert message Objects and Strings/CharSequences into actual log Messages.
      *
-     * @param <MF> The type of the MessageFactory.
-     * @return the message factory, as an instance of {@link MessageFactory}
+     * @return the message factory
      */
-    <MF extends MessageFactory> MF getMessageFactory();
+    MessageFactory getMessageFactory();
 
     /**
      * Gets the logger name.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -1168,10 +1168,9 @@ public abstract class AbstractLogger implements ExtendedLogger, Serializable {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
-    public <MF extends MessageFactory> MF getMessageFactory() {
-        return (MF) messageFactory;
+    public MessageFactory getMessageFactory() {
+        return messageFactory;
     }
 
     @Override
@@ -2031,6 +2030,7 @@ public abstract class AbstractLogger implements ExtendedLogger, Serializable {
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
+    @Override
     public void logMessage(final Level level, final Marker marker, final String fqcn, final StackTraceElement location,
             final Message message, final Throwable throwable) {
         try {


### PR DESCRIPTION
Commit 2e9fdc135545eee435cad14ee9d74101c93694be added the unbound return type to allow easier usage with `MessageFactory2`. However, an unbound return type causes loss of type safety: You could claim that the return type of `getMessageFactory()` is XYZ even though there is no guarantee for that.

Commit 3bd605d2c4eb24657396d4fe4cee78edc3d2c1b6 deprecated `MessageFactory2`, therefore the need for this unbound return type is not as urgent anymore.

----

Edit: This change will however break source compatibility.