### PR TITLE
update log4j-config.xsd fixed one default type

### DIFF
--- a/log4j-core/src/main/resources/Log4j-config.xsd
+++ b/log4j-core/src/main/resources/Log4j-config.xsd
@@ -459,7 +459,7 @@
             <documentation>The character set to use when converting the syslog String to a byte array.</documentation>
          </annotation>
       </attribute>
-      <attribute name="disableAnsi" type="tns:BooleanType" default="false">
+      <attribute name="disableAnsi" type="tns:BooleanType" default="true">
          <annotation>
             <documentation>If true, do not output ANSI escape codes.</documentation>
          </annotation>


### PR DESCRIPTION
some PatternLayOut.java source code about "disableAnsi" in master branch like this:
If {@code "true"} (default is value of system property `log4j.skipJansi`, or `true` if undefined), do not output ANSI escape codes