### PR TITLE
Liquibase 4.x Compatibility

### DIFF
--- a/log4j-liquibase/src/main/java/liquibase/ext/logging/log4j2/DeprecatedLog4j2Logger.java
+++ b/log4j-liquibase/src/main/java/liquibase/ext/logging/log4j2/DeprecatedLog4j2Logger.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package liquibase.ext.logging.log4j2;
+
+import liquibase.ExtensibleObject;
+import liquibase.ObjectMetaData;
+import liquibase.logging.LogMessageFilter;
+import liquibase.logging.Logger;
+import liquibase.logging.core.AbstractLogger;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.spi.ExtendedLogger;
+
+import java.util.List;
+import java.util.SortedSet;
+
+/**
+ * Logs Liquibase messages to Log4j 2.x.
+ * <p>
+ * This class must be in the {@code liquibase} package in order for the Liquibase plugin discovery mechanism to work.
+ * </p>
+ *
+ * @deprecated This class is used with liquibase versions prior to 4.0 and ignored in 4.0+
+ */
+public class DeprecatedLog4j2Logger implements Logger {
+
+    private static final String FQCN = DeprecatedLog4j2Logger.class.getName();
+
+    private ExtendedLogger logger;
+
+    public DeprecatedLog4j2Logger() {
+    }
+    
+    @Override
+    public void debug(final String message) {
+        logger.logIfEnabled(FQCN, Level.DEBUG, null, message);
+    }
+
+    @Override
+    public void debug(final String message, final Throwable e) {
+        logger.logIfEnabled(FQCN, Level.DEBUG, null, message, e);
+    }
+
+//    @Override //actually overrides a method that existed in 3.x but does not exist in 4.x
+    public int getPriority() {
+        return 5;
+    }
+
+    @Override
+    public void info(final String message) {
+        logger.logIfEnabled(FQCN, Level.INFO, null, message);
+    }
+
+    @Override
+    public void info(final String message, final Throwable e) {
+        logger.logIfEnabled(FQCN, Level.INFO, null, message, e);
+    }
+
+    //    @Override //actually overrides a method that existed in 3.x but does not exist in 4.x
+    public void setLogLevel(final String logLevel, final String logFile) {
+        // cannot set logLevel programmatically
+        // ignore logFile
+    }
+
+    //    @Override //actually overrides a method that existed in 3.x but does not exist in 4.x
+    public void setName(final String name) {
+        logger = LogManager.getContext(false).getLogger(name);
+    }
+
+    @Override
+    public void severe(final String message) {
+        logger.logIfEnabled(FQCN, Level.ERROR, null, message);
+    }
+
+    @Override
+    public void severe(final String message, final Throwable e) {
+        logger.logIfEnabled(FQCN, Level.ERROR, null, message, e);
+    }
+
+    @Override
+    public void warning(final String message) {
+        logger.logIfEnabled(FQCN, Level.WARN, null, message);
+    }
+
+    @Override
+    public void warning(final String message, final Throwable e) {
+        logger.logIfEnabled(FQCN, Level.WARN, null, message, e);
+    }
+
+    @Override
+    public void log(java.util.logging.Level level, String s, Throwable throwable) {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+    }
+
+    @Override
+    public void close() throws Exception {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+    }
+
+    @Override
+    public void config(String s) {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+    }
+
+    @Override
+    public void config(String s, Throwable throwable) {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+    }
+
+    @Override
+    public void fine(String s) {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+    }
+
+    @Override
+    public void fine(String s, Throwable throwable) {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+    }
+
+    @Override
+    public SortedSet<String> getAttributes() {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+
+        return null;
+    }
+
+    @Override
+    public ObjectMetaData getObjectMetaData() {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+        return null;
+    }
+
+    @Override
+    public boolean has(String s) {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+        return false;
+    }
+
+    @Override
+    public List getValuePath(String s, Class aClass) {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+        return null;
+    }
+
+    @Override
+    public <T> T get(String s, Class<T> aClass) {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+        return null;
+    }
+
+    @Override
+    public <T> T get(String s, T t) {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+        return null;
+    }
+
+    @Override
+    public ExtensibleObject set(String s, Object o) {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+        return null;
+    }
+
+    @Override
+    public String describe() {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+        return null;
+    }
+
+    @Override
+    public Object clone() {
+        //method exists to conform to the 4.x parent class, but is not used in the 3.x range where this class will be loaded.
+        return null;
+    }
+}

