### PR TITLE
Fix tests not restoring system properties

### DIFF
--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/EventParameterMemoryLeakTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/EventParameterMemoryLeakTest.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,14 @@ public class EventParameterMemoryLeakTest {
         System.setProperty("log4j2.enable.direct.encoders", "true");
         System.setProperty("log4j2.is.webapp", "false");
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "EventParameterMemoryLeakTest.xml");
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        System.clearProperty("log4j2.enable.threadlocals");
+        System.clearProperty("log4j2.enable.direct.encoders");
+        System.clearProperty("log4j2.is.webapp");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test
@@ -99,6 +108,7 @@ public class EventParameterMemoryLeakTest {
         }
     }
 
+    @SuppressWarnings("serial")
     private static final class ObjectThrowable extends RuntimeException {
         private final Object object;
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/Log4j1222Test.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/Log4j1222Test.java
@@ -34,8 +34,13 @@ public class Log4j1222Test
 	@Test
 	public void homepageRendersSuccessfully()
 	{
-        System.setProperty("log4j.configurationFile", "log4j2-console.xml");
-		Runtime.getRuntime().addShutdownHook(new ShutdownHook());
+		System.setProperty("log4j.configurationFile", "log4j2-console.xml");
+		try {
+			// TODO: Does not work correctly; when shutdown hook fails test has already finished successfully
+			Runtime.getRuntime().addShutdownHook(new ShutdownHook());
+		} finally {
+			System.clearProperty("log4j.configurationFile");
+		}
 	}
 
 	private static class ShutdownHook extends Thread {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/TimestampMessageTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/TimestampMessageTest.java
@@ -61,7 +61,6 @@ public class TimestampMessageTest {
 
     @AfterAll
     public static void afterClass() throws IllegalAccessException {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
         ClockFactoryTest.resetClocks();
     }
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/ConsoleAppenderTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/ConsoleAppenderTest.java
@@ -63,7 +63,6 @@ public class ConsoleAppenderTest {
 
     @BeforeEach
     public void before() {
-        System.setProperty(LOG4J_SKIP_JANSI, "true");
         baos = new ByteArrayOutputStream();
     }
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/FileAppenderPermissionsTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/FileAppenderPermissionsTest.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.test.junit.CleanUpDirectories;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.spi.ExtendedLogger;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -58,6 +59,11 @@ public class FileAppenderPermissionsTest {
     public static void beforeClass() {
         System.setProperty("log4j2.debug", "true");
         assumeTrue(FileUtils.isFilePosixAttributeViewSupported());
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        System.clearProperty("log4j2.debug");
     }
 
     @ParameterizedTest

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/RollingRandomAccessFileAppenderRolloverTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/RollingRandomAccessFileAppenderRolloverTest.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -37,6 +38,11 @@ public class RollingRandomAccessFileAppenderRolloverTest {
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
                 "RollingRandomAccessFileAppenderTest.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderWithJndiTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppenderWithJndiTest.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.core.appender.routing;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.Map;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -32,6 +31,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 
 import static org.junit.Assert.*;
@@ -48,13 +48,19 @@ public class RoutingAppenderWithJndiTest {
     public static LoggerContextRule loggerContextRule = new LoggerContextRule("log4j-routing-by-jndi.xml");
 
     @ClassRule
-    public static RuleChain rules = RuleChain.outerRule(new JndiRule(initBindings()))
-        .around(loggerContextRule);
+    public static RuleChain rules = RuleChain.outerRule(new ExternalResource() {
+        @Override
+        protected void before() throws Throwable {
+            System.setProperty("log4j2.enableJndi", "true");
+        }
 
-    private static Map<String, Object> initBindings() {
-        System.setProperty("log4j2.enableJndi", "true");
-        return Collections.emptyMap();
-    }
+        @Override
+        public void after() {
+            System.clearProperty("log4j2.enableJndi");
+        }
+    })
+        .around(new JndiRule(Collections.emptyMap()))
+        .around(loggerContextRule);
 
     @Before
     public void before() throws NamingException {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncAppenderConfigTest_LOG4J2_2032.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncAppenderConfigTest_LOG4J2_2032.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -39,6 +40,13 @@ public class AsyncAppenderConfigTest_LOG4J2_2032 {
         System.setProperty("Log4jLogEventFactory", "org.apache.logging.log4j.core.impl.ReusableLogEventFactory");
         System.setProperty("log4j2.messageFactory", "org.apache.logging.log4j.message.ReusableMessageFactory");
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncAppenderConfigTest-LOG4J2-2032.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("Log4jLogEventFactory");
+        System.clearProperty("log4j2.messageFactory");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncAppenderExceptionHandlingTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncAppenderExceptionHandlingTest.java
@@ -90,7 +90,7 @@ class AsyncAppenderExceptionHandlingTest {
             Assertions.assertEquals(Collections.singletonList(lastLogMessage), accumulatedMessages);
 
         } finally {
-            System.setProperty(throwableClassNamePropertyName, Strings.EMPTY);
+            System.clearProperty(throwableClassNamePropertyName);
         }
 
     }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerClassLoadDeadlockTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerClassLoadDeadlockTest.java
@@ -18,6 +18,7 @@ package org.apache.logging.log4j.core.async;
 
 import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -37,6 +38,13 @@ public class AsyncLoggerClassLoadDeadlockTest {
         System.setProperty("Log4jContextSelector", "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector");
         System.setProperty("AsyncLogger.RingBufferSize", String.valueOf(RING_BUFFER_SIZE));
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConsoleTest.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("Log4jContextSelector");
+        System.clearProperty("AsyncLogger.RingBufferSize");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test(timeout = 30000)

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigAutoFlushTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigAutoFlushTest.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -38,6 +39,11 @@ public class AsyncLoggerConfigAutoFlushTest {
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
                 "AsyncLoggerConfigAutoFlushTest.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigErrorOnFormat.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigErrorOnFormat.java
@@ -52,6 +52,7 @@ public class AsyncLoggerConfigErrorOnFormat {
     @AfterClass
     public static void afterClass() {
         System.clearProperty("log4j2.is.webapp");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
         System.clearProperty("log4j2.logEventFactory");
     }
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.core.config.AppenderRef;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -43,6 +44,11 @@ public class AsyncLoggerConfigTest {
     @BeforeClass
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigTest.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test
@@ -71,17 +77,17 @@ public class AsyncLoggerConfigTest {
 
     @Test
     public void testIncludeLocationDefaultsToFalse() {
-    	final LoggerConfig rootLoggerConfig =
-    			AsyncLoggerConfig.RootLogger.createLogger(
-    					null, Level.INFO, null, new AppenderRef[0], null, new DefaultConfiguration(), null);
-	assertFalse("Include location should default to false for async loggers",
-    			    rootLoggerConfig.isIncludeLocation());
+        final LoggerConfig rootLoggerConfig =
+                AsyncLoggerConfig.RootLogger.createLogger(
+                        null, Level.INFO, null, new AppenderRef[0], null, new DefaultConfiguration(), null);
+        assertFalse("Include location should default to false for async loggers",
+                    rootLoggerConfig.isIncludeLocation());
 
-    	final LoggerConfig loggerConfig =
-    	        AsyncLoggerConfig.createLogger(
-    	                false, Level.INFO, "com.foo.Bar", null, new AppenderRef[0], null, new DefaultConfiguration(),
-    	        		null);
-	assertFalse("Include location should default to false for async loggers",
-    			    loggerConfig.isIncludeLocation());
+        final LoggerConfig loggerConfig =
+                AsyncLoggerConfig.createLogger(
+                        false, Level.INFO, "com.foo.Bar", null, new AppenderRef[0], null, new DefaultConfiguration(),
+                        null);
+        assertFalse("Include location should default to false for async loggers",
+                    loggerConfig.isIncludeLocation());
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest2.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest2.java
@@ -26,6 +26,8 @@ import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -34,10 +36,19 @@ import static org.junit.Assert.*;
 @Category(AsyncLoggers.class)
 public class AsyncLoggerConfigTest2 {
 
-    @Test
-    public void testConsecutiveReconfigure() throws Exception {
+    @BeforeClass
+    public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
                 "AsyncLoggerConfigTest2.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
+    }
+
+    @Test
+    public void testConsecutiveReconfigure() throws Exception {
         final File file = new File("target", "AsyncLoggerConfigTest2.log");
         assertTrue("Deleted old file before test", !file.exists() || file.delete());
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest3.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest3.java
@@ -28,6 +28,8 @@ import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -36,10 +38,19 @@ import static org.junit.Assert.*;
 @Category(AsyncLoggers.class)
 public class AsyncLoggerConfigTest3 {
 
-    @Test
-    public void testNoConcurrentModificationException() throws Exception {
+    @BeforeClass
+    public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
                 "AsyncLoggerConfigTest2.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
+    }
+
+    @Test
+    public void testNoConcurrentModificationException() throws Exception {
         final File file = new File("target", "AsyncLoggerConfigTest2.log");
         assertTrue("Deleted old file before test", !file.exists() || file.delete());
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest4.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest4.java
@@ -47,6 +47,7 @@ public class AsyncLoggerConfigTest4 {
     @AfterClass
     public static void afterClass() {
         System.clearProperty("log4j2.is.webapp");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigUseAfterShutdownTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigUseAfterShutdownTest.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.core.test.CoreLoggerContexts;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.spi.AbstractLogger;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -34,6 +35,11 @@ public class AsyncLoggerConfigUseAfterShutdownTest {
     @BeforeClass
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigTest.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigWithAsyncEnabledTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigWithAsyncEnabledTest.java
@@ -49,6 +49,7 @@ public class AsyncLoggerConfigWithAsyncEnabledTest {
     public static void afterClass() {
         System.clearProperty("log4j2.is.webapp");
         System.clearProperty("Log4jContextSelector");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerCustomSelectorLocationTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerCustomSelectorLocationTest.java
@@ -57,7 +57,8 @@ public class AsyncLoggerCustomSelectorLocationTest {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerLocationTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerLocationTest.java
@@ -50,7 +50,8 @@ public class AsyncLoggerLocationTest {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTest.java
@@ -47,7 +47,8 @@ public class AsyncLoggerTest {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestArgumentFreedOnError.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestArgumentFreedOnError.java
@@ -48,7 +48,11 @@ public class AsyncLoggerTestArgumentFreedOnError {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty("log4j2.enable.threadlocals");
+        System.clearProperty("log4j2.enable.direct.encoders");
+        System.clearProperty("log4j2.is.webapp");
+        System.clearProperty("log4j.format.msg.async");
+        System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
     }
 
     // LOG4J2-2725: events are cleared even after failure

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestCachedThreadName.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestCachedThreadName.java
@@ -47,7 +47,8 @@ public class AsyncLoggerTestCachedThreadName {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestNanoTime.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestNanoTime.java
@@ -49,7 +49,8 @@ public class AsyncLoggerTestNanoTime {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestUncachedThreadName.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestUncachedThreadName.java
@@ -48,7 +48,9 @@ public class AsyncLoggerTestUncachedThreadName {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty("AsyncLogger.ThreadNameStrategy");
+        System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerThreadContextTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerThreadContextTest.java
@@ -48,7 +48,8 @@ public class AsyncLoggerThreadContextTest {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerThreadNameStrategyTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerThreadNameStrategyTest.java
@@ -26,13 +26,9 @@ import static org.junit.Assert.*;
 
 @Category(AsyncLoggers.class)
 public class AsyncLoggerThreadNameStrategyTest {
-    @After
-    public void after() {
-        System.clearProperty("AsyncLogger.ThreadNameStrategy");
-    }
-
     @Before
-    public void before() {
+    @After
+    public void resetProperties() {
         System.clearProperty("AsyncLogger.ThreadNameStrategy");
     }
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTimestampMessageTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTimestampMessageTest.java
@@ -61,7 +61,8 @@ public class AsyncLoggerTimestampMessageTest {
 
     @AfterClass
     public static void afterClass() throws IllegalAccessException {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
         ClockFactoryTest.resetClocks();
     }
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerUseAfterShutdownTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerUseAfterShutdownTest.java
@@ -47,7 +47,8 @@ public class AsyncLoggerUseAfterShutdownTest {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/Log4j2Jira1688AsyncTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/Log4j2Jira1688AsyncTest.java
@@ -56,7 +56,8 @@ public class Log4j2Jira1688AsyncTest {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/Log4j2Jira1688Test.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/Log4j2Jira1688Test.java
@@ -54,7 +54,7 @@ public class Log4j2Jira1688Test {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncAppenderTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncAppenderTest.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -46,6 +47,11 @@ public class QueueFullAsyncAppenderTest extends QueueFullAbstractTest {
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
                 "log4j2-queueFullAsyncAppender.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncAppenderTest2.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncAppenderTest2.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -45,6 +46,12 @@ public class QueueFullAsyncAppenderTest2 extends QueueFullAbstractTest {
 
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
                 "log4j2-queueFullAsyncAppender.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("log4j.format.msg.async");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.status.StatusData;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -53,6 +54,14 @@ public class QueueFullAsyncLoggerConfigLoggingFromToStringTest extends QueueFull
         System.setProperty("AsyncLoggerConfig.RingBufferSize", "128");
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
                 "log4j2-queueFullAsyncLoggerConfig.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("log4j2.enable.threadlocals");
+        System.clearProperty("log4j2.is.webapp");
+        System.clearProperty("AsyncLoggerConfig.RingBufferSize");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest2.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest2.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -48,6 +49,15 @@ public class QueueFullAsyncLoggerConfigLoggingFromToStringTest2 extends QueueFul
         System.setProperty("AsyncLoggerConfig.RingBufferSize", "128");
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
                 "log4j2-queueFullAsyncLoggerConfig.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("log4j.format.msg.async");
+        System.clearProperty("log4j2.enable.threadlocals");
+        System.clearProperty("log4j2.is.webapp");
+        System.clearProperty("AsyncLoggerConfig.RingBufferSize");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigTest.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -47,6 +48,12 @@ public class QueueFullAsyncLoggerConfigTest extends QueueFullAbstractTest {
         System.setProperty("AsyncLoggerConfig.RingBufferSize", "128"); // minimum ringbuffer size
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
                 "log4j2-queueFullAsyncLoggerConfig.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("AsyncLoggerConfig.RingBufferSize");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigTest2.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigTest2.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -46,6 +47,13 @@ public class QueueFullAsyncLoggerConfigTest2 extends QueueFullAbstractTest {
         System.setProperty("AsyncLoggerConfig.RingBufferSize", "128"); // minimum ringbuffer size
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
                 "log4j2-queueFullAsyncLoggerConfig.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("log4j.format.msg.async");
+        System.clearProperty("AsyncLoggerConfig.RingBufferSize");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest.java
@@ -55,7 +55,8 @@ public class QueueFullAsyncLoggerLoggingFromToStringTest extends QueueFullAbstra
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty("AsyncLogger.RingBufferSize");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest2.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest2.java
@@ -60,7 +60,9 @@ public class QueueFullAsyncLoggerLoggingFromToStringTest2 extends QueueFullAbstr
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty("log4j.format.msg.async");
+        System.clearProperty("AsyncLogger.RingBufferSize");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest.java
@@ -54,7 +54,8 @@ public class QueueFullAsyncLoggerTest extends QueueFullAbstractTest {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty("AsyncLogger.RingBufferSize");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest2.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest2.java
@@ -53,7 +53,9 @@ public class QueueFullAsyncLoggerTest2 extends QueueFullAbstractTest {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty("log4j.format.msg.async");
+        System.clearProperty("AsyncLogger.RingBufferSize");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest3.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest3.java
@@ -59,7 +59,10 @@ public class QueueFullAsyncLoggerTest3 extends QueueFullAbstractTest {
 
     @AfterClass
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty("log4j.format.msg.async");
+        System.clearProperty("log4j2.asyncQueueFullPolicy");
+        System.clearProperty("AsyncLogger.RingBufferSize");
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CompositeConfigurationMissingTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CompositeConfigurationMissingTest.java
@@ -19,6 +19,7 @@ package org.apache.logging.log4j.core.config;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -29,6 +30,11 @@ public class CompositeConfigurationMissingTest {
     @BeforeAll
     public static void beforeClass() {
         System.setProperty("log4j2.configurationFile", "classpath:log4j-comp-logger-root.xml,log4j-does-not-exist.json");
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        System.clearProperty("log4j2.configurationFile");
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CustomConfigurationTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CustomConfigurationTest.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.status.StatusConsoleListener;
 import org.apache.logging.log4j.status.StatusListener;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -52,6 +53,12 @@ public class CustomConfigurationTest {
     public static void before() {
         System.setProperty("log4j.level", "info");
         System.setProperty("log.level", "info");
+    }
+
+    @AfterAll
+    public static void after() {
+        System.clearProperty("log4j.level");
+        System.clearProperty("log.level");
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/TestConfigurator.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/TestConfigurator.java
@@ -178,18 +178,22 @@ public class TestConfigurator {
     @Test
     public void testFromClassPathProperty() throws Exception {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "classpath:log4j2-config.xml");
-        ctx = Configurator.initialize("Test1", null);
-        LogManager.getLogger("org.apache.test.TestConfigurator");
-        Configuration config = ctx.getConfiguration();
-        assertNotNull(config, "No configuration");
-        assertEquals(CONFIG_NAME, config.getName(), "Incorrect Configuration.");
-        final Map<String, Appender> map = config.getAppenders();
-        assertNotNull(map, "Appenders map should not be null.");
-        assertThat(map, hasSize(greaterThan(0)));
-        assertThat("Wrong configuration", map, hasKey("List"));
-        Configurator.shutdown(ctx);
-        config = ctx.getConfiguration();
-        assertEquals(NullConfiguration.NULL_NAME, config.getName(), "Unexpected Configuration.");
+        try {
+            ctx = Configurator.initialize("Test1", null);
+            LogManager.getLogger("org.apache.test.TestConfigurator");
+            Configuration config = ctx.getConfiguration();
+            assertNotNull(config, "No configuration");
+            assertEquals(CONFIG_NAME, config.getName(), "Incorrect Configuration.");
+            final Map<String, Appender> map = config.getAppenders();
+            assertNotNull(map, "Appenders map should not be null.");
+            assertThat(map, hasSize(greaterThan(0)));
+            assertThat("Wrong configuration", map, hasKey("List"));
+            Configurator.shutdown(ctx);
+            config = ctx.getConfiguration();
+            assertEquals(NullConfiguration.NULL_NAME, config.getName(), "Unexpected Configuration.");
+        } finally {
+            System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
+        }
     }
 
     @Test
@@ -367,12 +371,16 @@ public class TestConfigurator {
         }
         final String value = FILESEP.equals("/") ? dir.toString() + "/test.log" : "1:/target/bad:file.log";
         System.setProperty("testfile", value);
-        ctx = Configurator.initialize("Test1", "bad/log4j-badfilename.xml");
-        LogManager.getLogger("org.apache.test.TestConfigurator");
-        final Configuration config = ctx.getConfiguration();
-        assertNotNull(config, "No configuration");
-        assertEquals("XMLConfigTest", config.getName(), "Unexpected Configuration");
-        assertThat(config.getAppenders(), hasSize(equalTo(2)));
+        try {
+            ctx = Configurator.initialize("Test1", "bad/log4j-badfilename.xml");
+            LogManager.getLogger("org.apache.test.TestConfigurator");
+            final Configuration config = ctx.getConfiguration();
+            assertNotNull(config, "No configuration");
+            assertEquals("XMLConfigTest", config.getName(), "Unexpected Configuration");
+            assertThat(config.getAppenders(), hasSize(equalTo(2)));
+        } finally {
+            System.clearProperty("testfile");
+        }
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/arbiters/BasicArbiterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/arbiters/BasicArbiterTest.java
@@ -39,6 +39,7 @@ public class BasicArbiterTest {
     public void after() {
         loggerContext.stop();
         loggerContext = null;
+        System.clearProperty("env");
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/arbiters/ScriptArbiterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/arbiters/ScriptArbiterTest.java
@@ -42,6 +42,7 @@ public class ScriptArbiterTest {
     public void after() {
         loggerContext.stop();
         loggerContext = null;
+        System.clearProperty("env");
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/arbiters/SelectArbiterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/arbiters/SelectArbiterTest.java
@@ -39,6 +39,7 @@ public class SelectArbiterTest {
     public void after() {
         loggerContext.stop();
         loggerContext = null;
+        System.clearProperty("env");
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/builder/ConfigurationAssemblerTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/builder/ConfigurationAssemblerTest.java
@@ -58,7 +58,7 @@ public class ConfigurationAssemblerTest {
                 validate(configuration);
             }
         } finally {
-            System.getProperties().remove(Constants.LOG4J_CONTEXT_SELECTOR);
+            System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
         }
     }
 
@@ -72,8 +72,8 @@ public class ConfigurationAssemblerTest {
             final Configuration config = ((LoggerContext) LogManager.getContext(false)).getConfiguration();
             validate(config);
         } finally {
-            System.getProperties().remove(Constants.LOG4J_CONTEXT_SELECTOR);
-            System.getProperties().remove(ConfigurationFactory.CONFIGURATION_FACTORY_PROPERTY);
+            System.clearProperty(Constants.LOG4J_CONTEXT_SELECTOR);
+            System.clearProperty(ConfigurationFactory.CONFIGURATION_FACTORY_PROPERTY);
         }
     }
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/xml/XmlConfigurationPropsTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/xml/XmlConfigurationPropsTest.java
@@ -43,10 +43,14 @@ public class XmlConfigurationPropsTest {
     @Test
     public void testNoProps() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, CONFIG);
-        final LoggerContext ctx = LoggerContext.getContext();
-        ctx.reconfigure();
-        final Configuration config = ctx.getConfiguration();
-        assertThat(config, instanceOf(XmlConfiguration.class));
+        try {
+            final LoggerContext ctx = LoggerContext.getContext();
+            ctx.reconfigure();
+            final Configuration config = ctx.getConfiguration();
+            assertThat(config, instanceOf(XmlConfiguration.class));
+        } finally {
+            System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
+        }
     }
 
     @Test
@@ -59,6 +63,7 @@ public class XmlConfigurationPropsTest {
             final Configuration config = ctx.getConfiguration();
             assertThat(config, instanceOf(XmlConfiguration.class));
         } finally {
+            System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
             System.clearProperty(Constants.LOG4J_DEFAULT_STATUS_LEVEL);
         }
     }
@@ -73,6 +78,7 @@ public class XmlConfigurationPropsTest {
             final Configuration config = ctx.getConfiguration();
             assertThat(config, instanceOf(XmlConfiguration.class));
         } finally {
+            System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
             System.clearProperty("log4j.level");
         }
     }
@@ -88,6 +94,7 @@ public class XmlConfigurationPropsTest {
             final Configuration config = ctx.getConfiguration();
             assertThat(config, instanceOf(XmlConfiguration.class));
         } finally {
+            System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
             System.clearProperty("log4j.level");
             System.clearProperty("log.level");
         }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/ContextDataFactoryPropertySetMissingConstructorTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/ContextDataFactoryPropertySetMissingConstructorTest.java
@@ -29,9 +29,12 @@ public class ContextDataFactoryPropertySetMissingConstructorTest {
     @Test
     public void intArgReturnsSortedArrayStringMapIfPropertySpecifiedButMissingIntConstructor() throws Exception {
         System.setProperty("log4j2.ContextData", FactoryTestStringMapWithoutIntConstructor.class.getName());
-        assertTrue(ContextDataFactory.createContextData(2) instanceof SortedArrayStringMap);
-        final SortedArrayStringMap actual = (SortedArrayStringMap) ContextDataFactory.createContextData(2);
-        assertEquals(2, actual.getThreshold());
-        System.clearProperty("log4j2.ContextData");
+        try {
+            assertTrue(ContextDataFactory.createContextData(2) instanceof SortedArrayStringMap);
+            final SortedArrayStringMap actual = (SortedArrayStringMap) ContextDataFactory.createContextData(2);
+            assertEquals(2, actual.getThreshold());
+        } finally {
+            System.clearProperty("log4j2.ContextData");
+        }
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/ContextDataFactoryPropertySetTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/ContextDataFactoryPropertySetTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.core.impl;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -25,18 +26,21 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class ContextDataFactoryPropertySetTest {
 
+    @AfterEach
+    public void afterEach() {
+        System.clearProperty("log4j2.ContextData");
+    }
+
     @Test
     public void noArgReturnsSpecifiedImplIfPropertySpecified() throws Exception {
         System.setProperty("log4j2.ContextData", FactoryTestStringMap.class.getName());
         assertTrue(ContextDataFactory.createContextData() instanceof FactoryTestStringMap);
-        System.clearProperty("log4j2.ContextData");
     }
 
     @Test
     public void intArgReturnsSpecifiedImplIfPropertySpecified() throws Exception {
         System.setProperty("log4j2.ContextData", FactoryTestStringMap.class.getName());
         assertTrue(ContextDataFactory.createContextData(2) instanceof FactoryTestStringMap);
-        System.clearProperty("log4j2.ContextData");
     }
 
     @Test
@@ -44,6 +48,5 @@ public class ContextDataFactoryPropertySetTest {
         System.setProperty("log4j2.ContextData", FactoryTestStringMap.class.getName());
         final FactoryTestStringMap actual = (FactoryTestStringMap) ContextDataFactory.createContextData(2);
         assertEquals(2, actual.initialCapacity);
-        System.clearProperty("log4j2.ContextData");
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/Log4jLogEventNanoTimeTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/Log4jLogEventNanoTimeTest.java
@@ -47,7 +47,7 @@ public class Log4jLogEventNanoTimeTest {
 
     @AfterAll
     public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/NestedLoggingFromThrowableMessageTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/NestedLoggingFromThrowableMessageTest.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -51,6 +52,13 @@ public class NestedLoggingFromThrowableMessageTest {
         System.setProperty("log4j2.is.webapp", "false");
     }
 
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("log4j2.is.webapp");
+        file1.delete();
+        file2.delete();
+    }
+
     @Rule
     public LoggerContextRule context = new LoggerContextRule("log4j-nested-logging-throwable-message.xml");
     private Logger logger;
@@ -60,6 +68,7 @@ public class NestedLoggingFromThrowableMessageTest {
         logger = LogManager.getLogger(NestedLoggingFromThrowableMessageTest.class);
     }
 
+    @SuppressWarnings("serial")
     class ThrowableLogsInGetMessage extends RuntimeException {
 
         @Override

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/NestedLoggingFromToStringTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/impl/NestedLoggingFromToStringTest.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -49,6 +50,11 @@ public class NestedLoggingFromToStringTest {
     @BeforeClass
     public static void beforeClass() {
         System.setProperty("log4j2.is.webapp", "false");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("log4j2.is.webapp");
     }
 
     @Rule

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/JndiLookupTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/JndiLookupTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.logging.log4j.core.test.junit.JndiRule;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +47,11 @@ public class JndiLookupTest {
     @BeforeClass
     public static void beforeClass() {
         System.setProperty("log4j2.enableJndi", "true");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("log4j2.enableJndi");
     }
 
     private Map<String, Object> createBindings() {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/JndiRestrictedLookupTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/JndiRestrictedLookupTest.java
@@ -24,6 +24,7 @@ import javax.naming.StringRefAddr;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.message.SimpleMessage;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,6 +56,13 @@ public class JndiRestrictedLookupTest {
         System.setProperty("log4j2.allowedLdapClasses", Level.class.getName());
         System.setProperty("log4j2.allowedJndiProtocols", "dns");
         System.setProperty("log4j2.enableJndi", "true");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        System.clearProperty("log4j2.allowedLdapClasses");
+        System.clearProperty("log4j2.allowedJndiProtocols");
+        System.clearProperty("log4j2.enableJndi");
     }
 
     @Test
@@ -144,12 +152,14 @@ public class JndiRestrictedLookupTest {
             fruit = f;
         }
 
+        @Override
         public Reference getReference() throws NamingException {
 
             return new Reference(Fruit.class.getName(), new StringRefAddr("fruit",
                     fruit), JndiExploit.class.getName(), null); // factory location
         }
 
+        @Override
         public String toString() {
             return fruit;
         }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/StyleConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/StyleConverterTest.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.util.Strings;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -38,6 +39,11 @@ public class StyleConverterTest {
     @BeforeAll
     public static void beforeClass() {
         System.setProperty("log4j.skipJansi", "false"); // LOG4J2-2087: explicitly enable
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        System.clearProperty("log4j.skipJansi");
     }
 
     @Test

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/time/ClockFactoryTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/time/ClockFactoryTest.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.time.internal.CachedClock;
 import org.apache.logging.log4j.core.time.internal.CoarseCachedClock;
 import org.apache.logging.log4j.core.time.internal.SystemClock;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnJre;
@@ -48,7 +49,8 @@ public class ClockFactoryTest {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    @AfterEach
+    public void cleanUpClocks() throws Exception {
         resetClocks();
     }
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/tools/GenerateCustomLoggerTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/tools/GenerateCustomLoggerTest.java
@@ -61,6 +61,8 @@ public class GenerateCustomLoggerTest {
 
     @AfterAll
     public static void afterClass() {
+        System.clearProperty("log4j2.loggerContextFactory");
+
         File file = new File(TEST_SOURCE);
         File parent = file.getParentFile();
         if (file.exists()) {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/tools/GenerateExtendedLoggerTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/tools/GenerateExtendedLoggerTest.java
@@ -62,6 +62,8 @@ public class GenerateExtendedLoggerTest {
 
     @AfterAll
     public static void afterClass() {
+        System.clearProperty("log4j2.loggerContextFactory");
+
         File file = new File(TEST_SOURCE);
         File parent = file.getParentFile();
         if (file.exists()) {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/util/ContextDataProviderTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/util/ContextDataProviderTest.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.impl.ThreadContextDataInjector;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -47,6 +48,11 @@ public class ContextDataProviderTest {
         logger = loggerContext.getLogger(ContextDataProviderTest.class.getName());
         appender = loggerContext.getConfiguration().getAppender("List");
         assertNotNull(appender, "No List appender");
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
     }
 
     @Test


### PR DESCRIPTION
Some tests were changing system properties, but were not reverting their changes. This pull request tries to address this issue.

In some cases there were `System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);` calls without that system property being set explicitly. I have removed them (and replaced them with the correct property names, if any) because I assumed that they were copy and paste errors.

Maybe in the future it would be good to use extensions such as [JUnit Pioneer (JUnit 5)](https://junit-pioneer.org/docs/system-properties/) which support setting and restoring system properties, since manually doing it is rather error-prone.