### PR TITLE
Improve worst-case NameAbbreviator performance

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/NameAbbreviator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/NameAbbreviator.java
@@ -291,12 +291,13 @@ public abstract class NameAbbreviator {
          * @return starting  index of next element.
          */
         int abbreviate(final String input, final int inputIndex, final StringBuilder buf) {
-            // ckozak: indexOf with a string is intentional. indexOf(String, int) appears to
-            // have optimizations that don't apply to indexOf(char, int)
-            // which result in a >10% performance improvement in some
-            // NamePatternConverterBenchmark cases. This should be re-evaluated with
-            // future java releases.
-            int nextDot = input.indexOf(".", inputIndex);
+            // Note that indexOf(char) performs worse than indexOf(String) on pre-16 JREs
+            // due to missing intrinsics for the character implementation. The difference
+            // is a few nanoseconds in most cases, so we opt to give the jre as much
+            // information as possible for best performance on new runtimes, with the
+            // possibility that such optimizations may be back-ported.
+            // See https://bugs.openjdk.java.net/browse/JDK-8173585
+            int nextDot = input.indexOf('.', inputIndex);
             if (nextDot < 0) {
                 buf.append(input, inputIndex, input.length());
                 return nextDot;

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/NamePatternConverterBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/NamePatternConverterBenchmark.java
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 @Fork(1)
 @Threads(1)
 @Warmup(iterations = 3, time = 3)
-@Measurement(iterations = 3, time = 3)
+@Measurement(iterations = 4, time = 3)
 public class NamePatternConverterBenchmark {
 
     @State(Scope.Benchmark)

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/NamePatternConverterBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/NamePatternConverterBenchmark.java
@@ -1,0 +1,90 @@
+package org.apache.logging.log4j.perf.jmh;
+
+import org.apache.logging.log4j.core.AbstractLogEvent;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.pattern.LoggerPatternConverter;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests Log4j2 NamePatternConverter's performance.<br>
+ *
+ * How to run these benchmarks:<br>
+ *
+ * Single thread:<br>
+ * <pre>java -jar log4j-perf/target/benchmarks.jar ".*NamePatternConverterBenchmark.*" -f 1 -wi 2 -i 3 -r 3s -jvmArgs '-server -XX:+AggressiveOpts'</pre>
+ *
+ * Multiple threads (for example, 4 threads):<br>
+ * <pre>java -jar log4j-perf/target/benchmarks.jar ".*NamePatternConverterBenchmark.*" -f 1 -wi 4 -i 20 -t 4 -si true</pre>
+ *
+ * Usage help:<br>
+ * <pre>java -jar log4j-perf/target/benchmarks.jar -help</pre>
+ */
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 3, time = 3)
+public class NamePatternConverterBenchmark {
+
+    @State(Scope.Benchmark)
+    public static class ExecutionPlan {
+        @Param({
+                "org.bogus.hokus.pokus.org.bogus.hokus.pokus.org.bogus.hokus.pokus.RetroEncabulatorFactorySingleton",
+                "org.bogus.hokus.pokus.Clazz1",
+                "com.bogus.hokus.pokus.Clazz2",
+                "edu.bogus.hokus.pokus.a.Clazz3",
+                "de.bogus.hokus.b.Clazz4",
+                "jp.bogus.c.Clazz5",
+                "cn.d.Clazz6"
+        })
+        String className;
+        LogEvent event;
+        private final ThreadLocal<StringBuilder> destination = ThreadLocal.withInitial(StringBuilder::new);
+
+        final LoggerPatternConverter converter = LoggerPatternConverter.newInstance(new String[] {"1."});
+
+        @Setup
+        public void setup() {
+            event = new BenchmarkLogEvent(className);
+        }
+
+        StringBuilder destination() {
+            StringBuilder result = destination.get();
+            result.setLength(0);
+            return result;
+        }
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    public void benchNamePatternConverter(ExecutionPlan plan) {
+        plan.converter.format(plan.event, plan.destination());
+    }
+
+    private static class BenchmarkLogEvent extends AbstractLogEvent {
+        private final String loggerName;
+
+        BenchmarkLogEvent(String loggerName) {
+            this.loggerName = loggerName;
+        }
+
+        @Override
+        public String getLoggerName() {
+            return loggerName;
+        }
+    }
+
+}


### PR DESCRIPTION
Previously the entire input string was written to the output
buffer, then small sections were deleted or replaced within that
string. This meant that for each section that was abbreviated,
nearly all following characters from subsequent sections would
be migrated, resulting in O(n^2) performance.

Now we read from the existing input String, and write sections
to the output buffer piece-by-piece. For small strings this may
result in more pointer-hopping (may cost ~tens of nanoseconds) while
larger values with many abbreviated sections are substantially
less expensive. I would expect large "enterprise-grade" class
names to perform better than previously.

Note that the new approach may result in multiple StringBuilder
resize operations in the worst case, where previously writing
the original string to the output would have caused it to grow
all at once. In most cases we attempt to initialize builders
with a reasonable size, so I opted not to add an `ensureCapacity`
given the estimated size may be substantially larger than we need.

Benchmarks with this change:
```
NamePatternConverterBenchmark.benchNamePatternConverter  org.bogus.hokus.pokus.org.bogus.hokus.pokus.org.bogus.hokus.pokus.RetroEncabulatorFactorySingleton  avgt    3  202.992 ±  1.584  ns/op
NamePatternConverterBenchmark.benchNamePatternConverter                                                                        org.bogus.hokus.pokus.Clazz1  avgt    3   76.517 ±  2.979  ns/op
NamePatternConverterBenchmark.benchNamePatternConverter                                                                        com.bogus.hokus.pokus.Clazz2  avgt    3   75.369 ±  3.217  ns/op
NamePatternConverterBenchmark.benchNamePatternConverter                                                                      edu.bogus.hokus.pokus.a.Clazz3  avgt    3   97.546 ± 12.164  ns/op
NamePatternConverterBenchmark.benchNamePatternConverter                                                                             de.bogus.hokus.b.Clazz4  avgt    3   82.240 ± 14.489  ns/op
NamePatternConverterBenchmark.benchNamePatternConverter                                                                                   jp.bogus.c.Clazz5  avgt    3   65.274 ±  3.938  ns/op
NamePatternConverterBenchmark.benchNamePatternConverter                                                                                         cn.d.Clazz6  avgt    3   50.239 ±  0.456  ns/op
```

Previous results:
```
NamePatternConverterBenchmark.benchNamePatternConverter  org.bogus.hokus.pokus.org.bogus.hokus.pokus.org.bogus.hokus.pokus.RetroEncabulatorFactorySingleton  avgt    3  209.477 ± 62.262  ns/op
NamePatternConverterBenchmark.benchNamePatternConverter                                                                        org.bogus.hokus.pokus.Clazz1  avgt    3   76.083 ±  8.123  ns/op
NamePatternConverterBenchmark.benchNamePatternConverter                                                                        com.bogus.hokus.pokus.Clazz2  avgt    3   76.109 ± 19.293  ns/op
NamePatternConverterBenchmark.benchNamePatternConverter                                                                      edu.bogus.hokus.pokus.a.Clazz3  avgt    3   91.913 ± 46.029  ns/op
NamePatternConverterBenchmark.benchNamePatternConverter                                                                             de.bogus.hokus.b.Clazz4  avgt    3   74.703 ± 28.086  ns/op
NamePatternConverterBenchmark.benchNamePatternConverter                                                                                   jp.bogus.c.Clazz5  avgt    3   59.788 ±  7.298  ns/op
NamePatternConverterBenchmark.benchNamePatternConverter                                                                                         cn.d.Clazz6  avgt    3   41.092 ± 19.660  ns/op
```