### PR TITLE
LOG4J2-2816: Handle Disruptor event translation exceptions

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
@@ -62,6 +62,7 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
         }
     }
 
+    private boolean isPopulated;
     private int threadPriority;
     private long threadId;
     private final MutableInstant instant = new MutableInstant();
@@ -107,6 +108,8 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
         this.contextData = mutableContextData;
         this.contextStack = aContextStack;
         this.asyncLogger = anAsyncLogger;
+
+        this.isPopulated = true;
     }
 
     private void initTime(final Clock clock) {
@@ -152,6 +155,13 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
     public void execute(final boolean endOfBatch) {
         this.endOfBatch = endOfBatch;
         asyncLogger.actualAsyncLog(this);
+    }
+
+    /**
+     * @return {@code true} if this event is populated with data, {@code false} otherwise
+     */
+    public boolean isPopulated() {
+        return isPopulated;
     }
 
     /**
@@ -389,6 +399,8 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
      * Release references held by ring buffer to allow objects to be garbage-collected.
      */
     public void clear() {
+        this.isPopulated = false;
+
         this.asyncLogger = null;
         this.loggerName = null;
         this.marker = null;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventTranslator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventTranslator.java
@@ -56,14 +56,15 @@ public class RingBufferLogEventTranslator implements
     // @Override
     @Override
     public void translateTo(final RingBufferLogEvent event, final long sequence) {
-
-        event.setValues(asyncLogger, loggerName, marker, fqcn, level, message, thrown,
-                // config properties are taken care of in the EventHandler thread
-                // in the AsyncLogger#actualAsyncLog method
-                INJECTOR.injectContextData(null, (StringMap) event.getContextData()), contextStack,
-                threadId, threadName, threadPriority, location, clock, nanoClock);
-
-        clear(); // clear the translator
+        try {
+            event.setValues(asyncLogger, loggerName, marker, fqcn, level, message, thrown,
+                    // config properties are taken care of in the EventHandler thread
+                    // in the AsyncLogger#actualAsyncLog method
+                    INJECTOR.injectContextData(null, (StringMap) event.getContextData()), contextStack,
+                    threadId, threadName, threadPriority, location, clock, nanoClock);
+        } finally {
+            clear(); // clear the translator
+        }
     }
 
     /**

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerEventTranslationExceptionTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerEventTranslationExceptionTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.async;
+
+import com.lmax.disruptor.ExceptionHandler;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.categories.AsyncLoggers;
+import org.apache.logging.log4j.core.CoreLoggerContexts;
+import org.apache.logging.log4j.core.util.Constants;
+import org.apache.logging.log4j.message.*;
+import org.apache.logging.log4j.spi.AbstractLogger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test for https://issues.apache.org/jira/browse/LOG4J2-2816: an exception thrown in
+ * RingBufferLogEventTranslator#translateTo should not cause another exception to be thrown later in the background
+ * thread in RingBufferLogEventHandler#onEvent.
+ */
+@Category(AsyncLoggers.class)
+public class AsyncLoggerEventTranslationExceptionTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, AsyncLoggerContextSelector.class.getName());
+        System.setProperty("AsyncLogger.ExceptionHandler", TestExceptionHandler.class.getName());
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
+        System.clearProperty("AsyncLogger.ExceptionHandler");
+    }
+
+    @Test
+    public void testEventTranslationExceptionDoesNotCauseAsyncEventException() {
+        final Logger log = LogManager.getLogger("com.foo.Bar");
+
+        assertTrue("TestExceptionHandler was not configured properly", TestExceptionHandler.wasInstantiated);
+
+        final Message exceptionThrowingMessage = new ExceptionThrowingMessage();
+
+        try {
+            ((AbstractLogger) log).logMessage("com.foo.Bar", Level.INFO, null, exceptionThrowingMessage, null);
+
+            fail("TestMessageException should have been thrown");
+        } catch (TestMessageException e) {
+            // We expect the TestMessageException to be propagated, so ignore it.
+            // The point of this test is to ensure that the ExceptionHandler is not called in the background thread.
+        }
+
+        CoreLoggerContexts.stopLoggerContext(); // stop async thread
+
+        assertFalse("ExceptionHandler encountered an event exception",
+                TestExceptionHandler.encounteredEventException);
+    }
+
+    public static class TestExceptionHandler implements ExceptionHandler<RingBufferLogEvent> {
+
+        public static boolean wasInstantiated = false;
+        public static boolean encounteredEventException = false;
+
+        public TestExceptionHandler() {
+            wasInstantiated = true;
+        }
+
+        @Override
+        public void handleEventException(final Throwable ex, final long sequence, final RingBufferLogEvent event) {
+            encounteredEventException = true;
+        }
+
+        @Override
+        public void handleOnStartException(final Throwable ex) {
+            fail("Unexpected start exception: " + ex.getMessage());
+        }
+
+        @Override
+        public void handleOnShutdownException(final Throwable ex) {
+            fail("Unexpected shutdown exception: " + ex.getMessage());
+        }
+    }
+
+    private static class TestMessageException extends RuntimeException {
+
+    }
+
+    private static class ExceptionThrowingMessage extends ReusableSimpleMessage {
+
+        @Override
+        public String getFormattedMessage() {
+            throw new TestMessageException();
+        }
+
+        @Override
+        public String getFormat() {
+            throw new TestMessageException();
+        }
+
+        @Override
+        public Object[] getParameters() {
+            throw new TestMessageException();
+        }
+
+        @Override
+        public void formatTo(final StringBuilder buffer) {
+            throw new TestMessageException();
+        }
+
+        @Override
+        public Object[] swapParameters(final Object[] emptyReplacement) {
+            throw new TestMessageException();
+        }
+
+        @Override
+        public short getParameterCount() {
+            throw new TestMessageException();
+        }
+    }
+
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/RingBufferLogEventTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/RingBufferLogEventTest.java
@@ -59,6 +59,31 @@ public class RingBufferLogEventTest {
     }
 
     @Test
