### PR TITLE
LOG4J2-3289: Fix log4j-to-slf4j re-interpolation of formatted message data

### DIFF
--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogger.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogger.java
@@ -86,10 +86,13 @@ public class SLF4JLogger extends AbstractLogger {
         return locationAwareLogger != null ? locationAwareLogger : logger;
     }
 
-    private org.slf4j.Marker getMarker(final Marker marker) {
-        if (marker == null) {
-            return null;
-        }
+    private static org.slf4j.Marker getMarker(final Marker marker) {
+        // No marker is provided in the common case, small methods
+        // are optimized more effectively.
+        return marker == null ? null : convertMarker(marker);
+    }
+
+    private static org.slf4j.Marker convertMarker(final Marker marker) {
         final org.slf4j.Marker slf4jMarker = MarkerFactory.getMarker(marker.getName());
         final Marker[] parents = marker.getParents();
         if (parents != null) {
@@ -222,31 +225,32 @@ public class SLF4JLogger extends AbstractLogger {
 
     @Override
     public void logMessage(final String fqcn, final Level level, final Marker marker, final Message message, final Throwable t) {
+        org.slf4j.Marker slf4jMarker = getMarker(marker);
+        String formattedMessage = message.getFormattedMessage();
         if (locationAwareLogger != null) {
             if (message instanceof LoggerNameAwareMessage) {
                 ((LoggerNameAwareMessage) message).setLoggerName(getName());
             }
-            locationAwareLogger.log(getMarker(marker), fqcn, convertLevel(level), message.getFormattedMessage(),
-                    message.getParameters(), t);
+            locationAwareLogger.log(slf4jMarker, fqcn, convertLevel(level), formattedMessage, null, t);
         } else {
             switch (level.getStandardLevel()) {
                 case DEBUG :
-                    logger.debug(getMarker(marker), message.getFormattedMessage(), message.getParameters(), t);
+                    logger.debug(slf4jMarker, formattedMessage, t);
                     break;
                 case TRACE :
-                    logger.trace(getMarker(marker), message.getFormattedMessage(), message.getParameters(), t);
+                    logger.trace(slf4jMarker, formattedMessage, t);
                     break;
                 case INFO :
-                    logger.info(getMarker(marker), message.getFormattedMessage(), message.getParameters(), t);
+                    logger.info(slf4jMarker, formattedMessage, t);
                     break;
                 case WARN :
-                    logger.warn(getMarker(marker), message.getFormattedMessage(), message.getParameters(), t);
+                    logger.warn(slf4jMarker, formattedMessage, t);
                     break;
                 case ERROR :
-                    logger.error(getMarker(marker), message.getFormattedMessage(), message.getParameters(), t);
+                    logger.error(slf4jMarker, formattedMessage, t);
                     break;
                 default :
-                    logger.error(getMarker(marker), message.getFormattedMessage(), message.getParameters(), t);
+                    logger.error(slf4jMarker, formattedMessage, t);
                     break;
             }
         }

--- a/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/LoggerTest.java
+++ b/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/LoggerTest.java
@@ -17,6 +17,8 @@
 */
 package org.apache.logging.slf4j;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
 import java.util.Date;
 import java.util.List;
 
@@ -160,6 +162,37 @@ public class LoggerTest {
     public void debugWithParms() {
         logger.debug("Hello, {}", "World");
         assertThat(list.strList, hasSize(1));
+        String message = list.strList.get(0);
+        assertEquals("Hello, World", message);
+    }
+
+    @Test
+    public void paramIncludesSubstitutionMarker_locationAware() {
+        logger.info("Hello, {}", "foo {} bar");
+        assertThat(list.strList, hasSize(1));
+        String message = list.strList.get(0);
+        assertEquals("Hello, foo {} bar", message);
+    }
+
+    @Test
+    public void paramIncludesSubstitutionMarker_nonLocationAware() {
+        final org.slf4j.Logger slf4jLogger = CTX.getLogger();
+        Logger nonLocationAwareLogger = new SLF4JLogger(
+                slf4jLogger.getName(),
+                (org.slf4j.Logger) Proxy.newProxyInstance(
+                        getClass().getClassLoader(),
+                        new Class<?>[]{org.slf4j.Logger.class},
+                        (proxy, method, args) -> {
+                            try {
+                                return method.invoke(slf4jLogger, args);
+                            } catch (InvocationTargetException e) {
+                                throw e.getCause();
+                            }
+                        }));
+        nonLocationAwareLogger.info("Hello, {}", "foo {} bar");
+        assertThat(list.strList, hasSize(1));
+        String message = list.strList.get(0);
+        assertEquals("Hello, foo {} bar", message);
     }
 
     @Test

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -31,6 +31,9 @@
     -->
     <release version="2.17.1" date="2021-MM-dd" description="GA Release 2.17.1">
       <!-- FIXES -->
+      <action issue="LOG4J2-3289" dev="ckozak" type="fix">
+        log4j-to-slf4j no longer re-interpolates formatted message contents.
+      </action>
       <action issue="LOG4J2-3288" dev="ckozak" type="fix">
         Interpolator non-plugin constructor registers all lookups from log4j-core, previously it was missing event, sd, and bundle.
       </action>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LOG4J2-3289

By passing a parameter array to slf4j, we hinted that the message string was a template and should be substituted, however the result of `getFormattedMessage` is the final form of the message.