### PR TITLE
Fixing typos in docs.

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/LogEventAdapter.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/LogEventAdapter.java
@@ -153,7 +153,7 @@ public class LogEventAdapter extends LoggingEvent {
     }
 
     /*
-     Returns the the context corresponding to the <code>key</code> parameter.
+     Returns the context corresponding to the <code>key</code> parameter.
      */
     @Override
     public Object getMDC(String key) {

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/spi/ErrorHandler.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/spi/ErrorHandler.java
@@ -49,7 +49,7 @@ public interface ErrorHandler {
 
     /**
      * Equivalent to the {@link #error(String, Exception, int,
-     * LoggingEvent)} with the the event parameter set to
+     * LoggingEvent)} with the event parameter set to
      * <code>null</code>.
      *
      * @param message   The message associated with the error.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
@@ -373,7 +373,7 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
     }
 
     /**
-     * Formats the message according the the specified format.
+     * Formats the message according to the specified format.
      * @param formats An array of Strings that provide extra information about how to format the message.
      * StructuredDataMessage accepts only a format of "FULL" which will cause the event type to be
      * prepended and the event message to be appended. Specifying any other value will cause only the

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMap.java
@@ -81,7 +81,7 @@ public interface ThreadContextMap {
     void put(final String key, final String value);
 
     /**
-     * Removes the the context identified by the <code>key</code>
+     * Removes the context identified by the <code>key</code>
      * parameter.
      * @param key The key to remove.
      */

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ReflectionUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ReflectionUtil.java
@@ -179,7 +179,7 @@ public final class ReflectionUtil {
      * @throws IllegalArgumentException if the given class is abstract, an interface, an array class, a primitive type,
      *                                  or void
      * @throws IllegalStateException    if access is denied to the constructor, or there are no default constructors
-     * @throws InternalException        wrapper of the the underlying exception if checked
+     * @throws InternalException        wrapper of the underlying exception if checked
      */
     public static <T> T instantiate(final Class<T> clazz) {
         Objects.requireNonNull(clazz, "No class provided");

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Timer.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Timer.java
@@ -22,7 +22,7 @@ import java.text.DecimalFormat;
 /**
  * Primarily used in unit tests, but can be used to track elapsed time for a request or portion of any other operation
  * so long as all the timer methods are called on the same thread in which it was started. Calling start on
- * multiple threads will cause the the times to be aggregated.
+ * multiple threads will cause the times to be aggregated.
  */
 public class Timer implements Serializable, StringBuilderFormattable
 {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AbstractManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AbstractManager.java
@@ -36,7 +36,7 @@ import org.apache.logging.log4j.status.StatusLogger;
  * This class implements {@link AutoCloseable} mostly to allow unit tests to be written safely and succinctly. While
  * managers do need to allocate resources (usually on construction) and then free these resources, a manager is longer
  * lived than other auto-closeable objects like streams. None the less, making a manager AutoCloseable forces readers to
- * be aware of the the pattern: allocate resources on construction and call {@link #close()} at some point.
+ * be aware of the pattern: allocate resources on construction and call {@link #close()} at some point.
  * </p>
  */
 public abstract class AbstractManager implements AutoCloseable {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/OutputStreamManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/OutputStreamManager.java
@@ -332,7 +332,7 @@ public class OutputStreamManager extends AbstractManager implements ByteBufferDe
      * {@link #flushBuffer(ByteBuffer)} directly instead.
      * </p>
      *
-     * @param buf the buffer whose contents to write the the destination
+     * @param buf the buffer whose contents to write the destination
      * @return the specified buffer
      * @since 2.6
      */

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/AbstractPathAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/AbstractPathAction.java
@@ -138,7 +138,7 @@ public abstract class AbstractPathAction extends AbstractAction {
     }
 
     /**
-     * Returns the the maximum number of directory levels to visit.
+     * Returns the maximum number of directory levels to visit.
      * 
      * @return the maxDepth
      */

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Loader.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Loader.java
@@ -73,7 +73,7 @@ public final class Loader {
      * <li>Search for {@code resource} using the thread context
      * class loader under Java2. If that fails, search for
      * {@code resource} using the class loader that loaded this
-     * class ({@code Loader}). Under JDK 1.1, only the the class
+     * class ({@code Loader}). Under JDK 1.1, only the class
      * loader that loaded this class ({@code Loader}) is used.</li>
      * <li>Try one last time with
      * {@code ClassLoader.getSystemResource(resource)}, that is is
@@ -135,7 +135,7 @@ public final class Loader {
      * <li>Search for {@code resource} using the thread context
      * class loader under Java2. If that fails, search for
      * {@code resource} using the class loader that loaded this
-     * class ({@code Loader}). Under JDK 1.1, only the the class
+     * class ({@code Loader}). Under JDK 1.1, only the class
      * loader that loaded this class ({@code Loader}) is used.</li>
      * <li>Try one last time with
      * {@code ClassLoader.getSystemResource(resource)}, that is is

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/ReconfigureAppenderTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/ReconfigureAppenderTest.java
@@ -139,7 +139,7 @@ public class ReconfigureAppenderTest {
 			ConfigurationBuilderFactory.newConfigurationBuilder();
 
 		// All loggers must have a root logger. The default root logger logs ERRORs to the console.
-		// Override this with a root logger that does not log anywhere as we leave it up the the
+		// Override this with a root logger that does not log anywhere as we leave it up the
 		// appenders on the logger.
 		config_builder.add(config_builder.newRootLogger(Level.INFO));
 

--- a/log4j-liquibase/src/site/markdown/index.md
+++ b/log4j-liquibase/src/site/markdown/index.md
@@ -27,5 +27,5 @@ For more information, see [Runtime Dependencies](../runtime-dependencies.html).
 
 ## Usage
 
-Including this module will automatically make Liquibase log via Log4j 2, due the the plugin auto discovery mechanism of
+Including this module will automatically make Liquibase log via Log4j 2, due the plugin auto discovery mechanism of
 Liquibase.

--- a/src/site/asciidoc/manual/json-template-layout.vm.adoc
+++ b/src/site/asciidoc/manual/json-template-layout.vm.adoc
@@ -42,7 +42,7 @@ enough to enable access to `JsonTemplateLayout` in your Log4j configuration:
 </dependency>
 ----
 
-For instance, given the following JSON template modelling the
+For instance, given the following JSON template modelling
 https://github.com/logstash/log4j-jsonevent-layout[the official Logstash
 `JSONEventLayoutV1`] (accessible via `classpath:LogstashJsonEventLayoutV1.json`)
 

--- a/src/site/asciidoc/manual/layouts.adoc
+++ b/src/site/asciidoc/manual/layouts.adoc
@@ -516,7 +516,7 @@ required for using JsonLayout.
 `JsonTemplateLayout` is a customizable, efficient, and garbage-free JSON
 emitting layout. It encodes ``LogEvent``s according to the structure described
 by the JSON template provided. For instance, given the following JSON template
-modelling the https://github.com/logstash/log4j-jsonevent-layout[the official
+modelling https://github.com/logstash/log4j-jsonevent-layout[the official
 Logstash `JSONEventLayoutV1`]
 
 [source,json]


### PR DESCRIPTION
I noticed a typo in the docs, and then realised the same typo existed in a bunch of places.