### PR TITLE
LOG4J2-3198: Log4j2 no longer formats lookups in messages by default

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
@@ -55,13 +55,17 @@ public final class Constants {
             "log4j.format.msg.async", false);
 
     /**
-     * LOG4J2-2109 if {@code true}, MessagePatternConverter will always operate as though
-     * <pre>%m{nolookups}</pre> is configured.
+     * LOG4J2-3198 property which used to globally opt out of lookups in pattern layout message text, however
+     * this is the default and this property is no longer read.
+     *
+     * Deprecated in 2.15.
      *
      * @since 2.10
+     * @deprecated no longer used, lookups are only used when {@code %m{lookups}} is specified
      */
+    @Deprecated
     public static final boolean FORMAT_MESSAGES_PATTERN_DISABLE_LOOKUPS = PropertiesUtil.getProperties().getBooleanProperty(
-            "log4j2.formatMsgNoLookups", false);
+            "log4j2.formatMsgNoLookups", true);
 
     /**
      * {@code true} if we think we are running in a web container, based on the boolean value of system property

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/PatternLayoutLookupDateTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/PatternLayoutLookupDateTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  *
  * This shows the behavior this user wants to disable.
  */
-@LoggerContextSource("log4j-list.xml")
+@LoggerContextSource("log4j-list-lookups.xml")
 public class PatternLayoutLookupDateTest {
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/PatternLayoutNoLookupDateTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/PatternLayoutNoLookupDateTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 /**
  * See (LOG4J2-905) Ability to disable (date) lookup completely, compatibility issues with other libraries like camel.
  */
-@LoggerContextSource("log4j-list-nolookups.xml")
+@LoggerContextSource("log4j-list.xml")
 public class PatternLayoutNoLookupDateTest {
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/MessagePatternConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/MessagePatternConverterTest.java
@@ -22,7 +22,6 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.config.builder.impl.DefaultConfigurationBuilder;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
-import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
@@ -76,12 +75,7 @@ public class MessagePatternConverterTest {
     }
 
     @Test
-    public void testLookupEnabledByDefault() {
-        assertFalse(Constants.FORMAT_MESSAGES_PATTERN_DISABLE_LOOKUPS, "Expected lookups to be enabled");
-    }
-
-    @Test
-    public void testLookup() {
+    public void testDefaultDisabledLookup() {
         final Configuration config = new DefaultConfigurationBuilder()
                 .addProperty("foo", "bar")
                 .build(true);
@@ -93,7 +87,7 @@ public class MessagePatternConverterTest {
                 .setMessage(msg).build();
         final StringBuilder sb = new StringBuilder();
         converter.format(event, sb);
-        assertEquals("bar", sb.toString(), "Unexpected result");
+        assertEquals("${foo}", sb.toString(), "Unexpected result");
     }
 
     @Test
@@ -111,6 +105,23 @@ public class MessagePatternConverterTest {
         final StringBuilder sb = new StringBuilder();
         converter.format(event, sb);
         assertEquals("${foo}", sb.toString(), "Expected the raw pattern string without lookup");
+    }
+
+    @Test
+    public void testLookup() {
+        final Configuration config = new DefaultConfigurationBuilder()
+                .addProperty("foo", "bar")
+                .build(true);
+        final MessagePatternConverter converter =
+                MessagePatternConverter.newInstance(config, new String[] {"lookups"});
+        final Message msg = new ParameterizedMessage("${foo}");
+        final LogEvent event = Log4jLogEvent.newBuilder() //
+                .setLoggerName("MyLogger") //
+                .setLevel(Level.DEBUG) //
+                .setMessage(msg).build();
+        final StringBuilder sb = new StringBuilder();
+        converter.format(event, sb);
+        assertEquals("bar", sb.toString(), "Unexpected result");
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/RegexReplacementTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/RegexReplacementTest.java
@@ -16,6 +16,12 @@
  */
 package org.apache.logging.log4j.core.pattern;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.junit.LoggerContextSource;
@@ -24,10 +30,6 @@ import org.apache.logging.log4j.junit.UsingThreadContextMap;
 import org.apache.logging.log4j.test.appender.ListAppender;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @LoggerContextSource("log4j-replace.xml")
 @UsingThreadContextMap
@@ -55,10 +57,14 @@ public class RegexReplacementTest {
         assertEquals(1, msgs.size(), "Incorrect number of messages. Should be 1 is " + msgs.size());
         assertTrue(
                 msgs.get(0).endsWith(EXPECTED), "Replacement failed - expected ending " + EXPECTED + " Actual " + msgs.get(0));
-        app.clear();
+
+    }
+
+    @Test
+    public void testMessageReplacement() {
         ThreadContext.put("MyKey", "Apache");
         logger.error("This is a test for ${ctx:MyKey}");
-        msgs = app.getMessages();
+        List<String> msgs = app.getMessages();
         assertNotNull(msgs);
         assertEquals(1, msgs.size(), "Incorrect number of messages. Should be 1 is " + msgs.size());
         assertEquals("LoggerTest This is a test for Apache" + Strings.LINE_SEPARATOR, msgs.get(0));

--- a/log4j-core/src/test/resources/log4j-list-lookups.xml
+++ b/log4j-core/src/test/resources/log4j-list-lookups.xml
@@ -18,7 +18,7 @@
 <Configuration status="WARN">
   <Appenders>
     <List name="List">
-      <PatternLayout pattern="[%-5level] %c{1.} %msg{ansi}{nolookups}%n" />
+      <PatternLayout pattern="[%-5level] %c{1.} %msg{ansi}{lookups}%n" />
     </List>
   </Appenders>
   <Loggers>

--- a/log4j-core/src/test/resources/log4j-replace.xml
+++ b/log4j-core/src/test/resources/log4j-replace.xml
@@ -21,12 +21,12 @@
     <List name="List">
        <PatternLayout>
          <replace regex="\." replacement="/"/>
-         <Pattern>%logger %msg%n</Pattern>
+         <Pattern>%logger %msg{lookups}%n</Pattern>
       </PatternLayout>
     </List>
     <List name="List2">
        <PatternLayout>
-         <Pattern>%replace{%logger %C{1.} %msg%n}{\.}{/}</Pattern>
+         <Pattern>%replace{%logger %C{1.} %msg{lookups}%n}{\.}{/}</Pattern>
       </PatternLayout>
     </List>
   </Appenders>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -31,6 +31,12 @@
     -->
     <release version="2.15.0" date="2021-MM-DD" description="GA Release 2.15.0">
       <!-- ADDS -->
+      <action issue="LOG4J2-3198" dev="ckozak" type="add">
+        Pattern layout no longer enables lookups within message text by default for cleaner API boundaries and reduced
+        formatting overhead. The old 'log4j2.formatMsgNoLookups' which enabled this behavior has been removed as well
+        as the 'nolookups' message pattern converter option. The old behavior can be enabled on a per-pattern basis
+        using '%m{lookups}'.
+      </action>
       <action issue="LOG4J2-3194" dev="rgoers" type="add" due-to="markuss">
         Allow fractional attributes for size attribute of SizeBsaedTriggeringPolicy.
       </action>

--- a/src/site/xdoc/manual/configuration.xml.vm
+++ b/src/site/xdoc/manual/configuration.xml.vm
@@ -1264,14 +1264,13 @@ rootLogger.appenderRef.stdout.ref = STDOUT
             <code>app.properties</code> would be used as the default value.
           </p>
         </subsection>
-        <a name="DisablingMessagePatternLookups"/>
-        <subsection name="Disables Message Pattern Lookups">
+        <a name="EnablingMessagePatternLookups"/>
+        <subsection name="Enabling Message Pattern Lookups">
         <p>
-          A message is processed (by default) by lookups, for example if you defined
+          A message is processed (by default) without using lookups, for example if you defined
           <code> &lt;Property name="foo.bar">FOO_BAR &lt;/Property></code>, then <code>logger.info("${foo.bar}")</code>
-          will output <code>FOO_BAR</code> instead of <code>${dollar}{foo.bar}</code>. You could disable message pattern
-          lookups globally by setting system property <code>log4j2.formatMsgNoLookups</code> to true,
-          or defining message pattern using %m{nolookups}.
+          will output <code>${dollar}{foo.bar}</code> instead of <code>FOO_BAR</code>. You could enable message pattern
+          lookups by defining message pattern using %m{lookups}.
         </p>
         </subsection>
         <a name="RuntimeLookup"/>
@@ -2645,16 +2644,6 @@ public class AwesomeTest {
     <td>false</td>
     <td>Prints a stacktrace to the <a href="#StatusMessages">status logger</a> at DEBUG level
     when the LoggerContext is started. For debug purposes.</td>
-  </tr>
-  <tr>
-      <td><a name="formatMsgNoLookups"/>log4j2.formatMsgNoLookups
-        <br />
-        (<a name="log4j2.formatMsgNoLookups" />log4j2.formatMsgNoLookups)
-      </td>
-      <td>FORMAT_MESSAGES_PATTERN_DISABLE_LOOKUPS</td>
-      <td>false</td>
-      <td>Disables message pattern lookups globally when set to <tt>true</tt>.
-          This is equivalent to defining all message patterns using <tt>%m{nolookups}</tt>.</td>
   </tr>
   <tr>
     <td><a name="log4j2.trustStoreLocation "/>log4j2.trustStoreLocation</td>

--- a/src/site/xdoc/manual/layouts.xml.vm
+++ b/src/site/xdoc/manual/layouts.xml.vm
@@ -1455,9 +1455,9 @@ WARN  [main]: Message 2</pre>
             <tr>
               <td align="center">
                 <a name="PatternMessage"/>
-                <b>m</b>{nolookups}{ansi}<br />
-                <b>msg</b>{nolookups}{ansi}<br />
-                <b>message</b>{nolookups}{ansi}
+                <b>m</b>{ookups}{ansi}<br />
+                <b>msg</b>{lookups}{ansi}<br />
+                <b>message</b>{lookups}{ansi}
               </td>
               <td>
                 <p>
@@ -1493,10 +1493,11 @@ WARN  [main]: Message 2</pre>
                 </p>
                 <pre class="prettyprint linenums">logger.info("@|KeyStyle {}|@ = @|ValueStyle {}|@", entry.getKey(), entry.getValue());</pre>
                 <p>
-                  Use <code>{nolookups}</code> to log messages like <code>"${esc.d}{date:YYYY-MM-dd}"</code>
-                  without using any lookups. Normally calling <code>logger.info("Try ${esc.d}{date:YYYY-MM-dd}")</code>
-                  would replace the date template <code>${esc.d}{date:YYYY-MM-dd}</code> with an actual date.
-                  Using <code>nolookups</code> disables this feature and logs the message string untouched.
+                  Use <code>{lookups}</code> to log messages like <code>logger.info("Try ${esc.d}{date:YYYY-MM-dd}")</code>
+                  using lookups, this will replace the date template <code>${esc.d}{date:YYYY-MM-dd}</code>
+                  with an actual date. This can be confusing in many cases, and it's often both easier and
+                  more obvious to handle the lookup in code.
+                  This feature is disabled by default and the message string is logged untouched.
                 </p>
               </td>
             </tr>


### PR DESCRIPTION
Lookups in messages are confusing, and muddy the line between logging APIs
and implementation. Given a particular API, there's an expectation that a
particular shape of call will result in specific results. However, lookups
in messages can be passed into JUL and will result in resolved output in
log4j formatted output, but not any other implementations despite no direct
dependency on those implementations.

There's also a cost to searching formatted message strings for particular
escape sequences which define lookups. This feature is not used as far as
we've been able to tell searching github and stackoverflow, so it's
unnecessary for every log event in every application to burn several cpu
cycles searching for the value.

We've had several users run into confusion due to this feature and request
a way to turn it off globally. Off should be the default to make the framework
behave more reasonably. Cases when lookups are used would be more obvious
and efficient if the lookup code itself was written directly as a log-line parameter,
for example:
```diff
if (log.isInfoEnabled()) {
-    log.error("Foo {ctx:bar}");
+    log.error("Foo {}", ThreadContext.get("bar"));
}
```