### PR TITLE
LOG4J2-3292 Fix ExtendedLoggerWrapper.logMessage double-logging

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLoggerWrapper.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLoggerWrapper.java
@@ -218,7 +218,8 @@ public class ExtendedLoggerWrapper extends AbstractLogger {
         if (logger instanceof LocationAwareLogger && requiresLocation()) {
             ((LocationAwareLogger) logger).logMessage(level, marker, fqcn, StackLocatorUtil.calcLocation(fqcn),
                 message, t);
+        } else {
+            logger.logMessage(fqcn, level, marker, message, t);
         }
-        logger.logMessage(fqcn, level, marker, message, t);
     }
 }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -31,6 +31,9 @@
     -->
     <release version="2.17.1" date="2021-MM-dd" description="GA Release 2.17.1">
       <!-- FIXES -->
+      <action issue="LOG4J2-3292" dev="ckozak" type="fix">
+        ExtendedLoggerWrapper.logMessage no longer double-logs when location is requested.
+      </action>
       <action issue="LOG4J2-3289" dev="ckozak" type="fix">
         log4j-to-slf4j no longer re-interpolates formatted message contents.
       </action>


### PR DESCRIPTION
Previously when the logger instance was location-aware and
the logger was configured to require location info, both branches
were invoked rather than only the location-aware branch.