### PR TITLE
[DOC] fix Duration string

### DIFF
--- a/src/site/asciidoc/manual/appenders.adoc
+++ b/src/site/asciidoc/manual/appenders.adoc
@@ -3290,7 +3290,7 @@ and are 60 days old or older are deleted at rollover time.
       <DefaultRolloverStrategy>
         <Delete basePath="${baseDir}" maxDepth="2">
           <IfFileName glob="*/app-*.log.gz" />
-          <IfLastModified age="60d" />
+          <IfLastModified age="P60D" />
         </Delete>
       </DefaultRolloverStrategy>
     </RollingFile>
@@ -3334,7 +3334,7 @@ comes first.
         -->
         <Delete basePath="${baseDir}" maxDepth="2">
           <IfFileName glob="*/app-*.log.gz">
-            <IfLastModified age="30d">
+            <IfLastModified age="P30D">
               <IfAny>
                 <IfAccumulatedFileSize exceeds="100 GB" />
                 <IfAccumulatedFileCount exceeds="10" />


### PR DESCRIPTION
According to
https://logging.apache.org/log4j/2.x/log4j-core/apidocs/org/apache/logging/log4j/core/appender/rolling/action/Duration.html#parseCharSequence
a Duration looks like "P2D" or "PT20S".

In serveral instances our configuration did not work as expected and
didn't delete files despite them beeing older then the period that we
thought was configured. After some digging into the configuration we
found that the above mention string fixed the configuration.