### PR TITLE
LOG4J2-3110 - Logger Improvements

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/TcpSocketManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/TcpSocketManager.java
@@ -416,7 +416,7 @@ public class TcpSocketManager extends AbstractSocketManager {
                 os = socket.getOutputStream();
                 return createManager(name, os, socket, inetAddress, data);
             } catch (final IOException ex) {
-                LOGGER.error("TcpSocketManager ({}) caught exception and will continue:", name, ex, ex);
+                LOGGER.error("TcpSocketManager ({}) caught exception and will continue:", name, ex);
                 os = NullOutputStream.getInstance();
             }
             if (data.reconnectDelayMillis == 0) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/AbstractKeyStoreConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/AbstractKeyStoreConfiguration.java
@@ -76,7 +76,7 @@ public class AbstractKeyStoreConfiguration extends StoreConfiguration<KeyStore> 
             LOGGER.error("The keystore file {} is not found", loadLocation, e);
             throw new StoreConfigurationException(loadLocation, e);
         } catch (final IOException e) {
-            LOGGER.error("Something is wrong with the format of the keystore or the given password for location", loadLocation, e);
+            LOGGER.error("Something is wrong with the format of the keystore or the given password for location {}", loadLocation, e);
             throw new StoreConfigurationException(loadLocation, e);
         }
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/script/ScriptManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/script/ScriptManager.java
@@ -152,7 +152,7 @@ public class ScriptManager implements FileWatcher, Serializable {
     public void fileModified(final File file) {
         final ScriptRunner runner = scriptRunners.get(file.toString());
         if (runner == null) {
-            logger.info("{} is not a running script");
+            logger.info("{} is not a running script", file.getName());
             return;
         }
         final ScriptEngine engine = runner.getScriptEngine();
@@ -168,7 +168,7 @@ public class ScriptManager implements FileWatcher, Serializable {
     public Object execute(final String name, final Bindings bindings) {
         final ScriptRunner scriptRunner = scriptRunners.get(name);
         if (scriptRunner == null) {
-            logger.warn("No script named {} could be found");
+            logger.warn("No script named {} could be found", name);
             return null;
         }
         return AccessController.doPrivileged((PrivilegedAction<Object>) () -> scriptRunner.execute(bindings));

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/OptionConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/OptionConverter.java
@@ -298,7 +298,7 @@ public final class OptionConverter {
                     LOGGER.error("A \"{}\" object is not assignable to a \"{}\" variable.", className,
                         superClass.getName());
                     LOGGER.error("The class \"{}\" was loaded by [{}] whereas object of type [{}] was loaded by [{}].",
-                        superClass.getName(), superClass.getClassLoader(), classObj.getName());
+                        superClass.getName(), superClass.getClassLoader(), classObj.getTypeName(), classObj.getName());
                     return defaultValue;
                 }
                 return classObj.newInstance();

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/Log4jEventSource.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/Log4jEventSource.java
@@ -58,7 +58,7 @@ public class Log4jEventSource extends AbstractSource implements EventDrivenSourc
         try {
             getChannelProcessor().processEvent(event);
         } catch (final ChannelException ex) {
-            LOGGER.warn("Unable to process event {}" + event, ex);
+            LOGGER.warn("Unable to process event {}", event, ex);
             throw ex;
         }
         sourceCounter.incrementAppendAcceptedCount();


### PR DESCRIPTION
Fix the number of {}-placeholders in the string literal argument does not match the number of other arguments to the logging call.