### PR TITLE
LOG4J2-3345: log4j-jpl formats messages correctly using MessageFormat

### DIFF
--- a/log4j-jpl/src/main/java/org/apache/logging/log4j/jpl/Log4jSystemLogger.java
+++ b/log4j-jpl/src/main/java/org/apache/logging/log4j/jpl/Log4jSystemLogger.java
@@ -23,6 +23,9 @@ import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.function.Supplier;
 
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.MessageFormatMessage;
+import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.spi.ExtendedLogger;
 
 /**
@@ -53,14 +56,14 @@ public class Log4jSystemLogger implements Logger {
 
     @Override
     public void log(Level level, String msg) {
-        log(level, (ResourceBundle) null, msg, (Object[]) null);
+        log(level, (ResourceBundle) null, msg, (Throwable) null);
     }
 
     @Override
     public void log(Level level, Supplier<String> msgSupplier) {
         Objects.requireNonNull(msgSupplier);
         if (isLoggable(Objects.requireNonNull(level))) {
-            log(level, (ResourceBundle) null, msgSupplier.get(), (Object[]) null);
+            log(level, (ResourceBundle) null, msgSupplier.get(), (Throwable) null);
         }
     }
 
@@ -68,7 +71,7 @@ public class Log4jSystemLogger implements Logger {
     public void log(Level level, Object obj) {
         Objects.requireNonNull(obj);
         if (isLoggable(Objects.requireNonNull(level))) {
-            log(level, (ResourceBundle) null, obj.toString(), (Object[]) null);
+            log(level, (ResourceBundle) null, obj.toString(), (Throwable) null);
         }
     }
 
@@ -97,7 +100,15 @@ public class Log4jSystemLogger implements Logger {
 
     @Override
     public void log(final Level level, final ResourceBundle bundle, final String format, final Object... params) {
-        logger.logIfEnabled(FQCN, getLevel(level), null, getResource(bundle, format), params);
+        Message message = createMessage(getResource(bundle, format), params);
+        logger.logIfEnabled(FQCN, getLevel(level), null, message, message.getThrowable());
+    }
+
+    private static Message createMessage(final String format, final Object... params) {
+        if (params == null || params.length == 0) {
+            return new SimpleMessage(format);
+        }
+        return new MessageFormatMessage(format, params);
     }
 
     private static org.apache.logging.log4j.Level getLevel(final Level level) {

--- a/log4j-jpl/src/test/java/org/apache/logging/log4j/jpl/Log4jSystemLoggerTest.java
+++ b/log4j-jpl/src/test/java/org/apache/logging/log4j/jpl/Log4jSystemLoggerTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 
 import java.lang.System.Logger;
@@ -83,6 +84,34 @@ public class Log4jSystemLoggerTest {
         assertEquals(LOGGER_NAME, event.getLoggerName());
         assertEquals("Informative message here.", event.getMessage().getFormattedMessage());
         assertEquals(Log4jSystemLogger.class.getName(), event.getLoggerFqcn());
+    }
+
+    @Test
+    public void testParameterizedLogging() {
+        logger.log(Logger.Level.INFO, "Hello, {0}!", "World");
+        final List<LogEvent> events = eventAppender.getEvents();
+        assertThat(events, hasSize(1));
+        final LogEvent event = events.get(0);
+        assertThat(event, instanceOf(Log4jLogEvent.class));
+        assertEquals(Level.INFO, event.getLevel());
+        assertEquals(LOGGER_NAME, event.getLoggerName());
+        assertEquals("Hello, World!", event.getMessage().getFormattedMessage());
+        assertEquals(Log4jSystemLogger.class.getName(), event.getLoggerFqcn());
+    }
+
+    @Test
+    public void testParameterizedLoggingWithThrowable() {
+        Throwable throwable = new RuntimeException();
+        logger.log(Logger.Level.INFO, "Hello, {0}!", "World", throwable);
+        final List<LogEvent> events = eventAppender.getEvents();
+        assertThat(events, hasSize(1));
+        final LogEvent event = events.get(0);
+        assertThat(event, instanceOf(Log4jLogEvent.class));
+        assertEquals(Level.INFO, event.getLevel());
+        assertEquals(LOGGER_NAME, event.getLoggerName());
+        assertEquals("Hello, World!", event.getMessage().getFormattedMessage());
+        assertEquals(Log4jSystemLogger.class.getName(), event.getLoggerFqcn());
+        assertSame(throwable, event.getThrown());
     }
 
     @Test

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -31,6 +31,9 @@
     -->
     <release version="2.17.2" date="20YY-MM-DD" description="GA Release 2.17.2">
       <!-- FIXES -->
+      <action issue="LOG4J2-3345" dev="ckozak">
+        log4j-jpl formats message parameters correctly using MessageFormat.
+      </action>
       <action issue="LOG4J2-3215" dev="vy" due-to="quapka">
         Replace usages of "compile" with "implementation" in the Gradle docs.
       </action>


### PR DESCRIPTION
Tests will fail until #714 is merged or the original regression is resolved.