### PR TITLE
Check javaClassName before JNDI lookup

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/JndiManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/JndiManager.java
@@ -17,6 +17,10 @@
 
 package org.apache.logging.log4j.core.net;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -27,6 +31,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
@@ -256,6 +261,9 @@ public class JndiManager extends AbstractManager {
                                 if (!allowedClasses.contains(className)) {
                                     LOGGER.warn("Deserialization of {} is not allowed", className);
                                     return null;
+                                } else if (!checkClassNameMatches(attributeMap)) {
+                                    LOGGER.warn("Attack!");
+                                    return null;
                                 }
                             } else {
                                 LOGGER.warn("No class name provided for {}", name);
@@ -274,6 +282,46 @@ public class JndiManager extends AbstractManager {
             return null;
         }
         return (T) this.context.lookup(name);
+    }
+
+    // Return true only if the class name in the javaClassName attribute exactly matches the class name in
+    // javaSerializedData attribute.
+    private boolean checkClassNameMatches(Map<String, Attribute> attributeMap) throws NamingException {
+        try {
+            Attribute classNameAttr = attributeMap.get(CLASS_NAME);
+            String className = (String) classNameAttr.get();
+            Attribute serializedDataAttr = attributeMap.get(SERIALIZED_DATA);
+            byte[] serializedData = (byte[]) serializedDataAttr.get();
+            AtomicBoolean javaClassNameMatchesSerializedClassName = new AtomicBoolean(false);
+            ByteArrayInputStream baos = new ByteArrayInputStream(serializedData);
+            ObjectInputStream ois = new ObjectInputStream(baos) {
+                @Override
+                protected Class<?> resolveClass(final ObjectStreamClass desc) throws ClassNotFoundException {
+                    String name = desc.getName();
+                    // This isn't strictly correct, since according to RFC 2713:
+                    //   "[javaClassName] may be the object's most
+                    //   derived class's name, but does not have to be; that of a superclass
+                    //   or interface in some cases might be most appropriate."
+                    // However, to do this properly would require loading the class, which it would be nice not to do.
+                    if (name.equals(className)) {
+                        javaClassNameMatchesSerializedClassName.set(true);
+                    }
+                    throw new ClassNotFoundException();
+                }
+            };
+            try {
+                // Start deserializing the object just to force a call to the above resolveClass method, which will
+                // throw ClassNotFoundException regardless, short-circuiting any actual (and potentially unsafe)
+                // deserialization.
+                ois.readObject();
+            } catch (ClassNotFoundException e) {
+                // ignore
+            }
+            return javaClassNameMatchesSerializedClassName.get();
+        } catch (IOException e) {
+            // Shouldn;t happen with a ByteArrayOutputStream
+            return false;
+        }
     }
 
     private static class JndiManagerFactory implements ManagerFactory<JndiManager, Properties> {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SerializationHelper.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SerializationHelper.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.net;
+
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import static java.io.ObjectStreamConstants.STREAM_MAGIC;
+import static java.io.ObjectStreamConstants.STREAM_VERSION;
+import static java.io.ObjectStreamConstants.TC_ARRAY;
+import static java.io.ObjectStreamConstants.TC_CLASS;
+import static java.io.ObjectStreamConstants.TC_CLASSDESC;
+import static java.io.ObjectStreamConstants.TC_ENUM;
+import static java.io.ObjectStreamConstants.TC_LONGSTRING;
+import static java.io.ObjectStreamConstants.TC_OBJECT;
+import static java.io.ObjectStreamConstants.TC_PROXYCLASSDESC;
+import static java.io.ObjectStreamConstants.TC_REFERENCE;
+import static java.io.ObjectStreamConstants.TC_STRING;
+
+// See https://docs.oracle.com/javase/7/docs/platform/serialization/spec/protocol.html for
+// specification of the Object Serialization Stream Protocol
+final class SerializationHelper {
+    // Return the class name of serializedObject, or null if the class name can not be extracted.
+    static String extractClassName(final byte[] serializedObject) {
+        ByteBuffer buffer = ByteBuffer.wrap(serializedObject);
+        try {
+            if (buffer.getShort() != STREAM_MAGIC) {
+                return null;
+            }
+            if (buffer.getShort() != STREAM_VERSION) {
+                return null;
+            }
+            byte tag = buffer.get();
+            switch (tag) {
+                case TC_STRING:
+                case TC_LONGSTRING:
+                    return String.class.getName();
+                case TC_ENUM:
+                case TC_OBJECT:
+                    byte classDescType = buffer.get();
+                    if (classDescType == TC_CLASSDESC) {
+                        short stringLength = buffer.getShort();
+                        return new String(serializedObject, buffer.position(), stringLength, StandardCharsets.UTF_8);
+                    } else if (classDescType == TC_PROXYCLASSDESC) {
+                        // Don't support proxies, at least for now
+                        return null;
+                    }
+                case TC_REFERENCE:
+                case TC_CLASSDESC:
+                case TC_CLASS:
+                case TC_ARRAY:
+                default:
+                    return null;
+            }
+        } catch (BufferUnderflowException | IndexOutOfBoundsException e) {
+            return null;
+        }
+    }
+
+    private SerializationHelper() {
+    }
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/net/SerializationHelperTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/net/SerializationHelperTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.net;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.nio.file.AccessMode;
+
+import static org.apache.logging.log4j.core.net.SerializationHelper.extractClassName;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SerializationHelperTest {
+    @Test
+    public void testClassNameExtractionForObject() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(42);
+        assertEquals("java.lang.Integer", extractClassName(baos.toByteArray()),
+                "Class name should be java.lang.Integer but is not");
+    }
+
+    @Test
+    public void testClassNameExtractionForString() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject("test");
+        assertEquals("java.lang.String", extractClassName(baos.toByteArray()),
+                "Class name should be java.lang.String but is not");
+    }
+
+    @Test
+    public void testClassNameExtractionForLongString() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(new String(new char[0xFFFF + 1]));
+        assertEquals("java.lang.String", extractClassName(baos.toByteArray()),
+                "Class name should be java.lang.String but is not");
+    }
+
+    @Test
+    public void testClassNameExtractionForEnum() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(AccessMode.WRITE);
+        assertEquals("java.nio.file.AccessMode", extractClassName(baos.toByteArray()),
+                "Class name should be java.nio.file.AccessMode but is not");
+    }
+
+    @Test
+    public void testClassNameExtractionForArray() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(new String[] {"foo", "bar"});
+        assertNull(extractClassName(baos.toByteArray()),
+                "Class name should null for an array but is not");
+    }
+
+    @Test
+    public void testClassNameExtractionForNull() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(null);
+        assertNull(extractClassName(baos.toByteArray()),
+                "Class name should null for null but is not");
+    }
+
+    @Test
+    public void testClassNameExtractionWithCorruptedSerializedForm() {
+        assertNull(extractClassName(new byte[0]), "Class name should be null but is not");
+    }
+}


