### PR TITLE
StatusLogger uses default status level configured from property not just for listeners but all its logging (fixes LOG4J2-3340)

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -107,11 +107,14 @@ public final class StatusLogger extends AbstractLogger {
         final boolean showDateTime = !Strings.isEmpty(dateFormat);
         this.logger = new SimpleLogger("StatusLogger", Level.ERROR, false, true, showDateTime, false,
                 dateFormat, messageFactory, PROPS, System.err);
-        this.listenersLevel = Level.toLevel(DEFAULT_STATUS_LEVEL, Level.WARN).intLevel();
+        final Level defaultStatusLevel = Level.toLevel(DEFAULT_STATUS_LEVEL, Level.WARN);
+        this.listenersLevel = defaultStatusLevel.intLevel();
 
         // LOG4J2-1813 if system property "log4j2.debug" is defined, print all status logging
         if (isDebugPropertyEnabled()) {
             logger.setLevel(Level.TRACE);
+        } else {
+            logger.setLevel(defaultStatusLevel);
         }
     }
 


### PR DESCRIPTION
With this StatusLogger uses default status level configured from property not just for listeners but all its logging.

This fixes https://issues.apache.org/jira/browse/LOG4J2-3340 for me.

If this is acceptable, I can raise a follow-up PR to do further clean-up / simplifcation around this topic.