### PR TITLE
Additional log4j-to-jul test coverage for correct formatting

### DIFF
--- a/log4j-to-jul/src/test/java/org/apache/logging/log4j/tojul/LoggerTest.java
+++ b/log4j-to-jul/src/test/java/org/apache/logging/log4j/tojul/LoggerTest.java
@@ -224,4 +224,26 @@ public class LoggerTest {
             anotherLog4jLogger.info("hello, another world");
         }
     }
+
+    @Test public void placeholdersInFormat() {
+        julLogger.setLevel(Level.INFO);
+        log4jLogger.info("hello, {0} {}", "world");
+
+        List<LogRecord> logs = handler.getStoredLogRecords();
+        assertThat(logs).hasSize(1);
+        LogRecord log1 = logs.get(0);
+        String formattedMessage = new java.util.logging.SimpleFormatter().formatMessage(log1);
+        assertThat(formattedMessage).isEqualTo("hello, {0} world");
+    }
+
+    @Test public void placeholdersInFormattedMessage() {
+        julLogger.setLevel(Level.INFO);
+        log4jLogger.info("hello, {}", "{0} world");
+
+        List<LogRecord> logs = handler.getStoredLogRecords();
+        assertThat(logs).hasSize(1);
+        LogRecord log1 = logs.get(0);
+        String formattedMessage = new java.util.logging.SimpleFormatter().formatMessage(log1);
+        assertThat(formattedMessage).isEqualTo("hello, {0} world");
+    }
 }


### PR DESCRIPTION
These tests provide additional coverage in the event parameters
are passed through, demonstrating how JUL formatters are likely
to misinterpret such LogRecords.