### PR TITLE
Fix incorrect LogManager accessor used by LOG4J2-2940

### DIFF
--- a/log4j-slf4j-impl/src/main/java/org/apache/logging/slf4j/Log4jLoggerFactory.java
+++ b/log4j-slf4j-impl/src/main/java/org/apache/logging/slf4j/Log4jLoggerFactory.java
@@ -45,7 +45,7 @@ public class Log4jLoggerFactory extends AbstractLoggerAdapter<Logger> implements
                 ? StackLocatorUtil.getCallerClass(FQCN, PACKAGE, 1)
                 : null;
         return anchor == null
-                ? LogManager.getContext()
+                ? LogManager.getContext(false)
                 : getContext(anchor);
     }
     private LoggerContext validateContext(final LoggerContext context) {

--- a/log4j-slf4j18-impl/src/main/java/org/apache/logging/slf4j/Log4jLoggerFactory.java
+++ b/log4j-slf4j18-impl/src/main/java/org/apache/logging/slf4j/Log4jLoggerFactory.java
@@ -51,7 +51,7 @@ public class Log4jLoggerFactory extends AbstractLoggerAdapter<Logger> implements
                 ? StackLocatorUtil.getCallerClass(FQCN, PACKAGE, 1)
                 : null;
         return anchor == null
-                ? LogManager.getContext()
+                ? LogManager.getContext(false)
                 : getContext(anchor);
     }
 


### PR DESCRIPTION
The `getContext()` accessor with no args has been used as a fallback
for Log4jLoggerFactory slf4j implementations for a while, but it's
much more likely to be used now that LOG4J2-2940 is resolved.
Without the `false` argument, the first slf4j LoggerFactory.getLogger
call will not cause log4j to initialize itself.