### PR TITLE
[LOG4J2-3326] Fix parsing filters from Log4j 1.2 properties configuration file

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/PropertiesConfiguration.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/PropertiesConfiguration.java
@@ -549,7 +549,7 @@ public class PropertiesConfiguration  extends Log4j1Configuration {
             String clazz = props.getProperty(entry.getKey());
             Filter filter = null;
             if (clazz != null) {
-                filter = manager.parseFilter(clazz, filterPrefix, props, this);
+                filter = manager.parseFilter(clazz, entry.getKey(), props, this);
                 if (filter == null) {
                     LOGGER.debug("Filter key: [{}] class: [{}] props: {}", entry.getKey(), clazz, entry.getValue());
                     filter = buildFilter(clazz, appenderName, entry.getValue());

--- a/log4j-1.2-api/src/test/resources/LOG4J2-3326.properties
+++ b/log4j-1.2-api/src/test/resources/LOG4J2-3326.properties
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+log4j.appender.CUSTOM=org.apache.log4j.CustomNoopAppender
+log4j.appender.CUSTOM.filter.1=org.apache.log4j.varia.LevelRangeFilter
+log4j.appender.CUSTOM.filter.1.levelMin=ALL
+log4j.appender.CUSTOM.filter.2=org.apache.log4j.varia.LevelRangeFilter
+
+log4j.rootLogger=trace, CUSTOM


### PR DESCRIPTION
Problem: The log4j 1.x configuration file is not properly parsed, in regards of filters. Whatever is configured in file, is getting ignored, and default values are used. 
E.g. for "level range filter" the LevelMax is not properly found (eventhough properly read as property).

Root cause: The default filter prefix is used, instead of specific filter key.