### PR TITLE
Expand test suite for SortedArrayStringMap

### DIFF
--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/SortedArrayStringMapTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/SortedArrayStringMapTest.java
@@ -72,9 +72,17 @@ public class SortedArrayStringMapTest {
     public void testSerialization() throws Exception {
         final SortedArrayStringMap original = new SortedArrayStringMap();
         original.putValue("a", "avalue");
-        original.putValue("B", "Bvalue");
+        original.putValue("B", null); // null may be treated differently
         original.putValue("3", "3value");
 
+        final byte[] binary = serialize(original);
+        final SortedArrayStringMap copy = deserialize(binary);
+        assertEquals(original, copy);
+    }
+
+    @Test
+    public void testSerializationOfEmptyMap() throws Exception {
+        final SortedArrayStringMap original = new SortedArrayStringMap();
         final byte[] binary = serialize(original);
         final SortedArrayStringMap copy = deserialize(binary);
         assertEquals(original, copy);
@@ -170,8 +178,7 @@ public class SortedArrayStringMapTest {
     private SortedArrayStringMap deserialize(final byte[] binary) throws IOException, ClassNotFoundException {
         final ByteArrayInputStream inArr = new ByteArrayInputStream(binary);
         try (final ObjectInputStream in = new FilteredObjectInputStream(inArr)) {
-            final SortedArrayStringMap result = (SortedArrayStringMap) in.readObject();
-            return result;
+            return (SortedArrayStringMap) in.readObject();
         }
     }
 
@@ -393,12 +400,17 @@ public class SortedArrayStringMapTest {
     @Test
     public void testEquals() {
         final SortedArrayStringMap original = new SortedArrayStringMap();
+        final SortedArrayStringMap other = new SortedArrayStringMap();
+
+        assertEquals(other, original, "Empty maps are equal");
+        assertEquals(other.hashCode(), original.hashCode(), "Empty maps have equal hashcode");
+        assertNotEquals(original, "Object other than SortedArrayStringMap");
+
         original.putValue("a", "avalue");
         original.putValue("B", "Bvalue");
         original.putValue("3", "3value");
         assertEquals(original, original); // equal to itself
 
-        final SortedArrayStringMap other = new SortedArrayStringMap();
         other.putValue("a", "avalue");
         assertNotEquals(original, other);
 
@@ -407,15 +419,23 @@ public class SortedArrayStringMapTest {
 
         other.putValue("3", "3value");
         assertEquals(original, other);
+        assertEquals(original.hashCode(), other.hashCode());
 
         other.putValue("3", "otherValue");
         assertNotEquals(original, other);
 
         other.putValue("3", null);
         assertNotEquals(original, other);
+        assertNotEquals(original.hashCode(), other.hashCode());
 
         other.putValue("3", "3value");
         assertEquals(original, other);
+        assertEquals(other, original); // symmetry
+
+        original.putValue("key not in other", "4value");
+        other.putValue("key not in original", "4value");
+        assertNotEquals(original, other);
+        assertNotEquals(other, original); // symmetry
     }
 
     @Test


### PR DESCRIPTION
I noticed that some corner cases of the equals and serialization methods of the `SortedArrayStringMap` class were not (unit) tested, and that its `hashCode` method was not tested at all. This pull request provides small changes to the test suite to address this.

Let me know if you have any questions, or if you would like a similar PR against the master (3.x) branch.

I also included [a change](https://github.com/apache/logging-log4j2/commit/3401968127d88c6e74cd388384cbecfed91fd8aa#diff-f720426a77cc010bfc9fbc5501a137b2bd5feebdcda0b2c2768090a67a34568e) earlier made in `master` on this file to bring the 2.x and 3.x versions more in sync.

Thanks for your hard work on log4j.
