### PR TITLE
add gflog for comparison

### DIFF
--- a/log4j-perf/pom.xml
+++ b/log4j-perf/pom.xml
@@ -114,6 +114,16 @@
       <version>1.2.17</version>
     </dependency>
     <dependency>
+      <groupId>com.epam.deltix</groupId>
+      <artifactId>gflog-api</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.epam.deltix</groupId>
+      <artifactId>gflog-core</artifactId>
+      <version>3.0.1</version>
+    </dependency>
+    <dependency>
       <groupId>com.lmax</groupId>
       <artifactId>disruptor</artifactId>
     </dependency>

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/FileAppenderBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/FileAppenderBenchmark.java
@@ -58,12 +58,14 @@ public class FileAppenderBenchmark {
     org.slf4j.Logger slf4jAsyncLogger;
     org.apache.log4j.Logger log4j1Logger;
     java.util.logging.Logger julLogger;
+    com.epam.deltix.gflog.api.Log gflog;
 
     @Setup
     public void setUp() throws Exception {
         System.setProperty("log4j.configurationFile", "log4j2-perf.xml");
         System.setProperty("log4j.configuration", "log4j12-perf.xml");
         System.setProperty("logback.configurationFile", "logback-perf.xml");
+        System.setProperty("gflog.config", "classpath:gflog-perf.xml");
 
         deleteLogFiles();
 
@@ -82,6 +84,8 @@ public class FileAppenderBenchmark {
         julLogger.setUseParentHandlers(false);
         julLogger.addHandler(julFileHandler);
         julLogger.setLevel(Level.ALL);
+
+        gflog = com.epam.deltix.gflog.api.LogFactory.getLog("defaultLogger");
     }
 
     @TearDown
@@ -106,6 +110,8 @@ public class FileAppenderBenchmark {
         log4j2File.delete();
         final File julFile = new File("target/testJulLog.log");
         julFile.delete();
+        final File gflogFile = new File("target/testgflog.log");
+        gflogFile.delete();
     }
 /*
     @BenchmarkMode(Mode.Throughput)
@@ -163,6 +169,13 @@ public class FileAppenderBenchmark {
     @Benchmark
     public void logbackFile() {
         slf4jLogger.debug(MESSAGE);
+    }
+
+    @BenchmarkMode(Mode.Throughput)
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    @Benchmark
+    public void gflog() {
+        gflog.debug(MESSAGE);
     }
 /*
     @BenchmarkMode(Mode.Throughput)

--- a/log4j-perf/src/main/resources/gflog-perf.xml
+++ b/log4j-perf/src/main/resources/gflog-perf.xml
@@ -1,0 +1,11 @@
+<config>
+    <appender name="defaultAppenderFactory"
+              factory="com.epam.deltix.gflog.core.appender.FileAppenderFactory"
+              file="target\testgflog.log">
+        <layout template="%d %5p [%t] %c{1} %X{transactionId} - %m%n"/>
+    </appender>
+    <logger name="defaultLogger" level="DEBUG">
+        <appender-ref ref="defaultAppenderFactory"/>
+    </logger>
+
+</config>


### PR DESCRIPTION
More about gflog library - https://deltix.io/gflog.html
Library github - https://github.com/epam/GFLog

Test results
```
java -jar log4j-perf/target/benchmarks.jar ".*FileAppenderBenchmark.*" -f 1 -wi 2 -i 5
...
Benchmark                             Mode  Cnt        Score        Error  Units
FileAppenderBenchmark.gflog          thrpt    5  1220063,390 ?  31420,841  ops/s
FileAppenderBenchmark.log4j2Builder  thrpt    5   148083,391 ?  15267,028  ops/s
FileAppenderBenchmark.log4j2File     thrpt    5   474979,883 ?  56547,704  ops/s
FileAppenderBenchmark.logbackFile    thrpt    5   900614,359 ? 222864,811  ops/s
```

```
java -jar log4j-perf/target/benchmarks.jar ".*FileAppenderBenchmark.*" -f 1 -wi 2 -i 5 -prof gc
...
Benchmark                                                          Mode  Cnt        Score        Error   Units
FileAppenderBenchmark.gflog                                       thrpt    5  1172272,252 ? 183965,605   ops/s
FileAppenderBenchmark.gflog:·gc.alloc.rate                        thrpt    5        0,002 ?      0,001  MB/sec
FileAppenderBenchmark.gflog:·gc.alloc.rate.norm                   thrpt    5        0,002 ?      0,001    B/op
FileAppenderBenchmark.gflog:·gc.count                             thrpt    5          ? 0               counts
FileAppenderBenchmark.log4j2Builder                               thrpt    5   128522,247 ?  60545,666   ops/s
FileAppenderBenchmark.log4j2Builder:·gc.alloc.rate                thrpt    5      105,014 ?     52,727  MB/sec
FileAppenderBenchmark.log4j2Builder:·gc.alloc.rate.norm           thrpt    5      904,018 ?      0,005    B/op
FileAppenderBenchmark.log4j2Builder:·gc.churn.G1_Eden_Space       thrpt    5      106,425 ?     43,729  MB/sec
FileAppenderBenchmark.log4j2Builder:·gc.churn.G1_Eden_Space.norm  thrpt    5      919,026 ?    134,877    B/op
FileAppenderBenchmark.log4j2Builder:·gc.churn.G1_Old_Gen          thrpt    5        0,001 ?      0,001  MB/sec
FileAppenderBenchmark.log4j2Builder:·gc.churn.G1_Old_Gen.norm     thrpt    5        0,004 ?      0,010    B/op
FileAppenderBenchmark.log4j2Builder:·gc.count                     thrpt    5       77,000               counts
FileAppenderBenchmark.log4j2Builder:·gc.time                      thrpt    5       42,000                   ms
FileAppenderBenchmark.log4j2File                                  thrpt    5   346317,715 ? 271452,329   ops/s
FileAppenderBenchmark.log4j2File:·gc.alloc.rate                   thrpt    5        0,002 ?      0,001  MB/sec
FileAppenderBenchmark.log4j2File:·gc.alloc.rate.norm              thrpt    5        0,006 ?      0,004    B/op
FileAppenderBenchmark.log4j2File:·gc.count                        thrpt    5          ? 0               counts
FileAppenderBenchmark.logbackFile                                 thrpt    5   900240,674 ? 106682,668   ops/s
FileAppenderBenchmark.logbackFile:·gc.alloc.rate                  thrpt    5      673,530 ?     79,604  MB/sec
FileAppenderBenchmark.logbackFile:·gc.alloc.rate.norm             thrpt    5      824,704 ?      0,083    B/op
FileAppenderBenchmark.logbackFile:·gc.churn.G1_Eden_Space         thrpt    5      676,973 ?     84,224  MB/sec
FileAppenderBenchmark.logbackFile:·gc.churn.G1_Eden_Space.norm    thrpt    5      828,903 ?     22,204    B/op
FileAppenderBenchmark.logbackFile:·gc.churn.G1_Old_Gen            thrpt    5        0,001 ?      0,001  MB/sec
FileAppenderBenchmark.logbackFile:·gc.churn.G1_Old_Gen.norm       thrpt    5        0,002 ?      0,002    B/op
FileAppenderBenchmark.logbackFile:·gc.count                       thrpt    5      336,000               counts
FileAppenderBenchmark.logbackFile:·gc.time                        thrpt    5      160,000                   ms

```
