### PR TITLE
LOG4J2-2940: Context selectors are aware of ClassLoader dependency

### DIFF
--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -45,9 +45,18 @@ public class StackLocator {
     }
 
     public Class<?> getCallerClass(final String fqcn, final String pkg) {
-        return walker.walk(s -> s.dropWhile(f -> !f.getClassName().equals(fqcn)).
-                dropWhile(f -> f.getClassName().equals(fqcn)).dropWhile(f -> !f.getClassName().startsWith(pkg)).
-                findFirst()).map(StackWalker.StackFrame::getDeclaringClass).orElse(null);
+        return getCallerClass(fqcn, pkg, 0);
+    }
+
+    public Class<?> getCallerClass(final String fqcn, final String pkg, final int skipDepth) {
+        return walker.walk(s -> s
+                .dropWhile(f -> !f.getClassName().equals(fqcn))
+                .dropWhile(f -> f.getClassName().equals(fqcn))
+                .dropWhile(f -> !f.getClassName().startsWith(pkg))
+                .skip(skipDepth)
+                .findFirst())
+                .map(StackWalker.StackFrame::getDeclaringClass)
+                .orElse(null);
     }
 
     public Class<?> getCallerClass(final Class<?> anchor) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContextFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContextFactory.java
@@ -44,4 +44,9 @@ public class SimpleLoggerContextFactory implements LoggerContextFactory {
     public void removeContext(final LoggerContext removeContext) {
         // do nothing
     }
+
+    @Override
+    public boolean isClassLoaderDependent() {
+        return false;
+    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextFactory.java
@@ -87,4 +87,17 @@ public interface LoggerContextFactory {
      * @param context The context to remove.
      */
     void removeContext(LoggerContext context);
+
+    /**
+     * Determines whether or not this factory and perhaps the underlying
+     * ContextSelector behavior depend on the callers classloader.
+     *
+     * This method should be overridden by implementations, however a default method is provided which always
+     * returns {@code true} to preserve the old behavior.
+     *
+     * @since 2.15.0
+     */
+    default boolean isClassLoaderDependent() {
+        return true;
+    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -119,6 +119,14 @@ public final class StackLocator {
     // migrated from Log4jLoggerFactory
     @PerformanceSensitive
     public Class<?> getCallerClass(final String fqcn, final String pkg) {
+        return getCallerClass(fqcn, pkg, 0);
+    }
+
+    @PerformanceSensitive
+    public Class<?> getCallerClass(final String fqcn, final String pkg, final int skipDepth) {
+        if (skipDepth < 0) {
+            throw new IllegalArgumentException("skipDepth cannot be negative");
+        }
         boolean next = false;
         Class<?> clazz;
         for (int i = 2; null != (clazz = getCallerClass(i)); i++) {
@@ -127,7 +135,9 @@ public final class StackLocator {
                 continue;
             }
             if (next && clazz.getName().startsWith(pkg)) {
-                return clazz;
+                return skipDepth == 0
+                        ? clazz
+                        : getCallerClass(i + skipDepth);
             }
         }
         // TODO: return Object.class

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
@@ -48,16 +48,34 @@ public final class StackLocatorUtil {
         return stackLocator.getStackTraceElement(depth + 1);
     }
 
+    /**
+     * Equivalent to {@link #getCallerClass(String, String)} with an empty {@code pkg}.
+     */
     // migrated from ClassLoaderContextSelector
     @PerformanceSensitive
     public static Class<?> getCallerClass(final String fqcn) {
         return getCallerClass(fqcn, Strings.EMPTY);
     }
 
-    // migrated from Log4jLoggerFactory
+    /**
+     * Equivalent to {@link #getCallerClass(String, String, int)} with {@code skipDepth = 0}.
+     */
     @PerformanceSensitive
     public static Class<?> getCallerClass(final String fqcn, final String pkg) {
         return stackLocator.getCallerClass(fqcn, pkg);
+    }
+
+    /**
+     * Search for a calling class.
+     *
+     * @param fqcn Root class name whose caller to search for.
+     * @param pkg Package name prefix that must be matched after the {@code fqcn} has been found.
+     * @param skipDepth Number of stack frames to skip after the {@code fqcn} and {@code pkg} have been matched.
+     * @return The caller class that was matched, or null if one could not be located.
+     */
+    @PerformanceSensitive
+    public static Class<?> getCallerClass(final String fqcn, final String pkg, final int skipDepth) {
+        return stackLocator.getCallerClass(fqcn, pkg, skipDepth);
     }
 
     // added for use in LoggerAdapter implementations mainly

--- a/log4j-api/src/test/java/org/apache/logging/log4j/TestLoggerContextFactory.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/TestLoggerContextFactory.java
@@ -43,4 +43,9 @@ public class TestLoggerContextFactory implements LoggerContextFactory {
     @Override
     public void removeContext(final LoggerContext context) {
     }
+
+    @Override
+    public boolean isClassLoaderDependent() {
+        return false;
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/BasicAsyncLoggerContextSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/BasicAsyncLoggerContextSelector.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.async;
+
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.impl.ContextAnchor;
+import org.apache.logging.log4j.core.selector.ContextSelector;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Returns either this Thread's context or the default {@link AsyncLoggerContext}.
+ * Single-application instances should prefer this implementation over the {@link AsyncLoggerContextSelector}
+ * due the the reduced overhead avoiding classloader lookups.
+ */
+public class BasicAsyncLoggerContextSelector implements ContextSelector {
+
+    private static final AsyncLoggerContext CONTEXT = new AsyncLoggerContext("AsyncDefault");
+
+    @Override
+    public void shutdown(String fqcn, ClassLoader loader, boolean currentContext, boolean allContexts) {
+        LoggerContext ctx = getContext(fqcn, loader, currentContext);
+        if (ctx != null && ctx.isStarted()) {
+            ctx.stop(DEFAULT_STOP_TIMEOUT, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Override
+    public boolean hasContext(String fqcn, ClassLoader loader, boolean currentContext) {
+        LoggerContext ctx = getContext(fqcn, loader, currentContext);
+        return ctx != null && ctx.isStarted();
+    }
+
+    @Override
+    public LoggerContext getContext(final String fqcn, final ClassLoader loader, final boolean currentContext) {
+        final LoggerContext ctx = ContextAnchor.THREAD_CONTEXT.get();
+        return ctx != null ? ctx : CONTEXT;
+    }
+
+
+    @Override
+    public LoggerContext getContext(
+            final String fqcn,
+            final ClassLoader loader,
+            final boolean currentContext,
+            final URI configLocation) {
+        final LoggerContext ctx = ContextAnchor.THREAD_CONTEXT.get();
+        return ctx != null ? ctx : CONTEXT;
+    }
+
+    @Override
+    public void removeContext(final LoggerContext context) {
+        // does not remove anything
+    }
+
+    @Override
+    public boolean isClassLoaderDependent() {
+        return false;
+    }
+
+    @Override
+    public List<LoggerContext> getLoggerContexts() {
+        return Collections.singletonList(CONTEXT);
+    }
+
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jContextFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jContextFactory.java
@@ -374,6 +374,11 @@ public class Log4jContextFactory implements LoggerContextFactory, ShutdownCallba
     }
 
     @Override
+    public boolean isClassLoaderDependent() {
+        return selector.isClassLoaderDependent();
+    }
+
+    @Override
     public Cancellable addShutdownCallback(final Runnable callback) {
         return isShutdownHookEnabled() ? shutdownCallbackRegistry.addShutdownCallback(callback) : null;
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/BasicContextSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/BasicContextSelector.java
@@ -71,6 +71,11 @@ public class BasicContextSelector implements ContextSelector {
     }
 
     @Override
+    public boolean isClassLoaderDependent() {
+        return false;
+    }
+
+    @Override
     public List<LoggerContext> getLoggerContexts() {
         final List<LoggerContext> list = new ArrayList<>();
         list.add(CONTEXT);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/ClassLoaderContextSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/ClassLoaderContextSelector.java
@@ -158,6 +158,12 @@ public class ClassLoaderContextSelector implements ContextSelector, LoggerContex
     }
 
     @Override
+    public boolean isClassLoaderDependent() {
+        // By definition the ClassLoaderContextSelector depends on the callers class loader.
+        return true;
+    }
+
+    @Override
     public List<LoggerContext> getLoggerContexts() {
         final List<LoggerContext> list = new ArrayList<>();
         final Collection<AtomicReference<WeakReference<LoggerContext>>> coll = CONTEXT_MAP.values();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/ContextSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/ContextSelector.java
@@ -126,5 +126,15 @@ public interface ContextSelector {
      */
     void removeContext(LoggerContext context);
 
-
+    /**
+     * Determines whether or not this ContextSelector depends on the callers classloader.
+     * This method should be overridden by implementations, however a default method is provided which always
+     * returns {@code true} to preserve the old behavior.
+     *
+     * @return true if the class loader is required.
+     * @since 2.15.0
+     */
+    default boolean isClassLoaderDependent() {
+        return true;
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/CoreContextSelectors.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/CoreContextSelectors.java
@@ -17,9 +17,15 @@
 package org.apache.logging.log4j.core.selector;
 
 import org.apache.logging.log4j.core.async.AsyncLoggerContextSelector;
+import org.apache.logging.log4j.core.async.BasicAsyncLoggerContextSelector;
 
 public class CoreContextSelectors {
 
-    public static final Class<?>[] CLASSES = new Class<?>[] { ClassLoaderContextSelector.class, BasicContextSelector.class, AsyncLoggerContextSelector.class };
+    public static final Class<?>[] CLASSES = new Class<?>[] {
+            ClassLoaderContextSelector.class,
+            BasicContextSelector.class,
+            AsyncLoggerContextSelector.class,
+            BasicAsyncLoggerContextSelector.class
+    };
 
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/JndiContextSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/JndiContextSelector.java
@@ -180,6 +180,11 @@ public class JndiContextSelector implements NamedContextSelector {
     }
 
     @Override
+    public boolean isClassLoaderDependent() {
+        return false;
+    }
+
+    @Override
     public LoggerContext removeContext(final String name) {
         return CONTEXT_MAP.remove(name);
     }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerContextSelectorTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerContextSelectorTest.java
@@ -65,4 +65,9 @@ public class AsyncLoggerContextSelectorTest {
         assertEquals(expectedContextName, context.getName());
     }
 
+    @Test
+    public void testDependentOnClassLoader() {
+        final AsyncLoggerContextSelector selector = new AsyncLoggerContextSelector();
+        assertTrue(selector.isClassLoaderDependent());
+    }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerCustomSelectorLocationTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerCustomSelectorLocationTest.java
@@ -106,5 +106,10 @@ public class AsyncLoggerCustomSelectorLocationTest {
         public void removeContext(final LoggerContext context) {
             // does not remove anything
         }
+
+        @Override
+        public boolean isClassLoaderDependent() {
+            return false;
+        }
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTest.java
@@ -72,6 +72,8 @@ public class AsyncLoggerTest {
 
         final String location = "testAsyncLogWritesToLog";
         assertTrue("no location", !line1.contains(location));
+
+        assertTrue(LogManager.getFactory().isClassLoaderDependent());
     }
 
     // NOTE: only define one @Test method per test class with Async Loggers to prevent spurious failures

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/BasicAsyncLoggerContextSelectorTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/BasicAsyncLoggerContextSelectorTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.async;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.categories.AsyncLoggers;
+import org.apache.logging.log4j.core.LifeCycle;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.util.Constants;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Category(AsyncLoggers.class)
+public class BasicAsyncLoggerContextSelectorTest {
+
+    private static final String FQCN = BasicAsyncLoggerContextSelectorTest.class.getName();
+
+    @BeforeClass
+    public static void beforeClass() {
+        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR,
+                BasicAsyncLoggerContextSelector.class.getName());
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
+    }
+
+    @Test
+    public void testContextReturnsAsyncLoggerContext() {
+        final BasicAsyncLoggerContextSelector selector = new BasicAsyncLoggerContextSelector();
+        final LoggerContext context = selector.getContext(FQCN, null, false);
+
+        assertTrue(context instanceof AsyncLoggerContext);
+    }
+
+    @Test
+    public void testContext2ReturnsAsyncLoggerContext() {
+        final BasicAsyncLoggerContextSelector selector = new BasicAsyncLoggerContextSelector();
+        final LoggerContext context = selector.getContext(FQCN, null, false, null);
+
+        assertTrue(context instanceof AsyncLoggerContext);
+    }
+
+    @Test
+    public void testLoggerContextsReturnsAsyncLoggerContext() {
+        final BasicAsyncLoggerContextSelector selector = new BasicAsyncLoggerContextSelector();
+
+        List<LoggerContext> list = selector.getLoggerContexts();
+        assertEquals(1, list.size());
+        assertTrue(list.get(0) instanceof AsyncLoggerContext);
+
+        selector.getContext(FQCN, null, false);
+
+        list = selector.getLoggerContexts();
+        assertEquals(1, list.size());
+        assertTrue(list.get(0) instanceof AsyncLoggerContext);
+    }
+
+    @Test
+    public void testContextNameIsAsyncDefault() {
+        final BasicAsyncLoggerContextSelector selector = new BasicAsyncLoggerContextSelector();
+        final LoggerContext context = selector.getContext(FQCN, null, false);
+        assertEquals("AsyncDefault" , context.getName());
+    }
+
+    @Test
+    public void testDependentOnClassLoader() {
+        final BasicAsyncLoggerContextSelector selector = new BasicAsyncLoggerContextSelector();
+        assertFalse(selector.isClassLoaderDependent());
+    }
+
+    @Test
+    public void testFactoryIsNotDependentOnClassLoader() {
+        assertFalse(LogManager.getFactory().isClassLoaderDependent());
+    }
+
+    @Test
+    public void testLogManagerShutdown() {
+        LoggerContext context = (LoggerContext) LogManager.getContext();
+        assertEquals(LifeCycle.State.STARTED, context.getState());
+        LogManager.shutdown();
+        assertEquals(LifeCycle.State.STOPPED, context.getState());
+    }
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/selector/BasicContextSelectorTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/selector/BasicContextSelectorTest.java
@@ -25,9 +25,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public final class BasicContextSelectorTest {
-
 
     @BeforeClass
     public static void beforeClass() {
@@ -46,5 +46,10 @@ public final class BasicContextSelectorTest {
         assertEquals(LifeCycle.State.STARTED, context.getState());
         LogManager.shutdown();
         assertEquals(LifeCycle.State.STOPPED, context.getState());
+    }
+
+    @Test
+    public void testNotDependentOnClassLoader() {
+        assertFalse(LogManager.getFactory().isClassLoaderDependent());
     }
 }

--- a/log4j-jcl/src/main/java/org/apache/logging/log4j/jcl/LogAdapter.java
+++ b/log4j-jcl/src/main/java/org/apache/logging/log4j/jcl/LogAdapter.java
@@ -18,6 +18,7 @@ package org.apache.logging.log4j.jcl;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.spi.AbstractLoggerAdapter;
 import org.apache.logging.log4j.spi.LoggerContext;
 import org.apache.logging.log4j.util.StackLocatorUtil;
@@ -36,7 +37,9 @@ public class LogAdapter extends AbstractLoggerAdapter<Log> {
 
     @Override
     protected LoggerContext getContext() {
-        return getContext(StackLocatorUtil.getCallerClass(LogFactory.class));
+        return getContext(LogManager.getFactory().isClassLoaderDependent()
+                ? StackLocatorUtil.getCallerClass(LogFactory.class)
+                : null);
     }
 
 }

--- a/log4j-jpl/src/main/java/org/apache/logging/log4j/jpl/Log4jSystemLoggerAdapter.java
+++ b/log4j-jpl/src/main/java/org/apache/logging/log4j/jpl/Log4jSystemLoggerAdapter.java
@@ -20,6 +20,7 @@ package org.apache.logging.log4j.jpl;
 import java.lang.System.Logger;
 import java.lang.System.LoggerFinder;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.spi.AbstractLoggerAdapter;
 import org.apache.logging.log4j.spi.LoggerContext;
 import org.apache.logging.log4j.util.StackLocatorUtil;
@@ -38,6 +39,8 @@ public class Log4jSystemLoggerAdapter extends AbstractLoggerAdapter<Logger> {
 
     @Override
     protected LoggerContext getContext() {
-        return getContext(StackLocatorUtil.getCallerClass(LoggerFinder.class));
+        return getContext(LogManager.getFactory().isClassLoaderDependent()
+                ? StackLocatorUtil.getCallerClass(LoggerFinder.class)
+                : null);
     }
 }

--- a/log4j-jul/src/main/java/org/apache/logging/log4j/jul/AbstractLoggerAdapter.java
+++ b/log4j-jul/src/main/java/org/apache/logging/log4j/jul/AbstractLoggerAdapter.java
@@ -18,6 +18,7 @@ package org.apache.logging.log4j.jul;
 
 import java.util.logging.Logger;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.spi.LoggerContext;
 import org.apache.logging.log4j.util.StackLocatorUtil;
 
@@ -31,7 +32,9 @@ public abstract class AbstractLoggerAdapter extends org.apache.logging.log4j.spi
 
     @Override
     protected LoggerContext getContext() {
-        return getContext(StackLocatorUtil.getCallerClass(java.util.logging.LogManager.class));
+        return getContext(LogManager.getFactory().isClassLoaderDependent()
+                ? StackLocatorUtil.getCallerClass(java.util.logging.LogManager.class)
+                : null);
     }
 
 }

--- a/log4j-slf4j-impl/src/main/java/org/apache/logging/slf4j/Log4jLoggerFactory.java
+++ b/log4j-slf4j-impl/src/main/java/org/apache/logging/slf4j/Log4jLoggerFactory.java
@@ -41,8 +41,12 @@ public class Log4jLoggerFactory extends AbstractLoggerAdapter<Logger> implements
 
     @Override
     protected LoggerContext getContext() {
-        final Class<?> anchor = StackLocatorUtil.getCallerClass(FQCN, PACKAGE);
-        return anchor == null ? LogManager.getContext() : getContext(StackLocatorUtil.getCallerClass(anchor));
+        final Class<?> anchor = LogManager.getFactory().isClassLoaderDependent()
+                ? StackLocatorUtil.getCallerClass(FQCN, PACKAGE)
+                : null;
+        return anchor == null
+                ? LogManager.getContext()
+                : getContext(StackLocatorUtil.getCallerClass(anchor));
     }
     private LoggerContext validateContext(final LoggerContext context) {
         if (TO_SLF4J_CONTEXT.equals(context.getClass().getName())) {

--- a/log4j-slf4j-impl/src/main/java/org/apache/logging/slf4j/Log4jLoggerFactory.java
+++ b/log4j-slf4j-impl/src/main/java/org/apache/logging/slf4j/Log4jLoggerFactory.java
@@ -42,11 +42,11 @@ public class Log4jLoggerFactory extends AbstractLoggerAdapter<Logger> implements
     @Override
     protected LoggerContext getContext() {
         final Class<?> anchor = LogManager.getFactory().isClassLoaderDependent()
-                ? StackLocatorUtil.getCallerClass(FQCN, PACKAGE)
+                ? StackLocatorUtil.getCallerClass(FQCN, PACKAGE, 1)
                 : null;
         return anchor == null
                 ? LogManager.getContext()
-                : getContext(StackLocatorUtil.getCallerClass(anchor));
+                : getContext(anchor);
     }
     private LoggerContext validateContext(final LoggerContext context) {
         if (TO_SLF4J_CONTEXT.equals(context.getClass().getName())) {

--- a/log4j-slf4j18-impl/src/main/java/org/apache/logging/slf4j/Log4jLoggerFactory.java
+++ b/log4j-slf4j18-impl/src/main/java/org/apache/logging/slf4j/Log4jLoggerFactory.java
@@ -48,11 +48,11 @@ public class Log4jLoggerFactory extends AbstractLoggerAdapter<Logger> implements
     @Override
     protected LoggerContext getContext() {
         final Class<?> anchor = LogManager.getFactory().isClassLoaderDependent()
-                ? StackLocatorUtil.getCallerClass(FQCN, PACKAGE)
+                ? StackLocatorUtil.getCallerClass(FQCN, PACKAGE, 1)
                 : null;
         return anchor == null
                 ? LogManager.getContext()
-                : getContext(StackLocatorUtil.getCallerClass(anchor));
+                : getContext(anchor);
     }
 
     Log4jMarkerFactory getMarkerFactory() {

--- a/log4j-slf4j18-impl/src/main/java/org/apache/logging/slf4j/Log4jLoggerFactory.java
+++ b/log4j-slf4j18-impl/src/main/java/org/apache/logging/slf4j/Log4jLoggerFactory.java
@@ -47,8 +47,12 @@ public class Log4jLoggerFactory extends AbstractLoggerAdapter<Logger> implements
 
     @Override
     protected LoggerContext getContext() {
-        final Class<?> anchor = StackLocatorUtil.getCallerClass(FQCN, PACKAGE);
-        return anchor == null ? LogManager.getContext() : getContext(StackLocatorUtil.getCallerClass(anchor));
+        final Class<?> anchor = LogManager.getFactory().isClassLoaderDependent()
+                ? StackLocatorUtil.getCallerClass(FQCN, PACKAGE)
+                : null;
+        return anchor == null
+                ? LogManager.getContext()
+                : getContext(StackLocatorUtil.getCallerClass(anchor));
     }
 
     Log4jMarkerFactory getMarkerFactory() {

--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLoggerContextFactory.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLoggerContextFactory.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.util.LoaderUtil;
  */
 public class SLF4JLoggerContextFactory implements LoggerContextFactory {
     private static final StatusLogger LOGGER = StatusLogger.getLogger();
-    private static LoggerContext context = new SLF4JLoggerContext();
+    private static final LoggerContext context = new SLF4JLoggerContext();
 
     public SLF4JLoggerContextFactory() {
         // LOG4J2-230, LOG4J2-204 (improve error reporting when misconfigured)
@@ -59,5 +59,11 @@ public class SLF4JLoggerContextFactory implements LoggerContextFactory {
 
     @Override
     public void removeContext(final LoggerContext ignored) {
+    }
+
+    @Override
+    public boolean isClassLoaderDependent() {
+        // context is always used
+        return false;
     }
 }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -53,6 +53,9 @@
       <action issue="LOG4J2-3054" dev="ckozak" type="fix">
         BasicContextSelector hasContext and shutdown take the default context into account
       </action>
+      <action issue="LOG4J2-2940" dev="ckozak" type="fix">
+        Slf4j implementations walk the stack at most once rather than twice to determine the caller's class loader.
+      </action>
     </release>
     <release version="2.14.1" date="2021-03-06" description="GA Release 2.14.1">
       <!-- FIXES -->

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -42,6 +42,11 @@
       <action issue="LOG4J2-3044" dev="rgoers" type="add">
         Add RepeatPatternConverter.
       </action>
+      <action issue="LOG4J2-2940" dev="ckozak" type="add">
+        Context selectors are aware of their dependence upon the callers ClassLoader, allowing
+        basic context selectors to avoid the unnecessary overhead of walking the stack to
+        determine the caller's ClassLoader.
+      </action>
       <action issue="LOG4J2-3041" dev="rgoers" type="update">
         Allow a PatternSelector to be specified on GelfLayout.
       </action>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -47,6 +47,11 @@
         basic context selectors to avoid the unnecessary overhead of walking the stack to
         determine the caller's ClassLoader.
       </action>
+      <action issue="LOG4J2-2940" dev="ckozak" type="add">
+        Add BasicAsyncLoggerContextSelector equivalent to AsyncLoggerContextSelector for
+        applications with a single LoggerContext. This selector avoids classloader lookup
+        overhead incurred by the existing AsyncLoggerContextSelector.
+      </action>
       <action issue="LOG4J2-3041" dev="rgoers" type="update">
         Allow a PatternSelector to be specified on GelfLayout.
       </action>

--- a/src/site/xdoc/manual/async.xml
+++ b/src/site/xdoc/manual/async.xml
@@ -133,7 +133,8 @@
         <p>
           This is simplest to configure and gives the best performance. To make all loggers asynchronous,
           add the disruptor jar to the classpath and set the system property <tt>log4j2.contextSelector</tt>
-          to <tt>org.apache.logging.log4j.core.async.AsyncLoggerContextSelector</tt>.
+          to <tt>org.apache.logging.log4j.core.async.AsyncLoggerContextSelector</tt> or
+          <tt>org.apache.logging.log4j.core.async.BasicAsyncLoggerContextSelector</tt>.
         </p>
         <p>
           By default, <a href="#Location">location</a> is not passed to the I/O thread by
@@ -147,6 +148,8 @@
 
 <!-- Don't forget to set system property
 -Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
+or
+-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.BasicAsyncLoggerContextSelector
      to make all loggers asynchronous. -->
 
 <Configuration status="WARN">
@@ -165,9 +168,10 @@
   </Loggers>
 </Configuration>]]></pre>
         <p>
-          When <tt>AsyncLoggerContextSelector</tt> is used to make all loggers asynchronous, make sure to use normal
+          When <tt>AsyncLoggerContextSelector</tt> or <tt>BasicAsyncLoggerContextSelector</tt> is used to make all
+          loggers asynchronous, make sure to use normal
           <tt>&lt;root&gt;</tt> and <tt>&lt;logger&gt;</tt> elements in the configuration. The
-          AsyncLoggerContextSelector will ensure that all loggers are asynchronous, using a mechanism
+          context selector will ensure that all loggers are asynchronous, using a mechanism
           that is different from what happens when you configure <tt>&lt;asyncRoot&gt;</tt>
           or <tt>&lt;asyncLogger&gt;</tt>.
           The latter elements are intended for mixing async with sync loggers. If you use both mechanisms

--- a/src/site/xdoc/manual/configuration.xml.vm
+++ b/src/site/xdoc/manual/configuration.xml.vm
@@ -1740,6 +1740,7 @@ public class AwesomeTest {
       Available context selector implementation classes:<br />
     <!-- deliberately inserted spaces to allow line break -->
       <tt>org.apache.logging.log4j.core.async .AsyncLoggerContextSelector</tt> - makes <a href="async.html">all loggers asynchronous</a>.<br />
+      <tt>org.apache.logging.log4j.core.async .BasicAsyncLoggerContextSelector</tt> - makes <a href="async.html"> all loggers asynchronous using a single shared AsyncLoggerContext.<br />
       <tt>org.apache.logging.log4j.core.selector .BasicContextSelector</tt> - creates a single shared LoggerContext.<br />
       <tt>org.apache.logging.log4j.core.selector .ClassLoaderContextSelector</tt> - separate LoggerContexts for each web application.<br />
       <tt>org.apache.logging.log4j.core.selector .JndiContextSelector</tt> - use JNDI to locate each web application's LoggerContext.<br/>


### PR DESCRIPTION
This allows LoggerContext lookups to avoid searching for the calling
class to discover a classloader when the ContextSelector implementation
is declared to be agnostic to the class loader.

Custom LoggerContextFactory and ContextSelector implementations
should be updated to override the new `isClassLoaderDependent` method.