### PR TITLE
[DOC] fix Duration string

### DIFF
--- a/src/site/xdoc/manual/appenders.xml
+++ b/src/site/xdoc/manual/appenders.xml
@@ -3851,7 +3851,7 @@ public class JpaLogEntity extends AbstractLogEventWrapperEntity {
       <DefaultRolloverStrategy>
         <Delete basePath="${baseDir}" maxDepth="2">
           <IfFileName glob="*/app-*.log.gz" />
-          <IfLastModified age="60d" />
+          <IfLastModified age="P60D" />
         </Delete>
       </DefaultRolloverStrategy>
     </RollingFile>
@@ -3893,7 +3893,7 @@ public class JpaLogEntity extends AbstractLogEventWrapperEntity {
         -->
         <Delete basePath="${baseDir}" maxDepth="2">
           <IfFileName glob="*/app-*.log.gz">
-            <IfLastModified age="30d">
+            <IfLastModified age="P30D">
               <IfAny>
                 <IfAccumulatedFileSize exceeds="100 GB" />
                 <IfAccumulatedFileCount exceeds="10" />


### PR DESCRIPTION
According to
https://logging.apache.org/log4j/2.x/log4j-core/apidocs/org/apache/logging/log4j/core/appender/rolling/action/Duration.html#parseCharSequence
a Duration looks like "P2D" or "PT20S".

In serveral instances our configuration did not work as expected and
didn't delete files despite them beeing older then the period that we
thought was configured. After some digging into the configuration we
found that the above mention string fixed the configuration.