--- a/log4j-liquibase/src/main/java/liquibase/ext/logging/log4j2/Log4j2Logger.java
+++ b/log4j-liquibase/src/main/java/liquibase/ext/logging/log4j2/Log4j2Logger.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
 package liquibase.ext.logging.log4j2;
 
 import liquibase.logging.LogMessageFilter;
@@ -7,6 +23,9 @@ import org.apache.logging.log4j.spi.ExtendedLogger;
 
 import java.util.logging.Level;
 
+/**
+ * Logs Liquibase 4.0+ messages to Log4j 2.x. Managed by {@link Log4j2LoggerService}
+ */
 public class Log4j2Logger extends AbstractLogger {
 
     private final ExtendedLogger logger;

--- a/log4j-liquibase/src/main/java/liquibase/ext/logging/log4j2/Log4j2Logger.java
+++ b/log4j-liquibase/src/main/java/liquibase/ext/logging/log4j2/Log4j2Logger.java
@@ -1,93 +1,45 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache license, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the license for the specific language governing permissions and
- * limitations under the license.
- */
 package liquibase.ext.logging.log4j2;
 
+import liquibase.logging.LogMessageFilter;
 import liquibase.logging.core.AbstractLogger;
-
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.spi.ExtendedLogger;
 
-/**
- * Logs Liquibase messages to Log4j 2.x.
- * <p>
- * This class must be in the {@code liquibase} package in order for the Liquibase plugin discovery mechanism to work.
- * </p>
- */
+import java.util.logging.Level;
+
 public class Log4j2Logger extends AbstractLogger {
 
-    private static final String FQCN = Log4j2Logger.class.getName();
+    private final ExtendedLogger logger;
+    private final String FQCN;
 
-    private ExtendedLogger logger;
-
-    @Override
-    public void debug(final String message) {
-        logger.logIfEnabled(FQCN, Level.DEBUG, null, buildMessage(message));
+    public Log4j2Logger(Class aClass, LogMessageFilter filter) {
+        super(filter);
+        logger = LogManager.getContext(false).getLogger(aClass);
+        FQCN = getClass().getName();
     }
 
     @Override
-    public void debug(final String message, final Throwable e) {
-        logger.logIfEnabled(FQCN, Level.DEBUG, null, buildMessage(message), e);
+    public void log(Level level, String message, Throwable throwable) {
+        org.apache.logging.log4j.Level log4jLevel;
+        if (level.equals(Level.ALL)) {
+            log4jLevel = org.apache.logging.log4j.Level.ALL;
+        } else if (level.equals(Level.SEVERE)) {
+            log4jLevel = org.apache.logging.log4j.Level.FATAL;
+        } else if (level.equals(Level.WARNING)) {
+            log4jLevel = org.apache.logging.log4j.Level.WARN;
+        } else if (level.equals(Level.INFO)) {
+            log4jLevel = org.apache.logging.log4j.Level.INFO;
+        } else if (level.equals(Level.FINE)) {
+            log4jLevel = org.apache.logging.log4j.Level.DEBUG;
+        } else {
+            log4jLevel = org.apache.logging.log4j.Level.TRACE;
+        }
+
+        logger.logIfEnabled(FQCN, log4jLevel, null, message, throwable);
     }
 
     @Override
-    public int getPriority() {
-        return PRIORITY_DATABASE;
-    }
+    public void close() throws Exception {
 
-    @Override
-    public void info(final String message) {
-        logger.logIfEnabled(FQCN, Level.INFO, null, buildMessage(message));
     }
-
-    @Override
-    public void info(final String message, final Throwable e) {
-        logger.logIfEnabled(FQCN, Level.INFO, null, buildMessage(message), e);
-    }
-
-    @Override
-    public void setLogLevel(final String logLevel, final String logFile) {
-        setLogLevel(logLevel);
-        // ignore logFile
-    }
-
-    @Override
-    public void setName(final String name) {
-        logger = LogManager.getContext(false).getLogger(name);
-    }
-
-    @Override
-    public void severe(final String message) {
-        logger.logIfEnabled(FQCN, Level.ERROR, null, buildMessage(message));
-    }
-
-    @Override
-    public void severe(final String message, final Throwable e) {
-        logger.logIfEnabled(FQCN, Level.ERROR, null, buildMessage(message), e);
-    }
-
-    @Override
-    public void warning(final String message) {
-        logger.logIfEnabled(FQCN, Level.WARN, null, buildMessage(message));
-    }
-
-    @Override
-    public void warning(final String message, final Throwable e) {
-        logger.logIfEnabled(FQCN, Level.WARN, null, buildMessage(message), e);
-    }
-
 }

--- a/log4j-liquibase/src/main/java/liquibase/ext/logging/log4j2/Log4j2LoggerService.java
+++ b/log4j-liquibase/src/main/java/liquibase/ext/logging/log4j2/Log4j2LoggerService.java
@@ -1,0 +1,28 @@
+package liquibase.ext.logging.log4j2;
+
+import liquibase.logging.Logger;
+import liquibase.logging.core.AbstractLogService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Log4j2LoggerService extends AbstractLogService {
+
+    private static Map<Class, Log4j2Logger> loggers = new HashMap<>();
+
+    @Override
+    public int getPriority() {
+        return PRIORITY_SPECIALIZED;
+    }
+
+    @Override
+    public Logger getLog(Class aClass) {
+        Log4j2Logger logger = loggers.get(aClass);
+        if (logger == null) {
+            logger = new Log4j2Logger(aClass, this.filter);
+            loggers.put(aClass, logger);
+        }
+
+        return logger;
+    }
+}

--- a/log4j-liquibase/src/main/java/liquibase/ext/logging/log4j2/Log4j2LoggerService.java
+++ b/log4j-liquibase/src/main/java/liquibase/ext/logging/log4j2/Log4j2LoggerService.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
 package liquibase.ext.logging.log4j2;
 
 import liquibase.logging.Logger;
@@ -6,6 +22,9 @@ import liquibase.logging.core.AbstractLogService;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Logs Liquibase 4.0+ messages to Log4j 2.x.
+ */
 public class Log4j2LoggerService extends AbstractLogService {
 
     private static Map<Class, Log4j2Logger> loggers = new HashMap<>();

--- a/log4j-liquibase/src/main/resources/META-INF/services/liquibase.logging.LogService
+++ b/log4j-liquibase/src/main/resources/META-INF/services/liquibase.logging.LogService
@@ -1,0 +1,1 @@
+liquibase.ext.logging.log4j2.Log4j2LoggerService

--- a/log4j-liquibase/src/test/java/liquibase/ext/logging/log4j2/DeprecatedLog4J2LoggerTest.java
+++ b/log4j-liquibase/src/test/java/liquibase/ext/logging/log4j2/DeprecatedLog4J2LoggerTest.java
@@ -22,23 +22,21 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import liquibase.logging.Logger;
-
 import org.apache.logging.log4j.test.appender.ListAppender;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class LoggingTest {
+public class DeprecatedLog4J2LoggerTest {
 
     private static final String NAME = "LoggerName";
 
-    static Logger logger;
+    static DeprecatedLog4j2Logger logger;
 
     @BeforeClass
     public static void setupClass() {
-        logger = new Log4j2Logger();
+        logger = new DeprecatedLog4j2Logger();
         logger.setName(NAME);
         logger.setLogLevel("debug", null);
     }

--- a/log4j-liquibase/src/test/java/liquibase/ext/logging/log4j2/Log4j2LoggerTest.java
+++ b/log4j-liquibase/src/test/java/liquibase/ext/logging/log4j2/Log4j2LoggerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
 package liquibase.ext.logging.log4j2;
 
 import liquibase.Scope;

--- a/log4j-liquibase/src/test/java/liquibase/ext/logging/log4j2/Log4j2LoggerTest.java
+++ b/log4j-liquibase/src/test/java/liquibase/ext/logging/log4j2/Log4j2LoggerTest.java
@@ -1,0 +1,70 @@
+package liquibase.ext.logging.log4j2;
+
+import liquibase.Scope;
+import org.apache.logging.log4j.test.appender.ListAppender;
+import org.apache.logging.log4j.util.Strings;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class Log4j2LoggerTest {
+
+    static Log4j2Logger logger;
+
+    @BeforeClass
+    public static void setupClass() {
+        logger = (Log4j2Logger) Scope.getCurrentScope().getLog(Log4j2LoggerTest.class);
+        ListAppender.getListAppender("List").clear();
+    }
+
+    @Test
+    public void debug() {
+        logger.debug("Debug message");
+        verify(getClass().getName() + " liquibase.logging.core.AbstractLogger DEBUG Debug message" + Strings.LINE_SEPARATOR);
+    }
+
+    @Test
+    public void info() {
+        logger.info("Info message");
+        verify(getClass().getName() + " liquibase.logging.core.AbstractLogger INFO Info message" + Strings.LINE_SEPARATOR);
+    }
+
+    @Test
+    public void warning() {
+        logger.warning("Warning message");
+        verify(getClass().getName() + " liquibase.logging.core.AbstractLogger WARN Warning message" + Strings.LINE_SEPARATOR);
+    }
+
+    @Test
+    public void severe() {
+        logger.severe("Severe message");
+        verify(getClass().getName() + " liquibase.logging.core.AbstractLogger FATAL Severe message" + Strings.LINE_SEPARATOR);
+    }
+
+    @Test
+    public void severeStacktrace() {
+        logger.severe("Severe message with stacktrace", new RuntimeException("thrown error"));
+        verify(getClass().getName() + " liquibase.logging.core.AbstractLogger FATAL Severe message with stacktrace" + Strings.LINE_SEPARATOR
+                + "java.lang.RuntimeException: thrown error");
+    }
+
+    private void verify(final String expected) {
+        final ListAppender listApp = ListAppender.getListAppender("List");
+        assertNotNull("Missing Appender", listApp);
+        final List<String> events = listApp.getMessages();
+        assertTrue("Incorrect number of messages. Expected 1 Actual " + events.size(), events.size() == 1);
+        final String actual = events.get(0);
+        assertEquals("Incorrect message. Expected " + expected + ". Actual " + actual, expected, actual);
+        listApp.clear();
+    }
+
+    @After
+    public void cleanup() {
+        ListAppender.getListAppender("List").clear();
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -843,8 +843,7 @@
       <dependency>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-core</artifactId>
-        <!-- 3.6.0 to 4.3.2 break binary compatibility. -->
-        <version>3.5.5</version>
+        <version>4.3.2</version>
       </dependency>
       <dependency>
         <groupId>net.javacrumbs.json-unit</groupId>


### PR DESCRIPTION
## Overview

Liquibase 3.6 as well as 4.0 introduced API compatibility issues with the current log4j-liquibase codebase. See liquibase/liquibase#1777

This updates the code to be compatible with 4.0+ while still supporting 3.5 and 3.6+ users.
