### PR TITLE
Allow JsonLayout output JSON `null` for ContextMap

### DIFF
--- a/log4j-layout-jackson/src/main/java/org/apache/logging/log4j/jackson/ContextDataSerializer.java
+++ b/log4j-layout-jackson/src/main/java/org/apache/logging/log4j/jackson/ContextDataSerializer.java
@@ -42,7 +42,11 @@ public class ContextDataSerializer extends StdSerializer<ReadOnlyStringMap> {
         @Override
         public void accept(final String key, final Object value, final JsonGenerator jsonGenerator) {
             try {
-                jsonGenerator.writeStringField(key, String.valueOf(value));
+                if (value == null) {
+                    jsonGenerator.writeNullField(key);
+                } else {
+                    jsonGenerator.writeStringField(key, String.valueOf(value));
+                }
             } catch (final Exception ex) {
                 throw new IllegalStateException("Problem with key " + key, ex);
             }


### PR DESCRIPTION
For now JsonLayout write string "null" to result output if ContextMap contains values equals Java Null.
But JSON have own `null` concept. I change ContextDataSerializer for write normal JSON `null` in case ContextMap contains Null.