### PR TITLE
LOG4J2-3162 Improve immediateFlush docs regarding its write guarantees.

### DIFF
--- a/log4j-core/src/main/resources/Log4j-config.xsd
+++ b/log4j-core/src/main/resources/Log4j-config.xsd
@@ -910,8 +910,9 @@
                <annotation>
                   <documentation>
                      When set to true, each write will be followed by a flush.
-                     This will guarantee the data is written to disk but could impact
-                     performance.
+                     This will guarantee that the data is passed to the operating system for writing;
+                     it does not guarantee that the data is actually written to a physical device
+                     such as a disk drive.
                   </documentation>
                </annotation>
             </attribute>

--- a/src/site/asciidoc/manual/appenders.adoc
+++ b/src/site/asciidoc/manual/appenders.adoc
@@ -501,14 +501,15 @@ of its parent directories, do not exist, they will be created.
 
 |immediateFlush |boolean a|
 When set to true - the default, each write will be followed by a flush.
-This will guarantee the data is written to disk but could impact
-performance.
+This will guarantee that the data is passed to the operating system for writing;
+it does not guarantee that the data is actually written to a physical device
+such as a disk drive.
 
 Flushing after every write is only useful when using this appender with
 synchronous loggers. Asynchronous loggers and appenders will
 automatically flush at the end of a batch of events, even if
-immediateFlush is set to false. This also guarantees the data is written
-to disk but is more efficient.
+immediateFlush is set to false. This also guarantees the data is passed
+to the operating system but is more efficient.
 
 |layout |Layout |The Layout to use to format the LogEvent. If no layout
 is supplied the default pattern layout of "%m%n" will be used.
@@ -2223,14 +2224,15 @@ CompositeFilter.
 
 |immediateFlush |boolean a|
 When set to true - the default, each write will be followed by a flush.
-This will guarantee the data is written to disk but could impact
-performance.
+This will guarantee that the data is passed to the operating system for writing;
+it does not guarantee that the data is actually written to a physical device
+such as a disk drive.
 
 Flushing after every write is only useful when using this appender with
 synchronous loggers. Asynchronous loggers and appenders will
 automatically flush at the end of a batch of events, even if
-immediateFlush is set to false. This also guarantees the data is written
-to disk but is more efficient.
+immediateFlush is set to false. This also guarantees the data is passed
+to the operating system but is more efficient.
 
 |bufferSize |int |The buffer size, defaults to 262,144 bytes (256 *
 1024).
@@ -2605,14 +2607,15 @@ pattern.
 
 |immediateFlush |boolean a|
 When set to true - the default, each write will be followed by a flush.
-This will guarantee the data is written to disk but could impact
-performance.
+This will guarantee that the data is passed to the operating system for writing;
+it does not guarantee that the data is actually written to a physical device
+such as a disk drive.
 
 Flushing after every write is only useful when using this appender with
 synchronous loggers. Asynchronous loggers and appenders will
 automatically flush at the end of a batch of events, even if
-immediateFlush is set to false. This also guarantees the data is written
-to disk but is more efficient.
+immediateFlush is set to false. This also guarantees the data is passed
+to the operating system but is more efficient.
 
 |layout |Layout |The Layout to use to format the LogEvent. If no layout
 is supplied the default pattern layout of "%m%n" will be used.

--- a/src/site/asciidoc/manual/appenders.adoc
+++ b/src/site/asciidoc/manual/appenders.adoc
@@ -505,6 +505,12 @@ This will guarantee that the data is passed to the operating system for writing;
 it does not guarantee that the data is actually written to a physical device
 such as a disk drive.
 
+Note that if this flag is set to false, and the logging activity is sparse,
+there may be an indefinite delay in the data eventually making it to the
+operating system, because it is held up in a buffer.
+This can cause surprising effects such as the logs not
+appearing in the tail output of a file immediately after writing to the log.
+
 Flushing after every write is only useful when using this appender with
 synchronous loggers. Asynchronous loggers and appenders will
 automatically flush at the end of a batch of events, even if
@@ -2228,6 +2234,12 @@ This will guarantee that the data is passed to the operating system for writing;
 it does not guarantee that the data is actually written to a physical device
 such as a disk drive.
 
+Note that if this flag is set to false, and the logging activity is sparse,
+there may be an indefinite delay in the data eventually making it to the
+operating system, because it is held up in a buffer.
+This can cause surprising effects such as the logs not
+appearing in the tail output of a file immediately after writing to the log.
+
 Flushing after every write is only useful when using this appender with
 synchronous loggers. Asynchronous loggers and appenders will
 automatically flush at the end of a batch of events, even if
@@ -2610,6 +2622,12 @@ When set to true - the default, each write will be followed by a flush.
 This will guarantee that the data is passed to the operating system for writing;
 it does not guarantee that the data is actually written to a physical device
 such as a disk drive.
+
+Note that if this flag is set to false, and the logging activity is sparse,
+there may be an indefinite delay in the data eventually making it to the
+operating system, because it is held up in a buffer.
+This can cause surprising effects such as the logs not
+appearing in the tail output of a file immediately after writing to the log.
 
 Flushing after every write is only useful when using this appender with
 synchronous loggers. Asynchronous loggers and appenders will


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LOG4J2-3162


In the documentation of RollingFileAppender

> immediateFlush boolean When set to true - the default, each write will be followed by a flush. 
> This will guarantee the data is written to disk but could impact performance.
> Flushing after every write is only useful when using this appender with synchronous loggers. 
> Asynchronous loggers and appenders will automatically flush at the end of a batch of events, 
> even if immediateFlush is set to false. This also guarantees the data is written to disk but is more efficient.
> This is misleading. The appender does not really guarantee that the data is written to disk . 
> All it does is call the underlying OutputStream.flush()method, 
> which does not guaratee that data is written to disk. It only guaratees that the data is handed over to the operating system
> 

This is misleading. The appender does not really `guarantee that the data is written to disk` . All it does is [call](https://github.com/agsha/logging-log4j2/blob/1d56dac20d0827300a49a8cd9f0324185451757e/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/OutputStreamManager.java#L264) the underlying [OutputStream.flush()](https://docs.oracle.com/javase/7/docs/api/java/io/OutputStream.html#flush()) method, which does not guaratee that data is written to disk. It only guaratees that the data is handed over to the operating system

