### PR TITLE
Use java.home property to determine what JDK distribution to use during a test.

### DIFF
--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/SortedArrayStringMapTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/SortedArrayStringMapTest.java
@@ -110,7 +110,10 @@ public class SortedArrayStringMapTest {
             fout.flush();
         }
         final String classpath = createClassPath(SortedArrayStringMap.class, DeserializerHelper.class);
-        final Process process = new ProcessBuilder("java", "-cp", classpath,
+        final String command = System.getProperty("java.home")
+                + File.separatorChar + "bin"
+                + File.separatorChar + (System.getProperty("os.name", "").toLowerCase().contains("windows") ? "java.exe" : "java");
+        final Process process = new ProcessBuilder(command, "-cp", classpath,
                 DeserializerHelper.class.getName(), file.getPath()).start();
         final BufferedReader in = new BufferedReader(new InputStreamReader(process.getErrorStream()));
         final int exitValue = process.waitFor();


### PR DESCRIPTION
Observed when investigating https://github.com/mockito/mockito/issues/2282 on my setup where only JAVA_HOME was adjusted which is used by Maven and IDE but not the unit test.