### PR TITLE
remove cache-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,14 +16,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Setup Maven caching
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Setup JDK 11
         uses: actions/setup-java@v2.4.0
         with:


### PR DESCRIPTION
The cache action is no longer needed. 
We already have the 'cache' property enabled in setup-java.
