### PR TITLE
LOG4J2-3107: SmtpManager.createManagerName ignores port

### DIFF
--- a/log4j-smtp/src/main/java/org/apache/logging/log4j/smtp/appender/SmtpManager.java
+++ b/log4j-smtp/src/main/java/org/apache/logging/log4j/smtp/appender/SmtpManager.java
@@ -108,7 +108,7 @@ public class SmtpManager extends AbstractManager {
             protocol = "smtp";
         }
 
-        final String managerName = createManagerName(to, cc, bcc, from, replyTo, subject, protocol, host, username, password, isDebug, filterName);
+        final String managerName = createManagerName(to, cc, bcc, from, replyTo, subject, protocol, host, port, username, password, isDebug, filterName);
         final Serializer subjectSerializer = PatternLayout.newSerializerBuilder().setConfiguration(config).setPattern(subject).build();
 
         return getManager(managerName, FACTORY, new FactoryData(to, cc, bcc, from, replyTo, subjectSerializer,
@@ -125,6 +125,7 @@ public class SmtpManager extends AbstractManager {
             final String subject,
             final String protocol,
             final String host,
+            final int port,
             final String username,
             final String password,
             final boolean isDebug,
@@ -156,7 +157,7 @@ public class SmtpManager extends AbstractManager {
             sb.append(subject);
         }
         sb.append(':');
-        sb.append(protocol).append(':').append(host).append(':').append("port").append(':');
+        sb.append(protocol).append(':').append(host).append(':').append(port).append(':');
         if (username != null) {
             sb.append(username);
         }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -31,6 +31,9 @@
          - "remove" - Removed
     -->
     <release version="3.0.0" date="2021-MM-DD" description="GA Release 3.0.0">
+      <action issue="LOG4J2-3107" dev="spannjp" type="fix" due-to="Markus Spann">
+        SmtpManager.createManagerName ignores port.
+      </action>
       <action issue="LOG4J2-2400" dev="rgoers" type="add" due-to="Natalie Meurer">
         Add Redis Appender.
       </action>


### PR DESCRIPTION
This patch is short and affects only one class.