### PR TITLE
LOG4J2-2785: Added support for pattern Layout to abbreviate logger or class names except n rightmost words

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/DynamicWordAbbreviator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/DynamicWordAbbreviator.java
@@ -1,0 +1,103 @@
+package org.apache.logging.log4j.core.pattern;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * <p>Specialized abbreviator that shortens all words to the first char except the indicated number of rightmost words.
+ * To select this abbreviator, use pattern <code>1.n*</code> where n (&gt; 0) is the number of rightmost words to leave unchanged.</p>
+ *
+ * By example for input <code>org.apache.logging.log4j.core.pattern.NameAbbreviator</code>:<br>
+ * <pre>
+ * 1.1*     =&gt;   o.a.l.l.c.p.NameAbbreviator
+ * 1.2*     =&gt;   o.a.l.l.c.pattern.NameAbbreviator
+ * 1.3*     =&gt;   o.a.l.l.core.pattern.NameAbbreviator
+ * ..
+ * 1.999*   =&gt;   org.apache.logging.log4j.core.pattern.NameAbbreviator
+ * </pre>
+ * @since 2.x
+ * @author Markus Spann
+ */
+class DynamicWordAbbreviator extends NameAbbreviator {
+
+    /** Right-most number of words (at least one) that will not be abbreviated. */
+    private final int rightWordCount;
+
+    static DynamicWordAbbreviator create(String pattern) {
+        if (pattern != null) {
+            Matcher matcher = Pattern.compile("1\\.([1-9][0-9]*)\\*").matcher(pattern);
+            if (matcher.matches()) {
+                return new DynamicWordAbbreviator(Integer.parseInt(matcher.group(1)));
+            }
+        }
+        return null;
+    }
+
+    private DynamicWordAbbreviator(int rightWordCount) {
+        this.rightWordCount = rightWordCount;
+    }
+
+    @Override
+    public void abbreviate(final String original, final StringBuilder destination) {
+        if (original == null || destination == null) {
+            return;
+        }
+
+        // for efficiency refrain from using String#split or StringTokenizer
+        final String[] words = split(original, '.');
+        final int wordCount = words.length;
+
+        if (rightWordCount >= wordCount) {
+            // nothing to abbreviate
+            destination.append(original);
+            return;
+        }
+
+        final int lastAbbrevIdx = wordCount - rightWordCount; // last index to abbreviate
+        for (int i = 0; i < wordCount; i++) {
+            if (i >= lastAbbrevIdx) {
+                destination.append(words[i]);
+                if (i < wordCount - 1) {
+                    destination.append(".");
+                }
+            } else if (words[i].length() > 0) {
+                destination.append(words[i].charAt(0))
+                           .append(".");
+            }
+        }
+    }
+
+    static String[] split(final String input, final char delim) {
+        if (input == null) {
+            return null;
+        } else if (input.isEmpty()) {
+            return new String[0];
+        }
+
+        int countDelim = input.chars().filter(c -> c == delim).map(c -> 1).sum();
+        final String[] tokens = new String[countDelim + 1];
+
+        int countToken = 0;
+        int idxBegin = 0;
+        int idxDelim = 0;
+
+        while ((idxDelim = input.indexOf(delim, idxBegin)) > -1) {
+            if (idxBegin < idxDelim) {
+                tokens[countToken++] = input.substring(idxBegin, idxDelim);
+            }
+            idxBegin = idxDelim + 1;
+        }
+
+        if (idxBegin < input.length()) { // remains
+            tokens[countToken++] = input.substring(idxBegin);
+        }
+
+        if (countToken < tokens.length) {
+            return Arrays.copyOf(tokens, countToken);
+        }
+
+        return tokens;
+    }
+
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/NameAbbreviator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/NameAbbreviator.java
@@ -17,10 +17,10 @@
 package org.apache.logging.log4j.core.pattern;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.logging.log4j.util.PerformanceSensitive;
-
 
 /**
  * NameAbbreviator generates abbreviated logger and class names.
@@ -55,6 +55,11 @@ public abstract class NameAbbreviator {
                 return DEFAULT;
             }
 
+            NameAbbreviator dwa = DynamicWordAbbreviator.create(trimmed);
+            if (dwa != null) {
+                return dwa;
+            }
+
             boolean isNegativeNumber;
             final String number;
 
@@ -82,7 +87,7 @@ public abstract class NameAbbreviator {
                         isNegativeNumber? MaxElementAbbreviator.Strategy.DROP : MaxElementAbbreviator.Strategy.RETAIN);
             }
 
-            final ArrayList<PatternAbbreviatorFragment> fragments = new ArrayList<>(5);
+            final List<PatternAbbreviatorFragment> fragments = new ArrayList<>(5);
             char ellipsis;
             int charCount;
             int pos = 0;
@@ -313,6 +318,12 @@ public abstract class NameAbbreviator {
             }
             return nextDot;
         }
+
+        @Override
+        public String toString() {
+            return String.format("%s[charCount=%s, ellipsis=%s]",
+                    getClass().getSimpleName(), charCount, Integer.toHexString(ellipsis));
+        }
     }
 
     /**
@@ -364,5 +375,11 @@ public abstract class NameAbbreviator {
                 }
             }
         }
+
+        @Override
+        public String toString() {
+            return String.format("%s[fragments=%s]", getClass().getSimpleName(), Arrays.toString(fragments));
+        }
     }
+
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/DynamicWordAbbreviatorTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/DynamicWordAbbreviatorTest.java
@@ -1,0 +1,60 @@
+package org.apache.logging.log4j.core.pattern;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit tests for the {@link DynamicWordAbbreviator} class.
+ */
+class DynamicWordAbbreviatorTest extends Assertions {
+
+    @Test
+    void testNullAndEmptyInputs() {
+        DynamicWordAbbreviator abbreviator = DynamicWordAbbreviator.create("1.1*");
+
+        assertDoesNotThrow(() -> abbreviator.abbreviate("orig", null));
+        assertDoesNotThrow(() -> abbreviator.abbreviate(null, new StringBuilder()));
+
+        StringBuilder dest = new StringBuilder();
+        abbreviator.abbreviate(null, dest);
+        assertEquals("", dest.toString());
+
+        abbreviator.abbreviate("", dest);
+        assertEquals("", dest.toString());
+    }
+
+    @ParameterizedTest(name = "[{index}] \"{0}\"")
+    @ValueSource(strings = {
+            "",
+            " ",
+            "0.0*",
+            "0,0*",
+            "1.2",
+            "1.2**",
+            "1.0*"
+    })
+    void testInvalidPatterns(String pattern) {
+        assertNull(DynamicWordAbbreviator.create(pattern));
+    }
+
+    @ParameterizedTest(name = "[{index}] \"{0}\" \"{1}\" \"{2}\"")
+    @CsvSource(delimiter = '|', value = {
+            "1.1*|.|.",
+            "1.1*|\\ |\\ ",
+            "1.1*|org.novice.o|o.n.o",
+            "1.1*|org.novice.|o.novice",
+            "1.1*|org......novice|o.novice",
+            "1.1*|org. . .novice|o. . .novice",
+    })
+    void testStrangeWords(String pattern, String input, String expected) {
+        DynamicWordAbbreviator abbreviator = DynamicWordAbbreviator.create(pattern);
+        StringBuilder actual = new StringBuilder();
+        abbreviator.abbreviate(input, actual);
+        assertEquals(expected, actual.toString());
+    }
+
+}
+

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/NameAbbreviatorTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/NameAbbreviatorTest.java
@@ -26,7 +26,7 @@ import org.junit.runners.Parameterized;
 import static org.junit.Assert.*;
 
 /**
- *
+ * Unit tests for {@link NameAbbreviator} which abbreviates dot-delimited strings such as logger and class names.
  */
 @RunWith(Parameterized.class)
 public class NameAbbreviatorTest {
@@ -51,7 +51,10 @@ public class NameAbbreviatorTest {
                 { "1.", "o.a.l.l.c.p.NameAbbreviatorTest" },
                 { "1.1.~", "o.a.~.~.~.~.NameAbbreviatorTest" },
                 { "1.1.1.*", "o.a.l.log4j.core.pattern.NameAbbreviatorTest" },
-                { ".", "......NameAbbreviatorTest" }
+                { ".", "......NameAbbreviatorTest" },
+                { "1.2*", "o.a.l.l.c.pattern.NameAbbreviatorTest" },
+                { "1.3*", "o.a.l.l.core.pattern.NameAbbreviatorTest" },
+                { "1.8*", "org.apache.logging.log4j.core.pattern.NameAbbreviatorTest" }
             }
         );
     }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -31,6 +31,9 @@
     -->
     <release version="2.15.0" date="2021-MM-DD" description="GA Release 2.15.0">
       <!-- ADDS -->
+      <action issue="LOG4J2-2785" dev="ckozak" type="add" due-to="Markus Spann">
+        Pattern Layout to abbreviate the name of all logger components except the 2 rightmost.
+      </action>
       <action issue="LOG4J2-3133" dev="ckozak" type="add">
         Add missing slf4j-api singleton accessors to log4j-slf4j-impl (1.7) StaticMarkerBinder and StaticMDCBinder.
         This doesn't impact behavior or correctness, but avoids throwing and catching NoSuchMethodErrors when slf4j


### PR DESCRIPTION
Hi, I've added a specialized abbreviator named `DynamicWordAbbreviator` to address the specific requirement of this feature request. Javadoc added and JUnit test updated to cover the new feature.