### PR TITLE
LOG4J2-2986: introduce filters.startFrames config element to specifc starting frame(s) during Throwable rendering

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxy.java
@@ -185,48 +185,53 @@ public class ThrowableProxy implements Serializable {
      * @param suffix
      */
     public void formatWrapper(final StringBuilder sb, final ThrowableProxy cause, final String suffix) {
-        this.formatWrapper(sb, cause, null, PlainTextRenderer.getInstance(), suffix);
+        this.formatWrapper(sb, cause, null, null, PlainTextRenderer.getInstance(), suffix);
     }
 
     /**
      * Formats the specified Throwable.
      *  @param sb             StringBuilder to contain the formatted Throwable.
      * @param cause          The Throwable to format.
-     * @param ignorePackages The List of packages to be suppressed from the trace.
+     * @param filterPackages The List of packages to be suppressed from the trace.
+     * @param filterStartFrames The List of packages to be suppressed from the trace.
      * @param suffix
      */
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
-    public void formatWrapper(final StringBuilder sb, final ThrowableProxy cause, final List<String> ignorePackages, final String suffix) {
-        this.formatWrapper(sb, cause, ignorePackages, PlainTextRenderer.getInstance(), suffix);
+    public void formatWrapper(final StringBuilder sb, final ThrowableProxy cause, final List<String> filterPackages,
+                              final List<String> filterStartFrames, final String suffix) {
+        this.formatWrapper(sb, cause, filterPackages, filterStartFrames, PlainTextRenderer.getInstance(), suffix);
     }
 
     /**
      * Formats the specified Throwable.
      * @param sb StringBuilder to contain the formatted Throwable.
      * @param cause The Throwable to format.
-     * @param ignorePackages The List of packages to be suppressed from the stack trace.
+     * @param filterPackages The List of packages to be suppressed from the stack trace.
+     * @param filterStartFrames The List of packages to be suppressed from the stack trace.
      * @param textRenderer The text renderer.
      * @param suffix Append this to the end of each stack frame.
      */
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
-    public void formatWrapper(final StringBuilder sb, final ThrowableProxy cause, final List<String> ignorePackages,
-            final TextRenderer textRenderer, final String suffix) {
-        formatWrapper(sb, cause, ignorePackages, textRenderer, suffix, EOL_STR);
+    public void formatWrapper(final StringBuilder sb, final ThrowableProxy cause, final List<String> filterPackages,
+                              final List<String> filterStartFrames, final TextRenderer textRenderer, final String suffix) {
+        formatWrapper(sb, cause, filterPackages, filterStartFrames, textRenderer, suffix, EOL_STR);
     }
 
     /**
      * Formats the specified Throwable.
      * @param sb StringBuilder to contain the formatted Throwable.
      * @param cause The Throwable to format.
-     * @param ignorePackages The List of packages to be suppressed from the stack trace.
+     * @param filterPackages The List of packages to be suppressed from the stack trace.
+     * @param filterStartFrames The List of packages to be suppressed from the stack trace.
      * @param textRenderer The text renderer.
      * @param suffix Append this to the end of each stack frame.
      * @param lineSeparator The end-of-line separator.
      */
     @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
-    public void formatWrapper(final StringBuilder sb, final ThrowableProxy cause, final List<String> ignorePackages,
-                              final TextRenderer textRenderer, final String suffix, final String lineSeparator) {
-        ThrowableProxyRenderer.formatWrapper(sb,  cause, ignorePackages, textRenderer, suffix, lineSeparator);
+    public void formatWrapper(final StringBuilder sb, final ThrowableProxy cause, final List<String> filterPackages,
+                              final List<String> filterStartFrames, final TextRenderer textRenderer, final String suffix,
+                              final String lineSeparator) {
+        ThrowableProxyRenderer.formatWrapper(sb,  cause, filterPackages, filterStartFrames, textRenderer, suffix, lineSeparator);
     }
 
     public ThrowableProxy getCauseProxy() {
@@ -240,44 +245,47 @@ public class ThrowableProxy implements Serializable {
      * @param suffix
      */
     public String getCauseStackTraceAsString(final String suffix) {
-        return this.getCauseStackTraceAsString(null, PlainTextRenderer.getInstance(), suffix, EOL_STR);
+        return this.getCauseStackTraceAsString(null, null, PlainTextRenderer.getInstance(), suffix, EOL_STR);
     }
 
     /**
      * Formats the Throwable that is the cause of this Throwable.
      *
-     * @param packages The List of packages to be suppressed from the trace.
+     * @param filterPackages The List of packages to be suppressed from the trace.
+     * @param filterStartFrames The List of packages to be suppressed from the trace.
      * @param suffix Append this to the end of each stack frame.
      * @return The formatted Throwable that caused this Throwable.
      */
-    public String getCauseStackTraceAsString(final List<String> packages, final String suffix) {
-        return getCauseStackTraceAsString(packages, PlainTextRenderer.getInstance(), suffix, EOL_STR);
+    public String getCauseStackTraceAsString(final List<String> filterPackages, final List<String> filterStartFrames, final String suffix) {
+        return getCauseStackTraceAsString(filterPackages, filterStartFrames, PlainTextRenderer.getInstance(), suffix, EOL_STR);
     }
 
     /**
      * Formats the Throwable that is the cause of this Throwable.
      *
-     * @param ignorePackages The List of packages to be suppressed from the trace.
+     * @param filterPackages The List of packages to be suppressed from the trace.
+     * @param filterStartFrames The List of packages to be suppressed from the trace.
      * @param textRenderer The text renderer.
      * @param suffix Append this to the end of each stack frame.
      * @return The formatted Throwable that caused this Throwable.
      */
-    public String getCauseStackTraceAsString(final List<String> ignorePackages, final TextRenderer textRenderer, final String suffix) {
-        return getCauseStackTraceAsString(ignorePackages, textRenderer, suffix, EOL_STR);
+    public String getCauseStackTraceAsString(final List<String> filterPackages, final List<String> filterStartFrames, final TextRenderer textRenderer, final String suffix) {
+        return getCauseStackTraceAsString(filterPackages, filterStartFrames, textRenderer, suffix, EOL_STR);
     }
 
     /**
      * Formats the Throwable that is the cause of this Throwable.
      *
-     * @param ignorePackages The List of packages to be suppressed from the stack trace.
+     * @param filterPackages The List of packages to be suppressed from the stack trace.
+     * @param filterStartFrames The List of packages to be suppressed from the stack trace.
      * @param textRenderer The text renderer.
      * @param suffix Append this to the end of each stack frame.
      * @param lineSeparator The end-of-line separator.
      * @return The formatted Throwable that caused this Throwable.
      */
-    public String getCauseStackTraceAsString(final List<String> ignorePackages, final TextRenderer textRenderer, final String suffix, final String lineSeparator) {
+    public String getCauseStackTraceAsString(final List<String> filterPackages, final List<String> filterStartFrames, final TextRenderer textRenderer, final String suffix, final String lineSeparator) {
         final StringBuilder sb = new StringBuilder();
-        ThrowableProxyRenderer.formatCauseStackTrace(this, sb, ignorePackages, textRenderer, suffix, lineSeparator);
+        ThrowableProxyRenderer.formatCauseStackTrace(this, sb, filterPackages, filterStartFrames, textRenderer, suffix, lineSeparator);
         return sb.toString();
     }
 
@@ -317,7 +325,7 @@ public class ThrowableProxy implements Serializable {
      * @return The formatted stack trace including packaging information.
      */
     public String getExtendedStackTraceAsString() {
-        return this.getExtendedStackTraceAsString(null, PlainTextRenderer.getInstance(), Strings.EMPTY, EOL_STR);
+        return this.getExtendedStackTraceAsString(null, null, PlainTextRenderer.getInstance(), Strings.EMPTY, EOL_STR);
     }
 
     /**
@@ -327,44 +335,47 @@ public class ThrowableProxy implements Serializable {
      * @param suffix Append this to the end of each stack frame.
      */
     public String getExtendedStackTraceAsString(final String suffix) {
-        return this.getExtendedStackTraceAsString(null, PlainTextRenderer.getInstance(), suffix, EOL_STR);
+        return this.getExtendedStackTraceAsString(null, null, PlainTextRenderer.getInstance(), suffix, EOL_STR);
     }
 
     /**
      * Formats the stack trace including packaging information.
      *
-     * @param ignorePackages List of packages to be ignored in the trace.
+     * @param filterPackages List of packages to be ignored in the trace.
+     * @param filterStartFrames List of packages to be ignored in the trace.
      * @param suffix Append this to the end of each stack frame.
      * @return The formatted stack trace including packaging information.
      */
-    public String getExtendedStackTraceAsString(final List<String> ignorePackages, final String suffix) {
-        return getExtendedStackTraceAsString(ignorePackages, PlainTextRenderer.getInstance(), suffix, EOL_STR);
+    public String getExtendedStackTraceAsString(final List<String> filterPackages, final List<String> filterStartFrames, final String suffix) {
+        return getExtendedStackTraceAsString(filterPackages, filterStartFrames, PlainTextRenderer.getInstance(), suffix, EOL_STR);
     }
 
     /**
      * Formats the stack trace including packaging information.
      *
-     * @param ignorePackages List of packages to be ignored in the trace.
+     * @param filterPackages List of packages to be ignored in the trace.
+     * @param filterStartFrames List of packages to be ignored in the trace.
      * @param textRenderer The message renderer.
      * @param suffix Append this to the end of each stack frame.
      * @return The formatted stack trace including packaging information.
      */
-    public String getExtendedStackTraceAsString(final List<String> ignorePackages, final TextRenderer textRenderer, final String suffix) {
-        return getExtendedStackTraceAsString(ignorePackages, textRenderer, suffix, EOL_STR);
+    public String getExtendedStackTraceAsString(final List<String> filterPackages, final List<String> filterStartFrames, final TextRenderer textRenderer, final String suffix) {
+        return getExtendedStackTraceAsString(filterPackages, filterStartFrames, textRenderer, suffix, EOL_STR);
     }
 
     /**
      * Formats the stack trace including packaging information.
      *
-     * @param ignorePackages List of packages to be ignored in the trace.
+     * @param filterPackages List of packages to be ignored in the trace.
+     * @param filterStartFrames List of packages to be ignored in the trace.
      * @param textRenderer The message renderer.
      * @param suffix Append this to the end of each stack frame.
      * @param lineSeparator The end-of-line separator.
      * @return The formatted stack trace including packaging information.
      */
-    public String getExtendedStackTraceAsString(final List<String> ignorePackages, final TextRenderer textRenderer, final String suffix, final String lineSeparator) {
+    public String getExtendedStackTraceAsString(final List<String> filterPackages, final List<String> filterStartFrames, final TextRenderer textRenderer, final String suffix, final String lineSeparator) {
         final StringBuilder sb = new StringBuilder(1024);
-        formatExtendedStackTraceTo(sb, ignorePackages, textRenderer, suffix, lineSeparator);
+        formatExtendedStackTraceTo(sb, filterPackages, filterStartFrames, textRenderer, suffix, lineSeparator);
         return sb.toString();
     }
 
@@ -372,13 +383,14 @@ public class ThrowableProxy implements Serializable {
      * Formats the stack trace including packaging information.
      *
      * @param sb Destination.
-     * @param ignorePackages List of packages to be ignored in the trace.
+     * @param filterPackages List of packages to be ignored in the trace.
+     * @param filterStartFrames List of packages to be ignored in the trace.
      * @param textRenderer The message renderer.
      * @param suffix Append this to the end of each stack frame.
      * @param lineSeparator The end-of-line separator.
      */
-    public void formatExtendedStackTraceTo(final StringBuilder sb, final List<String> ignorePackages, final TextRenderer textRenderer, final String suffix, final String lineSeparator) {
-        ThrowableProxyRenderer.formatExtendedStackTraceTo(this, sb, ignorePackages, textRenderer, suffix, lineSeparator);
+    public void formatExtendedStackTraceTo(final StringBuilder sb, final List<String> filterPackages, final List<String> filterStartFrames, final TextRenderer textRenderer, final String suffix, final String lineSeparator) {
+        ThrowableProxyRenderer.formatExtendedStackTraceTo(this, sb, filterPackages, filterStartFrames, textRenderer, suffix, lineSeparator);
     }
 
     public String getLocalizedMessage() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ExtendedThrowablePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ExtendedThrowablePatternConverter.java
@@ -71,8 +71,8 @@ public final class ExtendedThrowablePatternConverter extends ThrowablePatternCon
             if (len > 0 && !Character.isWhitespace(toAppendTo.charAt(len - 1))) {
                 toAppendTo.append(' ');
             }
-            proxy.formatExtendedStackTraceTo(toAppendTo, options.getIgnorePackages(),
-                    options.getTextRenderer(), getSuffix(event), options.getSeparator());
+            proxy.formatExtendedStackTraceTo(toAppendTo, options.getFilterPackages(),
+                    options.getFilterStartFrames(), options.getTextRenderer(), getSuffix(event), options.getSeparator());
         }
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/RootThrowablePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/RootThrowablePatternConverter.java
@@ -68,7 +68,7 @@ public final class RootThrowablePatternConverter extends ThrowablePatternConvert
                 super.format(event, toAppendTo);
                 return;
             }
-            final String trace = proxy.getCauseStackTraceAsString(options.getIgnorePackages(), options.getTextRenderer(), getSuffix(event), options.getSeparator());
+            final String trace = proxy.getCauseStackTraceAsString(options.getFilterPackages(), options.getFilterStartFrames(), options.getTextRenderer(), getSuffix(event), options.getSeparator());
             final int len = toAppendTo.length();
             if (len > 0 && !Character.isWhitespace(toAppendTo.charAt(len - 1))) {
                 toAppendTo.append(' ');

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/ThrowableFormatOptionsTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/ThrowableFormatOptionsTest.java
@@ -41,22 +41,22 @@ public final class ThrowableFormatOptionsTest {
      *            The list of options to parse.
      * @param expectedLines
      *            The expected lines.
-     * @param expectedPackages
+     * @param expectedFilterPackages
      *            The expected package filters.
      * @param expectedSeparator
      *            The expected separator.
      */
     private static ThrowableFormatOptions test(final String[] options, final int expectedLines,
-            final String expectedSeparator, final List<String> expectedPackages) {
+            final String expectedSeparator, final List<String> expectedFilterPackages) {
         final ThrowableFormatOptions tfo = ThrowableFormatOptions.newInstance(options);
         assertEquals(expectedLines, tfo.getLines(), "getLines");
         assertEquals(expectedSeparator, tfo.getSeparator(), "getSeparator");
-        assertEquals(expectedPackages, tfo.getIgnorePackages(), "getPackages");
+        assertEquals(expectedFilterPackages, tfo.getFilterPackages(), "getFilterPackages");
         assertEquals(expectedLines == Integer.MAX_VALUE, tfo.allLines(), "allLines");
         assertEquals(expectedLines != 0, tfo.anyLines(), "anyLines");
         assertEquals(0, tfo.minLines(0), "minLines");
         assertEquals(expectedLines, tfo.minLines(Integer.MAX_VALUE), "minLines");
-        assertEquals(expectedPackages != null && !expectedPackages.isEmpty(), tfo.hasPackages(), "hasPackages");
+        assertEquals(expectedFilterPackages != null && !expectedFilterPackages.isEmpty(), tfo.getFilterPackages(), "hasFilteredPackages");
         assertNotNull(tfo.toString(), "toString");
         return tfo;
     }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/ThrowableProxyTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/ThrowableProxyTest.java
@@ -287,7 +287,7 @@ public class ThrowableProxyTest {
         final ThrowableProxy proxy = new ThrowableProxy(throwable);
 
         final String separator = " | ";
-        final String extendedStackTraceAsString = proxy.getExtendedStackTraceAsString(null,
+        final String extendedStackTraceAsString = proxy.getExtendedStackTraceAsString(null,null,
                 PlainTextRenderer.getInstance(), " | ", Strings.EMPTY);
         assertTrue(allLinesContain(extendedStackTraceAsString, separator), extendedStackTraceAsString);
     }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/PatternParserTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/PatternParserTest.java
@@ -377,8 +377,8 @@ public class PatternParserTest {
         assertEquals(ExtendedThrowablePatternConverter.class, converter.getClass());
         final ExtendedThrowablePatternConverter exConverter = (ExtendedThrowablePatternConverter) converter;
         final ThrowableFormatOptions options = exConverter.getOptions();
-        assertTrue(options.getIgnorePackages().contains("org.junit"));
-        assertTrue(options.getIgnorePackages().contains("org.eclipse"));
+        assertTrue(options.getFilterPackages().contains("org.junit"));
+        assertTrue(options.getFilterPackages().contains("org.eclipse"));
         assertEquals(System.lineSeparator(), options.getSeparator());
     }
 
@@ -393,7 +393,7 @@ public class PatternParserTest {
         assertEquals(ExtendedThrowablePatternConverter.class, converter.getClass());
         final ExtendedThrowablePatternConverter exConverter = (ExtendedThrowablePatternConverter) converter;
         final ThrowableFormatOptions options = exConverter.getOptions();
-        final List<String> ignorePackages = options.getIgnorePackages();
+        final List<String> ignorePackages = options.getFilterPackages();
         assertNotNull(ignorePackages);
         final String ignorePackagesString = ignorePackages.toString();
         assertTrue(ignorePackages.contains("org.junit"), ignorePackagesString);


### PR DESCRIPTION
- Allow frame (package + method name) specific starting point on stack traces to suppress boilerplate web container, vendor framework, etc frames
- _filters.startFrames(frame1,frame2)_ name selected because its related to _filters(package1,package2)_
- Suppress web container frames beneath the servlet entry point using _filters.startFrame(javax.servlet.http.HttpServlet.service)_
- Updated various _packages_, _ignorePackages_, _hasPackages_ variables to more descriptive and consistent _filterPackages_
- Change a few signatures to accept new _filterStartFrames_ parameter alongside _filterPackages_
  - Future: combine both Lists into some kind of FilterConfig object to support future filters and reduce arguments to methods
 