### PR TITLE
Increase to-jul priority from 15 to 20

### DIFF
--- a/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/JULProvider.java
+++ b/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/JULProvider.java
@@ -25,6 +25,6 @@ import org.apache.logging.log4j.spi.Provider;
  */
 public class JULProvider extends Provider {
     public JULProvider() {
-        super(15, "2.6.0", JULLoggerContextFactory.class, null);
+        super(20, "2.6.0", JULLoggerContextFactory.class, null);
     }
 }


### PR DESCRIPTION
The original 15 was blindly copied from SLF4JProvider (by myself).

It's probably better to not have them be the same, and have To-JUL's higher than SLF4j's (which in turn is higher than Core's 10).