### PR TITLE
Adds test for the XmlLayoutBuilder

### DIFF
--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -17,6 +17,7 @@
 package org.apache.log4j.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -33,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.log4j.layout.Log4j1XmlLayout;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Layout;
@@ -282,6 +284,12 @@ public abstract class AbstractLog4j1ConfigurationTest {
         assertNotNull(appender);
         assertEquals("NullAppender", appender.getName());
         assertTrue(appender.getClass().getName(), appender instanceof NullAppender);
+    }
+
+    public void testConsoleXmlLayout() throws Exception {
+        final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout");
+        assertTrue(layout.isLocationInfo());
+        assertFalse(layout.isProperties());
     }
 
     private boolean getFollowProperty(final ConsoleAppender consoleAppender)

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -17,14 +17,12 @@
 package org.apache.log4j.config;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.net.URISyntaxException;
 import java.net.URL;
 
-import org.apache.log4j.layout.Log4j1XmlLayout;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
@@ -90,11 +88,10 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
         super.testConsoleTtccLayout();
     }
 
+    @Override
     @Test
     public void testConsoleXmlLayout() throws Exception {
-        final Log4j1XmlLayout layout = (Log4j1XmlLayout) testConsole("config-1.2/log4j-console-XmlLayout");
-        assertTrue(layout.isLocationInfo());
-        assertFalse(layout.isProperties());
+        super.testConsoleXmlLayout();
     }
 
     @Override

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -234,6 +234,12 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
 
     @Override
     @Test
+    public void testConsoleXmlLayout() throws Exception {
+        super.testConsoleXmlLayout();
+    }
+
+    @Override
+    @Test
     public void testRollingFileAppender() throws Exception {
         super.testRollingFileAppender();
     }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -144,6 +144,12 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
 
     @Override
     @Test
+    public void testConsoleXmlLayout() throws Exception {
+        super.testConsoleXmlLayout();
+    }
+
+    @Override
+    @Test
     public void testRollingFileAppender() throws Exception {
         super.testRollingFileAppender();
     }

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-XmlLayout.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-console-XmlLayout.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="Console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.err" />
+    <layout class="org.apache.log4j.xml.XmlLayout">
+      <param name="LocationInfo" value="true" />
+      <param name="Properties" value="false" />
+    </layout>
+  </appender>
+
+  <logger name="com.example.foo">
+    <level value="DEBUG" />
+  </logger>
+
+  <root>
+    <priority value="trace" />
+    <appender-ref ref="Console" />
+  </root>
+</log4j:configuration>


### PR DESCRIPTION
The Log4j 1.x bridge should arguably use the `Log4j1XmlLayout` instead of the Log4j 2.x specific `XmlLayout`. That is also the layout used by the older `Log4j1ConfigurationFactory`.

This PR fixes one test in #706 .