### PR TITLE
fix deleteAction can't distinguish basePath of symbolicLink

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/AbstractPathAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/AbstractPathAction.java
@@ -103,7 +103,15 @@ public abstract class AbstractPathAction extends AbstractAction {
      * @return the base path (all lookups resolved)
      */
     public Path getBasePath() {
-        return Paths.get(subst.replace(getBasePathString()));
+        Path path = Paths.get(subst.replace(getBasePathString()));
+        if (Files.isSymbolicLink(path)) {
+            try {
+                path = Files.readSymbolicLink(path);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        return path;
     }
 
     /**


### PR DESCRIPTION
fix Appenders DeleteAction didn't work when basepath is symbolicLink.
jira:https://issues.apache.org/jira/browse/LOG4J2-3342

![image](https://user-images.githubusercontent.com/37694724/149617084-6f02f4bb-f3d1-45ee-bf76-389b289c2f25.png)
![image](https://user-images.githubusercontent.com/37694724/149616974-1c89645c-4b31-4319-ba15-61ea24233214.png)

getSortedPaths should return subFile [log4j-shix-....log],but it only return currentFile dirName [log/file]
problem:Files.walkFileTree api  in java.nio can't list File directly when file is symbolicLink ,it need do someThing to deal with it 