+    public void testIsPopulated() {
+        final RingBufferLogEvent evt = new RingBufferLogEvent();
+
+        assertFalse(evt.isPopulated());
+
+        final String loggerName = null;
+        final Marker marker = null;
+        final String fqcn = null;
+        final Level level = null;
+        final Message data = null;
+        final Throwable t = null;
+        final ContextStack contextStack = null;
+        final String threadName = null;
+        final StackTraceElement location = null;
+        evt.setValues(null, loggerName, marker, fqcn, level, data, t, (StringMap) evt.getContextData(),
+                contextStack, -1, threadName, -1, location, new FixedPreciseClock(), new DummyNanoClock(1));
+
+        assertTrue(evt.isPopulated());
+
+        evt.clear();
+
+        assertFalse(evt.isPopulated());
+    }
+
+    @Test
     public void testGetLevelReturnsOffIfNullLevelSet() {
         final RingBufferLogEvent evt = new RingBufferLogEvent();
         final String loggerName = null;


### PR DESCRIPTION
[LOG4J2-2816](https://issues.apache.org/jira/browse/LOG4J2-2816)

# Problem

If `RingBufferLogEventTranslator#translateTo` throws an exception for any reason, Disruptor's `RingBuffer#translateAndPublish` will still publish the sequence in a `finally` block ([source](https://github.com/LMAX-Exchange/disruptor/blob/ca35bc40eb7f834050793137b5996a0921173e2d/src/main/java/com/lmax/disruptor/RingBuffer.java#L958-L968)).

In such a case, the "untranslated" and unpopulated event will later be consumed by `RingBufferLogEventHandler`, since its sequence was published. However, the event will be missing all values, including `asyncLogger`. This causes a `NullPointerException` to be thrown during event handling in `RingBufferLogEvent#execute`:

```text
AsyncLogger error handling event seq=0, value='org.apache.logging.log4j.core.async.RingBufferLogEvent@7bb6d06c': java.lang.NullPointerException: null
java.lang.NullPointerException
        at org.apache.logging.log4j.core.async.RingBufferLogEvent.execute(RingBufferLogEvent.java:154)
        at org.apache.logging.log4j.core.async.RingBufferLogEventHandler.onEvent(RingBufferLogEventHandler.java:46)
        at org.apache.logging.log4j.core.async.RingBufferLogEventHandler.onEvent(RingBufferLogEventHandler.java:29)
        at com.lmax.disruptor.BatchEventProcessor.processEvents(BatchEventProcessor.java:168)
        at com.lmax.disruptor.BatchEventProcessor.run(BatchEventProcessor.java:125)
        at java.lang.Thread.run(Thread.java:748)
```

# Solution

Log4j needs to handle the case where an exception is thrown by `RingBufferLogEventTranslator#translateTo`.

The Disruptor documentation makes it clear that once a slot is claimed in the ring buffer, the sequence _must_ be published. Otherwise the state of the Disruptor can be corrupted ([source](https://lmax-exchange.github.io/disruptor/user-guide/index.html#_publishing_using_the_legacy_api)). That is why `RingBuffer#translateAndPublish` is designed the way it is, and why its usage is recommended over more manual methods.

In order to handle such exceptions, then, it seems like the `EventHandler` must be responsible for checking that the event it is handling is sufficiently populated. Such an approach is also suggested by [this Disruptor GitHub issue discussion](https://github.com/LMAX-Exchange/disruptor/issues/244#issuecomment-437814712). This PR implements that approach by adding an `isPopulated` property to `RingBufferLogEvent`.

# Tests

The new test in `AsyncLoggerEventTranslationExceptionTest` fails on `release-2.x` and passes on this branch.