### PR TITLE
LOG4J2-3190 Fix ScriptAppenderSelector docs using removed importPackage() in Nashorn.

### DIFF
--- a/src/site/xdoc/manual/appenders.xml
+++ b/src/site/xdoc/manual/appenders.xml
@@ -4463,8 +4463,7 @@ public class JpaLogEntity extends AbstractLogEventWrapperEntity {
   <Appenders>
     <Routing name="Routing">
       <Script name="RoutingInit" language="JavaScript"><![CDATA[
-        importPackage(java.lang);
-        System.getProperty("os.name").search("Windows") > -1 ? "ServiceWindows" : "ServiceOther";]]]]><![CDATA[>
+        java.lang.System.getProperty("os.name").search("Windows") > -1 ? "ServiceWindows" : "ServiceOther";]]]]><![CDATA[>
       </Script>
       <Routes>
         <Route key="ServiceOther">
@@ -4780,8 +4779,7 @@ public class JpaLogEntity extends AbstractLogEventWrapperEntity {
   <Appenders>
     <ScriptAppenderSelector name="SelectIt">
       <Script language="JavaScript"><![CDATA[
-        importPackage(java.lang);
-        System.getProperty("os.name").search("Windows") > -1 ? "MyCustomWindowsAppender" : "MySyslogAppender";]]]]><![CDATA[>
+        java.lang.System.getProperty("os.name").search("Windows") > -1 ? "MyCustomWindowsAppender" : "MySyslogAppender";]]]]><![CDATA[>
       </Script>
       <AppenderSet>
         <MyCustomWindowsAppender name="MyAppender" ... />


### PR DESCRIPTION
Fix for LOG4J2-3190.  Documentation referred to importPackage() method in ScriptAppenderSelector section which is broken in Nashorn so the fix was to remove the importPackage(java.lang) and replace it with fully qualified references.
