### PR TITLE
(doc) Fix environment variable for formatMsgNoLookups

### DIFF
--- a/src/site/asciidoc/manual/configuration.adoc
+++ b/src/site/asciidoc/manual/configuration.adoc
@@ -2479,7 +2479,7 @@ LoggerContext is started. For debug purposes.
 
 |[[formatMsgNoLookups]]log4j2.formatMsgNoLookups +
 ([[log4j2.formatMsgNoLookups]]log4j2.formatMsgNoLookups)
-|FORMAT_MESSAGES_PATTERN_DISABLE_LOOKUPS
+|LOG4J_FORMAT_MSG_NO_LOOKUPS
 |false
 |Disables message
 pattern lookups globally when set to `true`. This is equivalent to


### PR DESCRIPTION
The documentation currently says `FORMAT_MESSAGES_PATTERN_DISABLE_LOOKUPS` is the correct environment variable to disable the message pattern lookups, however after testing, it seems that `LOG4J_FORMAT_MSG_NO_LOOKUPS` is actually correct. (It also fits in with the other environment variables)

Even though this option is deprecated in the newest version, this could make people wrongfully think `FORMAT_MESSAGES_PATTERN_DISABLE_LOOKUPS` works on older deployments where the log4j version is not able to be updated.