### PR TITLE
Bugfix for LOG4J2-3107: SmtpManager.createManagerName ignores port

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SmtpManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SmtpManager.java
@@ -106,7 +106,7 @@ public class SmtpManager extends AbstractManager {
             protocol = "smtp";
         }
 
-        final String name = createManagerName(to, cc, bcc, from, replyTo, subject, protocol, host, port, username, password, isDebug, filterName);
+        final String name = createManagerName(to, cc, bcc, from, replyTo, subject, protocol, host, port, username, isDebug, filterName);
         final Serializer subjectSerializer = PatternLayout.newSerializerBuilder().setConfiguration(config).setPattern(subject).build();
 
         return getManager(name, FACTORY, new FactoryData(to, cc, bcc, from, replyTo, subjectSerializer,
@@ -131,7 +131,6 @@ public class SmtpManager extends AbstractManager {
             final String host,
             final int port,
             final String username,
-            final String password,
             final boolean isDebug,
             final String filterName) {
 
@@ -164,10 +163,6 @@ public class SmtpManager extends AbstractManager {
         sb.append(protocol).append(':').append(host).append(':').append(port).append(':');
         if (username != null) {
             sb.append(username);
-        }
-        sb.append(':');
-        if (password != null) {
-            sb.append(password);
         }
         sb.append(isDebug ? ":debug:" : "::");
         sb.append(filterName);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SmtpManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SmtpManager.java
@@ -49,7 +49,6 @@ import org.apache.logging.log4j.core.layout.AbstractStringLayout.Serializer;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.net.ssl.SslConfiguration;
 import org.apache.logging.log4j.core.util.CyclicBuffer;
-import org.apache.logging.log4j.core.util.NameUtil;
 import org.apache.logging.log4j.core.util.NetUtils;
 import org.apache.logging.log4j.message.ReusableMessage;
 import org.apache.logging.log4j.util.PropertiesUtil;
@@ -107,7 +106,7 @@ public class SmtpManager extends AbstractManager {
             protocol = "smtp";
         }
 
-        final String name = createManagerName(to, cc, bcc, from, replyTo, subject, protocol, host, username, password, isDebug, filterName);
+        final String name = createManagerName(to, cc, bcc, from, replyTo, subject, protocol, host, port, username, password, isDebug, filterName);
         final Serializer subjectSerializer = PatternLayout.newSerializerBuilder().setConfiguration(config).setPattern(subject).build();
 
         return getManager(name, FACTORY, new FactoryData(to, cc, bcc, from, replyTo, subjectSerializer,
@@ -115,7 +114,13 @@ public class SmtpManager extends AbstractManager {
 
     }
 
-    private static String createManagerName(
+    /**
+     * Creates a unique-per-configuration name for an smtp manager using the specified the parameters.<br>
+     * Using such a name allows us to maintain singletons per unique configurations.
+     *
+     * @return smtp manager name
+     */
+    static String createManagerName(
             final String to,
             final String cc,
             final String bcc,
@@ -124,6 +129,7 @@ public class SmtpManager extends AbstractManager {
             final String subject,
             final String protocol,
             final String host,
+            final int port,
             final String username,
             final String password,
             final boolean isDebug,
@@ -155,7 +161,7 @@ public class SmtpManager extends AbstractManager {
             sb.append(subject);
         }
         sb.append(':');
-        sb.append(protocol).append(':').append(host).append(':').append("port").append(':');
+        sb.append(protocol).append(':').append(host).append(':').append(port).append(':');
         if (username != null) {
             sb.append(username);
         }
@@ -166,9 +172,7 @@ public class SmtpManager extends AbstractManager {
         sb.append(isDebug ? ":debug:" : "::");
         sb.append(filterName);
 
-        final String hash = NameUtil.md5(sb.toString());
-        return "SMTP:" + hash;
-
+        return "SMTP:" + sb.toString();
     }
 
     /**

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/net/SmtpManagerTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/net/SmtpManagerTest.java
@@ -1,0 +1,19 @@
+package org.apache.logging.log4j.core.net;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link SmtpManager}.
+ */
+class SmtpManagerTest {
+
+    @Test
+    void testCreateManagerName() {
+        String managerName = SmtpManager.createManagerName("to", "cc", null, "from", null, "LOG4J2-3107",
+                "proto", "smtp.log4j.com", 4711, "username", "Alligator3", false, "filter");
+        assertEquals("SMTP:to:cc::from::LOG4J2-3107:proto:smtp.log4j.com:4711:username:Alligator3::filter", managerName);
+    }
+
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/net/SmtpManagerTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/net/SmtpManagerTest.java
@@ -12,8 +12,8 @@ class SmtpManagerTest {
     @Test
     void testCreateManagerName() {
         String managerName = SmtpManager.createManagerName("to", "cc", null, "from", null, "LOG4J2-3107",
-                "proto", "smtp.log4j.com", 4711, "username", "Alligator3", false, "filter");
-        assertEquals("SMTP:to:cc::from::LOG4J2-3107:proto:smtp.log4j.com:4711:username:Alligator3::filter", managerName);
+                "proto", "smtp.log4j.com", 4711, "username", false, "filter");
+        assertEquals("SMTP:to:cc::from::LOG4J2-3107:proto:smtp.log4j.com:4711:username::filter", managerName);
     }
 
 }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -69,6 +69,9 @@
         Allow a PatternSelector to be specified on GelfLayout.
       </action>
       <!-- FIXES -->
+      <action issue="LOG4J2-3107" dev="vy" type="fix" due-to="Markus Spann">
+        SmtpManager.createManagerName ignores port.
+      </action>
       <action issue="LOG4J2-3080" dev="vy" type="fix">
         Use SimpleMessage in Log4j 1 Category whenever possible.
       </action>


### PR DESCRIPTION
My fix for LOG4J2-3107 changes two files and adds one. The change is now targeted at the release-2.x branch not master.
Hope you find it useful.