### PR TITLE
Config defaults to formatMsgNoLookups=true

### DIFF
--- a/src/site/asciidoc/manual/configuration.adoc
+++ b/src/site/asciidoc/manual/configuration.adoc
@@ -2506,7 +2506,7 @@ LoggerContext is started. For debug purposes.
 |[[formatMsgNoLookups]]log4j2.formatMsgNoLookups +
 ([[log4j2.formatMsgNoLookups]]log4j2.formatMsgNoLookups)
 |LOG4J_FORMAT_MSG_NO_LOOKUPS
-|false
+|true
 |Disables message
 pattern lookups globally when set to `true`. This is equivalent to
 defining all message patterns using `%m{nolookups}`.

--- a/src/site/asciidoc/manual/lookups.adoc
+++ b/src/site/asciidoc/manual/lookups.adoc
@@ -267,7 +267,7 @@ For example:
 [#JndiLookup]
 == JNDI Lookup
 
-As of Log4j 2.15.1 JNDI operations require that `log4j2.enableJndi=tru`e be set as a system property or the
+As of Log4j 2.15.1 JNDI operations require that `log4j2.enableJndi=true` be set as a system property or the
 corresponding environment variable for this lookup to function. See the
 link:./configuration.html#enableJndi[log4j2.enableJndi] system property.
 

--- a/src/site/asciidoc/manual/lookups.adoc
+++ b/src/site/asciidoc/manual/lookups.adoc
@@ -267,7 +267,7 @@ For example:
 [#JndiLookup]
 == JNDI Lookup
 
-As of Log4j 2.15.1 JNDI operations require that `log4j2.enableJndi=true` be set as a system property or the
+As of Log4j 2.15.1 JNDI operations require that `log4j2.enableJndi=tru`e be set as a system property or the
 corresponding environment variable for this lookup to function. See the
 link:./configuration.html#enableJndi[log4j2.enableJndi] system property.
 


### PR DESCRIPTION
It is my understanding that as of 2.15.0 `formatMsgNoLookups=true` by default; this doc still showed that as "false".