### PR TITLE
ensure EncodingPatternConverter#handlesThrowable is implemented

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/EncodingPatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/EncodingPatternConverter.java
@@ -17,6 +17,8 @@
 package org.apache.logging.log4j.core.pattern;
 
 import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
@@ -49,6 +51,13 @@ public final class EncodingPatternConverter extends LogEventPatternConverter {
         super("encode", "encode");
         this.formatters = formatters;
         this.escapeFormat = escapeFormat;
+    }
+
+    @Override
+    public boolean handlesThrowable() {
+        return formatters != null && formatters.stream()
+                .map(PatternFormatter::getConverter)
+                .anyMatch(LogEventPatternConverter::handlesThrowable);
     }
 
     /**

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/EncodingPatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/EncodingPatternConverterTest.java
@@ -19,9 +19,16 @@ package org.apache.logging.log4j.core.pattern;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.TestPatternConverters;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.logging.log4j.plugins.Plugin;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -103,4 +110,36 @@ public class EncodingPatternConverterTest {
             sb.toString());
     }
 
+    @Test
+    public void testHandlesThrowable() {
+        final Configuration configuration = new DefaultConfiguration();
+        assertFalse(EncodingPatternConverter.newInstance(configuration, new String[]{"%msg", "XML"})
+            .handlesThrowable());
+        assertTrue(EncodingPatternConverter.newInstance(configuration, new String[]{"%xThrowable{full}", "JSON"})
+            .handlesThrowable());
+        assertTrue(EncodingPatternConverter.newInstance(configuration, new String[]{"%ex", "XML"})
+            .handlesThrowable());
+    }
+
+    @ConverterKeys("testhandlingthrowable")
+    @Plugin(name = "TestHandlingThrowableConverter", category = "Converter")
+    public static final class HandlingThrowableConverter extends LogEventPatternConverter {
+        private HandlingThrowableConverter() {
+            super("Format", "testhandlingthrowable");
+        }
+
+        public static HandlingThrowableConverter newInstance(final String[] options) {
+            return new HandlingThrowableConverter();
+        }
+
+        @Override
+        public boolean handlesThrowable() {
+            return true;
+        }
+
+        @Override
+        public void format(final LogEvent event, final StringBuilder toAppendTo) {
+            toAppendTo.append(event.getMessage().getFormat());
+        }
+    }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/EncodingPatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/EncodingPatternConverterTest.java
@@ -19,16 +19,11 @@ package org.apache.logging.log4j.core.pattern;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.TestPatternConverters;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.SimpleMessage;
-import org.apache.logging.log4j.plugins.Plugin;
 import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -119,27 +114,5 @@ public class EncodingPatternConverterTest {
             .handlesThrowable());
         assertTrue(EncodingPatternConverter.newInstance(configuration, new String[]{"%ex", "XML"})
             .handlesThrowable());
-    }
-
-    @ConverterKeys("testhandlingthrowable")
-    @Plugin(name = "TestHandlingThrowableConverter", category = "Converter")
-    public static final class HandlingThrowableConverter extends LogEventPatternConverter {
-        private HandlingThrowableConverter() {
-            super("Format", "testhandlingthrowable");
-        }
-
-        public static HandlingThrowableConverter newInstance(final String[] options) {
-            return new HandlingThrowableConverter();
-        }
-
-        @Override
-        public boolean handlesThrowable() {
-            return true;
-        }
-
-        @Override
-        public void format(final LogEvent event, final StringBuilder toAppendTo) {
-            toAppendTo.append(event.getMessage().getFormat());
-        }
     }
 }


### PR DESCRIPTION
Giess the title is enough to understand what happens ;).
Long story short the handlesThrowable() logic to skip forced (by default) append of the exception does not work as soon as encoding is used which is almost always the case when outputing JSON/XML using PatternFormatter (since Json appender required 3rd party libs which are often undesired).
This PR implements this method by checking the nested formatters.