### PR TITLE
LOG4J2-3182 Protect KafkaManager against start failures upon config changes

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
@@ -623,7 +623,12 @@ public class LoggerContext extends AbstractLifeCycle
                 map.putIfAbsent("hostName", "unknown");
             }
             map.putIfAbsent("contextName", contextName);
-            config.start();
+            try {
+            	config.start();
+            } catch (Exception e) {
+            	config.stop();
+            	throw e;
+            }
             this.configuration = config;
             updateLoggers();
             if (prev != null) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
@@ -126,7 +126,9 @@ public final class AsyncAppender extends AbstractAppender {
         super.stop(timeout, timeUnit, false);
         LOGGER.trace("AsyncAppender stopping. Queue still has {} events.", queue.size());
         try {
-            dispatcher.stop(shutdownTimeout);
+            if (null != dispatcher) {
+                dispatcher.stop(shutdownTimeout);
+            }
         } catch (final InterruptedException ignored) {
             // Restore the interrupted flag cleared when the exception is caught.
             Thread.currentThread().interrupt();

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/LoggerContextChangeTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/LoggerContextChangeTest.java
@@ -43,9 +43,9 @@ public class LoggerContextChangeTest {
         String errorFileName = destDir + targetErrorFileName;
         String originFileName = destDir + targetFileName;
         String tmpFile = destDir + tmpFileName;
-        wait(3);
+        wait(1);
         updateConfigFileModTime(originFileName, errorFileName, tmpFile);
-        wait(3);
+        wait(5);
         Set<Thread> allThreads = Thread.getAllStackTraces().keySet();
         Integer kafkaThreads = 0;
         Integer consoleThreads = 0;
@@ -80,6 +80,7 @@ public class LoggerContextChangeTest {
         }
         File destFile = new File(destFileName);
         if (destFile.exists()) {
+            destFile.setLastModified(System.currentTimeMillis());
             destFile.renameTo(new File(originFileName));
         }
     }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/LoggerContextChangeTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/LoggerContextChangeTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.core.config;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Set;
+
+public class LoggerContextChangeTest {
+    private static String targetFileName = "log4j2-3182.xml";
+    private static String targetErrorFileName = "log4j2-3182-error.xml";
+    private static String tmpFileName = "log4j2-3182-tmp.xml";
+    private static String destDir = "target/test-classes/";
+
+    @BeforeAll
+    public static void beforeClass() {
+        System.setProperty("log4j2.configurationFile", "classpath:" + targetFileName);
+    }
+
+
+    @Test
+    public void onChangeTest() {
+        String errorFileName = destDir + targetErrorFileName;
+        String originFileName = destDir + targetFileName;
+        String tmpFile = destDir + tmpFileName;
+        wait(3);
+        updateConfigFileModTime(originFileName, errorFileName, tmpFile);
+        wait(3);
+        Set<Thread> allThreads = Thread.getAllStackTraces().keySet();
+        Integer kafkaThreads = 0;
+        Integer consoleThreads = 0;
+        for (Thread thread:allThreads) {
+            if (thread.getName().contains("AsyncKafka")) {
+                kafkaThreads++;
+            }
+            if (thread.getName().contains("AsyncCONSOLE")) {
+                consoleThreads++;
+            }
+        }
+        Assert.assertTrue(kafkaThreads <= 1);
+        Assert.assertTrue(consoleThreads <= 1);
+        updateConfigFileModTime(originFileName, tmpFile, errorFileName);
+    }
+
+    private void wait(int seconds) {
+        try {
+            Logger logger = LogManager.getLogger();
+            logger.info("Test");
+            Thread.sleep(seconds * 1000);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    private void updateConfigFileModTime(String originFileName, String destFileName, String tmpFileName) {
+        File originFile = new File(originFileName);
+        if (originFile.exists()) {
+            originFile.renameTo(new File(tmpFileName));
+        }
+        File destFile = new File(destFileName);
+        if (destFile.exists()) {
+            destFile.renameTo(new File(originFileName));
+        }
+    }
+}

--- a/log4j-core/src/test/resources/log4j2-3182-error.xml
+++ b/log4j-core/src/test/resources/log4j2-3182-error.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<configuration status="WARN" packages="org.apache.logging.log4j.core.pattern" monitorInterval="3">
+    <properties>
+        <property name="PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} |-%-5level [%thread] %c [%L] -| %msg%n</property>
+    </properties>
+
+    <appenders>
+        <Console name="CONSOLE" target="system_out">
+            <PatternLayout pattern="${PATTERN}" />
+        </Console>
+
+        <Kafka name="KafkaLog" topic="acm">
+            <PatternLayout pattern="%msg"/>
+            <Property name="bootstrap.servers">10.20.10.111111:9092</Property>
+        </Kafka>
+
+        <Async name="AsyncKafkaLog" blocking="false">
+            <AppenderRef ref="KafkaLog" />
+        </Async>
+
+        <Async name="AsyncCONSOLE">
+            <AppenderRef ref="CONSOLE" />
+        </Async>
+    </appenders>
+
+    <loggers>
+        <root level="info">
+            <AppenderRef ref="AsyncCONSOLE" />
+            <AppenderRef ref="AsyncKafkaLog" />
+        </root>
+    </loggers>
+
+</configuration>

--- a/log4j-core/src/test/resources/log4j2-3182-error.xml
+++ b/log4j-core/src/test/resources/log4j2-3182-error.xml
@@ -16,7 +16,7 @@
   limitations under the License.
 
 -->
-<configuration status="WARN" packages="org.apache.logging.log4j.core.pattern" monitorInterval="3">
+<configuration status="WARN" packages="org.apache.logging.log4j.core.pattern" monitorInterval="1">
     <properties>
         <property name="PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} |-%-5level [%thread] %c [%L] -| %msg%n</property>
     </properties>
@@ -28,6 +28,7 @@
 
         <Kafka name="KafkaLog" topic="acm">
             <PatternLayout pattern="%msg"/>
+            <!-- Try to mock the configuration exception during onchange -->
             <Property name="bootstrap.servers">10.20.10.111111:9092</Property>
         </Kafka>
 

--- a/log4j-core/src/test/resources/log4j2-3182-error.xml
+++ b/log4j-core/src/test/resources/log4j2-3182-error.xml
@@ -16,7 +16,7 @@
   limitations under the License.
 
 -->
-<configuration status="WARN" packages="org.apache.logging.log4j.core.pattern" monitorInterval="1">
+<configuration status="WARN" packages="org.apache.logging.log4j.core.pattern" monitorInterval="2">
     <properties>
         <property name="PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} |-%-5level [%thread] %c [%L] -| %msg%n</property>
     </properties>

--- a/log4j-core/src/test/resources/log4j2-3182.xml
+++ b/log4j-core/src/test/resources/log4j2-3182.xml
@@ -16,7 +16,7 @@
   limitations under the License.
 
 -->
-<configuration status="WARN" packages="org.apache.logging.log4j.core.pattern" monitorInterval="1">
+<configuration status="WARN" packages="org.apache.logging.log4j.core.pattern" monitorInterval="2">
     <properties>
         <property name="PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} |-%-5level [%thread] %c [%L] -| %msg%n</property>
     </properties>

--- a/log4j-core/src/test/resources/log4j2-3182.xml
+++ b/log4j-core/src/test/resources/log4j2-3182.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+-->
+<configuration status="WARN" packages="org.apache.logging.log4j.core.pattern" monitorInterval="1">
+    <properties>
+        <property name="PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} |-%-5level [%thread] %c [%L] -| %msg%n</property>
+    </properties>
+
+    <appenders>
+        <Console name="CONSOLE" target="system_out">
+            <PatternLayout pattern="${PATTERN}" />
+        </Console>
+
+        <Kafka name="KafkaLog" topic="acm">
+            <PatternLayout pattern="%msg"/>
+            <Property name="bootstrap.servers">10.20.10.11:9092</Property>
+        </Kafka>
+
+        <Async name="AsyncKafkaLog" blocking="false">
+            <AppenderRef ref="KafkaLog" />
+        </Async>
+
+        <Async name="AsyncCONSOLE">
+            <AppenderRef ref="CONSOLE" />
+        </Async>
+    </appenders>
+
+    <loggers>
+        <root level="info">
+            <AppenderRef ref="AsyncCONSOLE" />
+            <AppenderRef ref="AsyncKafkaLog" />
+        </root>
+    </loggers>
+
+</configuration>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -110,6 +110,9 @@
       <action issue="LOG4J2-3175" dev="vy" type="fix" due-to="wuqian0808">
         Avoid KafkaManager override when topics differ.
       </action>
+      <action issue="LOG4J2-3182" dev="vy" type="fix" due-to="wuqian0808">
+        Protect KafkaManager against start failures upon config changes.
+      </action>
       <action issue="LOG4J2-3160" dev="vy" type="fix" due-to="Lars Bohl">
         Fix documentation on how to toggle log4j2.debug system property.
       </action>


### PR DESCRIPTION
LOG4J2-3182 Protect KafkaManager against start failures upon config changes. 