### PR TITLE
Log4j 1.2 bridge throws `ClassCastException` when using `SimpleLayout` and others

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
@@ -40,7 +40,7 @@ import org.w3c.dom.Element;
 /**
  * Base class for Log4j 1 component builders.
  */
-public abstract class AbstractBuilder {
+public abstract class AbstractBuilder implements Builder {
 
     private static Logger LOGGER = StatusLogger.getLogger();
     protected static final String FILE_PARAM = "File";

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/Builder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/Builder.java
@@ -19,6 +19,5 @@ package org.apache.log4j.builders;
 
 /**
  * A marker interface for Log4j 1.x component builders.
- *
  */
 public interface Builder {}

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/Builder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/Builder.java
@@ -14,20 +14,11 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.log4j.builders.layout;
 
-import org.apache.log4j.Layout;
-import org.apache.log4j.builders.Builder;
-import org.apache.log4j.config.PropertiesConfiguration;
-import org.apache.log4j.xml.XmlConfiguration;
-import org.w3c.dom.Element;
+package org.apache.log4j.builders;
 
 /**
- * Define a Layout Builder.
+ * A marker interface for Log4j 1.x component builders.
+ *
  */
-public interface LayoutBuilder extends Builder {
-
-    Layout parseLayout(Element element, XmlConfiguration config);
-
-    Layout parseLayout(PropertiesConfiguration config);
-}
+public interface Builder {}

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
@@ -152,7 +152,7 @@ public class BuilderManager {
         return null;
     }
 
-    private <T extends AbstractBuilder> T createBuilder(PluginType<?> plugin, String prefix, Properties props) {
+    private <T extends Builder> T createBuilder(PluginType<?> plugin, String prefix, Properties props) {
         try {
             Class<?> clazz = plugin.getPluginClass();
             if (AbstractBuilder.class.isAssignableFrom(clazz)) {

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
@@ -152,18 +152,22 @@ public class BuilderManager {
         return null;
     }
 
+    @SuppressWarnings("unchecked")
     private <T extends Builder> T createBuilder(PluginType<?> plugin, String prefix, Properties props) {
         try {
             Class<?> clazz = plugin.getPluginClass();
             if (AbstractBuilder.class.isAssignableFrom(clazz)) {
-                @SuppressWarnings("unchecked")
                 Constructor<T> constructor =
                         (Constructor<T>) clazz.getConstructor(CONSTRUCTOR_PARAMS);
                 return constructor.newInstance(prefix, props);
             }
-            @SuppressWarnings("unchecked")
-            T builder = (T) LoaderUtil.newInstanceOf(clazz);
-            return builder;
+            Object builder = LoaderUtil.newInstanceOf(clazz);
+            // Reasonable message instead of `ClassCastException`
+            if (!Builder.class.isAssignableFrom(clazz)) {
+                LOGGER.warn("Unable to load plugin: builder {} does not implement {}", clazz, Builder.class);
+                return null;
+            }
+            return (T) builder;
         } catch (ReflectiveOperationException ex) {
             LOGGER.warn("Unable to load plugin: {} due to: {}", plugin.getKey(), ex.getMessage());
             return null;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/AppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/AppenderBuilder.java
@@ -17,6 +17,7 @@
 package org.apache.log4j.builders.appender;
 
 import org.apache.log4j.Appender;
+import org.apache.log4j.builders.Builder;
 import org.apache.log4j.config.PropertiesConfiguration;
 import org.apache.log4j.xml.XmlConfiguration;
 import org.w3c.dom.Element;
@@ -26,7 +27,7 @@ import java.util.Properties;
 /**
  * Define an Appender Builder.
  */
-public interface AppenderBuilder {
+public interface AppenderBuilder extends Builder {
 
     Appender parseAppender(Element element, XmlConfiguration configuration);
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/FilterBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/filter/FilterBuilder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.log4j.builders.filter;
 
+import org.apache.log4j.builders.Builder;
 import org.apache.log4j.config.PropertiesConfiguration;
 import org.apache.log4j.spi.Filter;
 import org.apache.log4j.xml.XmlConfiguration;
@@ -24,7 +25,7 @@ import org.w3c.dom.Element;
 /**
  * Define a Filter Builder.
  */
-public interface FilterBuilder {
+public interface FilterBuilder extends Builder {
 
     Filter parseFilter(Element element, XmlConfiguration config);
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/rewrite/RewritePolicyBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/rewrite/RewritePolicyBuilder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.log4j.builders.rewrite;
 
+import org.apache.log4j.builders.Builder;
 import org.apache.log4j.config.PropertiesConfiguration;
 import org.apache.log4j.rewrite.RewritePolicy;
 import org.apache.log4j.xml.XmlConfiguration;
@@ -24,7 +25,7 @@ import org.w3c.dom.Element;
 /**
  * Define a RewritePolicy Builder.
  */
-public interface RewritePolicyBuilder {
+public interface RewritePolicyBuilder extends Builder {
 
     RewritePolicy parseRewritePolicy(Element element, XmlConfiguration config);
 

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -34,7 +34,6 @@ import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.appender.NullAppender;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.layout.HtmlLayout;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.Test;
 
@@ -66,43 +65,27 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
         return appender.getLayout();
     }
 
-    private Layout<?> testFile(final String configResource) throws Exception {
-        final Configuration configuration = getConfiguration(configResource);
-        final FileAppender appender = configuration.getAppender("File");
-        assertNotNull(appender);
-        assertEquals("target/mylog.txt", appender.getFileName());
-        //
-        final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
-        assertNotNull(loggerConfig);
-        assertEquals(Level.DEBUG, loggerConfig.getLevel());
-        configuration.start();
-        configuration.stop();
-        return appender.getLayout();
-    }
-
+    @Override
     @Test
     public void testConsoleEnhancedPatternLayout() throws Exception {
-        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-EnhancedPatternLayout");
-        assertEquals("%d{ISO8601} [%t][%c] %-5p %properties %ndc: %m%n", layout.getConversionPattern());
+        super.testConsoleEnhancedPatternLayout();
     }
 
+    @Override
     @Test
     public void testConsoleHtmlLayout() throws Exception {
-        final HtmlLayout layout = (HtmlLayout) testConsole("config-1.2/log4j-console-HtmlLayout");
-        assertEquals("Headline", layout.getTitle());
-        assertTrue(layout.isLocationInfo());
+        super.testConsoleHtmlLayout();
     }
 
     @Test
     public void testConsolePatternLayout() throws Exception {
-        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-PatternLayout");
-        assertEquals("%d{ISO8601} [%t][%c] %-5p: %m%n", layout.getConversionPattern());
+        super.testConsolePatternLayout();
     }
 
+    @Override
     @Test
     public void testConsoleSimpleLayout() throws Exception {
-        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-SimpleLayout");
-        assertEquals("%level - %m%n", layout.getConversionPattern());
+        super.testConsoleSimpleLayout();
     }
 
     @Override
@@ -118,20 +101,17 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
         assertFalse(layout.isProperties());
     }
 
+    @Override
     @Test
     public void testFileSimpleLayout() throws Exception {
-        final PatternLayout layout = (PatternLayout) testFile("config-1.2/log4j-file-SimpleLayout");
-        assertEquals("%level - %m%n", layout.getConversionPattern());
+        super.testFileSimpleLayout();
     }
 
+    @Override
     @Test
-    public void testNullAppender() throws Exception {
-        final Configuration configuration = getConfiguration("config-1.2/log4j-NullAppender");
-        final Appender appender = configuration.getAppender("NullAppender");
-        assertNotNull(appender);
-        assertEquals("NullAppender", appender.getName());
-        assertTrue(appender.getClass().getName(), appender instanceof NullAppender);
-    }
+	public void testNullAppender() throws Exception {
+        super.testNullAppender();
+	}
 
     @Override
     @Test

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -186,6 +186,42 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
 
     @Override
     @Test
+    public void testConsoleEnhancedPatternLayout() throws Exception {
+        super.testConsoleEnhancedPatternLayout();
+    }
+
+    @Override
+    @Test
+    public void testConsoleHtmlLayout() throws Exception {
+        super.testConsoleHtmlLayout();
+    }
+
+    @Override
+    @Test
+    public void testConsolePatternLayout() throws Exception {
+        super.testConsolePatternLayout();
+    }
+
+    @Override
+    @Test
+    public void testConsoleSimpleLayout() throws Exception {
+        super.testConsoleSimpleLayout();
+    }
+
+    @Override
+    @Test
+    public void testFileSimpleLayout() throws Exception {
+        super.testFileSimpleLayout();
+    }
+
+    @Override
+    @Test
+    public void testNullAppender() throws Exception {
+        super.testNullAppender();
+    }
+
+    @Override
+    @Test
     public void testConsoleCapitalization() throws Exception {
         super.testConsoleCapitalization();
     }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -96,6 +96,42 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
 
     @Override
     @Test
+    public void testConsoleEnhancedPatternLayout() throws Exception {
+        super.testConsoleEnhancedPatternLayout();
+    }
+
+    @Override
+    @Test
+    public void testConsoleHtmlLayout() throws Exception {
+        super.testConsoleHtmlLayout();
+    }
+
+    @Override
+    @Test
+    public void testConsolePatternLayout() throws Exception {
+        super.testConsolePatternLayout();
+    }
+
+    @Override
+    @Test
+    public void testConsoleSimpleLayout() throws Exception {
+        super.testConsoleSimpleLayout();
+    }
+
+    @Override
+    @Test
+    public void testFileSimpleLayout() throws Exception {
+        super.testFileSimpleLayout();
+    }
+
+    @Override
+    @Test
+    public void testNullAppender() throws Exception {
+        super.testNullAppender();
+    }
+
+    @Override
+    @Test
     public void testConsoleCapitalization() throws Exception {
         super.testConsoleCapitalization();
     }

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-NullAppender.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-NullAppender.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="NullAppender" class="org.apache.log4j.varia.NullAppender" />
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="NullAppender" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-EnhancedPatternLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-EnhancedPatternLayout.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.EnhancedPatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} [%t][%c] %-5p %X %x: %m%n" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-HtmlLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-HtmlLayout.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.HTMLLayout">
+      <param name="Title" value="Headline" />
+      <param name="LocationInfo" value="true" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-PatternLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-PatternLayout.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} [%t][%c] %-5p: %m%n" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-SimpleLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-SimpleLayout.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.SimpleLayout" />
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-SimpleLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-file-SimpleLayout.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="File" class="org.apache.log4j.FileAppender">
+    <param name="File" value="target/mylog.txt" />
+    <layout class="org.apache.log4j.SimpleLayout" />
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="File" />
+  </root>
+</log4j:configuration>


### PR DESCRIPTION
Since not all Log4j 1.x component builders extend `AbstractBuilder`, `BuilderManager#createBuilder` throws a `ClassCastException` when instantiating some of them.

For example using a `SimpleLayout` in `log4j.properties` file fails.

This PR fixes some test from #706 .