### PR TITLE
JTL InstantFormatter invalidates cached FixedDateFormat as expected

### DIFF
--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/InstantFormatter.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/InstantFormatter.java
@@ -309,20 +309,13 @@ public final class InstantFormatter {
 
     private static final class Log4jFixedFormatter implements Formatter {
 
-        @SuppressWarnings("OptionalGetWithoutIsPresent")
-        private static final int MAX_FORMATTED_INSTANT_LENGTH = Arrays
-                .stream(FixedDateFormat.FixedFormat.values())
-                .mapToInt(format -> format.getPattern().length())
-                .max()
-                .getAsInt();
-
         private final FixedDateFormat formatter;
 
         private final char[] buffer;
 
         private Log4jFixedFormatter(final FixedDateFormat formatter) {
             this.formatter = formatter;
-            this.buffer = new char[MAX_FORMATTED_INSTANT_LENGTH];
+            this.buffer = new char[formatter.getFormat().length()];
         }
 
         @Override
@@ -340,7 +333,11 @@ public final class InstantFormatter {
 
         @Override
         public boolean isInstantMatching(final Instant instant1, final Instant instant2) {
-            return instant1.getEpochMillisecond() == instant2.getEpochMillisecond();
+            return formatter.isEquivalent(
+                    instant1.getEpochSecond(),
+                    instant1.getNanoOfSecond(),
+                    instant2.getEpochSecond(),
+                    instant2.getNanoOfSecond());
         }
 
     }


### PR DESCRIPTION
Previously more precise patterns would be cached unexpectedly
within a millisecond interval, all using the microsecond or
nanosecond value of the first event that millisecond.