### PR TITLE
LOG4J2-3182 Protect KafkaManager against start failures upon config changes.

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
@@ -623,7 +623,12 @@ public class LoggerContext extends AbstractLifeCycle
                 map.putIfAbsent("hostName", "unknown");
             }
             map.putIfAbsent("contextName", contextName);
-            config.start();
+            try {
+            	config.start();
+            } catch (Exception e) {
+            	config.stop();
+            	return configuration;
+            }
             this.configuration = config;
             updateLoggers();
             if (prev != null) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
@@ -126,7 +126,9 @@ public final class AsyncAppender extends AbstractAppender {
         super.stop(timeout, timeUnit, false);
         LOGGER.trace("AsyncAppender stopping. Queue still has {} events.", queue.size());
         try {
-            dispatcher.stop(shutdownTimeout);
+            if (null != dispatcher) {
+                dispatcher.stop(shutdownTimeout);
+            }
         } catch (final InterruptedException ignored) {
             // Restore the interrupted flag cleared when the exception is caught.
             Thread.currentThread().interrupt();

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/LoggerContextChangeTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/LoggerContextChangeTest.java
@@ -2,7 +2,6 @@ package org.apache.logging.log4j.core.config;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.junit.LoggerContextSource;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -10,23 +9,23 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.util.Set;
 
-@LoggerContextSource("log4j2-3182.xml")
 public class LoggerContextChangeTest {
-    private String targetFileName = "log4j2-3182.xml";
-    private String targetErrorFileName = "log4j2-3182-error.xml";
-    private String tmpFileName = "log4j2-3182-tmp.xml";
+    private static String targetFileName = "log4j2-3182.xml";
+    private static String targetErrorFileName = "log4j2-3182-error.xml";
+    private static String tmpFileName = "log4j2-3182-tmp.xml";
+    private static String destDir = "target/test-classes/";
 
     @BeforeAll
     public static void beforeClass() {
-        System.setProperty("log4j2.configurationFile", "classpath:log4j2-3182.xml");
+        System.setProperty("log4j2.configurationFile", "classpath:" + targetFileName);
     }
 
 
     @Test
     public void onChangeTest() {
-        String errorFileName = "target/test-classes/" + targetErrorFileName;
-        String originFileName = "target/test-classes/" + targetFileName;
-        String tmpFile = "target/test-classes/" + tmpFileName;
+        String errorFileName = destDir + targetErrorFileName;
+        String originFileName = destDir + targetFileName;
+        String tmpFile = destDir + tmpFileName;
         wait(10);
         updateConfigFileModTime(originFileName, errorFileName, tmpFile);
         wait(30);

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/LoggerContextChangeTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/LoggerContextChangeTest.java
@@ -1,0 +1,72 @@
+package org.apache.logging.log4j.core.config;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.junit.LoggerContextSource;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Set;
+
+@LoggerContextSource("log4j2-3182.xml")
+public class LoggerContextChangeTest {
+    private String targetFileName = "log4j2-3182.xml";
+    private String targetErrorFileName = "log4j2-3182-error.xml";
+    private String tmpFileName = "log4j2-3182-tmp.xml";
+
+    @BeforeAll
+    public static void beforeClass() {
+        System.setProperty("log4j2.configurationFile", "classpath:log4j2-3182.xml");
+    }
+
+
+    @Test
+    public void onChangeTest() {
+        String errorFileName = "target/test-classes/" + targetErrorFileName;
+        String originFileName = "target/test-classes/" + targetFileName;
+        String tmpFile = "target/test-classes/" + tmpFileName;
+        wait(10);
+        updateConfigFileModTime(originFileName, errorFileName, tmpFile);
+        wait(30);
+        Set<Thread> allThreads = Thread.getAllStackTraces().keySet();
+        Integer kafkaThreads = 0;
+        Integer consoleThreads = 0;
+        for (Thread thread:allThreads) {
+            if (thread.getName().contains("AsyncKafka")) {
+                kafkaThreads++;
+            }
+            if (thread.getName().contains("AsyncCONSOLE")) {
+                consoleThreads++;
+            }
+        }
+        Assert.assertTrue(kafkaThreads <= 1);
+        Assert.assertTrue(consoleThreads <= 1);
+        updateConfigFileModTime(originFileName, tmpFile, errorFileName);
+    }
+
+    private void wait(int seconds) {
+        try {
+            Logger logger = LogManager.getLogger();
+            logger.info("Test");
+            Thread.sleep(seconds * 1000);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * 将原始文件改为目的文件
+     */
+    private void updateConfigFileModTime(String originFileName, String destFileName, String tmpFileName) {
+        File originFile = new File(originFileName);
+        if (originFile.exists()) {
+            originFile.renameTo(new File(tmpFileName));
+        }
+        File destFile = new File(destFileName);
+        if (destFile.exists()) {
+            destFile.renameTo(new File(originFileName));
+        }
+    }
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/LoggerContextChangeTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/LoggerContextChangeTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
 package org.apache.logging.log4j.core.config;
 
 import org.apache.logging.log4j.LogManager;

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/LoggerContextChangeTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/LoggerContextChangeTest.java
@@ -55,9 +55,7 @@ public class LoggerContextChangeTest {
         }
     }
 
-    /**
-     * 将原始文件改为目的文件
-     */
+
     private void updateConfigFileModTime(String originFileName, String destFileName, String tmpFileName) {
         File originFile = new File(originFileName);
         if (originFile.exists()) {

--- a/log4j-core/src/test/resources/log4j2-3182-error.xml
+++ b/log4j-core/src/test/resources/log4j2-3182-error.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration status="WARN" packages="org.apache.logging.log4j.core.pattern" monitorInterval="3">
+    <properties>
+        <property name="PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} |-%-5level [%thread] %c [%L] -| %msg%n</property>
+    </properties>
+
+    <appenders>
+        <Console name="CONSOLE" target="system_out">
+            <PatternLayout pattern="${PATTERN}" />
+        </Console>
+
+        <Kafka name="KafkaLog" topic="acm">
+            <PatternLayout pattern="%msg"/>
+            <Property name="bootstrap.servers">10.20.10.111111:9092</Property>
+        </Kafka>
+
+        <Async name="AsyncKafkaLog" blocking="false">
+            <AppenderRef ref="KafkaLog" />
+        </Async>
+
+        <Async name="AsyncCONSOLE">
+            <AppenderRef ref="CONSOLE" />
+        </Async>
+    </appenders>
+
+    <loggers>
+        <root level="info">
+            <AppenderRef ref="AsyncCONSOLE" />
+            <AppenderRef ref="AsyncKafkaLog" />
+        </root>
+    </loggers>
+
+</configuration>

--- a/log4j-core/src/test/resources/log4j2-3182-error.xml
+++ b/log4j-core/src/test/resources/log4j2-3182-error.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
 <configuration status="WARN" packages="org.apache.logging.log4j.core.pattern" monitorInterval="3">
     <properties>
         <property name="PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} |-%-5level [%thread] %c [%L] -| %msg%n</property>

--- a/log4j-core/src/test/resources/log4j2-3182.xml
+++ b/log4j-core/src/test/resources/log4j2-3182.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
 <configuration status="WARN" packages="org.apache.logging.log4j.core.pattern" monitorInterval="3">
     <properties>
         <property name="PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} |-%-5level [%thread] %c [%L] -| %msg%n</property>

--- a/log4j-core/src/test/resources/log4j2-3182.xml
+++ b/log4j-core/src/test/resources/log4j2-3182.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration status="WARN" packages="org.apache.logging.log4j.core.pattern" monitorInterval="3">
+    <properties>
+        <property name="PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} |-%-5level [%thread] %c [%L] -| %msg%n</property>
+    </properties>
+
+    <appenders>
+        <Console name="CONSOLE" target="system_out">
+            <PatternLayout pattern="${PATTERN}" />
+        </Console>
+
+        <Kafka name="KafkaLog" topic="acm">
+            <PatternLayout pattern="%msg"/>
+            <Property name="bootstrap.servers">10.20.10.11:9092</Property>
+        </Kafka>
+
+        <Async name="AsyncKafkaLog" blocking="false">
+            <AppenderRef ref="KafkaLog" />
+        </Async>
+
+        <Async name="AsyncCONSOLE">
+            <AppenderRef ref="CONSOLE" />
+        </Async>
+    </appenders>
+
+    <loggers>
+        <root level="info">
+            <AppenderRef ref="AsyncCONSOLE" />
+            <AppenderRef ref="AsyncKafkaLog" />
+        </root>
+    </loggers>
+
+</configuration>


### PR DESCRIPTION
With MonitorInterval, if new config start failed, the previous watchmanager and scheduler will never shut down.

Besides, the async threads will increase.

This is for fixing this issue