### PR TITLE
define current build outputTimestamp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <maven.doap.skip>false</maven.doap.skip>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputTimestamp>10</project.build.outputTimestamp>
     <docLabel>Site Documentation</docLabel>
     <projectDir />
     <commonsLoggingVersion>1.2</commonsLoggingVersion>


### PR DESCRIPTION
see https://maven.apache.org/guides/mini/guide-reproducible-builds.html
having a value defined here make it follow your releases, instead of having a value fixed by inheritance from parent