### PR TITLE
Avoid kafka with new topic configuration get overried by the old one

### DIFF
--- a/log4j-kafka/src/main/java/org/apache/logging/log4j/kafka/appender/KafkaManager.java
+++ b/log4j-kafka/src/main/java/org/apache/logging/log4j/kafka/appender/KafkaManager.java
@@ -160,6 +160,7 @@ public class KafkaManager extends AbstractManager {
             final boolean syncSend, final boolean sendTimestamp, final Property[] properties, final String key,
             final String retryCount) {
         StringBuilder sb = new StringBuilder(name);
+        sb.append(" ").append(topic).append(" ").append(syncSend + "");
         for (Property prop: properties) {
             sb.append(" ").append(prop.getName()).append("=").append(prop.getValue());
         }


### PR DESCRIPTION
Avoid kafka with new topic configuration get overried by the old one