### PR TITLE
Allows Java-style property names in Log4j 1.x XML configuration

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
@@ -83,7 +83,7 @@ public abstract class AbstractBuilder {
     }
 
     protected String getNameAttribute(Element element) {
-        return element.getAttribute(NAME_ATTR);
+        return capitalize(element.getAttribute(NAME_ATTR));
     }
 
     protected String getValueAttribute(Element element) {

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
@@ -83,7 +83,16 @@ public abstract class AbstractBuilder {
     }
 
     protected String getNameAttribute(Element element) {
-        return capitalize(element.getAttribute(NAME_ATTR));
+        return element.getAttribute(NAME_ATTR);
+    }
+
+    /**
+     * Normalized version of the "name" attribute of the &lt;param&gt; tag.
+     * @param element
+     * @return
+     */
+    protected String getNormalizedNameAttribute(Element element) {
+        return capitalize(getNameAttribute(element));
     }
 
     protected String getValueAttribute(Element element) {
@@ -151,4 +160,11 @@ public abstract class AbstractBuilder {
         return value == null ? null : value.toLowerCase(Locale.ROOT);
     }
 
+    private String capitalize(final String value) {
+        if (value == null || value.length() == 0)
+            return value;
+        char[] chars = value.toCharArray();
+        chars[0] = Character.toUpperCase(chars[0]);
+        return new String(chars);
+    }
 }

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
@@ -82,14 +82,26 @@ public abstract class AbstractBuilder {
         return value == null ? defaultValue : value;
     }
 
+    /**
+     * Returns the value of the "name" attribute.
+     * 
+     * @param element
+     *            an XML element
+     * @return the value of the "name" attribute
+     */
     protected String getNameAttribute(Element element) {
         return element.getAttribute(NAME_ATTR);
     }
 
     /**
      * Normalized version of the "name" attribute of the &lt;param&gt; tag.
+     * Since Log4j 1.x accepts component property names in both capitalized
+     * ('InfoLocation') and Java-style ('infoLocation') format, we return the
+     * capitalized form.
+     * 
      * @param element
-     * @return
+     *            an XML element
+     * @return a normalized attribute value
      */
     protected String getNormalizedNameAttribute(Element element) {
         return capitalize(getNameAttribute(element));

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/AsyncAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/AsyncAppenderBuilder.java
@@ -78,7 +78,7 @@ public class AsyncAppenderBuilder extends AbstractBuilder implements AppenderBui
                     }
                     break;
                 case PARAM_TAG: {
-                    switch (getNameAttribute(currentElement)) {
+                    switch (getNormalizedNameAttribute(currentElement)) {
                         case BUFFER_SIZE_PARAM: {
                             String value = getValueAttribute(currentElement);
                             if (value == null) {

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/ConsoleAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/ConsoleAppenderBuilder.java
@@ -51,7 +51,7 @@ import org.w3c.dom.Element;
 public class ConsoleAppenderBuilder extends AbstractBuilder implements AppenderBuilder {
     private static final String SYSTEM_OUT = "System.out";
     private static final String SYSTEM_ERR = "System.err";
-    private static final String TARGET = "target";
+    private static final String TARGET = "Target";
 
     private static final Logger LOGGER = StatusLogger.getLogger();
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/ConsoleAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/ConsoleAppenderBuilder.java
@@ -78,7 +78,7 @@ public class ConsoleAppenderBuilder extends AbstractBuilder implements AppenderB
                     filters.get().add(config.parseFilters(currentElement));
                     break;
                 case PARAM_TAG: {
-                    switch (getNameAttribute(currentElement)) {
+                    switch (getNormalizedNameAttribute(currentElement)) {
                         case TARGET: {
                             String value = getValueAttribute(currentElement);
                             if (value == null) {

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/DailyRollingFileAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/DailyRollingFileAppenderBuilder.java
@@ -85,7 +85,7 @@ public class DailyRollingFileAppenderBuilder extends AbstractBuilder implements 
                     filter.set(config.parseFilters(currentElement));
                     break;
                 case PARAM_TAG: {
-                    switch (getNameAttribute(currentElement)) {
+                    switch (getNormalizedNameAttribute(currentElement)) {
                         case FILE_PARAM:
                             fileName.set(getValueAttribute(currentElement));
                             break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/FileAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/FileAppenderBuilder.java
@@ -79,7 +79,7 @@ public class FileAppenderBuilder extends AbstractBuilder implements AppenderBuil
                     filter.set(config.parseFilters(currentElement));
                     break;
                 case PARAM_TAG: {
-                    switch (getNameAttribute(currentElement)) {
+                    switch (getNormalizedNameAttribute(currentElement)) {
                         case FILE_PARAM:
                             fileName.set(getValueAttribute(currentElement));
                             break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/RollingFileAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/RollingFileAppenderBuilder.java
@@ -88,7 +88,7 @@ public class RollingFileAppenderBuilder extends AbstractBuilder implements Appen
                     filter.set(config.parseFilters(currentElement));
                     break;
                 case PARAM_TAG: {
-                    switch (getNameAttribute(currentElement)) {
+                    switch (getNormalizedNameAttribute(currentElement)) {
                         case FILE_PARAM:
                             fileName.set(getValueAttribute(currentElement));
                             break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/SyslogAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/SyslogAppenderBuilder.java
@@ -88,7 +88,7 @@ public class SyslogAppenderBuilder extends AbstractBuilder implements AppenderBu
                     filter.set(config.parseFilters(currentElement));
                     break;
                 case PARAM_TAG: {
-                    switch (getNameAttribute(currentElement)) {
+                    switch (getNormalizedNameAttribute(currentElement)) {
                         case SYSLOG_HOST_PARAM: {
                             host.set(getValueAttribute(currentElement));
                             break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/SyslogAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/SyslogAppenderBuilder.java
@@ -60,7 +60,7 @@ public class SyslogAppenderBuilder extends AbstractBuilder implements AppenderBu
     private static final Logger LOGGER = StatusLogger.getLogger();
     private static final String FACILITY_PARAM = "Facility";
     private static final String SYSLOG_HOST_PARAM = "SyslogHost";
-    private static final String PROTOCOL_PARAM = "protocol";
+    private static final String PROTOCOL_PARAM = "Protocol";
 
 
     public SyslogAppenderBuilder() {

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/LevelMatchFilterBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/LevelMatchFilterBuilder.java
@@ -58,7 +58,7 @@ public class LevelMatchFilterBuilder extends AbstractBuilder implements FilterBu
         final AtomicBoolean acceptOnMatch = new AtomicBoolean();
         forEachElement(filterElement.getElementsByTagName("param"), currentElement -> {
             if (currentElement.getTagName().equals("param")) {
-                switch (getNameAttribute(currentElement)) {
+                switch (getNormalizedNameAttribute(currentElement)) {
                     case LEVEL:
                         level.set(getValueAttribute(currentElement));
                         break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/LevelRangeFilterBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/LevelRangeFilterBuilder.java
@@ -60,7 +60,7 @@ public class LevelRangeFilterBuilder extends AbstractBuilder implements FilterBu
         final AtomicBoolean acceptOnMatch = new AtomicBoolean();
         forEachElement(filterElement.getElementsByTagName("param"), currentElement -> {
             if (currentElement.getTagName().equals("param")) {
-                switch (getNameAttribute(currentElement)) {
+                switch (getNormalizedNameAttribute(currentElement)) {
                     case LEVEL_MAX:
                         levelMax.set(getValueAttribute(currentElement));
                         break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/StringMatchFilterBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/StringMatchFilterBuilder.java
@@ -49,7 +49,7 @@ public class StringMatchFilterBuilder extends AbstractBuilder implements FilterB
         final AtomicReference<String> text = new AtomicReference<>();
         forEachElement(filterElement.getElementsByTagName("param"), currentElement -> {
             if (currentElement.getTagName().equals("param")) {
-                switch (getNameAttribute(currentElement)) {
+                switch (getNormalizedNameAttribute(currentElement)) {
                     case STRING_TO_MATCH:
                         text.set(getValueAttribute(currentElement));
                         break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/layout/TTCCLayoutBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/layout/TTCCLayoutBuilder.java
@@ -66,7 +66,7 @@ public class TTCCLayoutBuilder extends AbstractBuilder implements LayoutBuilder 
         final AtomicReference<String> timezone = new AtomicReference<>();
         forEachElement(layoutElement.getElementsByTagName("param"), currentElement -> {
             if (currentElement.getTagName().equals(PARAM_TAG)) {
-                switch (getNameAttribute(currentElement)) {
+                switch (getNormalizedNameAttribute(currentElement)) {
                     case THREAD_PRINTING_PARAM:
                         threadPrinting.set(Boolean.parseBoolean(getValueAttribute(currentElement)));
                         break;

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.log4j.config;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import org.apache.logging.log4j.core.config.Configuration;
+
+public abstract class AbstractLog4j1ConfigurationTest {
+
+    abstract Configuration getConfiguration(String configResourcePrefix) throws URISyntaxException, IOException;
+
+}

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -16,13 +16,43 @@
  */
 package org.apache.log4j.config;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
 
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.layout.PatternLayout;
 
 public abstract class AbstractLog4j1ConfigurationTest {
 
     abstract Configuration getConfiguration(String configResourcePrefix) throws URISyntaxException, IOException;
 
+    public void testConsoleCapitalization() throws Exception {
+        final Configuration config = getConfiguration("config-1.2/log4j-capitalization");
+        final Appender capitalized = config.getAppender("ConsoleCapitalized");
+        assertNotNull(capitalized);
+        assertEquals(capitalized.getClass(), ConsoleAppender.class);
+        final Appender javaStyle = config.getAppender("ConsoleJavaStyle");
+        assertNotNull(javaStyle);
+        assertEquals(javaStyle.getClass(), ConsoleAppender.class);
+        testConsoleAppender((ConsoleAppender) capitalized, (ConsoleAppender) javaStyle);
+    }
+
+    private void testConsoleAppender(ConsoleAppender expected, ConsoleAppender actual) {
+        assertEquals("immediateFlush", expected.getImmediateFlush(), actual.getImmediateFlush());
+        assertEquals("target", expected.getTarget(), actual.getTarget());
+        assertEquals("layoutClass", expected.getLayout().getClass(), actual.getLayout().getClass());
+        if (expected.getLayout() instanceof PatternLayout) {
+            patternLayoutEquals((PatternLayout) expected.getLayout(), (PatternLayout) actual.getLayout());
+        }
+    }
+
+    private void patternLayoutEquals(PatternLayout expected, PatternLayout actual) {
+        assertEquals(expected.getCharset(), actual.getCharset());
+        assertEquals(expected.getConversionPattern(), actual.getConversionPattern());
+    }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -249,4 +249,9 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
 		configuration.stop();
 	}
 
+    @Override
+    @Test
+    public void testConsoleCapitalization() throws Exception {
+        super.testConsoleCapitalization();
+    }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -28,7 +27,6 @@ import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.log4j.layout.Log4j1XmlLayout;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
@@ -94,51 +92,51 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
 
     @Test
     public void testConsoleEnhancedPatternLayout() throws Exception {
-        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-EnhancedPatternLayout.properties");
+       final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-EnhancedPatternLayout");
         assertEquals("%d{ISO8601} [%t][%c] %-5p %properties %ndc: %m%n", layout.getConversionPattern());
     }
 
     @Test
     public void testConsoleHtmlLayout() throws Exception {
-        final HtmlLayout layout = (HtmlLayout) testConsole("config-1.2/log4j-console-HtmlLayout.properties");
+       final HtmlLayout layout = (HtmlLayout) testConsole("config-1.2/log4j-console-HtmlLayout");
         assertEquals("Headline", layout.getTitle());
         assertTrue(layout.isLocationInfo());
     }
 
     @Test
     public void testConsolePatternLayout() throws Exception {
-        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-PatternLayout.properties");
+       final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-PatternLayout");
         assertEquals("%d{ISO8601} [%t][%c] %-5p: %m%n", layout.getConversionPattern());
     }
 
     @Test
     public void testConsoleSimpleLayout() throws Exception {
-        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-SimpleLayout.properties");
+       final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-SimpleLayout");
         assertEquals("%level - %m%n", layout.getConversionPattern());
     }
 
     @Test
     public void testConsoleTtccLayout() throws Exception {
-        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout.properties");
+       final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout");
         assertEquals("%r [%t] %p %notEmpty{%ndc }- %m%n", layout.getConversionPattern());
     }
 
     @Test
     public void testConsoleXmlLayout() throws Exception {
-        final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout.properties");
+       final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout");
         assertTrue(layout.isLocationInfo());
         assertFalse(layout.isProperties());
     }
 
     @Test
     public void testFileSimpleLayout() throws Exception {
-        final PatternLayout layout = (PatternLayout) testFile("config-1.2/log4j-file-SimpleLayout.properties");
+       final PatternLayout layout = (PatternLayout) testFile("config-1.2/log4j-file-SimpleLayout");
         assertEquals("%level - %m%n", layout.getConversionPattern());
     }
 
     @Test
     public void testNullAppender() throws Exception {
-        final Configuration configuration = getConfiguration("config-1.2/log4j-NullAppender.properties");
+       final Configuration configuration = getConfiguration("config-1.2/log4j-NullAppender");
         final Appender appender = configuration.getAppender("NullAppender");
         assertNotNull(appender);
         assertEquals("NullAppender", appender.getName());
@@ -147,17 +145,17 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
 
     @Test
     public void testRollingFileAppender() throws Exception {
-        testRollingFileAppender("config-1.2/log4j-RollingFileAppender.properties", "RFA", "target/hadoop.log.%i");
+       testRollingFileAppender("config-1.2/log4j-RollingFileAppender", "RFA", "target/hadoop.log.%i");
     }
 
     @Test
     public void testDailyRollingFileAppender() throws Exception {
-        testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender.properties", "DRFA", "target/hadoop.log%d{.yyyy-MM-dd}");
+       testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender", "DRFA", "target/hadoop.log%d{.yyyy-MM-dd}");
     }
 
     @Test
     public void testRollingFileAppenderWithProperties() throws Exception {
-        testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props.properties", "RFA", "target/hadoop.log.%i");
+       testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props", "RFA", "target/hadoop.log.%i");
     }
 
     @Test
@@ -182,7 +180,7 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
 
     @Test
     public void testSystemProperties2() throws Exception {
-        final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2.properties");
+       final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2");
         final RollingFileAppender appender = configuration.getAppender("RFA");
         assertEquals("${java.io.tmpdir}/hadoop.log", appender.getFileName());
         appender.stop(10, TimeUnit.SECONDS);

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -50,9 +50,10 @@ import org.apache.logging.log4j.core.layout.HtmlLayout;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.Test;
 
-public class Log4j1ConfigurationFactoryTest {
+public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationTest {
 
-    static Configuration getConfiguration(final String configResource) throws URISyntaxException {
+    @Override
+    protected Configuration getConfiguration(final String configResource) throws URISyntaxException {
         final URL configLocation = ClassLoader.getSystemResource(configResource);
         assertNotNull(configResource, configLocation);
         final Configuration configuration = new Log4j1ConfigurationFactory().getConfiguration(null, "test",

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -52,9 +52,11 @@ import org.junit.Test;
 
 public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationTest {
 
+    private static final String SUFFIX = ".properties";
+
     @Override
     protected Configuration getConfiguration(final String configResource) throws URISyntaxException {
-        final URL configLocation = ClassLoader.getSystemResource(configResource);
+        final URL configLocation = ClassLoader.getSystemResource(configResource + SUFFIX);
         assertNotNull(configResource, configLocation);
         final Configuration configuration = new Log4j1ConfigurationFactory().getConfiguration(null, "test",
                 configLocation.toURI());
@@ -94,52 +96,51 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
 
 	@Test
 	public void testConsoleEnhancedPatternLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole(
-				"config-1.2/log4j-console-EnhancedPatternLayout.properties");
+        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-EnhancedPatternLayout");
 		assertEquals("%d{ISO8601} [%t][%c] %-5p %properties %ndc: %m%n", layout.getConversionPattern());
 	}
 
 	@Test
 	public void testConsoleHtmlLayout() throws Exception {
-		final HtmlLayout layout = (HtmlLayout) testConsole("config-1.2/log4j-console-HtmlLayout.properties");
+        final HtmlLayout layout = (HtmlLayout) testConsole("config-1.2/log4j-console-HtmlLayout");
 		assertEquals("Headline", layout.getTitle());
 		assertTrue(layout.isLocationInfo());
 	}
 
 	@Test
 	public void testConsolePatternLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-PatternLayout.properties");
+        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-PatternLayout");
 		assertEquals("%d{ISO8601} [%t][%c] %-5p: %m%n", layout.getConversionPattern());
 	}
 
 	@Test
 	public void testConsoleSimpleLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-SimpleLayout.properties");
+        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-SimpleLayout");
 		assertEquals("%level - %m%n", layout.getConversionPattern());
 	}
 
 	@Test
 	public void testConsoleTtccLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout.properties");
+        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout");
 		assertEquals("%r [%t] %p %notEmpty{%ndc }- %m%n", layout.getConversionPattern());
 	}
 
 	@Test
 	public void testConsoleXmlLayout() throws Exception {
-		final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout.properties");
+        final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout");
 		assertTrue(layout.isLocationInfo());
 		assertFalse(layout.isProperties());
 	}
 
 	@Test
 	public void testFileSimpleLayout() throws Exception {
-		final PatternLayout layout = (PatternLayout) testFile("config-1.2/log4j-file-SimpleLayout.properties");
+        final PatternLayout layout = (PatternLayout) testFile("config-1.2/log4j-file-SimpleLayout");
 		assertEquals("%level - %m%n", layout.getConversionPattern());
 	}
 
 	@Test
 	public void testNullAppender() throws Exception {
-		final Configuration configuration = getConfiguration("config-1.2/log4j-NullAppender.properties");
+        final Configuration configuration = getConfiguration("config-1.2/log4j-NullAppender");
 		final Appender appender = configuration.getAppender("NullAppender");
 		assertNotNull(appender);
 		assertEquals("NullAppender", appender.getName());
@@ -148,17 +149,18 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
 
 	@Test
 	public void testRollingFileAppender() throws Exception {
-		testRollingFileAppender("config-1.2/log4j-RollingFileAppender.properties", "RFA", "target/hadoop.log.%i");
+        testRollingFileAppender("config-1.2/log4j-RollingFileAppender", "RFA", "target/hadoop.log.%i");
 	}
 
 	@Test
 	public void testDailyRollingFileAppender() throws Exception {
-		testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender.properties", "DRFA", "target/hadoop.log%d{.yyyy-MM-dd}");
+        testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender", "DRFA",
+                "target/hadoop.log%d{.yyyy-MM-dd}");
 	}
 
 	@Test
 	public void testRollingFileAppenderWithProperties() throws Exception {
-		testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props.properties", "RFA", "target/hadoop.log.%i");
+        testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props", "RFA", "target/hadoop.log.%i");
 	}
 
 	@Test
@@ -167,7 +169,7 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
         final Path tempFilePath = new File(tempFileName).toPath();
         Files.deleteIfExists(tempFilePath);
         try {
-            final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-1.properties");
+            final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-1");
             final RollingFileAppender appender = configuration.getAppender("RFA");
 			appender.stop(10, TimeUnit.SECONDS);
             // System.out.println("expected: " + tempFileName + " Actual: " + appender.getFileName());
@@ -183,7 +185,7 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
 
 	@Test
 	public void testSystemProperties2() throws Exception {
-		final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2.properties");
+        final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2");
 		final RollingFileAppender appender = configuration.getAppender("RFA");
 		assertEquals("${java.io.tmpdir}/hadoop.log", appender.getFileName());
 		appender.stop(10, TimeUnit.SECONDS);

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -21,6 +21,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
@@ -31,11 +34,13 @@ import org.apache.log4j.bridge.AppenderAdapter;
 import org.apache.log4j.bridge.FilterAdapter;
 import org.apache.log4j.bridge.FilterWrapper;
 import org.apache.log4j.spi.LoggingEvent;
+import org.apache.log4j.xml.XmlConfigurationFactory;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.apache.logging.log4j.core.filter.CompositeFilter;
 import org.apache.logging.log4j.core.filter.Filterable;
@@ -45,9 +50,22 @@ import org.junit.Test;
 /**
  * Test configuration from Properties.
  */
-public class PropertiesConfigurationTest {
+public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest {
 
     private static final String TEST_KEY = "log4j.test.tmpdir";
+    private static final String SUFFIX = ".properties";
+
+    @Override
+    Configuration getConfiguration(String configResourcePrefix) throws URISyntaxException, IOException {
+        final String configResource = configResourcePrefix + SUFFIX;
+        final InputStream inputStream = ClassLoader.getSystemResourceAsStream(configResource);
+        final ConfigurationSource source = new ConfigurationSource(inputStream);
+        final LoggerContext context = LoggerContext.getContext(false);
+        final Configuration configuration = new XmlConfigurationFactory().getConfiguration(context, source);
+        assertNotNull("No configuration created", configuration);
+        configuration.initialize();
+        return configuration;
+    }
 
     @Test
     public void testConfigureNullPointerException() throws Exception {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -184,4 +184,10 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
         }
     }
 
+    @Override
+    @Test
+    public void testConsoleCapitalization() throws Exception {
+        super.testConsoleCapitalization();
+    }
+
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -34,7 +34,6 @@ import org.apache.log4j.bridge.AppenderAdapter;
 import org.apache.log4j.bridge.FilterAdapter;
 import org.apache.log4j.bridge.FilterWrapper;
 import org.apache.log4j.spi.LoggingEvent;
-import org.apache.log4j.xml.XmlConfigurationFactory;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -61,7 +60,7 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
         final InputStream inputStream = ClassLoader.getSystemResourceAsStream(configResource);
         final ConfigurationSource source = new ConfigurationSource(inputStream);
         final LoggerContext context = LoggerContext.getContext(false);
-        final Configuration configuration = new XmlConfigurationFactory().getConfiguration(context, source);
+        final Configuration configuration = new PropertiesConfigurationFactory().getConfiguration(context, source);
         assertNotNull("No configuration created", configuration);
         configuration.initialize();
         return configuration;

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -93,4 +93,11 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
         assertTrue("File A2 was not created", file.exists());
         assertTrue("File A2 is empty", file.length() > 0);
     }
+
+    @Override
+    @Test
+    public void testConsoleCapitalization() throws Exception {
+        super.testConsoleCapitalization();
+    }
+
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
@@ -28,15 +31,31 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.log4j.bridge.AppenderAdapter;
 import org.apache.log4j.spi.LoggingEvent;
+import org.apache.log4j.xml.XmlConfigurationFactory;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.junit.Test;
 
 /**
  * Test configuration from XML.
  */
-public class XmlConfigurationTest {
+public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
+
+    private static final String SUFFIX = ".xml";
+
+    @Override
+    Configuration getConfiguration(String configResourcePrefix) throws URISyntaxException, IOException {
+        final String configResource = configResourcePrefix + SUFFIX;
+        final InputStream inputStream = ClassLoader.getSystemResourceAsStream(configResource);
+        final ConfigurationSource source = new ConfigurationSource(inputStream);
+        final LoggerContext context = LoggerContext.getContext(false);
+        final Configuration configuration = new XmlConfigurationFactory().getConfiguration(context, source);
+        assertNotNull("No configuration created", configuration);
+        configuration.initialize();
+        return configuration;
+    }
 
     @Test
     public void testListAppender() throws Exception {
@@ -74,5 +93,4 @@ public class XmlConfigurationTest {
         assertTrue("File A2 was not created", file.exists());
         assertTrue("File A2 is empty", file.length() > 0);
     }
-
 }

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-capitalization.properties
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-capitalization.properties
@@ -1,0 +1,27 @@
+###############################################################################
+#
+# Log4J 1.2 Configuration.
+#
+
+log4j.rootLogger=TRACE, ConsoleCapitalized, ConsoleJavaStyle
+
+##############################################################################
+#
+# The Console log
+#
+
+log4j.appender.ConsoleCapitalized=org.apache.log4j.ConsoleAppender
+log4j.appender.ConsoleCapitalized.Encoding=ISO-8859-1
+log4j.appender.ConsoleCapitalized.Follow=true
+log4j.appender.ConsoleCapitalized.ImmediateFlush=false
+log4j.appender.ConsoleCapitalized.Target=System.err
+log4j.appender.ConsoleCapitalized.layout=org.apache.log4j.PatternLayout
+log4j.appender.ConsoleCapitalized.layout.ConversionPattern=%d{ISO8601} [%t][%c] %-5p: %m%n
+
+log4j.appender.ConsoleJavaStyle=org.apache.log4j.ConsoleAppender
+log4j.appender.ConsoleJavaStyle.Encoding=ISO-8859-1
+log4j.appender.ConsoleJavaStyle.Follow=true
+log4j.appender.ConsoleJavaStyle.ImmediateFlush=false
+log4j.appender.ConsoleJavaStyle.Target=System.err
+log4j.appender.ConsoleJavaStyle.layout=org.apache.log4j.PatternLayout
+log4j.appender.ConsoleJavaStyle.layout.ConversionPattern=%d{ISO8601} [%t][%c] %-5p: %m%n

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-capitalization.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-capitalization.xml
@@ -1,0 +1,28 @@
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="ConsoleCapitalized" class="org.apache.log4j.ConsoleAppender">
+    <param name="Encoding" value="ISO-8859-1" />
+    <param name="Follow" value="true" />
+    <param name="ImmediateFlush" value="false" />
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} [%t][%c] %-5p: %m%n" />
+    </layout>
+  </appender>
+
+  <appender name="ConsoleJavaStyle" class="org.apache.log4j.ConsoleAppender">
+    <param name="encoding" value="ISO-8859-1" />
+    <param name="follow" value="true" />
+    <param name="immediateFlush" value="false" />
+    <param name="target" value="System.err" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="conversionPattern" value="%d{ISO8601} [%t][%c] %-5p: %m%n" />
+    </layout>
+  </appender>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="ConsoleCapitalized" />
+    <appender-ref ref="ConsoleJavaStyle" />
+  </root>
+</log4j:configuration>

--- a/log4j-api/.gitignore
+++ b/log4j-api/.gitignore
@@ -1,0 +1,2 @@
+/.apt_generated/
+/.apt_generated_tests/

--- a/log4j-api/.gitignore
+++ b/log4j-api/.gitignore
@@ -1,2 +1,0 @@
-/.apt_generated/
-/.apt_generated_tests/


### PR DESCRIPTION
Log4j 1.x allows for both capitalized (`InfoLocation`) and Java-style (`infoLocation`) component property names (`PropertySetter` calls `Introspector.decapitalize`). This PR allows for Java-style property names in the Log4j 1.x bridge. It also fixes some capitalization typos (e.g. `target` instead of `Target`).

This fixes most XML tests from #706 .