### PR TITLE
Multiple small improvements in Log4j 1.x configuration parsing

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
@@ -83,7 +83,7 @@ public abstract class AbstractBuilder {
     }
 
     protected String getNameAttribute(Element element) {
-        return element.getAttribute(NAME_ATTR);
+        return capitalize(element.getAttribute(NAME_ATTR));
     }
 
     protected String getValueAttribute(Element element) {

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
@@ -91,7 +91,11 @@ public abstract class AbstractBuilder {
     }
 
     public boolean getBooleanProperty(String key) {
-        return Boolean.parseBoolean(getProperty(key, Boolean.FALSE.toString()));
+        return getBooleanProperty(key, false);
+    }
+
+    public boolean getBooleanProperty(String key, boolean defaultValue) {
+        return Boolean.parseBoolean(getProperty(key, Boolean.toString(defaultValue)));
     }
 
     public int getIntegerProperty(String key, int defaultValue) {
@@ -151,4 +155,11 @@ public abstract class AbstractBuilder {
         return value == null ? null : value.toLowerCase(Locale.ROOT);
     }
 
+    protected String capitalize(final String value) {
+        if (value == null || value.length() == 0)
+            return value;
+        char[] chars = value.toCharArray();
+        chars[0] = Character.toUpperCase(chars[0]);
+        return new String(chars);
+    }
 }

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
@@ -83,7 +83,16 @@ public abstract class AbstractBuilder {
     }
 
     protected String getNameAttribute(Element element) {
-        return capitalize(element.getAttribute(NAME_ATTR));
+        return element.getAttribute(NAME_ATTR);
+    }
+
+    /**
+     * Normalized version of the "name" attribute of the &lt;param&gt; tag.
+     * @param element
+     * @return
+     */
+    protected String getNormalizedNameAttribute(Element element) {
+        return capitalize(getNameAttribute(element));
     }
 
     protected String getValueAttribute(Element element) {
@@ -155,7 +164,7 @@ public abstract class AbstractBuilder {
         return value == null ? null : value.toLowerCase(Locale.ROOT);
     }
 
-    protected String capitalize(final String value) {
+    private String capitalize(final String value) {
         if (value == null || value.length() == 0)
             return value;
         char[] chars = value.toCharArray();

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
@@ -82,14 +82,26 @@ public abstract class AbstractBuilder {
         return value == null ? defaultValue : value;
     }
 
+    /**
+     * Returns the value of the "name" attribute.
+     * 
+     * @param element
+     *            an XML element
+     * @return the value of the "name" attribute
+     */
     protected String getNameAttribute(Element element) {
         return element.getAttribute(NAME_ATTR);
     }
 
     /**
      * Normalized version of the "name" attribute of the &lt;param&gt; tag.
+     * Since Log4j 1.x accepts component property names in both capitalized
+     * ('InfoLocation') and Java-style ('infoLocation') format, we return the
+     * capitalized form.
+     * 
      * @param element
-     * @return
+     *            an XML element
+     * @return a normalized attribute value
      */
     protected String getNormalizedNameAttribute(Element element) {
         return capitalize(getNameAttribute(element));

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/Builder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/Builder.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
 package org.apache.log4j.builders;
 
 /**

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/Builder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/Builder.java
@@ -1,0 +1,7 @@
+package org.apache.log4j.builders;
+
+/**
+ * A marker interface for Log4j 1.x component builders.
+ *
+ */
+public interface Builder {}

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
@@ -152,7 +152,7 @@ public class BuilderManager {
         return null;
     }
 
-    private <T extends AbstractBuilder> T createBuilder(PluginType<?> plugin, String prefix, Properties props) {
+    private <T extends Builder> T createBuilder(PluginType<?> plugin, String prefix, Properties props) {
         try {
             Class<?> clazz = plugin.getPluginClass();
             if (AbstractBuilder.class.isAssignableFrom(clazz)) {

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/AppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/AppenderBuilder.java
@@ -17,6 +17,7 @@
 package org.apache.log4j.builders.appender;
 
 import org.apache.log4j.Appender;
+import org.apache.log4j.builders.Builder;
 import org.apache.log4j.config.PropertiesConfiguration;
 import org.apache.log4j.xml.XmlConfiguration;
 import org.w3c.dom.Element;
@@ -26,7 +27,7 @@ import java.util.Properties;
 /**
  * Define an Appender Builder.
  */
-public interface AppenderBuilder {
+public interface AppenderBuilder extends Builder {
 
     Appender parseAppender(Element element, XmlConfiguration configuration);
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/AsyncAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/AsyncAppenderBuilder.java
@@ -78,7 +78,7 @@ public class AsyncAppenderBuilder extends AbstractBuilder implements AppenderBui
                     }
                     break;
                 case PARAM_TAG: {
-                    switch (getNameAttribute(currentElement)) {
+                    switch (getNormalizedNameAttribute(currentElement)) {
                         case BUFFER_SIZE_PARAM: {
                             String value = getValueAttribute(currentElement);
                             if (value == null) {

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/ConsoleAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/ConsoleAppenderBuilder.java
@@ -51,7 +51,7 @@ import org.w3c.dom.Element;
 public class ConsoleAppenderBuilder extends AbstractBuilder implements AppenderBuilder {
     private static final String SYSTEM_OUT = "System.out";
     private static final String SYSTEM_ERR = "System.err";
-    private static final String TARGET = "target";
+    private static final String TARGET = "Target";
 
     private static final Logger LOGGER = StatusLogger.getLogger();
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/ConsoleAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/ConsoleAppenderBuilder.java
@@ -78,7 +78,7 @@ public class ConsoleAppenderBuilder extends AbstractBuilder implements AppenderB
                     filters.get().add(config.parseFilters(currentElement));
                     break;
                 case PARAM_TAG: {
-                    switch (getNameAttribute(currentElement)) {
+                    switch (getNormalizedNameAttribute(currentElement)) {
                         case TARGET: {
                             String value = getValueAttribute(currentElement);
                             if (value == null) {

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/DailyRollingFileAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/DailyRollingFileAppenderBuilder.java
@@ -86,7 +86,7 @@ public class DailyRollingFileAppenderBuilder extends AbstractBuilder implements 
                     filter.set(config.parseFilters(currentElement));
                     break;
                 case PARAM_TAG: {
-                    switch (getNameAttribute(currentElement)) {
+                    switch (getNormalizedNameAttribute(currentElement)) {
                         case FILE_PARAM:
                             fileName.set(getValueAttribute(currentElement));
                             break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/DailyRollingFileAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/DailyRollingFileAppenderBuilder.java
@@ -40,6 +40,7 @@ import org.apache.log4j.spi.Filter;
 import org.apache.log4j.xml.XmlConfiguration;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.appender.rolling.CompositeTriggeringPolicy;
 import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.TimeBasedTriggeringPolicy;
@@ -167,8 +168,9 @@ public class DailyRollingFileAppenderBuilder extends AbstractBuilder implements 
             LOGGER.warn("Unable to create File Appender, no file name provided");
             return null;
         }
-        String filePattern = fileName +"%d{yyy-MM-dd}";
-        TriggeringPolicy policy = TimeBasedTriggeringPolicy.newBuilder().withModulate(true).build();
+        String filePattern = fileName +"%d{.yyyy-MM-dd}";
+        TriggeringPolicy timePolicy = TimeBasedTriggeringPolicy.newBuilder().withModulate(true).build();
+        TriggeringPolicy policy = CompositeTriggeringPolicy.createPolicy(timePolicy);
         RolloverStrategy strategy = DefaultRolloverStrategy.newBuilder()
                 .withConfig(configuration)
                 .withMax(Integer.toString(Integer.MAX_VALUE))

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/FileAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/FileAppenderBuilder.java
@@ -79,7 +79,7 @@ public class FileAppenderBuilder extends AbstractBuilder implements AppenderBuil
                     filter.set(config.parseFilters(currentElement));
                     break;
                 case PARAM_TAG: {
-                    switch (getNameAttribute(currentElement)) {
+                    switch (getNormalizedNameAttribute(currentElement)) {
                         case FILE_PARAM:
                             fileName.set(getValueAttribute(currentElement));
                             break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/RollingFileAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/RollingFileAppenderBuilder.java
@@ -187,10 +187,9 @@ public class RollingFileAppenderBuilder extends AbstractBuilder implements Appen
             LOGGER.warn("Unable to create File Appender, no file name provided");
             return null;
         }
-        String filePattern = fileName +"%d{yyy-MM-dd}";
-        TriggeringPolicy timePolicy = TimeBasedTriggeringPolicy.newBuilder().withModulate(true).build();
+        String filePattern = fileName +".%i";
         SizeBasedTriggeringPolicy sizePolicy = SizeBasedTriggeringPolicy.createPolicy(maxSize);
-        CompositeTriggeringPolicy policy = CompositeTriggeringPolicy.createPolicy(sizePolicy, timePolicy);
+        CompositeTriggeringPolicy policy = CompositeTriggeringPolicy.createPolicy(sizePolicy);
         RolloverStrategy strategy = DefaultRolloverStrategy.newBuilder()
                 .withConfig(config)
                 .withMax(maxBackups)

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/RollingFileAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/RollingFileAppenderBuilder.java
@@ -88,7 +88,7 @@ public class RollingFileAppenderBuilder extends AbstractBuilder implements Appen
                     filter.set(config.parseFilters(currentElement));
                     break;
                 case PARAM_TAG: {
-                    switch (getNameAttribute(currentElement)) {
+                    switch (getNormalizedNameAttribute(currentElement)) {
                         case FILE_PARAM:
                             fileName.set(getValueAttribute(currentElement));
                             break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/SyslogAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/SyslogAppenderBuilder.java
@@ -88,7 +88,7 @@ public class SyslogAppenderBuilder extends AbstractBuilder implements AppenderBu
                     filter.set(config.parseFilters(currentElement));
                     break;
                 case PARAM_TAG: {
-                    switch (getNameAttribute(currentElement)) {
+                    switch (getNormalizedNameAttribute(currentElement)) {
                         case SYSLOG_HOST_PARAM: {
                             host.set(getValueAttribute(currentElement));
                             break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/SyslogAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/SyslogAppenderBuilder.java
@@ -60,7 +60,7 @@ public class SyslogAppenderBuilder extends AbstractBuilder implements AppenderBu
     private static final Logger LOGGER = StatusLogger.getLogger();
     private static final String FACILITY_PARAM = "Facility";
     private static final String SYSLOG_HOST_PARAM = "SyslogHost";
-    private static final String PROTOCOL_PARAM = "protocol";
+    private static final String PROTOCOL_PARAM = "Protocol";
 
 
     public SyslogAppenderBuilder() {

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/FilterBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/FilterBuilder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.log4j.builders.filter;
 
+import org.apache.log4j.builders.Builder;
 import org.apache.log4j.config.PropertiesConfiguration;
 import org.apache.log4j.spi.Filter;
 import org.apache.log4j.xml.XmlConfiguration;
@@ -24,7 +25,7 @@ import org.w3c.dom.Element;
 /**
  * Define a Filter Builder.
  */
-public interface FilterBuilder {
+public interface FilterBuilder extends Builder {
 
     Filter parseFilter(Element element, XmlConfiguration config);
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/LevelMatchFilterBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/LevelMatchFilterBuilder.java
@@ -58,7 +58,7 @@ public class LevelMatchFilterBuilder extends AbstractBuilder implements FilterBu
         final AtomicBoolean acceptOnMatch = new AtomicBoolean();
         forEachElement(filterElement.getElementsByTagName("param"), currentElement -> {
             if (currentElement.getTagName().equals("param")) {
-                switch (getNameAttribute(currentElement)) {
+                switch (getNormalizedNameAttribute(currentElement)) {
                     case LEVEL:
                         level.set(getValueAttribute(currentElement));
                         break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/LevelRangeFilterBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/LevelRangeFilterBuilder.java
@@ -60,7 +60,7 @@ public class LevelRangeFilterBuilder extends AbstractBuilder implements FilterBu
         final AtomicBoolean acceptOnMatch = new AtomicBoolean();
         forEachElement(filterElement.getElementsByTagName("param"), currentElement -> {
             if (currentElement.getTagName().equals("param")) {
-                switch (getNameAttribute(currentElement)) {
+                switch (getNormalizedNameAttribute(currentElement)) {
                     case LEVEL_MAX:
                         levelMax.set(getValueAttribute(currentElement));
                         break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/StringMatchFilterBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/StringMatchFilterBuilder.java
@@ -49,7 +49,7 @@ public class StringMatchFilterBuilder extends AbstractBuilder implements FilterB
         final AtomicReference<String> text = new AtomicReference<>();
         forEachElement(filterElement.getElementsByTagName("param"), currentElement -> {
             if (currentElement.getTagName().equals("param")) {
-                switch (getNameAttribute(currentElement)) {
+                switch (getNormalizedNameAttribute(currentElement)) {
                     case STRING_TO_MATCH:
                         text.set(getValueAttribute(currentElement));
                         break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/layout/LayoutBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/layout/LayoutBuilder.java
@@ -17,6 +17,7 @@
 package org.apache.log4j.builders.layout;
 
 import org.apache.log4j.Layout;
+import org.apache.log4j.builders.Builder;
 import org.apache.log4j.config.PropertiesConfiguration;
 import org.apache.log4j.xml.XmlConfiguration;
 import org.w3c.dom.Element;
@@ -24,7 +25,7 @@ import org.w3c.dom.Element;
 /**
  * Define a Layout Builder.
  */
-public interface LayoutBuilder {
+public interface LayoutBuilder extends Builder {
 
     Layout parseLayout(Element element, XmlConfiguration config);
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/layout/TTCCLayoutBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/layout/TTCCLayoutBuilder.java
@@ -59,10 +59,10 @@ public class TTCCLayoutBuilder extends AbstractBuilder implements LayoutBuilder 
 
     @Override
     public Layout parseLayout(Element layoutElement, XmlConfiguration config) {
-        final AtomicBoolean threadPrinting = new AtomicBoolean();
-        final AtomicBoolean categoryPrefixing = new AtomicBoolean();
-        final AtomicBoolean contextPrinting = new AtomicBoolean();
-        final AtomicReference<String> dateFormat = new AtomicReference<>();
+        final AtomicBoolean threadPrinting = new AtomicBoolean(Boolean.TRUE);
+        final AtomicBoolean categoryPrefixing = new AtomicBoolean(Boolean.TRUE);
+        final AtomicBoolean contextPrinting = new AtomicBoolean(Boolean.TRUE);
+        final AtomicReference<String> dateFormat = new AtomicReference<>(RELATIVE);
         final AtomicReference<String> timezone = new AtomicReference<>();
         forEachElement(layoutElement.getElementsByTagName("param"), currentElement -> {
             if (currentElement.getTagName().equals(PARAM_TAG)) {
@@ -91,10 +91,10 @@ public class TTCCLayoutBuilder extends AbstractBuilder implements LayoutBuilder 
 
     @Override
     public Layout parseLayout(PropertiesConfiguration config) {
-        boolean threadPrinting = getBooleanProperty(THREAD_PRINTING_PARAM);
-        boolean categoryPrefixing = getBooleanProperty(CATEGORY_PREFIXING_PARAM);
-        boolean contextPrinting = getBooleanProperty(CONTEXT_PRINTING_PARAM);
-        String dateFormat = getProperty(DATE_FORMAT_PARAM);
+        boolean threadPrinting = getBooleanProperty(THREAD_PRINTING_PARAM, true);
+        boolean categoryPrefixing = getBooleanProperty(CATEGORY_PREFIXING_PARAM, true);
+        boolean contextPrinting = getBooleanProperty(CONTEXT_PRINTING_PARAM, true);
+        String dateFormat = getProperty(DATE_FORMAT_PARAM, RELATIVE);
         String timezone = getProperty(TIMEZONE_FORMAT);
 
         return createLayout(threadPrinting, categoryPrefixing, contextPrinting,

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/layout/TTCCLayoutBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/layout/TTCCLayoutBuilder.java
@@ -66,7 +66,7 @@ public class TTCCLayoutBuilder extends AbstractBuilder implements LayoutBuilder 
         final AtomicReference<String> timezone = new AtomicReference<>();
         forEachElement(layoutElement.getElementsByTagName("param"), currentElement -> {
             if (currentElement.getTagName().equals(PARAM_TAG)) {
-                switch (getNameAttribute(currentElement)) {
+                switch (getNormalizedNameAttribute(currentElement)) {
                     case THREAD_PRINTING_PARAM:
                         threadPrinting.set(Boolean.parseBoolean(getValueAttribute(currentElement)));
                         break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/layout/XmlLayoutBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/layout/XmlLayoutBuilder.java
@@ -27,10 +27,10 @@ import org.apache.log4j.Layout;
 import org.apache.log4j.bridge.LayoutWrapper;
 import org.apache.log4j.builders.AbstractBuilder;
 import org.apache.log4j.config.PropertiesConfiguration;
+import org.apache.log4j.layout.Log4j1XmlLayout;
 import org.apache.log4j.xml.XmlConfiguration;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
-import org.apache.logging.log4j.core.layout.XmlLayout;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.w3c.dom.Element;
 
@@ -75,9 +75,6 @@ public class XmlLayoutBuilder extends AbstractBuilder implements LayoutBuilder {
     }
 
     private Layout createLayout(boolean properties, boolean locationInfo) {
-        return new LayoutWrapper(XmlLayout.newBuilder()
-                .setLocationInfo(locationInfo)
-                .setProperties(properties)
-                .build());
+        return new LayoutWrapper(Log4j1XmlLayout.createLayout(locationInfo, properties));
     }
 }

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/rewrite/RewritePolicyBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/rewrite/RewritePolicyBuilder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.log4j.builders.rewrite;
 
+import org.apache.log4j.builders.Builder;
 import org.apache.log4j.config.PropertiesConfiguration;
 import org.apache.log4j.rewrite.RewritePolicy;
 import org.apache.log4j.xml.XmlConfiguration;
@@ -24,7 +25,7 @@ import org.w3c.dom.Element;
 /**
  * Define a RewritePolicy Builder.
  */
-public interface RewritePolicyBuilder {
+public interface RewritePolicyBuilder extends Builder {
 
     RewritePolicy parseRewritePolicy(Element element, XmlConfiguration config);
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationParser.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationParser.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.TreeMap;
 
+import org.apache.log4j.helpers.OptionConverter;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.FileAppender;
@@ -39,8 +40,6 @@ import org.apache.logging.log4j.core.config.builder.api.LayoutComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.LoggerComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.RootLoggerComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
-import org.apache.logging.log4j.core.lookup.ConfigurationStrSubstitutor;
-import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
 
@@ -69,9 +68,6 @@ public class Log4j1ConfigurationParser {
     private static final String FALSE = "false";
 
     private final Properties properties = new Properties();
-    private StrSubstitutor strSubstitutorProperties;
-    private StrSubstitutor strSubstitutorSystem;
-
     private final ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory
             .newConfigurationBuilder();
 
@@ -90,8 +86,6 @@ public class Log4j1ConfigurationParser {
             throws IOException {
         try {
             properties.load(input);
-            strSubstitutorProperties = new ConfigurationStrSubstitutor(properties);
-            strSubstitutorSystem = new ConfigurationStrSubstitutor(System.getProperties());
             final String rootCategoryValue = getLog4jValue(ROOTCATEGORY);
             final String rootLoggerValue = getLog4jValue(ROOTLOGGER);
             if (rootCategoryValue == null && rootLoggerValue == null) {
@@ -422,8 +416,7 @@ public class Log4j1ConfigurationParser {
 
     private String getProperty(final String key) {
         final String value = properties.getProperty(key);
-        final String sysValue = strSubstitutorSystem.replace(value);
-        return strSubstitutorProperties.replace(sysValue);
+        return OptionConverter.substVars(value, properties);
     }
 
     private String getProperty(final String key, final String defaultValue) {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
 package org.apache.log4j.config;
 
 import static org.junit.Assert.assertEquals;

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -27,6 +27,9 @@ import java.net.URISyntaxException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.log4j.layout.Log4j1XmlLayout;
@@ -35,10 +38,10 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LifeCycle.State;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.appender.NullAppender;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
 import org.apache.logging.log4j.core.appender.rolling.CompositeTriggeringPolicy;
 import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
@@ -47,7 +50,6 @@ import org.apache.logging.log4j.core.appender.rolling.TimeBasedTriggeringPolicy;
 import org.apache.logging.log4j.core.appender.rolling.TriggeringPolicy;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.apache.logging.log4j.core.layout.HtmlLayout;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 
@@ -247,5 +249,15 @@ public abstract class AbstractLog4j1ConfigurationTest {
         assertEquals(Level.DEBUG, loggerConfig.getLevel());
         final LoggerConfig rootLogger = configuration.getRootLogger();
         assertEquals(Level.TRACE, rootLogger.getLevel());
+        appender.stop();
+        final List<Path> paths = Arrays.asList(Paths.get("target/path/to/the/logFile.txt"), Paths.get("target/path/to/the"),
+                Paths.get("target/path/to"), Paths.get("target/path"));
+        paths.forEach(t -> {
+            try {
+                Files.deleteIfExists(t);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -1,0 +1,213 @@
+package org.apache.log4j.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.log4j.layout.Log4j1XmlLayout;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.appender.FileAppender;
+import org.apache.logging.log4j.core.appender.NullAppender;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
+import org.apache.logging.log4j.core.appender.rolling.CompositeTriggeringPolicy;
+import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
+import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
+import org.apache.logging.log4j.core.appender.rolling.SizeBasedTriggeringPolicy;
+import org.apache.logging.log4j.core.appender.rolling.TimeBasedTriggeringPolicy;
+import org.apache.logging.log4j.core.appender.rolling.TriggeringPolicy;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
+import org.apache.logging.log4j.core.layout.HtmlLayout;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+public abstract class AbstractLog4j1ConfigurationTest {
+
+	abstract Configuration getConfiguration(String configResourcePrefix) throws URISyntaxException, IOException;
+
+	private Layout<?> testConsole(final String configResourcePrefix) throws Exception {
+		final Configuration configuration = getConfiguration(configResourcePrefix);
+		final String name = "Console";
+		final ConsoleAppender appender = configuration.getAppender(name);
+		assertNotNull("Missing appender '" + name + "' in configuration " + configResourcePrefix + " → " + configuration, appender);
+		assertEquals(Target.SYSTEM_ERR, appender.getTarget());
+		//
+		final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
+		assertNotNull(loggerConfig);
+		assertEquals(Level.DEBUG, loggerConfig.getLevel());
+		configuration.start();
+		configuration.stop();
+		return appender.getLayout();
+	}
+
+	private Layout<?> testFile(final String configResourcePrefix) throws Exception {
+		final Configuration configuration = getConfiguration(configResourcePrefix);
+		final FileAppender appender = configuration.getAppender("File");
+		assertNotNull(appender);
+		assertEquals("target/mylog.txt", appender.getFileName());
+		//
+		final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
+		assertNotNull(loggerConfig);
+		assertEquals(Level.DEBUG, loggerConfig.getLevel());
+		configuration.start();
+		configuration.stop();
+		return appender.getLayout();
+	}
+
+	public void testConsoleEnhancedPatternLayout() throws Exception {
+		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-EnhancedPatternLayout");
+		assertEquals("%d{ISO8601} [%t][%c] %-5p %properties %ndc: %m%n", layout.getConversionPattern());
+	}
+
+	public void testConsoleHtmlLayout() throws Exception {
+		final HtmlLayout layout = (HtmlLayout) testConsole("config-1.2/log4j-console-HtmlLayout");
+		assertEquals("Headline", layout.getTitle());
+		assertTrue(layout.isLocationInfo());
+	}
+
+	public void testConsolePatternLayout() throws Exception {
+		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-PatternLayout");
+		assertEquals("%d{ISO8601} [%t][%c] %-5p: %m%n", layout.getConversionPattern());
+	}
+
+	public void testConsoleSimpleLayout() throws Exception {
+		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-SimpleLayout");
+		assertEquals("%level - %m%n", layout.getConversionPattern());
+	}
+
+	public void testConsoleTtccLayout() throws Exception {
+		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout");
+		assertEquals("%r [%t] %p %notEmpty{%ndc }- %m%n", layout.getConversionPattern());
+	}
+
+	public void testConsoleXmlLayout() throws Exception {
+		final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout");
+		assertTrue(layout.isLocationInfo());
+		assertFalse(layout.isProperties());
+	}
+
+	public void testFileSimpleLayout() throws Exception {
+		final PatternLayout layout = (PatternLayout) testFile("config-1.2/log4j-file-SimpleLayout");
+		assertEquals("%level - %m%n", layout.getConversionPattern());
+	}
+
+	public void testNullAppender() throws Exception {
+		final Configuration configuration = getConfiguration("config-1.2/log4j-NullAppender");
+		final Appender appender = configuration.getAppender("NullAppender");
+		assertNotNull(appender);
+		assertEquals("NullAppender", appender.getName());
+		assertTrue(appender.getClass().getName(), appender instanceof NullAppender);
+	}
+
+	public void testRollingFileAppender() throws Exception {
+		testRollingFileAppender("config-1.2/log4j-RollingFileAppender", "RFA", "target/hadoop.log.%i");
+	}
+
+	public void testDailyRollingFileAppender() throws Exception {
+		testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender", "DRFA", "target/hadoop.log%d{.yyyy-MM-dd}");
+	}
+
+	public void testRollingFileAppenderWithProperties() throws Exception {
+		testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props", "RFA", "target/hadoop.log.%i");
+	}
+
+	public void testSystemProperties1() throws Exception {
+		final String tempFileName = System.getProperty("java.io.tmpdir") + "/hadoop.log";
+		final Path tempFilePath = new File(tempFileName).toPath();
+		Files.deleteIfExists(tempFilePath);
+		try {
+			final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-1");
+			final RollingFileAppender appender = configuration.getAppender("RFA");
+			appender.stop(10, TimeUnit.SECONDS);
+			// System.out.println("expected: " + tempFileName + " Actual: " +
+			// appender.getFileName());
+			assertEquals(tempFileName, appender.getFileName());
+		} finally {
+			try {
+				Files.deleteIfExists(tempFilePath);
+			} catch (final FileSystemException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	public void testSystemProperties2() throws Exception {
+		final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2");
+		final RollingFileAppender appender = configuration.getAppender("RFA");
+		assertEquals("${java.io.tmpdir}/hadoop.log", appender.getFileName());
+		appender.stop(10, TimeUnit.SECONDS);
+		Path path = new File(appender.getFileName()).toPath();
+		Files.deleteIfExists(path);
+		path = new File("${java.io.tmpdir}").toPath();
+		Files.deleteIfExists(path);
+	}
+
+	private void testRollingFileAppender(final String configResourcePrefix, final String name, final String filePattern)
+			throws Exception {
+		final Configuration configuration = getConfiguration(configResourcePrefix);
+		final Appender appender = configuration.getAppender(name);
+		assertNotNull(appender);
+		assertEquals(name, appender.getName());
+		assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
+		final RollingFileAppender rfa = (RollingFileAppender) appender;
+		assertEquals("target/hadoop.log", rfa.getFileName());
+		assertEquals(filePattern, rfa.getFilePattern());
+		final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
+		assertNotNull(triggeringPolicy);
+		assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
+		final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
+		final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
+		assertEquals(1, triggeringPolicies.length);
+		final TriggeringPolicy tp = triggeringPolicies[0];
+		assertTrue(tp.getClass().getName(), tp instanceof SizeBasedTriggeringPolicy);
+		final SizeBasedTriggeringPolicy sbtp = (SizeBasedTriggeringPolicy) tp;
+		assertEquals(256 * 1024 * 1024, sbtp.getMaxFileSize());
+		final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
+		assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
+		final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
+		assertEquals(20, drs.getMaxIndex());
+		configuration.start();
+		configuration.stop();
+	}
+
+	private void testDailyRollingFileAppender(final String configResourcePrefix, final String name, final String filePattern)
+			throws Exception {
+		final Configuration configuration = getConfiguration(configResourcePrefix);
+		final Appender appender = configuration.getAppender(name);
+		assertNotNull(appender);
+		assertEquals(name, appender.getName());
+		assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
+		final RollingFileAppender rfa = (RollingFileAppender) appender;
+		assertEquals("target/hadoop.log", rfa.getFileName());
+		assertEquals(filePattern, rfa.getFilePattern());
+		final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
+		assertNotNull(triggeringPolicy);
+		assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
+		final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
+		final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
+		assertEquals(1, triggeringPolicies.length);
+		final TriggeringPolicy tp = triggeringPolicies[0];
+		assertTrue(tp.getClass().getName(), tp instanceof TimeBasedTriggeringPolicy);
+		final TimeBasedTriggeringPolicy tbtp = (TimeBasedTriggeringPolicy) tp;
+		assertEquals(1, tbtp.getInterval());
+		final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
+		assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
+		final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
+		assertEquals(Integer.MAX_VALUE, drs.getMaxIndex());
+		configuration.start();
+		configuration.stop();
+	}
+}

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -210,4 +210,17 @@ public abstract class AbstractLog4j1ConfigurationTest {
 		configuration.start();
 		configuration.stop();
 	}
+
+    public void testRecursiveProperties() throws Exception {
+        final Configuration configuration = getConfiguration("config-1.2/log4j-file-recursive");
+        final FileAppender appender = configuration.getAppender("File");
+        assertNotNull(appender);
+        assertEquals("target/path/to/the/logFile.txt", appender.getFileName());
+        //
+        final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
+        assertNotNull(loggerConfig);
+        assertEquals(Level.DEBUG, loggerConfig.getLevel());
+        final LoggerConfig rootLogger = configuration.getRootLogger();
+        assertEquals(Level.TRACE, rootLogger.getLevel());
+    }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -16,234 +16,100 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.FileSystemException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.log4j.layout.Log4j1XmlLayout;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.Layout;
-import org.apache.logging.log4j.core.appender.ConsoleAppender;
-import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
-import org.apache.logging.log4j.core.appender.FileAppender;
-import org.apache.logging.log4j.core.appender.NullAppender;
-import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.apache.logging.log4j.core.appender.rolling.CompositeTriggeringPolicy;
-import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
-import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
-import org.apache.logging.log4j.core.appender.rolling.SizeBasedTriggeringPolicy;
-import org.apache.logging.log4j.core.appender.rolling.TimeBasedTriggeringPolicy;
-import org.apache.logging.log4j.core.appender.rolling.TriggeringPolicy;
 import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.layout.HtmlLayout;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.Test;
 
-public class Log4j1ConfigurationFactoryTest {
+public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationTest {
 
-    static Configuration getConfiguration(final String configResource) throws URISyntaxException {
-        final URL configLocation = ClassLoader.getSystemResource(configResource);
-        assertNotNull(configResource, configLocation);
-        final Configuration configuration = new Log4j1ConfigurationFactory().getConfiguration(null, "test",
-                configLocation.toURI());
-        assertNotNull(configuration);
-        return configuration;
-    }
-
-    private Layout<?> testConsole(final String configResource) throws Exception {
-        final Configuration configuration = getConfiguration(configResource);
-        final String name = "Console";
-        final ConsoleAppender appender = configuration.getAppender(name);
-        assertNotNull("Missing appender '" + name + "' in configuration " + configResource + " → " + configuration,
-                appender);
-        assertEquals(Target.SYSTEM_ERR, appender.getTarget());
-        //
-        final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
-        assertNotNull(loggerConfig);
-        assertEquals(Level.DEBUG, loggerConfig.getLevel());
-        configuration.start();
-        configuration.stop();
-        return appender.getLayout();
-    }
-
-	private Layout<?> testFile(final String configResource) throws Exception {
-		final Configuration configuration = getConfiguration(configResource);
-		final FileAppender appender = configuration.getAppender("File");
-		assertNotNull(appender);
-		assertEquals("target/mylog.txt", appender.getFileName());
-		//
-		final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
-		assertNotNull(loggerConfig);
-		assertEquals(Level.DEBUG, loggerConfig.getLevel());
-		configuration.start();
-		configuration.stop();
-		return appender.getLayout();
+	Configuration getConfiguration(final String configResourcePrefix) throws URISyntaxException {
+		final String configResource = configResourcePrefix + ".properties";
+		final URL configLocation = ClassLoader.getSystemResource(configResource);
+		assertNotNull(configResource, configLocation);
+		final Configuration configuration = new Log4j1ConfigurationFactory().getConfiguration(null, "test", configLocation.toURI());
+		assertNotNull(configuration);
+		configuration.initialize();
+		return configuration;
 	}
 
+	@Override
 	@Test
 	public void testConsoleEnhancedPatternLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole(
-				"config-1.2/log4j-console-EnhancedPatternLayout.properties");
-		assertEquals("%d{ISO8601} [%t][%c] %-5p %properties %ndc: %m%n", layout.getConversionPattern());
+		super.testConsoleEnhancedPatternLayout();
 	}
 
+	@Override
 	@Test
 	public void testConsoleHtmlLayout() throws Exception {
-		final HtmlLayout layout = (HtmlLayout) testConsole("config-1.2/log4j-console-HtmlLayout.properties");
-		assertEquals("Headline", layout.getTitle());
-		assertTrue(layout.isLocationInfo());
+		super.testConsoleHtmlLayout();
 	}
 
+	@Override
 	@Test
 	public void testConsolePatternLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-PatternLayout.properties");
-		assertEquals("%d{ISO8601} [%t][%c] %-5p: %m%n", layout.getConversionPattern());
+		super.testConsolePatternLayout();
 	}
 
+	@Override
 	@Test
 	public void testConsoleSimpleLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-SimpleLayout.properties");
-		assertEquals("%level - %m%n", layout.getConversionPattern());
+		super.testConsoleSimpleLayout();
 	}
 
+	@Override
 	@Test
 	public void testConsoleTtccLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout.properties");
-		assertEquals("%r [%t] %p %notEmpty{%ndc }- %m%n", layout.getConversionPattern());
+		super.testConsoleTtccLayout();
 	}
 
+	@Override
 	@Test
 	public void testConsoleXmlLayout() throws Exception {
-		final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout.properties");
-		assertTrue(layout.isLocationInfo());
-		assertFalse(layout.isProperties());
+		super.testConsoleXmlLayout();
 	}
 
+	@Override
 	@Test
 	public void testFileSimpleLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testFile("config-1.2/log4j-file-SimpleLayout.properties");
-		assertEquals("%level - %m%n", layout.getConversionPattern());
+		super.testFileSimpleLayout();
 	}
 
+	@Override
 	@Test
 	public void testNullAppender() throws Exception {
-		final Configuration configuration = getConfiguration("config-1.2/log4j-NullAppender.properties");
-		final Appender appender = configuration.getAppender("NullAppender");
-		assertNotNull(appender);
-		assertEquals("NullAppender", appender.getName());
-		assertTrue(appender.getClass().getName(), appender instanceof NullAppender);
+		super.testNullAppender();
 	}
 
+	@Override
 	@Test
 	public void testRollingFileAppender() throws Exception {
-		testRollingFileAppender("config-1.2/log4j-RollingFileAppender.properties", "RFA", "target/hadoop.log.%i");
+		super.testRollingFileAppender();
 	}
 
+	@Override
 	@Test
 	public void testDailyRollingFileAppender() throws Exception {
-		testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender.properties", "DRFA", "target/hadoop.log%d{.yyyy-MM-dd}");
+		super.testDailyRollingFileAppender();
 	}
 
+	@Override
 	@Test
 	public void testRollingFileAppenderWithProperties() throws Exception {
-		testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props.properties", "RFA", "target/hadoop.log.%i");
+		super.testRollingFileAppenderWithProperties();
 	}
 
+	@Override
 	@Test
 	public void testSystemProperties1() throws Exception {
-        final String tempFileName = System.getProperty("java.io.tmpdir") + "/hadoop.log";
-        final Path tempFilePath = new File(tempFileName).toPath();
-        Files.deleteIfExists(tempFilePath);
-        try {
-            final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-1.properties");
-            final RollingFileAppender appender = configuration.getAppender("RFA");
-			appender.stop(10, TimeUnit.SECONDS);
-            // System.out.println("expected: " + tempFileName + " Actual: " + appender.getFileName());
-            assertEquals(tempFileName, appender.getFileName());
-        } finally {
-			try {
-				Files.deleteIfExists(tempFilePath);
-			} catch (final FileSystemException e) {
-				e.printStackTrace();
-			}
-        }
+		super.testSystemProperties1();
 	}
 
+	@Override
 	@Test
 	public void testSystemProperties2() throws Exception {
-		final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2.properties");
-		final RollingFileAppender appender = configuration.getAppender("RFA");
-		assertEquals("${java.io.tmpdir}/hadoop.log", appender.getFileName());
-		appender.stop(10, TimeUnit.SECONDS);
-		Path path = new File(appender.getFileName()).toPath();
-        Files.deleteIfExists(path);
-        path = new File("${java.io.tmpdir}").toPath();
-        Files.deleteIfExists(path);
-	}
-
-	private void testRollingFileAppender(final String configResource, final String name, final String filePattern) throws URISyntaxException {
-		final Configuration configuration = getConfiguration(configResource);
-		final Appender appender = configuration.getAppender(name);
-		assertNotNull(appender);
-		assertEquals(name, appender.getName());
-		assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
-		final RollingFileAppender rfa = (RollingFileAppender) appender;
-		assertEquals("target/hadoop.log", rfa.getFileName());
-		assertEquals(filePattern, rfa.getFilePattern());
-		final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
-		assertNotNull(triggeringPolicy);
-		assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
-		final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
-		final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
-		assertEquals(1, triggeringPolicies.length);
-		final TriggeringPolicy tp = triggeringPolicies[0];
-		assertTrue(tp.getClass().getName(), tp instanceof SizeBasedTriggeringPolicy);
-		final SizeBasedTriggeringPolicy sbtp = (SizeBasedTriggeringPolicy) tp;
-		assertEquals(256 * 1024 * 1024, sbtp.getMaxFileSize());
-		final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
-		assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
-		final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
-		assertEquals(20, drs.getMaxIndex());
-		configuration.start();
-		configuration.stop();
-	}
-
-	private void testDailyRollingFileAppender(final String configResource, final String name, final String filePattern) throws URISyntaxException {
-		final Configuration configuration = getConfiguration(configResource);
-		final Appender appender = configuration.getAppender(name);
-		assertNotNull(appender);
-		assertEquals(name, appender.getName());
-		assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
-		final RollingFileAppender rfa = (RollingFileAppender) appender;
-		assertEquals("target/hadoop.log", rfa.getFileName());
-		assertEquals(filePattern, rfa.getFilePattern());
-		final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
-		assertNotNull(triggeringPolicy);
-		assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
-		final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
-		final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
-		assertEquals(1, triggeringPolicies.length);
-		final TriggeringPolicy tp = triggeringPolicies[0];
-		assertTrue(tp.getClass().getName(), tp instanceof TimeBasedTriggeringPolicy);
-		final TimeBasedTriggeringPolicy tbtp = (TimeBasedTriggeringPolicy) tp;
-		assertEquals(1, tbtp.getInterval());
-		final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
-		assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
-		final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
-		assertEquals(Integer.MAX_VALUE, drs.getMaxIndex());
-		configuration.start();
-		configuration.stop();
+		super.testSystemProperties2();
 	}
 
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -112,4 +112,10 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
 		super.testSystemProperties2();
 	}
 
+    @Override
+    @Test
+    public void testRecursiveProperties() throws Exception {
+        super.testRecursiveProperties();
+    }
+
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -19,8 +19,9 @@ package org.apache.log4j.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +37,8 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.apache.logging.log4j.core.filter.CompositeFilter;
 import org.apache.logging.log4j.core.filter.Filterable;
@@ -45,11 +48,23 @@ import org.junit.Test;
 /**
  * Test configuration from Properties.
  */
-public class PropertiesConfigurationTest {
+public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest {
 
     private static final String TEST_KEY = "log4j.test.tmpdir";
 
-    @Test
+	@Override
+	Configuration getConfiguration(String configResourcePrefix) throws IOException {
+		final String configResource = configResourcePrefix + ".properties";
+		final InputStream inputStream = ClassLoader.getSystemResourceAsStream(configResource);
+		final ConfigurationSource source = new ConfigurationSource(inputStream);
+		//final LoggerContext context = LoggerContext.getContext(false);
+		final Configuration configuration = new PropertiesConfigurationFactory().getConfiguration(null, source);
+		assertNotNull("No configuration created", configuration);
+		configuration.initialize();
+		return configuration;
+	}
+
+	@Test
     public void testConfigureNullPointerException() throws Exception {
         try (LoggerContext loggerContext = TestConfigurator.configure("target/test-classes/LOG4J2-3247.properties")) {
             // [LOG4J2-3247] configure() should not throw an NPE.
@@ -167,4 +182,81 @@ public class PropertiesConfigurationTest {
         }
     }
 
+	@Override
+	@Test
+	public void testConsoleEnhancedPatternLayout() throws Exception {
+		super.testConsoleEnhancedPatternLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleHtmlLayout() throws Exception {
+		super.testConsoleHtmlLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsolePatternLayout() throws Exception {
+		super.testConsolePatternLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleSimpleLayout() throws Exception {
+		super.testConsoleSimpleLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleTtccLayout() throws Exception {
+		super.testConsoleTtccLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleXmlLayout() throws Exception {
+		super.testConsoleXmlLayout();
+	}
+
+	@Override
+	@Test
+	public void testFileSimpleLayout() throws Exception {
+		super.testFileSimpleLayout();
+	}
+
+	@Override
+	@Test
+	public void testNullAppender() throws Exception {
+		super.testNullAppender();
+	}
+
+	@Override
+	@Test
+	public void testRollingFileAppender() throws Exception {
+		super.testRollingFileAppender();
+	}
+
+	@Override
+	@Test
+	public void testDailyRollingFileAppender() throws Exception {
+		super.testDailyRollingFileAppender();
+	}
+
+	@Override
+	@Test
+	public void testRollingFileAppenderWithProperties() throws Exception {
+		super.testRollingFileAppenderWithProperties();
+	}
+
+	@Override
+	@Test
+	public void testSystemProperties1() throws Exception {
+		super.testSystemProperties1();
+	}
+
+	@Override
+	@Test
+	public void testSystemProperties2() throws Exception {
+		super.testSystemProperties2();
+	}
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -259,4 +259,11 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
 	public void testSystemProperties2() throws Exception {
 		super.testSystemProperties2();
 	}
+
+    @Override
+    @Test
+    public void testRecursiveProperties() throws Exception {
+        super.testRecursiveProperties();
+    }
+
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
@@ -28,17 +31,32 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.log4j.bridge.AppenderAdapter;
 import org.apache.log4j.spi.LoggingEvent;
+import org.apache.log4j.xml.XmlConfigurationFactory;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.junit.Test;
 
 /**
  * Test configuration from XML.
  */
-public class XmlConfigurationTest {
+public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
 
-    @Test
+	@Override
+	Configuration getConfiguration(String configResourcePrefix) throws URISyntaxException, IOException {
+		final String configResource = configResourcePrefix + ".xml";
+		final InputStream inputStream = ClassLoader.getSystemResourceAsStream(configResource);
+		final ConfigurationSource source = new ConfigurationSource(inputStream);
+		final LoggerContext context = LoggerContext.getContext(false);
+		final Configuration configuration = new XmlConfigurationFactory().getConfiguration(context, source);
+		assertNotNull("No configuration created", configuration);
+		configuration.initialize();
+		return configuration;
+	}
+
+	@Test
     public void testListAppender() throws Exception {
         final LoggerContext loggerContext = TestConfigurator.configure("target/test-classes/log4j1-list.xml");
         final Logger logger = LogManager.getLogger("test");
@@ -75,4 +93,81 @@ public class XmlConfigurationTest {
         assertTrue("File A2 is empty", file.length() > 0);
     }
 
+	@Override
+	@Test
+	public void testConsoleEnhancedPatternLayout() throws Exception {
+		super.testConsoleEnhancedPatternLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleHtmlLayout() throws Exception {
+		super.testConsoleHtmlLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsolePatternLayout() throws Exception {
+		super.testConsolePatternLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleSimpleLayout() throws Exception {
+		super.testConsoleSimpleLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleTtccLayout() throws Exception {
+		super.testConsoleTtccLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleXmlLayout() throws Exception {
+		super.testConsoleXmlLayout();
+	}
+
+	@Override
+	@Test
+	public void testFileSimpleLayout() throws Exception {
+		super.testFileSimpleLayout();
+	}
+
+	@Override
+	@Test
+	public void testNullAppender() throws Exception {
+		super.testNullAppender();
+	}
+
+	@Override
+	@Test
+	public void testRollingFileAppender() throws Exception {
+		super.testRollingFileAppender();
+	}
+
+	@Override
+	@Test
+	public void testDailyRollingFileAppender() throws Exception {
+		super.testDailyRollingFileAppender();
+	}
+
+	@Override
+	// Don't test: XML does not allow properties.
+	public void testRollingFileAppenderWithProperties() throws Exception {
+		super.testRollingFileAppenderWithProperties();
+	}
+
+	@Override
+	@Test
+	public void testSystemProperties1() throws Exception {
+		super.testSystemProperties1();
+	}
+
+	@Override
+	// Don't test: XML does not allow properties.
+	public void testSystemProperties2() throws Exception {
+		super.testSystemProperties2();
+	}
 }

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-DailyRollingFileAppender.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-DailyRollingFileAppender.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="DRFA" class="org.apache.log4j.DailyRollingFileAppender">
+    <param name="File" value="target/hadoop.log" />
+    <param name="DatePattern" value=".yyyy-MM-dd" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} %p %c: %m%n" />
+    </layout>
+  </appender>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="DRFA" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-NullAppender.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-NullAppender.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="NullAppender" class="org.apache.log4j.varia.NullAppender" />
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="NullAppender" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-RollingFileAppender.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-RollingFileAppender.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
-  <appender name="RFA" class="org.apache.log4j.DailyRollingFileAppender">
+  <appender name="RFA" class="org.apache.log4j.RollingFileAppender">
     <param name="File" value="target/hadoop.log" />
     <param name="MaxFileSize" value="256MB" />
     <param name="MaxBackupIndex" value="20" />

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-RollingFileAppender.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-RollingFileAppender.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="RFA" class="org.apache.log4j.DailyRollingFileAppender">
+    <param name="File" value="target/hadoop.log" />
+    <param name="MaxFileSize" value="256MB" />
+    <param name="MaxBackupIndex" value="20" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} %p %c: %m%n" />
+    </layout>
+  </appender>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="RFA" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-EnhancedPatternLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-EnhancedPatternLayout.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="target" value="System.err" />
+    <layout class="org.apache.log4j.EnhancedPatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} [%t][%c] %-5p %X %x: %m%n" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-HtmlLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-HtmlLayout.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="target" value="System.err" />
+    <layout class="org.apache.log4j.HTMLLayout">
+      <param name="Title" value="Headline" />
+      <param name="LocationInfo" value="true" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-PatternLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-PatternLayout.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} [%t][%c] %-5p: %m%n" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-SimpleLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-SimpleLayout.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.SimpleLayout" />
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-TTCCLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-TTCCLayout.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.TTCCLayout">
+      <param name="ThreadPrinting" value="true" />
+      <param name="CategoryPrefixing" value="false" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-XmlLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-XmlLayout.xml
@@ -3,7 +3,7 @@
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
   <appender name="Console" class="org.apache.log4j.ConsoleAppender">
     <param name="Target" value="System.err" />
-    <layout class="org.apache.log4j.XmlLayout">
+    <layout class="org.apache.log4j.xml.XmlLayout">
       <param name="LocationInfo" value="true" />
       <param name="Properties" value="false" />
     </layout>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-XmlLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-XmlLayout.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.XmlLayout">
+      <param name="LocationInfo" value="true" />
+      <param name="Properties" value="false" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-SimpleLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-SimpleLayout.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="File" class="org.apache.log4j.FileAppender">
+    <param name="File" value="target/mylog.txt" />
+    <layout class="org.apache.log4j.SimpleLayout" />
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="File" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-recursive.properties
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-recursive.properties
@@ -5,7 +5,7 @@
 
 log4j.rootLogger=TRACE, File
 
-test.logFile0=${test.logFile1}/${test.logfile2}
+test.logFile0=${test.logFile1}/${test.logFile2}
 test.logFile1=${test.logFile3}/${test.logFile4}
 test.logFile2=${test.logFile5}/${test.logFile6}
 test.logFile3=path

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-recursive.properties
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-recursive.properties
@@ -1,0 +1,25 @@
+###############################################################################
+#
+# Log4J 1.2 Configuration.
+#
+
+log4j.rootLogger=TRACE, File
+
+test.logFile0=${test.logFile1}/${test.logfile2}
+test.logFile1=${test.logFile3}/${test.logFile4}
+test.logFile2=${test.logFile5}/${test.logFile6}
+test.logFile3=path
+test.logFile4=to
+test.logFile5=the
+test.logFile6=logFile.txt
+
+##############################################################################
+#
+# The Console log
+#
+
+log4j.appender.File=org.apache.log4j.FileAppender
+log4j.appender.File.File=target/${test.logFile0}
+log4j.appender.File.layout=org.apache.log4j.SimpleLayout
+
+log4j.logger.com.example.foo = DEBUG

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-system-properties-1.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-system-properties-1.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="RFA" class="org.apache.log4j.DailyRollingFileAppender">
+    <param name="File" value="${java.io.tmpdir}/hadoop.log" />
+  </appender>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="RFA" />
+  </root>
+</log4j:configuration>


### PR DESCRIPTION
The unit tests provided by `Log4j1ConfigurationFactoryTest` unfortunately were not applied to the newer `PropertiesConfigurationFactory` and `XmlConfigurationFactory`. After applying the tests, many small errors appeared, which this PR solves:

*  the `XmlConfiguration` didn't allow for system property replacement ([LOG4J2-3328]),
* the `TTCCLayoutBuilder` lacked proper default values for its properties,
* the `RollingFileAppender` and `DailyRollingFileAppender` used incorrect file patterns,
* the `XmlLayoutBuilder` used the native Log4j 2.x `XmlLayout` instead of the compatible `Log4j1XmlLayout`,
* builders that did not inherit from `AbstractBuilder` failed to be instantiated.

For an easier cherry-pick, I tried to solve each problem in a separate commit.