### PR TITLE
Log4j 1.2 bridge uses the wrong file pattern for rolling file appenders

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/DailyRollingFileAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/DailyRollingFileAppenderBuilder.java
@@ -40,6 +40,7 @@ import org.apache.log4j.spi.Filter;
 import org.apache.log4j.xml.XmlConfiguration;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.appender.rolling.CompositeTriggeringPolicy;
 import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.TimeBasedTriggeringPolicy;
@@ -167,8 +168,9 @@ public class DailyRollingFileAppenderBuilder extends AbstractBuilder implements 
             LOGGER.warn("Unable to create File Appender, no file name provided");
             return null;
         }
-        String filePattern = fileName +"%d{yyy-MM-dd}";
-        TriggeringPolicy policy = TimeBasedTriggeringPolicy.newBuilder().withModulate(true).build();
+        String filePattern = fileName +"%d{.yyyy-MM-dd}";
+        TriggeringPolicy timePolicy = TimeBasedTriggeringPolicy.newBuilder().withModulate(true).build();
+        TriggeringPolicy policy = CompositeTriggeringPolicy.createPolicy(timePolicy);
         RolloverStrategy strategy = DefaultRolloverStrategy.newBuilder()
                 .withConfig(configuration)
                 .withMax(Integer.toString(Integer.MAX_VALUE))

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/RollingFileAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/RollingFileAppenderBuilder.java
@@ -187,10 +187,9 @@ public class RollingFileAppenderBuilder extends AbstractBuilder implements Appen
             LOGGER.warn("Unable to create File Appender, no file name provided");
             return null;
         }
-        String filePattern = fileName +"%d{yyy-MM-dd}";
-        TriggeringPolicy timePolicy = TimeBasedTriggeringPolicy.newBuilder().withModulate(true).build();
+        String filePattern = fileName +".%i";
         SizeBasedTriggeringPolicy sizePolicy = SizeBasedTriggeringPolicy.createPolicy(maxSize);
-        CompositeTriggeringPolicy policy = CompositeTriggeringPolicy.createPolicy(sizePolicy, timePolicy);
+        CompositeTriggeringPolicy policy = CompositeTriggeringPolicy.createPolicy(sizePolicy);
         RolloverStrategy strategy = DefaultRolloverStrategy.newBuilder()
                 .withConfig(config)
                 .withMax(maxBackups)

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationParser.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationParser.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.TreeMap;
 
+import org.apache.log4j.helpers.OptionConverter;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.FileAppender;
@@ -39,8 +40,6 @@ import org.apache.logging.log4j.core.config.builder.api.LayoutComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.LoggerComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.RootLoggerComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
-import org.apache.logging.log4j.core.lookup.ConfigurationStrSubstitutor;
-import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
 
