### PR TITLE
LOG4J2-3288 Interpolator non-plugin ctor includes all core lookups

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
@@ -109,6 +109,9 @@ public class Interpolator extends AbstractConfigurationAwareLookup {
         strLookupMap.put("java", new JavaLookup());
         strLookupMap.put("lower", new LowerLookup());
         strLookupMap.put("upper", new UpperLookup());
+        strLookupMap.put("bundle", new ResourceBundleLookup());
+        strLookupMap.put("event", new EventLookup());
+        strLookupMap.put("sd", new StructuredDataLookup());
         // JNDI
         if (JndiManager.isJndiLookupEnabled()) {
             try {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/InterpolatorTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/InterpolatorTest.java
@@ -168,4 +168,14 @@ public class InterpolatorTest {
                 .build();
         assertEquals("mapMessage", interpolator.lookup(event, "map:key"));
     }
+
+    @Test
+    public void testDefaultLookups() {
+        Interpolator noPluginInterpolator = new Interpolator(Collections.emptyMap());
+        Interpolator pluginBasedInterpolator = new Interpolator(null, Collections.emptyList());
+        assertEquals(
+                pluginBasedInterpolator.getStrLookupMap().keySet(),
+                noPluginInterpolator.getStrLookupMap().keySet(),
+                "Plugin and non-plugin Interpolator constructors should support the same features");
+    }
 }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -31,6 +31,9 @@
     -->
     <release version="2.17.1" date="2021-MM-dd" description="GA Release 2.17.1">
       <!-- FIXES -->
+      <action issue="LOG4J2-3288" dev="ckozak" type="fix">
+        Interpolator non-plugin constructor registers all lookups from log4j-core, previously it was missing event, sd, and bundle.
+      </action>
       <action issue="LOG4J2-3204" dev="vy" type="fix" due-to="Francis-FY">
         Correct SpringLookup package name in Interpolator.
       </action>


### PR DESCRIPTION
This adds missing lookups: `bundle`, `event`, and `sd`

There's a comment suggesting that the PluginManager could be used,
however that will require additional validation before I'm comfortable
enabling it: Logging initialization is very static and tricky,
and it's easy to produce deadlocks when referencing logging code
within initialization.