### PR TITLE
LOG4J2-3142: Use log event time millis for timestamp in log event adapter

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/LogEventAdapter.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/LogEventAdapter.java
@@ -129,6 +129,11 @@ public class LogEventAdapter extends LoggingEvent {
         return event.getLoggerName();
     }
 
+    @Override
+    public long getTimeStamp() {
+        return event.getTimeMillis();
+    }
+
     /**
      * Gets the logger of the event.
      */

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/spi/LoggingEvent.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/spi/LoggingEvent.java
@@ -60,7 +60,7 @@ public class LoggingEvent {
         return null;
     }
 
-    public final long getTimeStamp() {
+    public long getTimeStamp() {
         return 0;
     }
 

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/RewriteAppenderTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/RewriteAppenderTest.java
@@ -57,6 +57,7 @@ public class RewriteAppenderTest {
         Logger logger = LogManager.getLogger("test");
         ThreadContext.put("key1", "This is a test");
         ThreadContext.put("hello", "world");
+        long logTime = System.currentTimeMillis();
         logger.debug("Say hello");
         LoggerContext context = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
         Configuration configuration = context.getConfiguration();
@@ -73,24 +74,6 @@ public class RewriteAppenderTest {
         assertNotNull("No properties in the event", events.get(0).getProperties());
         assertTrue("Key was not inserted", events.get(0).getProperties().containsKey("key2"));
         assertEquals("Key value is incorrect", "Log4j", events.get(0).getProperties().get("key2"));
-    }
-
-    @Test
-    public void testTimeStamp() {
-        Logger logger = LogManager.getLogger("test");
-        long logTime = System.currentTimeMillis();
-        logger.debug("hello, world");
-        LoggerContext context = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
-        Configuration configuration = context.getConfiguration();
-        Map<String, Appender> appenders = configuration.getAppenders();
-        ListAppender eventAppender = null;
-        for (Map.Entry<String, Appender> entry : appenders.entrySet()) {
-            if (entry.getKey().equals("events")) {
-                eventAppender = (ListAppender) ((AppenderAdapter.Adapter) entry.getValue()).getAppender();
-            }
-        }
-        assertNotNull("No Event Appender", eventAppender);
-        List<LoggingEvent> events = eventAppender.getEvents();
         assertTrue("Timestamp is before point of logging", events.get(0).getTimeStamp() >= logTime);
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/RewriteAppenderTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/RewriteAppenderTest.java
@@ -74,4 +74,23 @@ public class RewriteAppenderTest {
         assertTrue("Key was not inserted", events.get(0).getProperties().containsKey("key2"));
         assertEquals("Key value is incorrect", "Log4j", events.get(0).getProperties().get("key2"));
     }
+
+    @Test
+    public void testTimeStamp() {
+        Logger logger = LogManager.getLogger("test");
+        long logTime = System.currentTimeMillis();
+        logger.debug("hello, world");
+        LoggerContext context = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
+        Configuration configuration = context.getConfiguration();
+        Map<String, Appender> appenders = configuration.getAppenders();
+        ListAppender eventAppender = null;
+        for (Map.Entry<String, Appender> entry : appenders.entrySet()) {
+            if (entry.getKey().equals("events")) {
+                eventAppender = (ListAppender) ((AppenderAdapter.Adapter) entry.getValue()).getAppender();
+            }
+        }
+        assertNotNull("No Event Appender", eventAppender);
+        List<LoggingEvent> events = eventAppender.getEvents();
+        assertTrue("Timestamp is before point of logging", events.get(0).getTimeStamp() >= logTime);
+    }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LOG4J2-3142

When using the `LogEventAdapter.getTimeStamp()` we should return the `LogEvent.getTimeMillis()` as this is the equivalent timestamp value from Log4j2 to Log4j1 for compatibility.