### PR TITLE
LOG4J2-3150: RandomAccessFileAppender uses the correct default buffer size

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RandomAccessFileAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RandomAccessFileAppender.java
@@ -62,16 +62,20 @@ public final class RandomAccessFileAppender extends AbstractOutputStreamAppender
         @PluginBuilderAttribute("advertiseURI")
         private String advertiseURI;
 
+        public Builder() {
+            this.withBufferSize(RandomAccessFileManager.DEFAULT_BUFFER_SIZE);
+        }
+
         @Override
         public RandomAccessFileAppender build() {
             final String name = getName();
             if (name == null) {
-                LOGGER.error("No name provided for FileAppender");
+                LOGGER.error("No name provided for RandomAccessFileAppender");
                 return null;
             }
 
             if (fileName == null) {
-                LOGGER.error("No filename provided for FileAppender with name " + name);
+                LOGGER.error("No filename provided for RandomAccessFileAppender with name {}", name);
                 return null;
             }
             final Layout<? extends Serializable> layout = getOrCreateLayout();

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -95,6 +95,10 @@
 	based on performance improvements in modern Java releases.
       </action>
       <!-- FIXES -->
+      <action issue="LOG4J2-3150" dev="ckozak" type="fix">
+        RandomAccessFile appender uses the correct default buffer size of 256 kB
+        rather than the default appender buffer size of 8 kB.
+      </action>
       <action issue="LOG4J2-3142" dev="ckozak" type="fix" due-to="John Meikle">
         log4j-1.2-api implements LogEventAdapter.getTimestamp() based on the original event timestamp
         instead of returning zero.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LOG4J2-3150