### PR TITLE
Remove requirement of JndiLookup class to exist

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
@@ -164,7 +164,7 @@ public class Interpolator extends AbstractConfigurationAwareLookup {
         return strLookupMap;
     }
     
-    private final isJndiLookupClass(Class<? extends StrLookup> clazz) {
+    private final boolean isJndiLookupClass(Class<? extends StrLookup> clazz) {
         if (clazz == null) {
             return false;
         }


### PR DESCRIPTION
To address the log4j jndi-vulnerability, many companies have removed JndiLookup.class from the artifact, whether or not they upgraded log4j2. This is a safeguard against the potential of newly discovered routes to JndiLookup, which are not yet patched. We would rather remove the JndiLookup alltogether, to take away the core issue: that a logging-api should not allow code-execution, no matter how each patch tries to limit access to this class.

In 2.17.0 the check for the JndiLookup class is based on a FQCN: "org.apache.logging.log4j.core.lookup.JndiLookup"

However, in the master-branch, we see a dependency on: JndiLookup.class.getName(), which in the case of a removed class-file, would fail the loading of *any* interpolator-plugin, as all checks will cause an exception, and Interpolator.handleError to be executed.