### PR TITLE
LOG4J2-3102: AsyncAppender background thread is a daemon

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppenderEventDispatcher.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppenderEventDispatcher.java
@@ -50,6 +50,7 @@ class AsyncAppenderEventDispatcher extends Log4jThread {
             final List<AppenderControl> appenders,
             final BlockingQueue<LogEvent> queue) {
         super("AsyncAppenderEventDispatcher-" + THREAD_COUNTER.incrementAndGet() + "-" + name);
+        this.setDaemon(true);
         this.errorAppender = errorAppender;
         this.appenders = appenders;
         this.queue = queue;

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/AsyncAppenderTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/AsyncAppenderTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Timeout;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -74,6 +75,14 @@ class AsyncAppenderTest {
     void defaultAsyncAppenderConfig(final LoggerContext context) throws InterruptedException {
         rewriteTest(context);
         exceptionTest(context);
+
+        List<Thread> backgroundThreads = Thread.getAllStackTraces().keySet().stream()
+                .filter(AsyncAppenderEventDispatcher.class::isInstance)
+                .collect(Collectors.toList());
+        assertFalse(backgroundThreads.isEmpty(), "Failed to locate background thread");
+        for (Thread thread : backgroundThreads) {
+            assertTrue(thread.isDaemon(), "AsyncAppender should use daemon threads");
+        }
     }
 
     @Test

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -69,6 +69,10 @@
         Allow a PatternSelector to be specified on GelfLayout.
       </action>
       <!-- FIXES -->
+      <action issue="LOG4J2-3102" dev="ckozak" type="fix">
+        Fix a regression in 2.14.1 which allowed the AsyncAppender background thread to keep the JVM alive because
+        the daemon flag was not set.
+      </action>
       <action issue="LOG4J2-3092" dev="vy" type="fix" due-to="xmh51">
         Fix JsonWriter memory leaks due to retained excessive buffer growth.
       </action>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LOG4J2-3102

We didn't preserve the daemon flag in https://github.com/apache/logging-log4j2/pull/452/files#diff-6b30d73942796a35c3bcf93d46127d03cb6959fb69fb8eb84c4c6fca13bb68e6L390