### PR TITLE
JNDI enablement properties are loaded at most once

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/JndiManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/JndiManager.java
@@ -42,6 +42,10 @@ public class JndiManager extends AbstractManager {
     private static final String PREFIX = "log4j2.enableJndi";
     private static final String JAVA_SCHEME = "java";
 
+    private static final boolean JNDI_CONTEXT_SELECTOR_ENABLED = isJndiEnabled("ContextSelector");
+    private static final boolean JNDI_JMS_ENABLED = isJndiEnabled("Jms");
+    private static final boolean JNDI_LOOKUP_ENABLED = isJndiEnabled("Lookup");
+
     private final InitialContext context;
 
     private static boolean isJndiEnabled(final String subKey) {
@@ -53,15 +57,15 @@ public class JndiManager extends AbstractManager {
     }
 
     public static boolean isJndiContextSelectorEnabled() {
-        return isJndiEnabled("ContextSelector");
+        return JNDI_CONTEXT_SELECTOR_ENABLED;
     }
 
     public static boolean isJndiJmsEnabled() {
-        return isJndiEnabled("Jms");
+        return JNDI_JMS_ENABLED;
     }
 
     public static boolean isJndiLookupEnabled() {
-        return isJndiEnabled("Lookup");
+        return JNDI_LOOKUP_ENABLED;
     }
 
     private JndiManager(final String name, final InitialContext context) {


### PR DESCRIPTION
Rather than checking properties after each invocation, jndi
properties are all read into static final boolean fields when
the JndiManager class is initialized, this way properties cannot
be mutated and refreshed at runtime, and checks are cheaper.
This format matches other log4j configuration points as set
in `Constants.java`.