@@ -69,8 +68,6 @@ public class Log4j1ConfigurationParser {
     private static final String FALSE = "false";
 
     private final Properties properties = new Properties();
-    private StrSubstitutor strSubstitutorProperties;
-    private StrSubstitutor strSubstitutorSystem;
 
     private final ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory
             .newConfigurationBuilder();
@@ -90,8 +87,6 @@ public class Log4j1ConfigurationParser {
             throws IOException {
         try {
             properties.load(input);
-            strSubstitutorProperties = new ConfigurationStrSubstitutor(properties);
-            strSubstitutorSystem = new ConfigurationStrSubstitutor(System.getProperties());
             final String rootCategoryValue = getLog4jValue(ROOTCATEGORY);
             final String rootLoggerValue = getLog4jValue(ROOTLOGGER);
             if (rootCategoryValue == null && rootLoggerValue == null) {
@@ -422,8 +417,7 @@ public class Log4j1ConfigurationParser {
 
     private String getProperty(final String key) {
         final String value = properties.getProperty(key);
-        final String sysValue = strSubstitutorSystem.replace(value);
-        return strSubstitutorProperties.replace(sysValue);
+        return OptionConverter.substVars(value, properties);
     }
 
     private String getProperty(final String key, final String defaultValue) {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -18,15 +18,28 @@ package org.apache.log4j.config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.appender.rolling.CompositeTriggeringPolicy;
+import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
+import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
+import org.apache.logging.log4j.core.appender.rolling.SizeBasedTriggeringPolicy;
+import org.apache.logging.log4j.core.appender.rolling.TimeBasedTriggeringPolicy;
+import org.apache.logging.log4j.core.appender.rolling.TriggeringPolicy;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.layout.PatternLayout;
@@ -79,6 +92,111 @@ public abstract class AbstractLog4j1ConfigurationTest {
     public void testConsoleTtccLayout() throws Exception {
         final PatternLayout layout = (PatternLayout) testConsole("config-1.2/log4j-console-TTCCLayout");
         assertEquals("%r [%t] %p %notEmpty{%ndc }- %m%n", layout.getConversionPattern());
+    }
+
+    public void testRollingFileAppender() throws Exception {
+        testRollingFileAppender("config-1.2/log4j-RollingFileAppender", "RFA", "target/hadoop.log.%i");
+    }
+
+    public void testDailyRollingFileAppender() throws Exception {
+        testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender", "DRFA", "target/hadoop.log%d{.yyyy-MM-dd}");
+    }
+
+    public void testRollingFileAppenderWithProperties() throws Exception {
+        testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props", "RFA", "target/hadoop.log.%i");
+    }
+
+    public void testSystemProperties1() throws Exception {
+        final String tempFileName = System.getProperty("java.io.tmpdir") + "/hadoop.log";
+        final Path tempFilePath = new File(tempFileName).toPath();
+        Files.deleteIfExists(tempFilePath);
+        try {
+            final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-1");
+            final RollingFileAppender appender = configuration.getAppender("RFA");
+            appender.stop(10, TimeUnit.SECONDS);
+            // System.out.println("expected: " + tempFileName + " Actual: " +
+            // appender.getFileName());
+            assertEquals(tempFileName, appender.getFileName());
+        } finally {
+            try {
+                Files.deleteIfExists(tempFilePath);
+            } catch (final FileSystemException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public void testSystemProperties2() throws Exception {
+        final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2");
+        final RollingFileAppender appender = configuration.getAppender("RFA");
+        final String tmpDir = System.getProperty("java.io.tmpdir");
+        assertEquals(tmpDir + "/hadoop.log", appender.getFileName());
+        appender.stop(10, TimeUnit.SECONDS);
+        // Try to clean up
+        try {
+            Path path = new File(appender.getFileName()).toPath();
+            Files.deleteIfExists(path);
+            path = new File("${java.io.tmpdir}").toPath();
+            Files.deleteIfExists(path);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void testRollingFileAppender(final String configResource, final String name, final String filePattern)
+            throws Exception {
+        final Configuration configuration = getConfiguration(configResource);
+        final Appender appender = configuration.getAppender(name);
+        assertNotNull(appender);
+        assertEquals(name, appender.getName());
+        assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
+        final RollingFileAppender rfa = (RollingFileAppender) appender;
+        assertEquals("target/hadoop.log", rfa.getFileName());
+        assertEquals(filePattern, rfa.getFilePattern());
+        final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
+        assertNotNull(triggeringPolicy);
+        assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
+        final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
+        final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
+        assertEquals(1, triggeringPolicies.length);
+        final TriggeringPolicy tp = triggeringPolicies[0];
+        assertTrue(tp.getClass().getName(), tp instanceof SizeBasedTriggeringPolicy);
+        final SizeBasedTriggeringPolicy sbtp = (SizeBasedTriggeringPolicy) tp;
+        assertEquals(256 * 1024 * 1024, sbtp.getMaxFileSize());
+        final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
+        assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
+        final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
+        assertEquals(20, drs.getMaxIndex());
+        configuration.start();
+        configuration.stop();
+    }
+
+    private void testDailyRollingFileAppender(final String configResource, final String name, final String filePattern)
+            throws Exception {
+        final Configuration configuration = getConfiguration(configResource);
+        final Appender appender = configuration.getAppender(name);
+        assertNotNull(appender);
+        assertEquals(name, appender.getName());
+        assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
+        final RollingFileAppender rfa = (RollingFileAppender) appender;
+        assertEquals("target/hadoop.log", rfa.getFileName());
+        assertEquals(filePattern, rfa.getFilePattern());
+        final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
+        assertNotNull(triggeringPolicy);
+        assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
+        final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
+        final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
+        assertEquals(1, triggeringPolicies.length);
+        final TriggeringPolicy tp = triggeringPolicies[0];
+        assertTrue(tp.getClass().getName(), tp instanceof TimeBasedTriggeringPolicy);
+        final TimeBasedTriggeringPolicy tbtp = (TimeBasedTriggeringPolicy) tp;
+        assertEquals(1, tbtp.getInterval());
+        final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
+        assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
+        final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
+        assertEquals(Integer.MAX_VALUE, drs.getMaxIndex());
+        configuration.start();
+        configuration.stop();
     }
 
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -143,105 +143,33 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
         assertTrue(appender.getClass().getName(), appender instanceof NullAppender);
     }
 
+    @Override
     @Test
     public void testRollingFileAppender() throws Exception {
-        testRollingFileAppender("config-1.2/log4j-RollingFileAppender", "RFA", "target/hadoop.log.%i");
+        super.testRollingFileAppender();
     }
 
+    @Override
     @Test
     public void testDailyRollingFileAppender() throws Exception {
-        testDailyRollingFileAppender("config-1.2/log4j-DailyRollingFileAppender", "DRFA", "target/hadoop.log%d{.yyyy-MM-dd}");
+        super.testDailyRollingFileAppender();
     }
 
     @Test
     public void testRollingFileAppenderWithProperties() throws Exception {
-        testRollingFileAppender("config-1.2/log4j-RollingFileAppender-with-props", "RFA", "target/hadoop.log.%i");
+        super.testRollingFileAppenderWithProperties();
     }
 
+    @Override
     @Test
     public void testSystemProperties1() throws Exception {
-        final String tempFileName = System.getProperty("java.io.tmpdir") + "/hadoop.log";
-        final Path tempFilePath = new File(tempFileName).toPath();
-        Files.deleteIfExists(tempFilePath);
-        try {
-            final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-1");
-            final RollingFileAppender appender = configuration.getAppender("RFA");
-            appender.stop(10, TimeUnit.SECONDS);
-            // System.out.println("expected: " + tempFileName + " Actual: " + appender.getFileName());
-            assertEquals(tempFileName, appender.getFileName());
-        } finally {
-            try {
-                Files.deleteIfExists(tempFilePath);
-            } catch (final FileSystemException e) {
-                e.printStackTrace();
-            }
-        }
+        super.testSystemProperties1();
     }
 
+    @Override
     @Test
     public void testSystemProperties2() throws Exception {
-        final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-2");
-        final RollingFileAppender appender = configuration.getAppender("RFA");
-        assertEquals("${java.io.tmpdir}/hadoop.log", appender.getFileName());
-        appender.stop(10, TimeUnit.SECONDS);
-        Path path = new File(appender.getFileName()).toPath();
-        Files.deleteIfExists(path);
-        path = new File("${java.io.tmpdir}").toPath();
-        Files.deleteIfExists(path);
-    }
-
-    private void testRollingFileAppender(final String configResource, final String name, final String filePattern) throws URISyntaxException {
-        final Configuration configuration = getConfiguration(configResource);
-        final Appender appender = configuration.getAppender(name);
-        assertNotNull(appender);
-        assertEquals(name, appender.getName());
-        assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
-        final RollingFileAppender rfa = (RollingFileAppender) appender;
-        assertEquals("target/hadoop.log", rfa.getFileName());
-        assertEquals(filePattern, rfa.getFilePattern());
-        final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
-        assertNotNull(triggeringPolicy);
-        assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
-        final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
-        final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
-        assertEquals(1, triggeringPolicies.length);
-        final TriggeringPolicy tp = triggeringPolicies[0];
-        assertTrue(tp.getClass().getName(), tp instanceof SizeBasedTriggeringPolicy);
-        final SizeBasedTriggeringPolicy sbtp = (SizeBasedTriggeringPolicy) tp;
-        assertEquals(256 * 1024 * 1024, sbtp.getMaxFileSize());
-        final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
-        assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
-        final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
-        assertEquals(20, drs.getMaxIndex());
-        configuration.start();
-        configuration.stop();
-    }
-
-    private void testDailyRollingFileAppender(final String configResource, final String name, final String filePattern) throws URISyntaxException {
-        final Configuration configuration = getConfiguration(configResource);
-        final Appender appender = configuration.getAppender(name);
-        assertNotNull(appender);
-        assertEquals(name, appender.getName());
-        assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
-        final RollingFileAppender rfa = (RollingFileAppender) appender;
-        assertEquals("target/hadoop.log", rfa.getFileName());
-        assertEquals(filePattern, rfa.getFilePattern());
-        final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
-        assertNotNull(triggeringPolicy);
-        assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
-        final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
-        final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
-        assertEquals(1, triggeringPolicies.length);
-        final TriggeringPolicy tp = triggeringPolicies[0];
-        assertTrue(tp.getClass().getName(), tp instanceof TimeBasedTriggeringPolicy);
-        final TimeBasedTriggeringPolicy tbtp = (TimeBasedTriggeringPolicy) tp;
-        assertEquals(1, tbtp.getInterval());
-        final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
-        assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
-        final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
-        assertEquals(Integer.MAX_VALUE, drs.getMaxIndex());
-        configuration.start();
-        configuration.stop();
+        super.testSystemProperties2();
     }
 
     @Override
@@ -249,4 +177,5 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
     public void testConsoleCapitalization() throws Exception {
         super.testConsoleCapitalization();
     }
+
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -196,4 +196,33 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
         super.testConsoleTtccLayout();
     }
 
+    @Override
+    @Test
+    public void testRollingFileAppender() throws Exception {
+        super.testRollingFileAppender();
+    }
+
+    @Override
+    @Test
+    public void testDailyRollingFileAppender() throws Exception {
+        super.testDailyRollingFileAppender();
+    }
+
+    @Override
+    @Test
+    public void testRollingFileAppenderWithProperties() throws Exception {
+        super.testRollingFileAppenderWithProperties();
+    }
+
+    @Override
+    @Test
+    public void testSystemProperties1() throws Exception {
+        super.testSystemProperties1();
+    }
+
+    @Override
+    @Test
+    public void testSystemProperties2() throws Exception {
+        super.testSystemProperties2();
+    }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -106,4 +106,22 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
         super.testConsoleTtccLayout();
     }
 
+    @Override
+    @Test
+    public void testRollingFileAppender() throws Exception {
+        super.testRollingFileAppender();
+    }
+
+    @Override
+    @Test
+    public void testDailyRollingFileAppender() throws Exception {
+        super.testDailyRollingFileAppender();
+    }
+
+    @Override
+    @Test
+    public void testSystemProperties1() throws Exception {
+        super.testSystemProperties1();
+    }
+
 }

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-DailyRollingFileAppender.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-DailyRollingFileAppender.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="DRFA" class="org.apache.log4j.DailyRollingFileAppender">
+    <param name="File" value="target/hadoop.log" />
+    <param name="DatePattern" value=".yyyy-MM-dd" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} %p %c: %m%n" />
+    </layout>
+  </appender>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="DRFA" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-RollingFileAppender.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-RollingFileAppender.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="RFA" class="org.apache.log4j.RollingFileAppender">
+    <param name="File" value="target/hadoop.log" />
+    <param name="MaxFileSize" value="256MB" />
+    <param name="MaxBackupIndex" value="20" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%d{ISO8601} %p %c: %m%n" />
+    </layout>
+  </appender>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="RFA" />
+  </root>
+</log4j:configuration>

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-system-properties-1.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-system-properties-1.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="RFA" class="org.apache.log4j.DailyRollingFileAppender">
+    <param name="File" value="${java.io.tmpdir}/hadoop.log" />
+  </appender>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="RFA" />
+  </root>
+</log4j:configuration>


### PR DESCRIPTION
The Log4j 1.x bridge incorrectly sets the pattern of the rolling file appenders. Moreover the `RollingFileAppender` did not have a time based triggering policy in the original Log4j 1.x.

The triggering policies in this PR are configured in the same way as in the `Log4j1ConfigurationFactory`, i.e. with a useless `CompositeTriggeringPolicy`.

This PR is linked with the tests in #706.