### PR TITLE
Strengthen test coverage of StrSubstitutor class

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/StrSubstitutor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/StrSubstitutor.java
@@ -59,7 +59,7 @@ import org.apache.logging.log4j.util.Strings;
  * The following example demonstrates this:
  * </p>
  * <pre>
- * Map valuesMap = HashMap();
+ * Map valuesMap = new HashMap&lt;&gt;();
  * valuesMap.put(&quot;animal&quot;, &quot;quick brown fox&quot;);
  * valuesMap.put(&quot;target&quot;, &quot;lazy dog&quot;);
  * String templateString = &quot;The ${animal} jumped over the ${target}.&quot;;
@@ -80,7 +80,7 @@ import org.apache.logging.log4j.util.Strings;
  * The following shows an example with variable default value settings:
  * </p>
  * <pre>
- * Map valuesMap = HashMap();
+ * Map valuesMap = new HashMap&lt;&gt;();
  * valuesMap.put(&quot;animal&quot;, &quot;quick brown fox&quot;);
  * valuesMap.put(&quot;target&quot;, &quot;lazy dog&quot;);
  * String templateString = &quot;The ${animal} jumped over the ${target}. ${undefined.number:-1234567890}.&quot;;

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/StrSubstitutorTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/StrSubstitutorTest.java
@@ -45,6 +45,100 @@ public class StrSubstitutorTest {
         System.setProperty(TESTKEY, TESTVAL);
     }
 
+    @Test
+    public void testJavaDocExample() {
+        final Map<String, String> valuesMap = new HashMap<>();
+        valuesMap.put("animal", "quick brown fox");
+        valuesMap.put("target", "lazy dog");
+        final String templateString = "The ${animal} jumped over the ${target}.";
+        final StrSubstitutor sub = new StrSubstitutor(valuesMap);
+        final String resolvedString = sub.replace(templateString);
+        assertEquals("The quick brown fox jumped over the lazy dog.", resolvedString);
+    }
+
+    @Test
+    public void testDelimiterExampleFromJavaDoc() {
+        final Map<String, String> valuesMap = new HashMap<>();
+        valuesMap.put("animal", "quick brown fox");
+        valuesMap.put("target", "lazy dog");
+        final String templateString = "The ${animal} jumped over the ${target}. ${undefined.number:-1234567890}";
+        final StrSubstitutor sub = new StrSubstitutor(valuesMap);
+        final String resolvedString = sub.replace(templateString);
+        assertEquals("The quick brown fox jumped over the lazy dog. 1234567890", resolvedString);
+    }
+
+    @Test
+    public void testEscapedRecursionExampleFromJavaDoc() {
+        final Map<String, String> valuesMap = new HashMap<>();
+        valuesMap.put("name", "x");
+        final String templateString = "The variable $${${name}} must be used.";
+        final StrSubstitutor sub = new StrSubstitutor(valuesMap);
+
+        sub.setEnableSubstitutionInVariables(false);
+        final String resolvedString = sub.replace(templateString);
+        assertEquals("The variable ${x} must be used.", resolvedString);
+
+        // Due to escaping enabling recursion now should make no difference.
+        sub.setEnableSubstitutionInVariables(true);
+        final String resolvedStringWithRecursion = sub.replace(templateString);
+        assertEquals(resolvedString, resolvedStringWithRecursion);
+    }
+
+    @Test
+    public void testPrePostfixRecursionExampleFromJavaDoc() {
+        final Map<String, String> valuesMap = new HashMap<>();
+        valuesMap.put("name", "x");
+        final String templateString = "The variable ${$[name]} must be used.";
+        final StrSubstitutor sub = new StrSubstitutor(valuesMap, "$[", "]");
+        final String resolvedString = sub.replace(templateString);
+        assertEquals("The variable ${x} must be used.", resolvedString);
+    }
+
+    @Test
+    public void testRecursionExampleFromJavaDoc() {
+        final Map<String, String> valuesMap = new HashMap<>();
+        valuesMap.put("name", "x");
+        valuesMap.put("x", "3");
+        final String templateString = "The value ${${name}} must be used.";
+        final StrSubstitutor sub = new StrSubstitutor(valuesMap);
+
+        sub.setEnableSubstitutionInVariables(false);
+        assertEquals("The value ${${name}} must be used.", sub.replace(templateString));
+
+        sub.setEnableSubstitutionInVariables(true);
+        assertEquals("The value 3 must be used.", sub.replace(templateString));
+    }
+
+    @Test
+    public void testValueEscapeDelimiter() {
+        final Map<String, String> valuesMap = new HashMap<>();
+        // Example from MainMapLookup. Key contains ":-"
+        valuesMap.put("main:--file", "path/file.txt");
+        // Create substitutor, initially without support for escaping :-
+        final StrSubstitutor sub = new StrSubstitutor(
+                new PropertiesLookup(valuesMap),
+                StrSubstitutor.DEFAULT_PREFIX,
+                StrSubstitutor.DEFAULT_SUFFIX,
+                StrSubstitutor.DEFAULT_ESCAPE,
+                StrSubstitutor.DEFAULT_VALUE_DELIMITER,
+                null // Ensure valueEscapeMatcher == null
+        );
+        // regular default values work without a valueEscapeMatcher.
+        assertEquals("3", sub.replace("${y:-3}"));
+        // variables with ':-' are treated as if they have a default value
+        assertEquals("-file", sub.replace("${main:--file}"));
+        // yet escaping doesn't work anymore (results in the original string).
+        assertEquals("${main:\\--file}", sub.replace("${main:\\--file}"));
+
+        // ensure there is valueEscapeMatcher (by resetting the value delimiter)
+        sub.setValueDelimiter(StrSubstitutor.DEFAULT_VALUE_DELIMITER_STRING);
+        // now the escaped variable with ":-" in it will be resolved.
+        assertEquals("path/file.txt", sub.replace("${main:\\--file}"));
+        // default values continue to work:
+        assertEquals("no help", sub.replace("${main:\\--help:-no help}"));
+        // even in minimalistic corner case:
+        assertEquals("", sub.replace("${:\\-:-}"));
+    }
 
     @Test
     public void testDefault() {


### PR DESCRIPTION
I noticed that the central `substitute` method in the `StrSubstitutor` class that was involved in a recent CVE had some code not covered by (unit) tests. This untested logic related to cases where substitution in variables was disabled, and when no value escape delimiter (like `:\-`) was set.

I also noted some nice examples in the javadoc of `StrSubstitutor` that could be instructive test cases, and which indeed could cover some of the untested logic.

Therefore, this pull request:

- adds test cases for all examples listed in the `StrSubstitutor` javadoc
- applies small fixes to the javadoc
- adds test cases for value escape separator `:\\-` with and without a matcher for such escaped separators
- results in full statement coverage of the `substitute` method
- improves the branch coverage of the `substitute` method
- improves the test coverage of some helper methods.