### PR TITLE
[possibly redundant] Completely disable JNDI in Interpolator.java, in the hope to patch CVE-2021-44228

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
@@ -109,16 +109,6 @@ public class Interpolator extends AbstractConfigurationAwareLookup {
         strLookupMap.put("base64", new Base64StrLookup());
         strLookupMap.put("lower", new LowerLookup());
         strLookupMap.put("upper", new UpperLookup());
-        // JNDI
-        if (JndiManager.isJndiEnabled()) {
-            try {
-                // [LOG4J2-703] We might be on Android
-                strLookupMap.put(LOOKUP_KEY_JNDI,
-                        Loader.newCheckedInstanceOf("org.apache.logging.log4j.core.lookup.JndiLookup", StrLookup.class));
-            } catch (final LinkageError | Exception e) {
-                handleError(LOOKUP_KEY_JNDI, e);
-            }
-        }
         // JMX input args
         try {
             // We might be on Android


### PR DESCRIPTION
**edit:** I have read that JNDI has already been disabled, so this patch is probably redundant.

I have completely removed JNDI from the Interpolator, so that the CVE-2021-44228 exploit will not be able to call LDAP.

To do this, I have removed JNDI support from `Interpolator.java (org.apache.logging.log4j.core.lookup.Interpolator)`:
```diff
         strLookupMap.put("base64", new Base64StrLookup());
         strLookupMap.put("lower", new LowerLookup());
         strLookupMap.put("upper", new UpperLookup());
-        // JNDI
-        if (JndiManager.isJndiEnabled()) {
-            try {
-                // [LOG4J2-703] We might be on Android
-                strLookupMap.put(LOOKUP_KEY_JNDI,
-                        Loader.newCheckedInstanceOf("org.apache.logging.log4j.core.lookup.JndiLookup", StrLookup.class));
-            } catch (final LinkageError | Exception e) {
-                handleError(LOOKUP_KEY_JNDI, e);
-            }
-        }
```

I hope this helps.
\- Sky Swimmer