### PR TITLE
feat: lock feature by properties(PropertiesPropertySource order in properties)

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
@@ -29,7 +29,7 @@ public class PropertiesPropertySource implements PropertySource {
 
     private static final String PREFIX = "log4j2.";
 
-    private static final String KEY_PRIORITY = "log4j2.properties_load_priority";
+    private static final String KEY_PRIORITY = "log4j2.propertySourcePriority";
 
     private final int priority;
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
@@ -29,15 +29,21 @@ public class PropertiesPropertySource implements PropertySource {
 
     private static final String PREFIX = "log4j2.";
 
+    private static final String KEY_PRIORITY = "log4j2.properties_load_priority";
+
+    private final int priority;
+
     private final Properties properties;
 
     public PropertiesPropertySource(final Properties properties) {
         this.properties = properties;
+        final String order = (String)properties.get(KEY_PRIORITY);
+        priority = order == null ? 0 : Integer.parseInt(order);
     }
 
     @Override
     public int getPriority() {
-        return 0;
+        return priority;
     }
 
     @Override

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyFilePropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyFilePropertySource.java
@@ -44,9 +44,4 @@ public class PropertyFilePropertySource extends PropertiesPropertySource {
         return props;
     }
 
-    @Override
-    public int getPriority() {
-        return 0;
-    }
-
 }


### PR DESCRIPTION
so we can change the load order if we need:
such as lock some properties for force disable some feature we don't need.

ie:

SystemPropertiesPropertySource is priority=100, if we want log4j2.component.properties lock some properties(such as log4j2.enableJndi)
that we do not want to be changed by system properties or ENV.
with this feature, log4j2.component.properties as below:
```
log4j2.enableJndiLookup=false
log4j2.propertiesLoadPriority=1000
```
Our app do not need jndi lookup feature, so we want force disable it(Can't enable by -Dlog4j2.enableJndiLookup=true or by ENV)
