### PR TITLE
[LOG4J2-3319] Add support for log4j 1.2 API bundle in Eclipse IDE

### DIFF
--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -511,6 +511,7 @@
               *
             </Import-Package>
             <Bundle-Activator>org.apache.logging.log4j.core.osgi.Activator</Bundle-Activator>
+            <Eclipse-ExtensibleAPI>true</Eclipse-ExtensibleAPI>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
This will add the "Eclipse-ExtensibleAPI" header to the manifest of "core" bundle, to allow any fragement (resp. the log4j 1.2 bridge) to extend the API of core bundle.