### PR TITLE
 LOG4J2-3304 - Fix issue that the initialize status of LogManager is not set when factoryClassName is present and instantiate successfully

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
@@ -122,8 +122,8 @@ public class LogManager {
                         + "Please add log4j-core to the classpath. Using SimpleLogger to log to the console...");
                 factory = new SimpleLoggerContextFactory();
             }
-            LogManagerStatus.setInitialized(true);
         }
+        LogManagerStatus.setInitialized(true);
     }
 
     /**


### PR DESCRIPTION
Fix the issue that the initialize status of LogManager is not set when logger factoryClassName is present and instantiate successfully, see [LOG4J2-3304](https://issues.apache.org/jira/browse/LOG4J2-3304)