### PR TITLE
Common unit tests for Log4j 1.x configuration factories

### DIFF
--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
 package org.apache.log4j.config;
 
 import static org.junit.Assert.assertEquals;

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -56,120 +56,124 @@ import org.apache.logging.log4j.core.layout.PatternLayout;
 
 public abstract class AbstractLog4j1ConfigurationTest {
 
-	abstract Configuration getConfiguration(String configResourcePrefix) throws URISyntaxException, IOException;
+    abstract Configuration getConfiguration(String configResourcePrefix) throws URISyntaxException, IOException;
 
-	private Layout<?> testConsole(final String configResourcePrefix) throws Exception {
-		final Configuration configuration = getConfiguration(configResourcePrefix);
-		final String name = "Console";
-		final ConsoleAppender appender = configuration.getAppender(name);
-		assertNotNull("Missing appender '" + name + "' in configuration " + configResourcePrefix + " → " + configuration, appender);
-		assertEquals(Target.SYSTEM_ERR, appender.getTarget());
-		//
-		final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
-		assertNotNull(loggerConfig);
-		assertEquals(Level.DEBUG, loggerConfig.getLevel());
-		configuration.start();
-		configuration.stop();
-		return appender.getLayout();
-	}
+    private Layout<?> testConsole(final String configResourcePrefix) throws Exception {
+        final Configuration configuration = getConfiguration(configResourcePrefix);
+        final String name = "Console";
+        final ConsoleAppender appender = configuration.getAppender(name);
+        assertNotNull(
+                "Missing appender '" + name + "' in configuration " + configResourcePrefix + " → " + configuration,
+                appender);
+        assertEquals(Target.SYSTEM_ERR, appender.getTarget());
+        //
+        final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
+        assertNotNull(loggerConfig);
+        assertEquals(Level.DEBUG, loggerConfig.getLevel());
+        configuration.start();
+        configuration.stop();
+        return appender.getLayout();
+    }
 
-	private Layout<?> testFile(final String configResourcePrefix) throws Exception {
-		final Configuration configuration = getConfiguration(configResourcePrefix);
-		final FileAppender appender = configuration.getAppender("File");
-		assertNotNull(appender);
-		assertEquals("target/mylog.txt", appender.getFileName());
-		//
-		final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
-		assertNotNull(loggerConfig);
-		assertEquals(Level.DEBUG, loggerConfig.getLevel());
-		configuration.start();
-		configuration.stop();
-		return appender.getLayout();
-	}
+    private Layout<?> testFile(final String configResourcePrefix) throws Exception {
+        final Configuration configuration = getConfiguration(configResourcePrefix);
+        final FileAppender appender = configuration.getAppender("File");
+        assertNotNull(appender);
+        assertEquals("target/mylog.txt", appender.getFileName());
+        //
+        final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
+        assertNotNull(loggerConfig);
+        assertEquals(Level.DEBUG, loggerConfig.getLevel());
+        configuration.start();
+        configuration.stop();
+        return appender.getLayout();
+    }
 
-	public void testConsoleEnhancedPatternLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-EnhancedPatternLayout");
-		assertEquals("%d{ISO8601} [%t][%c] %-5p %properties %ndc: %m%n", layout.getConversionPattern());
-	}
+    public void testConsoleEnhancedPatternLayout() throws Exception {
+        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-EnhancedPatternLayout");
+        assertEquals("%d{ISO8601} [%t][%c] %-5p %properties %ndc: %m%n", layout.getConversionPattern());
+    }
 
-	public void testConsoleHtmlLayout() throws Exception {
-		final HtmlLayout layout = (HtmlLayout) testConsole("config-1.2/log4j-console-HtmlLayout");
-		assertEquals("Headline", layout.getTitle());
-		assertTrue(layout.isLocationInfo());
-	}
+    public void testConsoleHtmlLayout() throws Exception {
+        final HtmlLayout layout = (HtmlLayout) testConsole("config-1.2/log4j-console-HtmlLayout");
+        assertEquals("Headline", layout.getTitle());
+        assertTrue(layout.isLocationInfo());
+    }
 
-	public void testConsolePatternLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-PatternLayout");
-		assertEquals("%d{ISO8601} [%t][%c] %-5p: %m%n", layout.getConversionPattern());
-	}
+    public void testConsolePatternLayout() throws Exception {
+        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-PatternLayout");
+        assertEquals("%d{ISO8601} [%t][%c] %-5p: %m%n", layout.getConversionPattern());
+    }
 
-	public void testConsoleSimpleLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-SimpleLayout");
-		assertEquals("%level - %m%n", layout.getConversionPattern());
-	}
+    public void testConsoleSimpleLayout() throws Exception {
+        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-SimpleLayout");
+        assertEquals("%level - %m%n", layout.getConversionPattern());
+    }
 
-	public void testConsoleTtccLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout");
-		assertEquals("%r [%t] %p %notEmpty{%ndc }- %m%n", layout.getConversionPattern());
-	}
+    public void testConsoleTtccLayout() throws Exception {
+        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout");
+        assertEquals("%r [%t] %p %notEmpty{%ndc }- %m%n", layout.getConversionPattern());
+    }
 
-	public void testConsoleXmlLayout() throws Exception {
-		final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout");
-		assertTrue(layout.isLocationInfo());
-		assertFalse(layout.isProperties());
-	}
+    public void testConsoleXmlLayout() throws Exception {
+        final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout");
+        assertTrue(layout.isLocationInfo());
+        assertFalse(layout.isProperties());
+    }
 
-	public void testFileSimpleLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testFile("config-1.2/log4j-file-SimpleLayout");
-		assertEquals("%level - %m%n", layout.getConversionPattern());
-	}
+    public void testFileSimpleLayout() throws Exception {
+        final PatternLayout layout = (PatternLayout) testFile("config-1.2/log4j-file-SimpleLayout");
+        assertEquals("%level - %m%n", layout.getConversionPattern());
+    }
 
-	public void testNullAppender() throws Exception {
-		final Configuration configuration = getConfiguration("config-1.2/log4j-NullAppender");
-		final Appender appender = configuration.getAppender("NullAppender");
-		assertNotNull(appender);
-		assertEquals("NullAppender", appender.getName());
-		assertTrue(appender.getClass().getName(), appender instanceof NullAppender);
-	}
+    public void testNullAppender() throws Exception {
+        final Configuration configuration = getConfiguration("config-1.2/log4j-NullAppender");
+        final Appender appender = configuration.getAppender("NullAppender");
+        assertNotNull(appender);
+        assertEquals("NullAppender", appender.getName());
+        assertTrue(appender.getClass().getName(), appender instanceof NullAppender);
+    }
 
-	public void testRollingFileAppender() throws Exception {
-		testRollingFileAppender("config-1.2/log4j-RollingFileAppender", "RFA", "target/hadoop.log.%i");
-	}
+    public void testRollingFileAppender() throws Exception {
+        testRollingFileAppender("config-1.2/log4j-RollingFileAppender", "RFA", "target/hadoop.log.%i");
+    }
 
-	public void testDailyRollingFileAppender() throws Exception {
-		testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender", "DRFA", "target/hadoop.log%d{.yyyy-MM-dd}");
-	}
+    public void testDailyRollingFileAppender() throws Exception {
+        testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender", "DRFA",
+                "target/hadoop.log%d{.yyyy-MM-dd}");
+    }
 
