### PR TITLE
LOG4J2-3270 Provide separation between MapMessage and properties lookups

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
@@ -58,7 +58,7 @@ import org.apache.logging.log4j.core.filter.AbstractFilterable;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.lookup.ConfigurationStrSubstitutor;
 import org.apache.logging.log4j.core.lookup.Interpolator;
-import org.apache.logging.log4j.core.lookup.MapLookup;
+import org.apache.logging.log4j.core.lookup.PropertiesLookup;
 import org.apache.logging.log4j.core.lookup.RuntimeStrSubstitutor;
 import org.apache.logging.log4j.core.lookup.StrLookup;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
@@ -633,7 +633,7 @@ public abstract class AbstractConfiguration extends AbstractFilterable implement
             }
         } else {
             final Map<String, String> map = this.getComponent(CONTEXT_PROPERTIES);
-            final StrLookup lookup = map == null ? null : new MapLookup(map);
+            final StrLookup lookup = map == null ? null : new PropertiesLookup(map);
             Interpolator interpolator = new Interpolator(lookup, pluginPackages);
             subst.setVariableResolver(interpolator);
             configurationStrSubstitutor.setVariableResolver(interpolator);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/PropertiesPlugin.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/PropertiesPlugin.java
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.lookup.Interpolator;
-import org.apache.logging.log4j.core.lookup.MapLookup;
+import org.apache.logging.log4j.core.lookup.PropertiesLookup;
 import org.apache.logging.log4j.core.lookup.StrLookup;
 
 /**
@@ -54,6 +54,6 @@ public final class PropertiesPlugin {
             map.put(prop.getName(), prop.getValue());
         }
 
-        return new Interpolator(new MapLookup(map), config.getPluginPackages());
+        return new Interpolator(new PropertiesLookup(map), config.getPluginPackages());
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
@@ -70,7 +70,7 @@ public class Interpolator extends AbstractConfigurationAwareLookup {
      * @since 2.1
      */
     public Interpolator(final StrLookup defaultLookup, final List<String> pluginPackages) {
-        this.defaultLookup = defaultLookup == null ? new MapLookup(new HashMap<String, String>()) : defaultLookup;
+        this.defaultLookup = defaultLookup == null ? new PropertiesLookup(new HashMap<String, String>()) : defaultLookup;
         final PluginManager manager = new PluginManager(CATEGORY);
         manager.collectPlugins(pluginPackages);
         final Map<String, PluginType<?>> plugins = manager.getPlugins();
@@ -98,12 +98,13 @@ public class Interpolator extends AbstractConfigurationAwareLookup {
      * Creates the Interpolator using only Lookups that work without an event and initial properties.
      */
     public Interpolator(final Map<String, String> properties) {
-        this.defaultLookup = new MapLookup(properties == null ? new HashMap<String, String>() : properties);
+        this.defaultLookup = new PropertiesLookup(properties);
         // TODO: this ought to use the PluginManager
         strLookupMap.put("log4j", new Log4jLookup());
         strLookupMap.put("sys", new SystemPropertiesLookup());
         strLookupMap.put("env", new EnvironmentLookup());
         strLookupMap.put("main", MainMapLookup.MAIN_SINGLETON);
+        strLookupMap.put("map", new MapLookup(properties));
         strLookupMap.put("marker", new MarkerLookup());
         strLookupMap.put("java", new JavaLookup());
         strLookupMap.put("lower", new LowerLookup());

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/JmxRuntimeInputArgumentsLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/JmxRuntimeInputArgumentsLookup.java
@@ -20,6 +20,7 @@ import java.lang.management.ManagementFactory;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 
 /**
@@ -48,4 +49,17 @@ public class JmxRuntimeInputArgumentsLookup extends MapLookup {
         super(map);
     }
 
+    @Override
+    public String lookup(final LogEvent event, final String key) {
+        return lookup(key);
+    }
+
+    @Override
+    public String lookup(final String key) {
+        if (key == null) {
+            return null;
+        }
+        Map<String, String> map = getMap();
+        return map == null ? null : map.get(key);
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/MapLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/MapLookup.java
@@ -43,7 +43,7 @@ public class MapLookup implements StrLookup {
     }
 
     /**
-     * Creates a new instance backed by a Map. Used by the default lookup.
+     * Creates a new instance backed by a Map.
      *
      * @param map
      *        the map of keys to values, may be null
@@ -146,7 +146,7 @@ public class MapLookup implements StrLookup {
      */
     @Override
     public String lookup(final String key) {
-        if (map == null) {
+        if (key == null || map == null) {
             return null;
         }
         return map.get(key);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/PropertiesLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/PropertiesLookup.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.lookup;
+
+import org.apache.logging.log4j.core.LogEvent;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A lookup designed for {@code Properties} defined in the configuration. This is similar
+ * to {@link MapLookup} without special handling for structured messages.
+ *
+ * Note that this lookup is not a plugin, but wired as a default lookup in the configuration.
+ */
+public final class PropertiesLookup implements StrLookup {
+
+    /**
+     * Configuration from which to read properties.
+     */
+    private final Map<String, String> properties;
+
+    public PropertiesLookup(final Map<String, String> properties) {
+        this.properties = properties == null
+                ? Collections.emptyMap()
+                : properties;
+    }
+
+    @Override
+    public String lookup(
+            @SuppressWarnings("ignored") final LogEvent event,
+            final String key) {
+        return lookup(key);
+    }
+
+    /**
+     * Looks a value from configuration properties.
+     * <p>
+     * If the property is not defined, then null is returned.
+     * </p>
+     *
+     * @param key the key to be looked up, may be null
+     * @return the matching value, null if no match
+     */
+    @Override
+    public String lookup(final String key) {
+        return key == null ? null : properties.get(key);
+    }
+
+    @Override
+    public String toString() {
+        return "PropertiesLookup{properties=" + properties + '}';
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/StrSubstitutor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/StrSubstitutor.java
@@ -227,7 +227,7 @@ public class StrSubstitutor implements ConfigurationAware {
      * @param valueMap  the map with the variables' values, may be null
      */
     public StrSubstitutor(final Map<String, String> valueMap) {
-        this(new MapLookup(valueMap), DEFAULT_PREFIX, DEFAULT_SUFFIX, DEFAULT_ESCAPE);
+        this(new PropertiesLookup(valueMap), DEFAULT_PREFIX, DEFAULT_SUFFIX, DEFAULT_ESCAPE);
     }
 
     /**
@@ -239,7 +239,7 @@ public class StrSubstitutor implements ConfigurationAware {
      * @throws IllegalArgumentException if the prefix or suffix is null
      */
     public StrSubstitutor(final Map<String, String> valueMap, final String prefix, final String suffix) {
-        this(new MapLookup(valueMap), prefix, suffix, DEFAULT_ESCAPE);
+        this(new PropertiesLookup(valueMap), prefix, suffix, DEFAULT_ESCAPE);
     }
 
     /**
@@ -253,7 +253,7 @@ public class StrSubstitutor implements ConfigurationAware {
      */
     public StrSubstitutor(final Map<String, String> valueMap, final String prefix, final String suffix,
                           final char escape) {
-        this(new MapLookup(valueMap), prefix, suffix, escape);
+        this(new PropertiesLookup(valueMap), prefix, suffix, escape);
     }
 
     /**
@@ -268,7 +268,7 @@ public class StrSubstitutor implements ConfigurationAware {
      */
     public StrSubstitutor(final Map<String, String> valueMap, final String prefix, final String suffix,
                               final char escape, final String valueDelimiter) {
-        this(new MapLookup(valueMap), prefix, suffix, escape, valueDelimiter);
+        this(new PropertiesLookup(valueMap), prefix, suffix, escape, valueDelimiter);
     }
 
     /**

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderReconfigureTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderReconfigureTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class RollingFileAppenderReconfigureTest {
 
     @Rule
-    public final LoggerContextRule loggerContextRule = new LoggerContextRule("src/test/rolling-file-appender-reconfigure.xml");
+    public final LoggerContextRule loggerContextRule = new LoggerContextRule("rolling-file-appender-reconfigure.xml");
 
     @Test
     public void testReconfigure() {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/MainInputArgumentsMapLookup.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/MainInputArgumentsMapLookup.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.core.lookup;
 
+import org.apache.logging.log4j.core.LogEvent;
+
 import java.util.Map;
 
 /**
@@ -53,5 +55,19 @@ public class MainInputArgumentsMapLookup extends MapLookup {
 
     public MainInputArgumentsMapLookup(final Map<String, String> map) {
         super(map);
+    }
+
+    @Override
+    public String lookup(final LogEvent event, final String key) {
+        return lookup(key);
+    }
+
+    @Override
+    public String lookup(final String key) {
+        if (key == null) {
+            return null;
+        }
+        Map<String, String> map = getMap();
+        return map == null ? null : map.get(key);
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/StrSubstitutorTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/StrSubstitutorTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.core.lookup;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -218,5 +218,35 @@ public class StrSubstitutorTest {
         assertNull(StrSubstitutor.replace((String) null, (Properties) null));
         assertEquals("A", StrSubstitutor.replace("${a}", properties));
         assertEquals("${a}", StrSubstitutor.replace("${a}", (Properties) null));
+    }
+
+    @Test
+    public void testTopLevelLookupsWithoutRecursiveEvaluation() {
+        final Map<String, String> map = new HashMap<>();
+        map.put("key", "VaLuE");
+        final StrLookup lookup = new Interpolator(new MapLookup(map));
+        final StrSubstitutor subst = new StrSubstitutor(lookup);
+        subst.setRecursiveEvaluationAllowed(false);
+        assertEquals("value", subst.replace("${lower:${ctx:key}}"));
+    }
+
+    @Test
+    public void testTopLevelLookupsWithoutRecursiveEvaluation_doubleLower() {
+        final Map<String, String> map = new HashMap<>();
+        map.put("key", "VaLuE");
+        final StrLookup lookup = new Interpolator(new MapLookup(map));
+        final StrSubstitutor subst = new StrSubstitutor(lookup);
+        subst.setRecursiveEvaluationAllowed(false);
+        assertEquals("value", subst.replace("${lower:${lower:${ctx:key}}}"));
+    }
+
+    @Test
+    public void testTopLevelLookupsWithoutRecursiveEvaluationAndDefaultValueLookup() {
+        final Map<String, String> map = new HashMap<>();
+        map.put("key2", "TWO");
+        final StrLookup lookup = new Interpolator(new MapLookup(map));
+        final StrSubstitutor subst = new StrSubstitutor(lookup);
+        subst.setRecursiveEvaluationAllowed(false);
+        assertEquals("two", subst.replace("${lower:${ctx:key1:-${ctx:key2}}}"));
     }
 }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -36,6 +36,9 @@
       <action dev="ggregory" type="fix">
         Fix NPE when input is null in StrSubstitutor.replace(String, Properties).
       </action>
+      <action issue="LOG4J2-3270" dev="ckozak" type="fix">
+        Lookups with no prefix only read values from the configuration properties as expected.
+      </action>
     </release>
     <release version="2.17.0" date="2021-12-17" description="GA Release 2.17.0">
       <action issue="LOG4J2-3230" dev="ckozak" type="fix">

--- a/src/site/xdoc/manual/lookups.xml
+++ b/src/site/xdoc/manual/lookups.xml
@@ -493,7 +493,6 @@ public static void main(String args[]) {
             <ol>
               <li>Provide the base for Properties declared in the configuration file.</li>
               <li>Retrieve values from MapMessages in LogEvents.</li>
-              <li>Retrieve values set with <a href="../log4j-core/apidocs/org/apache/logging/log4j/core/lookup/MapLookup.html#setMainArguments%28java.lang.String[]%29">MapLookup.setMainArguments(String[])</a></li>
             </ol>
           <p>
             The first item simply means that the MapLookup is used to substitute properties that are defined
@@ -511,7 +510,7 @@ public static void main(String args[]) {
 <Routing name="Routing">
   <Routes pattern="$${map:type}">
     <Route>
-      <RollingFile name="Rolling-${map:type}" fileName="${filename}"
+      <RollingFile name="Rolling-${map:type}" fileName="target/rolling1/test1-${map:type}.log"
                    filePattern="target/rolling1/test1-${map:type}.%i.log.gz">
         <PatternLayout>
           <pattern>%d %p %c{1.} [%t] %m%n</pattern>


### PR DESCRIPTION
`MapLookup` includes special handling for `MapMessages` in addition
to the configuration properties map. This change aims to prevent
unwanted interactions between these two concerns.