### PR DESCRIPTION
Check that the class name in the `javaClassName` attribute exactly matches the class name in the `javaSerializedData`
attribute.

Background:

The new documentation states the following:

> When using LDAP only references to the local host name or ip address are supported along with any hosts or ip addresses listed in the log4j2.allowedLdapHosts property.

This seems to be the primary line of defense against CVE-2021-44228 (Log4Shell).  However, the second line of defense goes further:

> Only the Java primitive classes are supported by default as well as any classes specified by the log4j2.allowedLdapClasses property. 

Unfortunately, this guarantee seems easily subverted. 

Suppose that an attacker in control of an LDAP server returns a set of attributes like this:
 
```
javaClassName: "java.lang.String"
javaSerializedData: <serialized data for some attackable class, not actually java.lang.String!>
```

In this scenario, Log4J's `JndiManager#lookup(java.lang.String)` will determine that the object is safe to deserialize based on the value of the `javaClassName` attribute (because `java.lang.String` is on the default allow list), and then proceed to call `javax.naming.Context#lookup(java.lang.String)`, which will deserialize the data in `javaSerializedData`. One might think that the JDK's LDAP implementation for JNDI would first check that the object in `javaSerializedData` actually matches `javaClassName` before proceeding with deserialization, but that's not the case.  It seems that it will happily deserialize and return whatever is in `javaSerializedData`, regardless of whether the actual class matches `javaClassName`.  This is problematic, and in my opinion a security issue with the JDK.

This patch is an attempt to mitigate the issue. It has a number of problems:

1. The attack scenario is untested.  I'm unsure how to recreate the scenario given the capabilities of `embedded-ldap-junit`.
2. It violates the strict definition of `javaClassName` in RFC 2713 (see inline comment).