-	public void testRollingFileAppenderWithProperties() throws Exception {
-		testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props", "RFA", "target/hadoop.log.%i");
-	}
+    public void testRollingFileAppenderWithProperties() throws Exception {
+        testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props", "RFA", "target/hadoop.log.%i");
+    }
 
-	public void testSystemProperties1() throws Exception {
-		final String tempFileName = System.getProperty("java.io.tmpdir") + "/hadoop.log";
-		final Path tempFilePath = new File(tempFileName).toPath();
-		Files.deleteIfExists(tempFilePath);
-		try {
-			final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-1");
-			final RollingFileAppender appender = configuration.getAppender("RFA");
-			appender.stop(10, TimeUnit.SECONDS);
-			// System.out.println("expected: " + tempFileName + " Actual: " +
-			// appender.getFileName());
-			assertEquals(tempFileName, appender.getFileName());
-		} finally {
-			try {
-				Files.deleteIfExists(tempFilePath);
-			} catch (final FileSystemException e) {
-				e.printStackTrace();
-			}
-		}
-	}
+    public void testSystemProperties1() throws Exception {
+        final String tempFileName = System.getProperty("java.io.tmpdir") + "/hadoop.log";
+        final Path tempFilePath = new File(tempFileName).toPath();
+        Files.deleteIfExists(tempFilePath);
+        try {
+            final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-1");
+            final RollingFileAppender appender = configuration.getAppender("RFA");
+            appender.stop(10, TimeUnit.SECONDS);
+            // System.out.println("expected: " + tempFileName + " Actual: " +
+            // appender.getFileName());
+            assertEquals(tempFileName, appender.getFileName());
+        } finally {
+            try {
+                Files.deleteIfExists(tempFilePath);
+            } catch (final FileSystemException e) {
+                e.printStackTrace();
+            }
+        }
+    }
 
     public void testSystemProperties2() throws Exception {
         final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2");
         final RollingFileAppender appender = configuration.getAppender("RFA");
         final String tmpDir = System.getProperty("java.io.tmpdir");
         assertEquals(tmpDir + "/hadoop.log", appender.getFileName());
-        // The appender should be in the INITIALIZED state, so no cleanup necessary
+        // The appender should be in the INITIALIZED state, so no cleanup
+        // necessary
         if (appender.getState() == State.STARTED) {
             appender.stop(10, TimeUnit.SECONDS);
             try {
@@ -183,61 +187,61 @@ public abstract class AbstractLog4j1ConfigurationTest {
         }
     }
 
-	private void testRollingFileAppender(final String configResourcePrefix, final String name, final String filePattern)
-			throws Exception {
-		final Configuration configuration = getConfiguration(configResourcePrefix);
-		final Appender appender = configuration.getAppender(name);
-		assertNotNull(appender);
-		assertEquals(name, appender.getName());
-		assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
-		final RollingFileAppender rfa = (RollingFileAppender) appender;
-		assertEquals("target/hadoop.log", rfa.getFileName());
-		assertEquals(filePattern, rfa.getFilePattern());
-		final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
-		assertNotNull(triggeringPolicy);
-		assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
-		final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
-		final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
-		assertEquals(1, triggeringPolicies.length);
-		final TriggeringPolicy tp = triggeringPolicies[0];
-		assertTrue(tp.getClass().getName(), tp instanceof SizeBasedTriggeringPolicy);
-		final SizeBasedTriggeringPolicy sbtp = (SizeBasedTriggeringPolicy) tp;
-		assertEquals(256 * 1024 * 1024, sbtp.getMaxFileSize());
-		final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
-		assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
-		final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
-		assertEquals(20, drs.getMaxIndex());
-		configuration.start();
-		configuration.stop();
-	}
+    private void testRollingFileAppender(final String configResourcePrefix, final String name, final String filePattern)
+            throws Exception {
+        final Configuration configuration = getConfiguration(configResourcePrefix);
+        final Appender appender = configuration.getAppender(name);
+        assertNotNull(appender);
+        assertEquals(name, appender.getName());
+        assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
+        final RollingFileAppender rfa = (RollingFileAppender) appender;
+        assertEquals("target/hadoop.log", rfa.getFileName());
+        assertEquals(filePattern, rfa.getFilePattern());
+        final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
+        assertNotNull(triggeringPolicy);
+        assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
+        final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
+        final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
+        assertEquals(1, triggeringPolicies.length);
+        final TriggeringPolicy tp = triggeringPolicies[0];
+        assertTrue(tp.getClass().getName(), tp instanceof SizeBasedTriggeringPolicy);
+        final SizeBasedTriggeringPolicy sbtp = (SizeBasedTriggeringPolicy) tp;
+        assertEquals(256 * 1024 * 1024, sbtp.getMaxFileSize());
+        final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
+        assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
+        final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
+        assertEquals(20, drs.getMaxIndex());
+        configuration.start();
+        configuration.stop();
+    }
 
-	private void testDailyRollingFileAppender(final String configResourcePrefix, final String name, final String filePattern)
-			throws Exception {
-		final Configuration configuration = getConfiguration(configResourcePrefix);
-		final Appender appender = configuration.getAppender(name);
-		assertNotNull(appender);
-		assertEquals(name, appender.getName());
-		assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
-		final RollingFileAppender rfa = (RollingFileAppender) appender;
-		assertEquals("target/hadoop.log", rfa.getFileName());
-		assertEquals(filePattern, rfa.getFilePattern());
-		final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
-		assertNotNull(triggeringPolicy);
-		assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
-		final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
-		final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
-		assertEquals(1, triggeringPolicies.length);
-		final TriggeringPolicy tp = triggeringPolicies[0];
-		assertTrue(tp.getClass().getName(), tp instanceof TimeBasedTriggeringPolicy);
-		final TimeBasedTriggeringPolicy tbtp = (TimeBasedTriggeringPolicy) tp;
-		assertEquals(1, tbtp.getInterval());
-		final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
-		assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
-		final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
-		assertEquals(Integer.MAX_VALUE, drs.getMaxIndex());
-		configuration.start();
-		configuration.stop();
-	}
+    private void testDailyRollingFileAppender(final String configResourcePrefix, final String name,
+            final String filePattern) throws Exception {
+        final Configuration configuration = getConfiguration(configResourcePrefix);
+        final Appender appender = configuration.getAppender(name);
+        assertNotNull(appender);
+        assertEquals(name, appender.getName());
+        assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
+        final RollingFileAppender rfa = (RollingFileAppender) appender;
+        assertEquals("target/hadoop.log", rfa.getFileName());
+        assertEquals(filePattern, rfa.getFilePattern());
+        final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
+        assertNotNull(triggeringPolicy);
+        assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
+        final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
+        final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
+        assertEquals(1, triggeringPolicies.length);
+        final TriggeringPolicy tp = triggeringPolicies[0];
+        assertTrue(tp.getClass().getName(), tp instanceof TimeBasedTriggeringPolicy);
+        final TimeBasedTriggeringPolicy tbtp = (TimeBasedTriggeringPolicy) tp;
+        assertEquals(1, tbtp.getInterval());
+        final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
+        assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
+        final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
+        assertEquals(Integer.MAX_VALUE, drs.getMaxIndex());
+        configuration.start();
+        configuration.stop();
+    }
 
     public void testRecursiveProperties() throws Exception {
         final Configuration configuration = getConfiguration("config-1.2/log4j-file-recursive");
@@ -251,8 +255,8 @@ public abstract class AbstractLog4j1ConfigurationTest {
         final LoggerConfig rootLogger = configuration.getRootLogger();
         assertEquals(Level.TRACE, rootLogger.getLevel());
         appender.stop();
-        final List<Path> paths = Arrays.asList(Paths.get("target/path/to/the/logFile.txt"), Paths.get("target/path/to/the"),
-                Paths.get("target/path/to"), Paths.get("target/path"));
+        final List<Path> paths = Arrays.asList(Paths.get("target/path/to/the/logFile.txt"),
+                Paths.get("target/path/to/the"), Paths.get("target/path/to"), Paths.get("target/path"));
         paths.forEach(t -> {
             try {
                 Files.deleteIfExists(t);

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -11,6 +11,9 @@ import java.net.URISyntaxException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.log4j.layout.Log4j1XmlLayout;
@@ -18,10 +21,10 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.appender.NullAppender;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
 import org.apache.logging.log4j.core.appender.rolling.CompositeTriggeringPolicy;
 import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
@@ -30,7 +33,6 @@ import org.apache.logging.log4j.core.appender.rolling.TimeBasedTriggeringPolicy;
 import org.apache.logging.log4j.core.appender.rolling.TriggeringPolicy;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.apache.logging.log4j.core.layout.HtmlLayout;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 
@@ -222,5 +224,15 @@ public abstract class AbstractLog4j1ConfigurationTest {
         assertEquals(Level.DEBUG, loggerConfig.getLevel());
         final LoggerConfig rootLogger = configuration.getRootLogger();
         assertEquals(Level.TRACE, rootLogger.getLevel());
+        appender.stop();
+        final List<Path> paths = Arrays.asList(Paths.get("target/path/to/the/logFile.txt"), Paths.get("target/path/to/the"),
+                Paths.get("target/path/to"), Paths.get("target/path"));
+        paths.forEach(t -> {
+            try {
+                Files.deleteIfExists(t);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        });
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -1,0 +1,213 @@
+package org.apache.log4j.config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.log4j.layout.Log4j1XmlLayout;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.appender.FileAppender;
+import org.apache.logging.log4j.core.appender.NullAppender;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
+import org.apache.logging.log4j.core.appender.rolling.CompositeTriggeringPolicy;
+import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
+import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
+import org.apache.logging.log4j.core.appender.rolling.SizeBasedTriggeringPolicy;
+import org.apache.logging.log4j.core.appender.rolling.TimeBasedTriggeringPolicy;
+import org.apache.logging.log4j.core.appender.rolling.TriggeringPolicy;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
+import org.apache.logging.log4j.core.layout.HtmlLayout;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+public abstract class AbstractLog4j1ConfigurationTest {
+
+	abstract Configuration getConfiguration(String configResourcePrefix) throws URISyntaxException, IOException;
+
+	private Layout<?> testConsole(final String configResourcePrefix) throws Exception {
+		final Configuration configuration = getConfiguration(configResourcePrefix);
+		final String name = "Console";
+		final ConsoleAppender appender = configuration.getAppender(name);
+		assertNotNull("Missing appender '" + name + "' in configuration " + configResourcePrefix + " → " + configuration, appender);
+		assertEquals(Target.SYSTEM_ERR, appender.getTarget());
+		//
+		final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
+		assertNotNull(loggerConfig);
+		assertEquals(Level.DEBUG, loggerConfig.getLevel());
+		configuration.start();
+		configuration.stop();
+		return appender.getLayout();
+	}
+
+	private Layout<?> testFile(final String configResourcePrefix) throws Exception {
+		final Configuration configuration = getConfiguration(configResourcePrefix);
+		final FileAppender appender = configuration.getAppender("File");
+		assertNotNull(appender);
+		assertEquals("target/mylog.txt", appender.getFileName());
+		//
+		final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
+		assertNotNull(loggerConfig);
+		assertEquals(Level.DEBUG, loggerConfig.getLevel());
+		configuration.start();
+		configuration.stop();
+		return appender.getLayout();
+	}
+
+	public void testConsoleEnhancedPatternLayout() throws Exception {
+		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-EnhancedPatternLayout");
+		assertEquals("%d{ISO8601} [%t][%c] %-5p %properties %ndc: %m%n", layout.getConversionPattern());
+	}
+
+	public void testConsoleHtmlLayout() throws Exception {
+		final HtmlLayout layout = (HtmlLayout) testConsole("config-1.2/log4j-console-HtmlLayout");
+		assertEquals("Headline", layout.getTitle());
+		assertTrue(layout.isLocationInfo());
+	}
+
+	public void testConsolePatternLayout() throws Exception {
+		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-PatternLayout");
+		assertEquals("%d{ISO8601} [%t][%c] %-5p: %m%n", layout.getConversionPattern());
+	}
+
+	public void testConsoleSimpleLayout() throws Exception {
+		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-SimpleLayout");
+		assertEquals("%level - %m%n", layout.getConversionPattern());
+	}
+
+	public void testConsoleTtccLayout() throws Exception {
+		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout");
+		assertEquals("%r [%t] %p %notEmpty{%ndc }- %m%n", layout.getConversionPattern());
+	}
+
+	public void testConsoleXmlLayout() throws Exception {
+		final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout");
+		assertTrue(layout.isLocationInfo());
+		assertFalse(layout.isProperties());
+	}
+
+	public void testFileSimpleLayout() throws Exception {
+		final PatternLayout layout = (PatternLayout) testFile("config-1.2/log4j-file-SimpleLayout");
+		assertEquals("%level - %m%n", layout.getConversionPattern());
+	}
+
+	public void testNullAppender() throws Exception {
+		final Configuration configuration = getConfiguration("config-1.2/log4j-NullAppender");
+		final Appender appender = configuration.getAppender("NullAppender");
+		assertNotNull(appender);
+		assertEquals("NullAppender", appender.getName());
+		assertTrue(appender.getClass().getName(), appender instanceof NullAppender);
+	}
+
+	public void testRollingFileAppender() throws Exception {
+		testRollingFileAppender("config-1.2/log4j-RollingFileAppender", "RFA", "target/hadoop.log.%i");
+	}
+
+	public void testDailyRollingFileAppender() throws Exception {
+		testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender", "DRFA", "target/hadoop.log%d{.yyyy-MM-dd}");
+	}
+
+	public void testRollingFileAppenderWithProperties() throws Exception {
+		testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props", "RFA", "target/hadoop.log.%i");
+	}
+
+	public void testSystemProperties1() throws Exception {
+		final String tempFileName = System.getProperty("java.io.tmpdir") + "/hadoop.log";
+		final Path tempFilePath = new File(tempFileName).toPath();
+		Files.deleteIfExists(tempFilePath);
+		try {
+			final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-1");
+			final RollingFileAppender appender = configuration.getAppender("RFA");
+			appender.stop(10, TimeUnit.SECONDS);
+			// System.out.println("expected: " + tempFileName + " Actual: " +
+			// appender.getFileName());
+			assertEquals(tempFileName, appender.getFileName());
+		} finally {
+			try {
+				Files.deleteIfExists(tempFilePath);
+			} catch (final FileSystemException e) {
+				e.printStackTrace();
+			}
+		}
+	}
+
+	public void testSystemProperties2() throws Exception {
+		final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2");
+		final RollingFileAppender appender = configuration.getAppender("RFA");
+		assertEquals("${java.io.tmpdir}/hadoop.log", appender.getFileName());
+		appender.stop(10, TimeUnit.SECONDS);
+		Path path = new File(appender.getFileName()).toPath();
+		Files.deleteIfExists(path);
+		path = new File("${java.io.tmpdir}").toPath();
+		Files.deleteIfExists(path);
+	}
+
+	private void testRollingFileAppender(final String configResourcePrefix, final String name, final String filePattern)
+			throws Exception {
+		final Configuration configuration = getConfiguration(configResourcePrefix);
+		final Appender appender = configuration.getAppender(name);
+		assertNotNull(appender);
+		assertEquals(name, appender.getName());
+		assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
+		final RollingFileAppender rfa = (RollingFileAppender) appender;
+		assertEquals("target/hadoop.log", rfa.getFileName());
+		assertEquals(filePattern, rfa.getFilePattern());
+		final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
+		assertNotNull(triggeringPolicy);
+		assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
+		final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
+		final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
+		assertEquals(1, triggeringPolicies.length);
+		final TriggeringPolicy tp = triggeringPolicies[0];
+		assertTrue(tp.getClass().getName(), tp instanceof SizeBasedTriggeringPolicy);
+		final SizeBasedTriggeringPolicy sbtp = (SizeBasedTriggeringPolicy) tp;
+		assertEquals(256 * 1024 * 1024, sbtp.getMaxFileSize());
+		final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
+		assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
+		final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
+		assertEquals(20, drs.getMaxIndex());
+		configuration.start();
+		configuration.stop();
+	}
+
+	private void testDailyRollingFileAppender(final String configResourcePrefix, final String name, final String filePattern)
+			throws Exception {
+		final Configuration configuration = getConfiguration(configResourcePrefix);
+		final Appender appender = configuration.getAppender(name);
+		assertNotNull(appender);
+		assertEquals(name, appender.getName());
+		assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
+		final RollingFileAppender rfa = (RollingFileAppender) appender;
+		assertEquals("target/hadoop.log", rfa.getFileName());
+		assertEquals(filePattern, rfa.getFilePattern());
+		final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
+		assertNotNull(triggeringPolicy);
+		assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
+		final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
+		final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
+		assertEquals(1, triggeringPolicies.length);
+		final TriggeringPolicy tp = triggeringPolicies[0];
+		assertTrue(tp.getClass().getName(), tp instanceof TimeBasedTriggeringPolicy);
+		final TimeBasedTriggeringPolicy tbtp = (TimeBasedTriggeringPolicy) tp;
+		assertEquals(1, tbtp.getInterval());
+		final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
+		assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
+		final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
+		assertEquals(Integer.MAX_VALUE, drs.getMaxIndex());
+		configuration.start();
+		configuration.stop();
+	}
+}

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -37,6 +37,7 @@ import org.apache.log4j.layout.Log4j1XmlLayout;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LifeCycle.State;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
 import org.apache.logging.log4j.core.appender.FileAppender;
@@ -163,16 +164,24 @@ public abstract class AbstractLog4j1ConfigurationTest {
 		}
 	}
 
-	public void testSystemProperties2() throws Exception {
-		final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2");
-		final RollingFileAppender appender = configuration.getAppender("RFA");
-		assertEquals("${java.io.tmpdir}/hadoop.log", appender.getFileName());
-		appender.stop(10, TimeUnit.SECONDS);
-		Path path = new File(appender.getFileName()).toPath();
-		Files.deleteIfExists(path);
-		path = new File("${java.io.tmpdir}").toPath();
-		Files.deleteIfExists(path);
-	}
+    public void testSystemProperties2() throws Exception {
+        final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2");
+        final RollingFileAppender appender = configuration.getAppender("RFA");
+        final String tmpDir = System.getProperty("java.io.tmpdir");
+        assertEquals(tmpDir + "/hadoop.log", appender.getFileName());
+        // The appender should be in the INITIALIZED state, so no cleanup necessary
+        if (appender.getState() == State.STARTED) {
+            appender.stop(10, TimeUnit.SECONDS);
+            try {
+                Path path = new File(appender.getFileName()).toPath();
+                Files.deleteIfExists(path);
+                path = new File("${java.io.tmpdir}").toPath();
+                Files.deleteIfExists(path);
+            } catch (FileSystemException e) {
+                e.printStackTrace();
+            }
+        }
+    }
 
 	private void testRollingFileAppender(final String configResourcePrefix, final String name, final String filePattern)
 			throws Exception {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -210,4 +210,17 @@ public abstract class AbstractLog4j1ConfigurationTest {
 		configuration.start();
 		configuration.stop();
 	}
+
+    public void testRecursiveProperties() throws Exception {
+        final Configuration configuration = getConfiguration("config-1.2/log4j-file-recursive");
+        final FileAppender appender = configuration.getAppender("File");
+        assertNotNull(appender);
+        assertEquals("target/path/to/the/logFile.txt", appender.getFileName());
+        //
+        final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
+        assertNotNull(loggerConfig);
+        assertEquals(Level.DEBUG, loggerConfig.getLevel());
+        final LoggerConfig rootLogger = configuration.getRootLogger();
+        assertEquals(Level.TRACE, rootLogger.getLevel());
+    }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -16,234 +16,100 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.FileSystemException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.log4j.layout.Log4j1XmlLayout;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.Layout;
-import org.apache.logging.log4j.core.appender.ConsoleAppender;
-import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
-import org.apache.logging.log4j.core.appender.FileAppender;
-import org.apache.logging.log4j.core.appender.NullAppender;
-import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.apache.logging.log4j.core.appender.rolling.CompositeTriggeringPolicy;
-import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
-import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
-import org.apache.logging.log4j.core.appender.rolling.SizeBasedTriggeringPolicy;
-import org.apache.logging.log4j.core.appender.rolling.TimeBasedTriggeringPolicy;
-import org.apache.logging.log4j.core.appender.rolling.TriggeringPolicy;
 import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.layout.HtmlLayout;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.Test;
 
-public class Log4j1ConfigurationFactoryTest {
+public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationTest {
 
-    static Configuration getConfiguration(final String configResource) throws URISyntaxException {
-        final URL configLocation = ClassLoader.getSystemResource(configResource);
-        assertNotNull(configResource, configLocation);
-        final Configuration configuration = new Log4j1ConfigurationFactory().getConfiguration(null, "test",
-                configLocation.toURI());
-        assertNotNull(configuration);
-        return configuration;
-    }
-
-    private Layout<?> testConsole(final String configResource) throws Exception {
-        final Configuration configuration = getConfiguration(configResource);
-        final String name = "Console";
-        final ConsoleAppender appender = configuration.getAppender(name);
-        assertNotNull("Missing appender '" + name + "' in configuration " + configResource + " → " + configuration,
-                appender);
-        assertEquals(Target.SYSTEM_ERR, appender.getTarget());
-        //
-        final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
-        assertNotNull(loggerConfig);
-        assertEquals(Level.DEBUG, loggerConfig.getLevel());
-        configuration.start();
-        configuration.stop();
-        return appender.getLayout();
-    }
-
-	private Layout<?> testFile(final String configResource) throws Exception {
-		final Configuration configuration = getConfiguration(configResource);
-		final FileAppender appender = configuration.getAppender("File");
-		assertNotNull(appender);
-		assertEquals("target/mylog.txt", appender.getFileName());
-		//
-		final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
-		assertNotNull(loggerConfig);
-		assertEquals(Level.DEBUG, loggerConfig.getLevel());
-		configuration.start();
-		configuration.stop();
-		return appender.getLayout();
+	Configuration getConfiguration(final String configResourcePrefix) throws URISyntaxException {
+		final String configResource = configResourcePrefix + ".properties";
+		final URL configLocation = ClassLoader.getSystemResource(configResource);
+		assertNotNull(configResource, configLocation);
+		final Configuration configuration = new Log4j1ConfigurationFactory().getConfiguration(null, "test", configLocation.toURI());
+		assertNotNull(configuration);
+		configuration.initialize();
+		return configuration;
 	}
 
+	@Override
 	@Test
 	public void testConsoleEnhancedPatternLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole(
-				"config-1.2/log4j-console-EnhancedPatternLayout.properties");
-		assertEquals("%d{ISO8601} [%t][%c] %-5p %properties %ndc: %m%n", layout.getConversionPattern());
+		super.testConsoleEnhancedPatternLayout();
 	}
 
+	@Override
 	@Test
 	public void testConsoleHtmlLayout() throws Exception {
-		final HtmlLayout layout = (HtmlLayout) testConsole("config-1.2/log4j-console-HtmlLayout.properties");
-		assertEquals("Headline", layout.getTitle());
-		assertTrue(layout.isLocationInfo());
+		super.testConsoleHtmlLayout();
 	}
 
+	@Override
 	@Test
 	public void testConsolePatternLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-PatternLayout.properties");
-		assertEquals("%d{ISO8601} [%t][%c] %-5p: %m%n", layout.getConversionPattern());
+		super.testConsolePatternLayout();
 	}
 
+	@Override
 	@Test
 	public void testConsoleSimpleLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-SimpleLayout.properties");
-		assertEquals("%level - %m%n", layout.getConversionPattern());
+		super.testConsoleSimpleLayout();
 	}
 
+	@Override
 	@Test
 	public void testConsoleTtccLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout.properties");
-		assertEquals("%r [%t] %p %notEmpty{%ndc }- %m%n", layout.getConversionPattern());
+		super.testConsoleTtccLayout();
 	}
 
+	@Override
 	@Test
 	public void testConsoleXmlLayout() throws Exception {
-		final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout.properties");
-		assertTrue(layout.isLocationInfo());
-		assertFalse(layout.isProperties());
+		super.testConsoleXmlLayout();
 	}
 
+	@Override
 	@Test
 	public void testFileSimpleLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testFile("config-1.2/log4j-file-SimpleLayout.properties");
-		assertEquals("%level - %m%n", layout.getConversionPattern());
+		super.testFileSimpleLayout();
 	}
 
+	@Override
 	@Test
 	public void testNullAppender() throws Exception {
-		final Configuration configuration = getConfiguration("config-1.2/log4j-NullAppender.properties");
-		final Appender appender = configuration.getAppender("NullAppender");
-		assertNotNull(appender);
-		assertEquals("NullAppender", appender.getName());
-		assertTrue(appender.getClass().getName(), appender instanceof NullAppender);
+		super.testNullAppender();
 	}
 
+	@Override
 	@Test
 	public void testRollingFileAppender() throws Exception {
-		testRollingFileAppender("config-1.2/log4j-RollingFileAppender.properties", "RFA", "target/hadoop.log.%i");
+		super.testRollingFileAppender();
 	}
 
+	@Override
 	@Test
 	public void testDailyRollingFileAppender() throws Exception {
-		testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender.properties", "DRFA", "target/hadoop.log%d{.yyyy-MM-dd}");
+		super.testDailyRollingFileAppender();
 	}
 
+	@Override
 	@Test
 	public void testRollingFileAppenderWithProperties() throws Exception {
-		testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props.properties", "RFA", "target/hadoop.log.%i");
+		super.testRollingFileAppenderWithProperties();
 	}
 
+	@Override
 	@Test
 	public void testSystemProperties1() throws Exception {
-        final String tempFileName = System.getProperty("java.io.tmpdir") + "/hadoop.log";
-        final Path tempFilePath = new File(tempFileName).toPath();
-        Files.deleteIfExists(tempFilePath);
-        try {
-            final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-1.properties");
-            final RollingFileAppender appender = configuration.getAppender("RFA");
-			appender.stop(10, TimeUnit.SECONDS);
-            // System.out.println("expected: " + tempFileName + " Actual: " + appender.getFileName());
-            assertEquals(tempFileName, appender.getFileName());
-        } finally {
-			try {
-				Files.deleteIfExists(tempFilePath);
-			} catch (final FileSystemException e) {
-				e.printStackTrace();
-			}
-        }
+		super.testSystemProperties1();
 	}
 
+	@Override
 	@Test
 	public void testSystemProperties2() throws Exception {
-		final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2.properties");
-		final RollingFileAppender appender = configuration.getAppender("RFA");
-		assertEquals("${java.io.tmpdir}/hadoop.log", appender.getFileName());
-		appender.stop(10, TimeUnit.SECONDS);
-		Path path = new File(appender.getFileName()).toPath();
-        Files.deleteIfExists(path);
-        path = new File("${java.io.tmpdir}").toPath();
-        Files.deleteIfExists(path);
-	}
-
-	private void testRollingFileAppender(final String configResource, final String name, final String filePattern) throws URISyntaxException {
-		final Configuration configuration = getConfiguration(configResource);
-		final Appender appender = configuration.getAppender(name);
-		assertNotNull(appender);
-		assertEquals(name, appender.getName());
-		assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
-		final RollingFileAppender rfa = (RollingFileAppender) appender;
-		assertEquals("target/hadoop.log", rfa.getFileName());
-		assertEquals(filePattern, rfa.getFilePattern());
-		final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
-		assertNotNull(triggeringPolicy);
-		assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
-		final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
-		final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
-		assertEquals(1, triggeringPolicies.length);
-		final TriggeringPolicy tp = triggeringPolicies[0];
-		assertTrue(tp.getClass().getName(), tp instanceof SizeBasedTriggeringPolicy);
-		final SizeBasedTriggeringPolicy sbtp = (SizeBasedTriggeringPolicy) tp;
-		assertEquals(256 * 1024 * 1024, sbtp.getMaxFileSize());
-		final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
-		assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
-		final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
-		assertEquals(20, drs.getMaxIndex());
-		configuration.start();
-		configuration.stop();
-	}
-
-	private void testDailyRollingFileAppender(final String configResource, final String name, final String filePattern) throws URISyntaxException {
-		final Configuration configuration = getConfiguration(configResource);
-		final Appender appender = configuration.getAppender(name);
-		assertNotNull(appender);
-		assertEquals(name, appender.getName());
-		assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
-		final RollingFileAppender rfa = (RollingFileAppender) appender;
-		assertEquals("target/hadoop.log", rfa.getFileName());
-		assertEquals(filePattern, rfa.getFilePattern());
-		final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
-		assertNotNull(triggeringPolicy);
-		assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
-		final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
-		final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
-		assertEquals(1, triggeringPolicies.length);
-		final TriggeringPolicy tp = triggeringPolicies[0];
-		assertTrue(tp.getClass().getName(), tp instanceof TimeBasedTriggeringPolicy);
-		final TimeBasedTriggeringPolicy tbtp = (TimeBasedTriggeringPolicy) tp;
-		assertEquals(1, tbtp.getInterval());
-		final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
-		assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
-		final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
-		assertEquals(Integer.MAX_VALUE, drs.getMaxIndex());
-		configuration.start();
-		configuration.stop();
+		super.testSystemProperties2();
 	}
 
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -112,4 +112,10 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
 		super.testSystemProperties2();
 	}
 
+    @Override
+    @Test
+    public void testRecursiveProperties() throws Exception {
+        super.testRecursiveProperties();
+    }
+
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -17,13 +17,16 @@
 package org.apache.log4j.config;
 
 import static org.junit.Assert.assertNotNull;
+
 import java.net.URISyntaxException;
 import java.net.URL;
+
 import org.apache.logging.log4j.core.config.Configuration;
 import org.junit.Test;
 
 public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationTest {
 
+	@Override
 	Configuration getConfiguration(final String configResourcePrefix) throws URISyntaxException {
 		final String configResource = configResourcePrefix + ".properties";
 		final URL configLocation = ClassLoader.getSystemResource(configResource);

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -19,8 +19,9 @@ package org.apache.log4j.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +37,8 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.apache.logging.log4j.core.filter.CompositeFilter;
 import org.apache.logging.log4j.core.filter.Filterable;
@@ -45,11 +48,23 @@ import org.junit.Test;
 /**
  * Test configuration from Properties.
  */
-public class PropertiesConfigurationTest {
+public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest {
 
     private static final String TEST_KEY = "log4j.test.tmpdir";
 
-    @Test
+	@Override
+	Configuration getConfiguration(String configResourcePrefix) throws IOException {
+		final String configResource = configResourcePrefix + ".properties";
+		final InputStream inputStream = ClassLoader.getSystemResourceAsStream(configResource);
+		final ConfigurationSource source = new ConfigurationSource(inputStream);
+		//final LoggerContext context = LoggerContext.getContext(false);
+		final Configuration configuration = new PropertiesConfigurationFactory().getConfiguration(null, source);
+		assertNotNull("No configuration created", configuration);
+		configuration.initialize();
+		return configuration;
+	}
+
+	@Test
     public void testConfigureNullPointerException() throws Exception {
         try (LoggerContext loggerContext = TestConfigurator.configure("target/test-classes/LOG4J2-3247.properties")) {
             // [LOG4J2-3247] configure() should not throw an NPE.
@@ -167,4 +182,81 @@ public class PropertiesConfigurationTest {
         }
     }
 
+	@Override
+	@Test
+	public void testConsoleEnhancedPatternLayout() throws Exception {
+		super.testConsoleEnhancedPatternLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleHtmlLayout() throws Exception {
+		super.testConsoleHtmlLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsolePatternLayout() throws Exception {
+		super.testConsolePatternLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleSimpleLayout() throws Exception {
+		super.testConsoleSimpleLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleTtccLayout() throws Exception {
+		super.testConsoleTtccLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleXmlLayout() throws Exception {
+		super.testConsoleXmlLayout();
+	}
+
+	@Override
+	@Test
+	public void testFileSimpleLayout() throws Exception {
+		super.testFileSimpleLayout();
+	}
+
+	@Override
+	@Test
+	public void testNullAppender() throws Exception {
+		super.testNullAppender();
+	}
+
+	@Override
+	@Test
+	public void testRollingFileAppender() throws Exception {
+		super.testRollingFileAppender();
+	}
+
+	@Override
+	@Test
+	public void testDailyRollingFileAppender() throws Exception {
+		super.testDailyRollingFileAppender();
+	}
+
+	@Override
+	@Test
+	public void testRollingFileAppenderWithProperties() throws Exception {
+		super.testRollingFileAppenderWithProperties();
+	}
+
+	@Override
+	@Test
+	public void testSystemProperties1() throws Exception {
+		super.testSystemProperties1();
+	}
+
+	@Override
+	@Test
+	public void testSystemProperties2() throws Exception {
+		super.testSystemProperties2();
+	}
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -259,4 +259,11 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
 	public void testSystemProperties2() throws Exception {
 		super.testSystemProperties2();
 	}
+
+    @Override
+    @Test
+    public void testRecursiveProperties() throws Exception {
+        super.testRecursiveProperties();
+    }
+
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -19,6 +19,7 @@ package org.apache.log4j.config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,7 +39,6 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
-import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.apache.logging.log4j.core.filter.CompositeFilter;
 import org.apache.logging.log4j.core.filter.Filterable;
@@ -52,19 +52,19 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
 
     private static final String TEST_KEY = "log4j.test.tmpdir";
 
-	@Override
-	Configuration getConfiguration(String configResourcePrefix) throws IOException {
-		final String configResource = configResourcePrefix + ".properties";
-		final InputStream inputStream = ClassLoader.getSystemResourceAsStream(configResource);
-		final ConfigurationSource source = new ConfigurationSource(inputStream);
-		//final LoggerContext context = LoggerContext.getContext(false);
-		final Configuration configuration = new PropertiesConfigurationFactory().getConfiguration(null, source);
-		assertNotNull("No configuration created", configuration);
-		configuration.initialize();
-		return configuration;
-	}
+    @Override
+    Configuration getConfiguration(String configResourcePrefix) throws IOException {
+        final String configResource = configResourcePrefix + ".properties";
+        final InputStream inputStream = ClassLoader.getSystemResourceAsStream(configResource);
+        final ConfigurationSource source = new ConfigurationSource(inputStream);
+        // final LoggerContext context = LoggerContext.getContext(false);
+        final Configuration configuration = new PropertiesConfigurationFactory().getConfiguration(null, source);
+        assertNotNull("No configuration created", configuration);
+        configuration.initialize();
+        return configuration;
+    }
 
-	@Test
+    @Test
     public void testConfigureNullPointerException() throws Exception {
         try (LoggerContext loggerContext = TestConfigurator.configure("target/test-classes/LOG4J2-3247.properties")) {
             // [LOG4J2-3247] configure() should not throw an NPE.
@@ -104,7 +104,7 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
             assertTrue(filter.getFilter() instanceof NeutralFilterFixture);
         }
     }
-    
+
     @Test
     public void testConsoleAppenderLevelRangeFilter() throws Exception {
         PluginManager.addPackage("org.apache.log4j.builders.filter");
@@ -182,83 +182,83 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
         }
     }
 
-	@Override
-	@Test
-	public void testConsoleEnhancedPatternLayout() throws Exception {
-		super.testConsoleEnhancedPatternLayout();
-	}
+    @Override
+    @Test
+    public void testConsoleEnhancedPatternLayout() throws Exception {
+        super.testConsoleEnhancedPatternLayout();
+    }
 
-	@Override
-	@Test
-	public void testConsoleHtmlLayout() throws Exception {
-		super.testConsoleHtmlLayout();
-	}
+    @Override
+    @Test
+    public void testConsoleHtmlLayout() throws Exception {
+        super.testConsoleHtmlLayout();
+    }
 
-	@Override
-	@Test
-	public void testConsolePatternLayout() throws Exception {
-		super.testConsolePatternLayout();
-	}
+    @Override
+    @Test
+    public void testConsolePatternLayout() throws Exception {
+        super.testConsolePatternLayout();
+    }
 
-	@Override
-	@Test
-	public void testConsoleSimpleLayout() throws Exception {
-		super.testConsoleSimpleLayout();
-	}
+    @Override
+    @Test
+    public void testConsoleSimpleLayout() throws Exception {
+        super.testConsoleSimpleLayout();
+    }
 
-	@Override
-	@Test
-	public void testConsoleTtccLayout() throws Exception {
-		super.testConsoleTtccLayout();
-	}
+    @Override
+    @Test
+    public void testConsoleTtccLayout() throws Exception {
+        super.testConsoleTtccLayout();
+    }
 
-	@Override
-	@Test
-	public void testConsoleXmlLayout() throws Exception {
-		super.testConsoleXmlLayout();
-	}
+    @Override
+    @Test
+    public void testConsoleXmlLayout() throws Exception {
+        super.testConsoleXmlLayout();
+    }
 
-	@Override
-	@Test
-	public void testFileSimpleLayout() throws Exception {
-		super.testFileSimpleLayout();
-	}
+    @Override
+    @Test
+    public void testFileSimpleLayout() throws Exception {
+        super.testFileSimpleLayout();
+    }
 
-	@Override
-	@Test
-	public void testNullAppender() throws Exception {
-		super.testNullAppender();
-	}
+    @Override
+    @Test
+    public void testNullAppender() throws Exception {
+        super.testNullAppender();
+    }
 
-	@Override
-	@Test
-	public void testRollingFileAppender() throws Exception {
-		super.testRollingFileAppender();
-	}
+    @Override
+    @Test
+    public void testRollingFileAppender() throws Exception {
+        super.testRollingFileAppender();
+    }
 
-	@Override
-	@Test
-	public void testDailyRollingFileAppender() throws Exception {
-		super.testDailyRollingFileAppender();
-	}
+    @Override
+    @Test
+    public void testDailyRollingFileAppender() throws Exception {
+        super.testDailyRollingFileAppender();
+    }
 
-	@Override
-	@Test
-	public void testRollingFileAppenderWithProperties() throws Exception {
-		super.testRollingFileAppenderWithProperties();
-	}
+    @Override
+    @Test
+    public void testRollingFileAppenderWithProperties() throws Exception {
+        super.testRollingFileAppenderWithProperties();
+    }
 
-	@Override
-	@Test
-	public void testSystemProperties1() throws Exception {
-		super.testSystemProperties1();
-	}
+    @Override
+    @Test
+    public void testSystemProperties1() throws Exception {
+        super.testSystemProperties1();
+    }
 
-	@Override
-	@Test
-	public void testSystemProperties2() throws Exception {
-		super.testSystemProperties2();
-	}
+    @Override
+    @Test
+    public void testSystemProperties2() throws Exception {
+        super.testSystemProperties2();
+    }
 
     @Override
     @Test

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
-import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.junit.Test;
 
 /**
@@ -44,19 +43,19 @@ import org.junit.Test;
  */
 public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
 
-	@Override
-	Configuration getConfiguration(String configResourcePrefix) throws URISyntaxException, IOException {
-		final String configResource = configResourcePrefix + ".xml";
-		final InputStream inputStream = ClassLoader.getSystemResourceAsStream(configResource);
-		final ConfigurationSource source = new ConfigurationSource(inputStream);
-		final LoggerContext context = LoggerContext.getContext(false);
-		final Configuration configuration = new XmlConfigurationFactory().getConfiguration(context, source);
-		assertNotNull("No configuration created", configuration);
-		configuration.initialize();
-		return configuration;
-	}
+    @Override
+    Configuration getConfiguration(String configResourcePrefix) throws URISyntaxException, IOException {
+        final String configResource = configResourcePrefix + ".xml";
+        final InputStream inputStream = ClassLoader.getSystemResourceAsStream(configResource);
+        final ConfigurationSource source = new ConfigurationSource(inputStream);
+        final LoggerContext context = LoggerContext.getContext(false);
+        final Configuration configuration = new XmlConfigurationFactory().getConfiguration(context, source);
+        assertNotNull("No configuration created", configuration);
+        configuration.initialize();
+        return configuration;
+    }
 
-	@Test
+    @Test
     public void testListAppender() throws Exception {
         final LoggerContext loggerContext = TestConfigurator.configure("target/test-classes/log4j1-list.xml");
         final Logger logger = LogManager.getLogger("test");
@@ -93,81 +92,81 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
         assertTrue("File A2 is empty", file.length() > 0);
     }
 
-	@Override
-	@Test
-	public void testConsoleEnhancedPatternLayout() throws Exception {
-		super.testConsoleEnhancedPatternLayout();
-	}
+    @Override
+    @Test
+    public void testConsoleEnhancedPatternLayout() throws Exception {
+        super.testConsoleEnhancedPatternLayout();
+    }
 
-	@Override
-	@Test
-	public void testConsoleHtmlLayout() throws Exception {
-		super.testConsoleHtmlLayout();
-	}
+    @Override
+    @Test
+    public void testConsoleHtmlLayout() throws Exception {
+        super.testConsoleHtmlLayout();
+    }
 
-	@Override
-	@Test
-	public void testConsolePatternLayout() throws Exception {
-		super.testConsolePatternLayout();
-	}
+    @Override
+    @Test
+    public void testConsolePatternLayout() throws Exception {
+        super.testConsolePatternLayout();
+    }
 
-	@Override
-	@Test
-	public void testConsoleSimpleLayout() throws Exception {
-		super.testConsoleSimpleLayout();
-	}
+    @Override
+    @Test
+    public void testConsoleSimpleLayout() throws Exception {
+        super.testConsoleSimpleLayout();
+    }
 
-	@Override
-	@Test
-	public void testConsoleTtccLayout() throws Exception {
-		super.testConsoleTtccLayout();
-	}
+    @Override
+    @Test
+    public void testConsoleTtccLayout() throws Exception {
+        super.testConsoleTtccLayout();
+    }
 
-	@Override
-	@Test
-	public void testConsoleXmlLayout() throws Exception {
-		super.testConsoleXmlLayout();
-	}
+    @Override
+    @Test
+    public void testConsoleXmlLayout() throws Exception {
+        super.testConsoleXmlLayout();
+    }
 
-	@Override
-	@Test
-	public void testFileSimpleLayout() throws Exception {
-		super.testFileSimpleLayout();
-	}
+    @Override
+    @Test
+    public void testFileSimpleLayout() throws Exception {
+        super.testFileSimpleLayout();
+    }
 
-	@Override
-	@Test
-	public void testNullAppender() throws Exception {
-		super.testNullAppender();
-	}
+    @Override
+    @Test
+    public void testNullAppender() throws Exception {
+        super.testNullAppender();
+    }
 
-	@Override
-	@Test
-	public void testRollingFileAppender() throws Exception {
-		super.testRollingFileAppender();
-	}
+    @Override
+    @Test
+    public void testRollingFileAppender() throws Exception {
+        super.testRollingFileAppender();
+    }
 
-	@Override
-	@Test
-	public void testDailyRollingFileAppender() throws Exception {
-		super.testDailyRollingFileAppender();
-	}
+    @Override
+    @Test
+    public void testDailyRollingFileAppender() throws Exception {
+        super.testDailyRollingFileAppender();
+    }
 
-	@Override
-	// Don't test: XML does not allow properties.
-	public void testRollingFileAppenderWithProperties() throws Exception {
-		super.testRollingFileAppenderWithProperties();
-	}
+    @Override
+    // Don't test: XML does not allow properties.
+    public void testRollingFileAppenderWithProperties() throws Exception {
+        super.testRollingFileAppenderWithProperties();
+    }
 
-	@Override
-	@Test
-	public void testSystemProperties1() throws Exception {
-		super.testSystemProperties1();
-	}
+    @Override
+    @Test
+    public void testSystemProperties1() throws Exception {
+        super.testSystemProperties1();
+    }
 
-	@Override
-	// Don't test: XML does not allow properties.
-	public void testSystemProperties2() throws Exception {
-		super.testSystemProperties2();
-	}
+    @Override
+    // Don't test: XML does not allow properties.
+    public void testSystemProperties2() throws Exception {
+        super.testSystemProperties2();
+    }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
@@ -28,17 +31,32 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.log4j.bridge.AppenderAdapter;
 import org.apache.log4j.spi.LoggingEvent;
+import org.apache.log4j.xml.XmlConfigurationFactory;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.junit.Test;
 
 /**
  * Test configuration from XML.
  */
-public class XmlConfigurationTest {
+public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
 
-    @Test
+	@Override
+	Configuration getConfiguration(String configResourcePrefix) throws URISyntaxException, IOException {
+		final String configResource = configResourcePrefix + ".xml";
+		final InputStream inputStream = ClassLoader.getSystemResourceAsStream(configResource);
+		final ConfigurationSource source = new ConfigurationSource(inputStream);
+		final LoggerContext context = LoggerContext.getContext(false);
+		final Configuration configuration = new XmlConfigurationFactory().getConfiguration(context, source);
+		assertNotNull("No configuration created", configuration);
+		configuration.initialize();
+		return configuration;
+	}
+
+	@Test
     public void testListAppender() throws Exception {
         final LoggerContext loggerContext = TestConfigurator.configure("target/test-classes/log4j1-list.xml");
         final Logger logger = LogManager.getLogger("test");
@@ -75,4 +93,81 @@ public class XmlConfigurationTest {
         assertTrue("File A2 is empty", file.length() > 0);
     }
 
+	@Override
+	@Test
+	public void testConsoleEnhancedPatternLayout() throws Exception {
+		super.testConsoleEnhancedPatternLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleHtmlLayout() throws Exception {
+		super.testConsoleHtmlLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsolePatternLayout() throws Exception {
+		super.testConsolePatternLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleSimpleLayout() throws Exception {
+		super.testConsoleSimpleLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleTtccLayout() throws Exception {
+		super.testConsoleTtccLayout();
+	}
+
+	@Override
+	@Test
+	public void testConsoleXmlLayout() throws Exception {
+		super.testConsoleXmlLayout();
+	}
+
+	@Override
+	@Test
+	public void testFileSimpleLayout() throws Exception {
+		super.testFileSimpleLayout();
+	}
+
+	@Override
+	@Test
+	public void testNullAppender() throws Exception {
+		super.testNullAppender();
+	}
+
+	@Override
+	@Test
+	public void testRollingFileAppender() throws Exception {
+		super.testRollingFileAppender();
+	}
+
+	@Override
+	@Test
+	public void testDailyRollingFileAppender() throws Exception {
+		super.testDailyRollingFileAppender();
+	}
+
+	@Override
+	// Don't test: XML does not allow properties.
+	public void testRollingFileAppenderWithProperties() throws Exception {
+		super.testRollingFileAppenderWithProperties();
+	}
+
+	@Override
+	@Test
+	public void testSystemProperties1() throws Exception {
+		super.testSystemProperties1();
+	}
+
+	@Override
+	// Don't test: XML does not allow properties.
+	public void testSystemProperties2() throws Exception {
+		super.testSystemProperties2();
+	}
 }

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-DailyRollingFileAppender.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-DailyRollingFileAppender.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="DRFA" class="org.apache.log4j.DailyRollingFileAppender">
+    <param name="File" value="target/hadoop.log" />
+    <param name="DatePattern" value=".yyyy-MM-dd" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} %p %c: %m%n" />
+    </layout>
+  </appender>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="DRFA" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-NullAppender.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-NullAppender.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="NullAppender" class="org.apache.log4j.varia.NullAppender" />
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="NullAppender" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-RollingFileAppender.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-RollingFileAppender.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
-  <appender name="RFA" class="org.apache.log4j.DailyRollingFileAppender">
+  <appender name="RFA" class="org.apache.log4j.RollingFileAppender">
     <param name="File" value="target/hadoop.log" />
     <param name="MaxFileSize" value="256MB" />
     <param name="MaxBackupIndex" value="20" />

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-RollingFileAppender.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-RollingFileAppender.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="RFA" class="org.apache.log4j.DailyRollingFileAppender">
+    <param name="File" value="target/hadoop.log" />
+    <param name="MaxFileSize" value="256MB" />
+    <param name="MaxBackupIndex" value="20" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} %p %c: %m%n" />
+    </layout>
+  </appender>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="RFA" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-EnhancedPatternLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-EnhancedPatternLayout.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="target" value="System.err" />
+    <layout class="org.apache.log4j.EnhancedPatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} [%t][%c] %-5p %X %x: %m%n" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-HtmlLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-HtmlLayout.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="target" value="System.err" />
+    <layout class="org.apache.log4j.HTMLLayout">
+      <param name="Title" value="Headline" />
+      <param name="LocationInfo" value="true" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-PatternLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-PatternLayout.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} [%t][%c] %-5p: %m%n" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-SimpleLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-SimpleLayout.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.SimpleLayout" />
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-TTCCLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-TTCCLayout.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.TTCCLayout">
+      <param name="ThreadPrinting" value="true" />
+      <param name="CategoryPrefixing" value="false" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-XmlLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-XmlLayout.xml
@@ -3,7 +3,7 @@
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
   <appender name="Console" class="org.apache.log4j.ConsoleAppender">
     <param name="Target" value="System.err" />
-    <layout class="org.apache.log4j.XmlLayout">
+    <layout class="org.apache.log4j.xml.XmlLayout">
       <param name="LocationInfo" value="true" />
       <param name="Properties" value="false" />
     </layout>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-XmlLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-XmlLayout.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.XmlLayout">
+      <param name="LocationInfo" value="true" />
+      <param name="Properties" value="false" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-SimpleLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-SimpleLayout.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="File" class="org.apache.log4j.FileAppender">
+    <param name="File" value="target/mylog.txt" />
+    <layout class="org.apache.log4j.SimpleLayout" />
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="File" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-recursive.properties
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-recursive.properties
@@ -5,7 +5,7 @@
 
 log4j.rootLogger=TRACE, File
 
-test.logFile0=${test.logFile1}/${test.logfile2}
+test.logFile0=${test.logFile1}/${test.logFile2}
 test.logFile1=${test.logFile3}/${test.logFile4}
 test.logFile2=${test.logFile5}/${test.logFile6}
 test.logFile3=path

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-recursive.properties
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-recursive.properties
@@ -1,0 +1,25 @@
+###############################################################################
+#
+# Log4J 1.2 Configuration.
+#
+
+log4j.rootLogger=TRACE, File
+
+test.logFile0=${test.logFile1}/${test.logfile2}
+test.logFile1=${test.logFile3}/${test.logFile4}
+test.logFile2=${test.logFile5}/${test.logFile6}
+test.logFile3=path
+test.logFile4=to
+test.logFile5=the
+test.logFile6=logFile.txt
+
+##############################################################################
+#
+# The Console log
+#
+
+log4j.appender.File=org.apache.log4j.FileAppender
+log4j.appender.File.File=target/${test.logFile0}
+log4j.appender.File.layout=org.apache.log4j.SimpleLayout
+
+log4j.logger.com.example.foo = DEBUG

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-system-properties-1.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-system-properties-1.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="RFA" class="org.apache.log4j.DailyRollingFileAppender">
+    <param name="File" value="${java.io.tmpdir}/hadoop.log" />
+  </appender>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="RFA" />
+  </root>
+</log4j:configuration>


### PR DESCRIPTION
`Log4j1ConfigurationFactoryTest` contains many interesting tests that fail if we apply them to the `PropertiesConfigurationFactory` and `XmlConfigurationFactory` that replaced `Log4j1ConfigurationFactory`.

This PR adapts those tests to the other two factories and provides 11 test XML configuration files. It was split from #704 for simpler analysis. Obviously many of the new tests **fail**.