### PR TITLE
Log4j 1.2 bridge uses the wrong default values for a TTCCLayout

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/AbstractBuilder.java
@@ -109,8 +109,12 @@ public abstract class AbstractBuilder {
         return new String(chars);
     }
 
+    public boolean getBooleanProperty(final String key, final boolean defaultValue) {
+        return Boolean.parseBoolean(getProperty(key, Boolean.toString(defaultValue)));
+    }
+
     public boolean getBooleanProperty(final String key) {
-        return Boolean.parseBoolean(getProperty(key, Boolean.FALSE.toString()));
+        return getBooleanProperty(key, false);
     }
 
     public int getIntegerProperty(final String key, final int defaultValue) {
@@ -174,5 +178,4 @@ public abstract class AbstractBuilder {
         chars[0] = Character.toLowerCase(chars[0]);
         return new String(chars);
     }
-
 }

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/layout/TTCCLayoutBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/layout/TTCCLayoutBuilder.java
@@ -55,10 +55,10 @@ public class TTCCLayoutBuilder extends AbstractBuilder implements LayoutBuilder 
 
     @Override
     public Layout parseLayout(Element layoutElement, XmlConfiguration config) {
-        final AtomicBoolean threadPrinting = new AtomicBoolean();
-        final AtomicBoolean categoryPrefixing = new AtomicBoolean();
-        final AtomicBoolean contextPrinting = new AtomicBoolean();
-        final AtomicReference<String> dateFormat = new AtomicReference<>();
+        final AtomicBoolean threadPrinting = new AtomicBoolean(Boolean.TRUE);
+        final AtomicBoolean categoryPrefixing = new AtomicBoolean(Boolean.TRUE);
+        final AtomicBoolean contextPrinting = new AtomicBoolean(Boolean.TRUE);
+        final AtomicReference<String> dateFormat = new AtomicReference<>(RELATIVE);
         final AtomicReference<String> timezone = new AtomicReference<>();
         forEachElement(layoutElement.getElementsByTagName("param"), currentElement -> {
             if (currentElement.getTagName().equals(PARAM_TAG)) {
@@ -87,10 +87,10 @@ public class TTCCLayoutBuilder extends AbstractBuilder implements LayoutBuilder 
 
     @Override
     public Layout parseLayout(PropertiesConfiguration config) {
-        boolean threadPrinting = getBooleanProperty(THREAD_PRINTING_PARAM);
-        boolean categoryPrefixing = getBooleanProperty(CATEGORY_PREFIXING_PARAM);
-        boolean contextPrinting = getBooleanProperty(CONTEXT_PRINTING_PARAM);
-        String dateFormat = getProperty(DATE_FORMAT_PARAM);
+        boolean threadPrinting = getBooleanProperty(THREAD_PRINTING_PARAM, true);
+        boolean categoryPrefixing = getBooleanProperty(CATEGORY_PREFIXING_PARAM, true);
+        boolean contextPrinting = getBooleanProperty(CONTEXT_PRINTING_PARAM, true);
+        String dateFormat = getProperty(DATE_FORMAT_PARAM, RELATIVE);
         String timezone = getProperty(TIMEZONE_FORMAT);
 
         return createLayout(threadPrinting, categoryPrefixing, contextPrinting,

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -22,10 +22,15 @@ import static org.junit.Assert.assertNotNull;
 import java.io.IOException;
 import java.net.URISyntaxException;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.junit.Test;
 
 public abstract class AbstractLog4j1ConfigurationTest {
 
@@ -55,4 +60,27 @@ public abstract class AbstractLog4j1ConfigurationTest {
         assertEquals(expected.getCharset(), actual.getCharset());
         assertEquals(expected.getConversionPattern(), actual.getConversionPattern());
     }
+
+    private Layout<?> testConsole(final String configResource) throws Exception {
+        final Configuration configuration = getConfiguration(configResource);
+        final String name = "Console";
+        final ConsoleAppender appender = configuration.getAppender(name);
+        assertNotNull("Missing appender '" + name + "' in configuration " + configResource + " → " + configuration,
+                appender);
+        assertEquals(Target.SYSTEM_ERR, appender.getTarget());
+        //
+        final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
+        assertNotNull(loggerConfig);
+        assertEquals(Level.DEBUG, loggerConfig.getLevel());
+        configuration.start();
+        configuration.stop();
+        return appender.getLayout();
+    }
+
+    @Test
+    public void testConsoleTtccLayout() throws Exception {
+        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout");
+        assertEquals("%r [%t] %p %notEmpty{%ndc }- %m%n", layout.getConversionPattern());
+    }
+
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.layout.PatternLayout;
-import org.junit.Test;
 
 public abstract class AbstractLog4j1ConfigurationTest {
 
@@ -77,7 +76,6 @@ public abstract class AbstractLog4j1ConfigurationTest {
         return appender.getLayout();
     }
 
-    @Test
     public void testConsoleTtccLayout() throws Exception {
         final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout");
         assertEquals("%r [%t] %p %notEmpty{%ndc }- %m%n", layout.getConversionPattern());

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -92,51 +92,51 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
 
     @Test
     public void testConsoleEnhancedPatternLayout() throws Exception {
-       final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-EnhancedPatternLayout");
+        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-EnhancedPatternLayout");
         assertEquals("%d{ISO8601} [%t][%c] %-5p %properties %ndc: %m%n", layout.getConversionPattern());
     }
 
     @Test
     public void testConsoleHtmlLayout() throws Exception {
-       final HtmlLayout layout = (HtmlLayout) testConsole("config-1.2/log4j-console-HtmlLayout");
+        final HtmlLayout layout = (HtmlLayout) testConsole("config-1.2/log4j-console-HtmlLayout");
         assertEquals("Headline", layout.getTitle());
         assertTrue(layout.isLocationInfo());
     }
 
     @Test
     public void testConsolePatternLayout() throws Exception {
-       final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-PatternLayout");
+        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-PatternLayout");
         assertEquals("%d{ISO8601} [%t][%c] %-5p: %m%n", layout.getConversionPattern());
     }
 
     @Test
     public void testConsoleSimpleLayout() throws Exception {
-       final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-SimpleLayout");
+        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-SimpleLayout");
         assertEquals("%level - %m%n", layout.getConversionPattern());
     }
 
     @Test
     public void testConsoleTtccLayout() throws Exception {
-       final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout");
+        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout");
         assertEquals("%r [%t] %p %notEmpty{%ndc }- %m%n", layout.getConversionPattern());
     }
 
     @Test
     public void testConsoleXmlLayout() throws Exception {
-       final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout");
+        final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout");
         assertTrue(layout.isLocationInfo());
         assertFalse(layout.isProperties());
     }
 
     @Test
     public void testFileSimpleLayout() throws Exception {
-       final PatternLayout layout = (PatternLayout) testFile("config-1.2/log4j-file-SimpleLayout");
+        final PatternLayout layout = (PatternLayout) testFile("config-1.2/log4j-file-SimpleLayout");
         assertEquals("%level - %m%n", layout.getConversionPattern());
     }
 
     @Test
     public void testNullAppender() throws Exception {
-       final Configuration configuration = getConfiguration("config-1.2/log4j-NullAppender");
+        final Configuration configuration = getConfiguration("config-1.2/log4j-NullAppender");
         final Appender appender = configuration.getAppender("NullAppender");
         assertNotNull(appender);
         assertEquals("NullAppender", appender.getName());
@@ -145,21 +145,22 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
 
     @Test
     public void testRollingFileAppender() throws Exception {
-       testRollingFileAppender("config-1.2/log4j-RollingFileAppender", "RFA", "target/hadoop.log.%i");
+        testRollingFileAppender("config-1.2/log4j-RollingFileAppender", "RFA", "target/hadoop.log.%i");
     }
 
     @Test
     public void testDailyRollingFileAppender() throws Exception {
-       testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender", "DRFA", "target/hadoop.log%d{.yyyy-MM-dd}");
+        testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender", "DRFA", "target/hadoop.log%d{.yyyy-MM-dd}");
     }
 
     @Test
     public void testRollingFileAppenderWithProperties() throws Exception {
-       testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props", "RFA", "target/hadoop.log.%i");
+        testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props", "RFA", "target/hadoop.log.%i");
     }
 
     @Test
     public void testSystemProperties1() throws Exception {
+
         final String tempFileName = System.getProperty("java.io.tmpdir") + "/hadoop.log";
         final Path tempFilePath = new File(tempFileName).toPath();
         Files.deleteIfExists(tempFilePath);
@@ -180,7 +181,7 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
 
     @Test
     public void testSystemProperties2() throws Exception {
-       final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2");
+        final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2");
         final RollingFileAppender appender = configuration.getAppender("RFA");
         assertEquals("${java.io.tmpdir}/hadoop.log", appender.getFileName());
         appender.stop(10, TimeUnit.SECONDS);

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -115,10 +115,10 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
         assertEquals("%level - %m%n", layout.getConversionPattern());
     }
 
+    @Override
     @Test
     public void testConsoleTtccLayout() throws Exception {
-        final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout");
-        assertEquals("%r [%t] %p %notEmpty{%ndc }- %m%n", layout.getConversionPattern());
+       super.testConsoleTtccLayout();
     }
 
     @Test
@@ -160,7 +160,6 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
 
     @Test
     public void testSystemProperties1() throws Exception {
-
         final String tempFileName = System.getProperty("java.io.tmpdir") + "/hadoop.log";
         final Path tempFilePath = new File(tempFileName).toPath();
         Files.deleteIfExists(tempFilePath);

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -118,7 +118,7 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
     @Override
     @Test
     public void testConsoleTtccLayout() throws Exception {
-       super.testConsoleTtccLayout();
+        super.testConsoleTtccLayout();
     }
 
     @Test

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -190,4 +190,10 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
         super.testConsoleCapitalization();
     }
 
+    @Override
+    @Test
+    public void testConsoleTtccLayout() throws Exception {
+        super.testConsoleTtccLayout();
+    }
+
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -100,4 +100,10 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
         super.testConsoleCapitalization();
     }
 
+    @Override
+    @Test
+    public void testConsoleTtccLayout() throws Exception {
+        super.testConsoleTtccLayout();
+    }
+
 }

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-TTCCLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-TTCCLayout.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.TTCCLayout">
+      <param name="ThreadPrinting" value="true" />
+      <param name="CategoryPrefixing" value="false" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>


### PR DESCRIPTION
The default values used by `TTCCLayoutBuilder` were different from those used by Log4j 1.x.

This PR fixes the tests concerning the `TTCCLayout` from #706.