### PR TITLE
LOG4J2-2977 Replace outdated PatternLayout.createLayout() calls in docs with PatternLayout.createDefaultLayout()

### DIFF
--- a/src/site/asciidoc/manual/customconfig.adoc
+++ b/src/site/asciidoc/manual/customconfig.adoc
@@ -274,8 +274,7 @@ public class MyXMLConfiguration extends XMLConfiguration {
     protected void doConfigure() {
         super.doConfigure();
         final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-        final Layout layout = PatternLayout.createLayout(PatternLayout.SIMPLE_CONVERSION_PATTERN, config, null,
-              null,null, null);
+        final Layout layout = PatternLayout.createDefaultLayout(config);
         final Appender appender = FileAppender.createAppender("target/test.log", "false", "false", "File", "true",
               "false", "false", "4000", layout, null, "false", null, config);
         appender.start();
@@ -314,8 +313,7 @@ Appender to the current configuration.
 ----
         final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
         final Configuration config = ctx.getConfiguration();
-        Layout layout = PatternLayout.createLayout(PatternLayout.SIMPLE_CONVERSION_PATTERN, config, null,
-            null,null, null);
+        Layout layout = PatternLayout.createDefaultLayout(config);
         Appender appender = FileAppender.createAppender("target/test.log", "false", "false", "File", "true",
             "false", "false", "4000", layout, null, "false", null, config);
         appender.start();


### PR DESCRIPTION
My first pull request to log4j2 to fix an outdated PatternLayout.create* method in a code example for LOG4J2-2977

Pull request is against _master_ because _release-2.x_'s logging-log4j2/src/site/asciidoc/manual/ is mostly empty. Website seems to live in _master_.

Couldn't get asciidoc running on Windows (complained about missing source-highlight, found outdated one but it didn't fully work), used AsciiDoc IntelliJ plugin to verify changes looked ok.



