### PR TITLE
2.12.1.sec1:Vulnerability fixed - based on 2.12.1 and supported Java7

### DIFF
--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/StackLocatorUtilTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/StackLocatorUtilTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.ParentRunner;
-import sun.reflect.Reflection;
+//import sun.reflect.Reflection;
 
 import static org.junit.Assert.*;
 
@@ -30,17 +30,17 @@ import static org.junit.Assert.*;
 public class StackLocatorUtilTest {
 
 
-    @Test
-    public void testStackTraceEquivalence() throws Exception {
-        for (int i = 1; i < 15; i++) {
-            final Class<?> expected = Reflection.getCallerClass(i + StackLocator.JDK_7u25_OFFSET);
-            final Class<?> actual = StackLocatorUtil.getCallerClass(i);
-            final Class<?> fallbackActual = Class.forName(
-                StackLocatorUtil.getStackTraceElement(i).getClassName());
-            assertSame(expected, actual);
-            assertSame(expected, fallbackActual);
-        }
-    }
+//    @Test
+//    public void testStackTraceEquivalence() throws Exception {
+//        for (int i = 1; i < 15; i++) {
+//            final Class<?> expected = Reflection.getCallerClass(i + StackLocator.JDK_7u25_OFFSET);
+//            final Class<?> actual = StackLocatorUtil.getCallerClass(i);
+//            final Class<?> fallbackActual = Class.forName(
+//                StackLocatorUtil.getStackTraceElement(i).getClassName());
+//            assertSame(expected, actual);
+//            assertSame(expected, fallbackActual);
+//        }
+//    }
 
     @Test
     public void testGetCallerClass() throws Exception {

--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/StackLocatorUtilTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/StackLocatorUtilTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.ParentRunner;
-//import sun.reflect.Reflection;
+import sun.reflect.Reflection;
 
 import static org.junit.Assert.*;
 
@@ -30,17 +30,17 @@ import static org.junit.Assert.*;
 public class StackLocatorUtilTest {
 
 
-//    @Test
-//    public void testStackTraceEquivalence() throws Exception {
-//        for (int i = 1; i < 15; i++) {
-//            final Class<?> expected = Reflection.getCallerClass(i + StackLocator.JDK_7u25_OFFSET);
-//            final Class<?> actual = StackLocatorUtil.getCallerClass(i);
-//            final Class<?> fallbackActual = Class.forName(
-//                StackLocatorUtil.getStackTraceElement(i).getClassName());
-//            assertSame(expected, actual);
-//            assertSame(expected, fallbackActual);
-//        }
-//    }
+    @Test
+    public void testStackTraceEquivalence() throws Exception {
+        for (int i = 1; i < 15; i++) {
+            final Class<?> expected = Reflection.getCallerClass(i + StackLocator.JDK_7u25_OFFSET);
+            final Class<?> actual = StackLocatorUtil.getCallerClass(i);
+            final Class<?> fallbackActual = Class.forName(
+                StackLocatorUtil.getStackTraceElement(i).getClassName());
+            assertSame(expected, actual);
+            assertSame(expected, fallbackActual);
+        }
+    }
 
     @Test
     public void testGetCallerClass() throws Exception {

--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -24,14 +24,12 @@
     <relativePath>../</relativePath>
   </parent>
   <artifactId>log4j-core</artifactId>
-  <version>2.12.1-safe58</version>
+  <version>2.12.1.sec1</version>
   <packaging>jar</packaging>
   <name>Apache Log4j Core</name>
   <description>The Apache Log4j Implementation</description>
   <properties>
     <log4jParentDir>${basedir}/..</log4jParentDir>
-    <custom-log4j-base.version>2.12.1</custom-log4j-base.version>
-    <custom-log4j-core.version>2.12.1-safe58</custom-log4j-core.version>
 
     <docLabel>Core Documentation</docLabel>
     <projectDir>/core</projectDir>

--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -24,11 +24,15 @@
     <relativePath>../</relativePath>
   </parent>
   <artifactId>log4j-core</artifactId>
+  <version>${custom-log4j-core.version}</version>
   <packaging>jar</packaging>
   <name>Apache Log4j Core</name>
   <description>The Apache Log4j Implementation</description>
   <properties>
     <log4jParentDir>${basedir}/..</log4jParentDir>
+    <custom-log4j-base.version>2.12.1</custom-log4j-base.version>
+    <custom-log4j-core.version>2.12.1-safe58</custom-log4j-core.version>
+
     <docLabel>Core Documentation</docLabel>
     <projectDir>/core</projectDir>
     <!--<revapi.skip>true</revapi.skip>-->
@@ -38,11 +42,13 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
+      <version>${custom-log4j-base.version}</version>
     </dependency>
     <!-- Classes and resources to be shaded into the core jar -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core-java9</artifactId>
+      <version>${custom-log4j-base.version}</version>
       <scope>provided</scope>
       <type>zip</type>
     </dependency>
@@ -152,6 +158,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
+      <version>${custom-log4j-base.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -352,7 +359,7 @@
                 <artifactItem>
                   <groupId>org.apache.logging.log4j</groupId>
                   <artifactId>log4j-core-java9</artifactId>
-                  <version>${project.version}</version>
+                  <version>${custom-log4j-base.version}</version>
                   <type>zip</type>
                   <overWrite>false</overWrite>
                 </artifactItem>

--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -24,7 +24,7 @@
     <relativePath>../</relativePath>
   </parent>
   <artifactId>log4j-core</artifactId>
-  <version>${custom-log4j-core.version}</version>
+  <version>2.12.1-safe58</version>
   <packaging>jar</packaging>
   <name>Apache Log4j Core</name>
   <description>The Apache Log4j Implementation</description>
@@ -42,13 +42,13 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${custom-log4j-base.version}</version>
+      <version>2.12.1</version>
     </dependency>
     <!-- Classes and resources to be shaded into the core jar -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core-java9</artifactId>
-      <version>${custom-log4j-base.version}</version>
+      <version>2.12.1</version>
       <scope>provided</scope>
       <type>zip</type>
     </dependency>
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${custom-log4j-base.version}</version>
+      <version>2.12.1</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -359,7 +359,7 @@
                 <artifactItem>
                   <groupId>org.apache.logging.log4j</groupId>
                   <artifactId>log4j-core-java9</artifactId>
-                  <version>${custom-log4j-base.version}</version>
+                  <version>2.12.1</version>
                   <type>zip</type>
                   <overWrite>false</overWrite>
                 </artifactItem>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/JmsManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/JmsManager.java
@@ -125,10 +125,15 @@ public class JmsManager extends AbstractManager {
 
         @Override
         public JmsManager createManager(final String name, final JmsManagerConfiguration data) {
-            try {
-                return new JmsManager(name, data);
-            } catch (final Exception e) {
-                logger().error("Error creating JmsManager using JmsManagerConfiguration [{}]", data, e);
+            if (JndiManager.isJndiEnabled()) {
+                try {
+                    return new JmsManager(name, data);
+                } catch (final Exception e) {
+                    logger().error("Error creating JmsManager using JmsManagerConfiguration [{}]", data, e);
+                    return null;
+                }
+            } else {
+                logger().error("JNDI has not been enabled. The log4j2.enableJndi property must be set to true");
                 return null;
             }
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/JndiManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/JndiManager.java
@@ -73,6 +73,10 @@ public class JndiManager extends AbstractManager {
 
     private final DirContext context;
 
+    public static boolean isJndiEnabled() {
+        return PropertiesUtil.getProperties().getBooleanProperty("log4j2.enableJndi", false);
+    }
+
     private JndiManager(final String name, final DirContext context, final List<String> allowedHosts,
                         final List<String> allowedClasses, final List<String> allowedProtocols) {
         super(null, name);
@@ -80,6 +84,14 @@ public class JndiManager extends AbstractManager {
         this.allowedHosts = allowedHosts;
         this.allowedClasses = allowedClasses;
         this.allowedProtocols = allowedProtocols;
+    }
+
+    private JndiManager(final String name) {
+        super(null, name);
+        this.context = null;
+        this.allowedProtocols = null;
+        this.allowedClasses = null;
+        this.allowedHosts = null;
     }
 
     /**
@@ -194,7 +206,10 @@ public class JndiManager extends AbstractManager {
 
     @Override
     protected boolean releaseSub(final long timeout, final TimeUnit timeUnit) {
-        return JndiCloser.closeSilently(this.context);
+        if (context != null) {
+            return JndiCloser.closeSilently(this.context);
+        }
+        return true;
     }
 
     /**
@@ -207,6 +222,9 @@ public class JndiManager extends AbstractManager {
      */
     @SuppressWarnings("unchecked")
     public synchronized <T> T lookup(final String name) throws NamingException {
+        if (context == null) {
+            return null;
+        }
         try {
             URI uri = new URI(name);
             if (uri.getScheme() != null) {
@@ -262,21 +280,25 @@ public class JndiManager extends AbstractManager {
 
         @Override
         public JndiManager createManager(final String name, final Properties data) {
-            String hosts = data != null ? data.getProperty(ALLOWED_HOSTS) : null;
-            String classes = data != null ? data.getProperty(ALLOWED_CLASSES) : null;
-            String protocols = data != null ? data.getProperty(ALLOWED_PROTOCOLS) : null;
-            List<String> allowedHosts = new ArrayList<>();
-            List<String> allowedClasses = new ArrayList<>();
-            List<String> allowedProtocols = new ArrayList<>();
-            addAll(hosts, allowedHosts, permanentAllowedHosts, ALLOWED_HOSTS, data);
-            addAll(classes, allowedClasses, permanentAllowedClasses, ALLOWED_CLASSES, data);
-            addAll(protocols, allowedProtocols, permanentAllowedProtocols, ALLOWED_PROTOCOLS, data);
-            try {
-                return new JndiManager(name, new InitialDirContext(data), allowedHosts, allowedClasses,
-                        allowedProtocols);
-            } catch (final NamingException e) {
-                LOGGER.error("Error creating JNDI InitialContext.", e);
-                return null;
+            if (isJndiEnabled()) {
+                String hosts = data != null ? data.getProperty(ALLOWED_HOSTS) : null;
+                String classes = data != null ? data.getProperty(ALLOWED_CLASSES) : null;
+                String protocols = data != null ? data.getProperty(ALLOWED_PROTOCOLS) : null;
+                List<String> allowedHosts = new ArrayList<>();
+                List<String> allowedClasses = new ArrayList<>();
+                List<String> allowedProtocols = new ArrayList<>();
+                addAll(hosts, allowedHosts, permanentAllowedHosts, ALLOWED_HOSTS, data);
+                addAll(classes, allowedClasses, permanentAllowedClasses, ALLOWED_CLASSES, data);
+                addAll(protocols, allowedProtocols, permanentAllowedProtocols, ALLOWED_PROTOCOLS, data);
+                try {
+                    return new JndiManager(name, new InitialDirContext(data), allowedHosts, allowedClasses,
+                            allowedProtocols);
+                } catch (final NamingException e) {
+                    LOGGER.error("Error creating JNDI InitialContext.", e);
+                    return null;
+                }
+            } else {
+                return new JndiManager(name);
             }
         }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MessagePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MessagePatternConverter.java
@@ -16,13 +16,13 @@
  */
 package org.apache.logging.log4j.core.pattern;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
-import org.apache.logging.log4j.core.util.ArrayUtils;
-import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MultiformatMessage;
@@ -37,55 +37,39 @@ import org.apache.logging.log4j.util.StringBuilderFormattable;
 @Plugin(name = "MessagePatternConverter", category = PatternConverter.CATEGORY)
 @ConverterKeys({ "m", "msg", "message" })
 @PerformanceSensitive("allocation")
-public final class MessagePatternConverter extends LogEventPatternConverter {
+public class MessagePatternConverter extends LogEventPatternConverter {
 
+    private static final String LOOKUPS = "lookups";
     private static final String NOLOOKUPS = "nolookups";
 
-    private final String[] formats;
-    private final Configuration config;
-    private final TextRenderer textRenderer;
-    private final boolean noLookups;
-
-    /**
-     * Private constructor.
-     *
-     * @param options
-     *            options, may be null.
-     */
-    private MessagePatternConverter(final Configuration config, final String[] options) {
+    private MessagePatternConverter() {
         super("Message", "message");
-        this.formats = options;
-        this.config = config;
-        final int noLookupsIdx = loadNoLookups(options);
-        this.noLookups = Constants.FORMAT_MESSAGES_PATTERN_DISABLE_LOOKUPS || noLookupsIdx >= 0;
-        this.textRenderer = loadMessageRenderer(noLookupsIdx >= 0 ? ArrayUtils.remove(options, noLookupsIdx) : options);
     }
 
-    private int loadNoLookups(final String[] options) {
+    private static boolean loadLookups(final String[] options) {
         if (options != null) {
-            for (int i = 0; i < options.length; i++) {
-                final String option = options[i];
-                if (NOLOOKUPS.equalsIgnoreCase(option)) {
-                    return i;
+            for (final String option : options) {
+                if (LOOKUPS.equalsIgnoreCase(option)) {
+                    return true;
                 }
             }
         }
-        return -1;
+        return false;
     }
 
-    private TextRenderer loadMessageRenderer(final String[] options) {
+    private static TextRenderer loadMessageRenderer(final String[] options) {
         if (options != null) {
             for (final String option : options) {
                 switch (option.toUpperCase(Locale.ROOT)) {
-                case "ANSI":
-                    if (Loader.isJansiAvailable()) {
-                        return new JAnsiTextRenderer(options, JAnsiTextRenderer.DefaultMessageStyleMap);
-                    }
-                    StatusLogger.getLogger()
-                            .warn("You requested ANSI message rendering but JANSI is not on the classpath.");
-                    return null;
-                case "HTML":
-                    return new HtmlTextRenderer(options);
+                    case "ANSI":
+                        if (Loader.isJansiAvailable()) {
+                            return new JAnsiTextRenderer(options, JAnsiTextRenderer.DefaultMessageStyleMap);
+                        }
+                        StatusLogger.getLogger()
+                                .warn("You requested ANSI message rendering but JANSI is not on the classpath.");
+                        return null;
+                    case "HTML":
+                        return new HtmlTextRenderer(options);
                 }
             }
         }
@@ -102,55 +86,127 @@ public final class MessagePatternConverter extends LogEventPatternConverter {
      * @return instance of pattern converter.
      */
     public static MessagePatternConverter newInstance(final Configuration config, final String[] options) {
-        return new MessagePatternConverter(config, options);
+        boolean lookups = loadLookups(options);
+        String[] formats = withoutLookupOptions(options);
+        TextRenderer textRenderer = loadMessageRenderer(formats);
+        MessagePatternConverter result = formats == null || formats.length == 0
+                ? SimpleMessagePatternConverter.INSTANCE
+                : new FormattedMessagePatternConverter(formats);
+        if (lookups && config != null) {
+            result = new LookupMessagePatternConverter(result, config);
+        }
+        if (textRenderer != null) {
+            result = new RenderingPatternConverter(result, textRenderer);
+        }
+        return result;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    private static String[] withoutLookupOptions(final String[] options) {
+        if (options == null || options.length == 0) {
+            return options;
+        }
+        List<String> results = new ArrayList<>(options.length);
+        for (String option : options) {
+            if (!LOOKUPS.equalsIgnoreCase(option) && !NOLOOKUPS.equalsIgnoreCase(option)) {
+                results.add(option);
+            }
+        }
+        return results.toArray(new String[0]);
+    }
+
     @Override
     public void format(final LogEvent event, final StringBuilder toAppendTo) {
-        final Message msg = event.getMessage();
-        if (msg instanceof StringBuilderFormattable) {
+        throw new UnsupportedOperationException();
+    }
 
-            final boolean doRender = textRenderer != null;
-            final StringBuilder workingBuilder = doRender ? new StringBuilder(80) : toAppendTo;
+    private static final class SimpleMessagePatternConverter extends MessagePatternConverter {
+        private static final MessagePatternConverter INSTANCE = new SimpleMessagePatternConverter();
 
-            final int offset = workingBuilder.length();
-            if (msg instanceof MultiFormatStringBuilderFormattable) {
-                ((MultiFormatStringBuilderFormattable) msg).formatTo(formats, workingBuilder);
-            } else {
-                ((StringBuilderFormattable) msg).formatTo(workingBuilder);
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void format(final LogEvent event, final StringBuilder toAppendTo) {
+            Message msg = event.getMessage();
+            if (msg instanceof StringBuilderFormattable) {
+                ((StringBuilderFormattable) msg).formatTo(toAppendTo);
+            } else if (msg != null) {
+                toAppendTo.append(msg.getFormattedMessage());
             }
+        }
+    }
 
-            // TODO can we optimize this?
-            if (config != null && !noLookups) {
-                for (int i = offset; i < workingBuilder.length() - 1; i++) {
-                    if (workingBuilder.charAt(i) == '$' && workingBuilder.charAt(i + 1) == '{') {
-                        final String value = workingBuilder.substring(offset, workingBuilder.length());
-                        workingBuilder.setLength(offset);
-                        workingBuilder.append(config.getStrSubstitutor().replace(event, value));
-                    }
+    private static final class FormattedMessagePatternConverter extends MessagePatternConverter {
+
+        private final String[] formats;
+
+        FormattedMessagePatternConverter(final String[] formats) {
+            this.formats = formats;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void format(final LogEvent event, final StringBuilder toAppendTo) {
+            Message msg = event.getMessage();
+            if (msg instanceof StringBuilderFormattable) {
+                if (msg instanceof MultiFormatStringBuilderFormattable) {
+                    ((MultiFormatStringBuilderFormattable) msg).formatTo(formats, toAppendTo);
+                } else {
+                    ((StringBuilderFormattable) msg).formatTo(toAppendTo);
                 }
-            }
-            if (doRender) {
-                textRenderer.render(workingBuilder, toAppendTo);
-            }
-            return;
-        }
-        if (msg != null) {
-            String result;
-            if (msg instanceof MultiformatMessage) {
-                result = ((MultiformatMessage) msg).getFormattedMessage(formats);
-            } else {
-                result = msg.getFormattedMessage();
-            }
-            if (result != null) {
-                toAppendTo.append(config != null && result.contains("${")
-                        ? config.getStrSubstitutor().replace(event, result) : result);
-            } else {
-                toAppendTo.append("null");
+            } else if (msg != null) {
+                toAppendTo.append(msg instanceof MultiformatMessage
+                        ? ((MultiformatMessage) msg).getFormattedMessage(formats)
+                        : msg.getFormattedMessage());
             }
         }
+    }
+
+    private static final class LookupMessagePatternConverter extends MessagePatternConverter {
+        private final MessagePatternConverter delegate;
+        private final Configuration config;
+
+        LookupMessagePatternConverter(final MessagePatternConverter delegate, final Configuration config) {
+            this.delegate = delegate;
+            this.config = config;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void format(final LogEvent event, final StringBuilder toAppendTo) {
+            int start = toAppendTo.length();
+            delegate.format(event, toAppendTo);
+            int indexOfSubstitution = toAppendTo.indexOf("${", start);
+            if (indexOfSubstitution >= 0) {
+                config.getStrSubstitutor()
+                        .replaceIn(event, toAppendTo, indexOfSubstitution, toAppendTo.length() - indexOfSubstitution);
+            }
+        }
+    }
+
+    private static final class RenderingPatternConverter extends MessagePatternConverter {
+
+        private final MessagePatternConverter delegate;
+        private final TextRenderer textRenderer;
+
+        RenderingPatternConverter(final MessagePatternConverter delegate, final TextRenderer textRenderer) {
+            this.delegate = delegate;
+            this.textRenderer = textRenderer;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void format(final LogEvent event, final StringBuilder toAppendTo) {
+            StringBuilder workingBuilder = new StringBuilder(80);
+            delegate.format(event, workingBuilder);
+            textRenderer.render(workingBuilder, toAppendTo);
+        }
+
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/JndiContextSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/JndiContextSelector.java
@@ -92,6 +92,12 @@ public class JndiContextSelector implements NamedContextSelector {
 
     private static final StatusLogger LOGGER = StatusLogger.getLogger();
 
+    public JndiContextSelector() {
+        if (!JndiManager.isJndiEnabled()) {
+            throw new IllegalStateException("JNDI must be enabled by setting log4j2.enableJndi=true");
+        }
+    }
+
     @Override
     public LoggerContext getContext(final String fqcn, final ClassLoader loader, final boolean currentContext) {
         return getContext(fqcn, loader, currentContext, null);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
@@ -55,13 +55,17 @@ public final class Constants {
             "log4j.format.msg.async", false);
 
     /**
-     * LOG4J2-2109 if {@code true}, MessagePatternConverter will always operate as though
-     * <pre>%m{nolookups}</pre> is configured.
+     * LOG4J2-3198 property which used to globally opt out of lookups in pattern layout message text, however
+     * this is the default and this property is no longer read.
+     *
+     * Deprecated in 2.15.
      *
      * @since 2.10
+     * @deprecated no longer used, lookups are only used when {@code %m{lookups}} is specified
      */
+    @Deprecated
     public static final boolean FORMAT_MESSAGES_PATTERN_DISABLE_LOOKUPS = PropertiesUtil.getProperties().getBooleanProperty(
-            "log4j2.formatMsgNoLookups", false);
+            "log4j2.formatMsgNoLookups", true);
 
     /**
      * {@code true} if we think we are running in a web container, based on the boolean value of system property

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/NetUtils.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/NetUtils.java
@@ -17,6 +17,8 @@
 package org.apache.logging.log4j.core.util;
 
 import java.io.File;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.NetworkInterface;
@@ -25,11 +27,14 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.List;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Strings;
 
 /**
  * Networking-related convenience methods.
@@ -75,6 +80,45 @@ public final class NetUtils {
             }
             LOGGER.error("Could not determine local host name", uhe);
             return UNKNOWN_LOCALHOST;
+        }
+    }
+
+    public static List<String> getLocalIps() {
+        List<String> localIps = new ArrayList<>();
+        localIps.add("localhost");
+        localIps.add("127.0.0.1");
+        try {
+            final InetAddress addr = Inet4Address.getLocalHost();
+            setHostName(addr, localIps);
+        } catch (final UnknownHostException ex) {
+            // Ignore this.
+        }
+        try {
+            final Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            if (interfaces != null) {
+                while (interfaces.hasMoreElements()) {
+                    final NetworkInterface nic = interfaces.nextElement();
+                    final Enumeration<InetAddress> addresses = nic.getInetAddresses();
+                    while (addresses.hasMoreElements()) {
+                        final InetAddress address = addresses.nextElement();
+                        setHostName(address, localIps);
+                    }
+                }
+            }
+        } catch (final SocketException se) {
+            // ignore.
+        }
+        return localIps;
+    }
+
+    private static void setHostName(InetAddress address, List<String> localIps) {
+        String[] parts = address.toString().split("\\s*/\\s*");
+        if (parts.length > 0) {
+            for (String part : parts) {
+                if (Strings.isNotBlank(part) && !localIps.contains(part)) {
+                    localIps.add(part);
+                }
+            }
         }
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/SetUtils.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/SetUtils.java
@@ -23,8 +23,10 @@ import java.util.Set;
  * Set-related convenience methods.
  */
 public final class SetUtils {
-    private SetUtils() {
-    }
+
+    private static final String[] EMPTY_STRINGS = new String[0];
+
+    private SetUtils() {}
 
     /**
      * Extracts the Strings from a Set that start with a given prefix.
@@ -34,6 +36,9 @@ public final class SetUtils {
      * @return an array of the matching strings from the given set
      */
     public static String[] prefixSet(final Set<String> set, final String prefix) {
+        if (set == null) {
+            return EMPTY_STRINGS;
+        }
         final Set<String> prefixSet = new HashSet<>();
         for (final String str : set) {
             if (str.startsWith(prefix)) {


### PR DESCRIPTION
This is a `log4j-core` [security-fixed](https://github.com/apache/logging-log4j2/pull/608) ([CVE-2021-44228](https://access.redhat.com/security/cve/CVE-2021-44228)) version based on `2.12.1` as it's the last version that supports `Java 7`.

The patch code is exactly the same as version `2.16.0`.