### PR TITLE
Fix StackLocator regression on java 9+

### DIFF
--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/PrivateSecurityManagerStackTraceUtil.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/PrivateSecurityManagerStackTraceUtil.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.util;
 
-import java.util.Stack;
+import java.util.Deque;
 
 /**
  * This is a dummy class and is only here to allow this module to compile. It will not
@@ -28,7 +28,7 @@ final class PrivateSecurityManagerStackTraceUtil {
         return false;
     }
 
-    static Stack<Class<?>> getCurrentStackTrace() {
+    static Deque<Class<?>> getCurrentStackTrace() {
         return null;
     }
 }

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -16,12 +16,11 @@
  */
 package org.apache.logging.log4j.util;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
-import java.util.Stack;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * <em>Consider this class private.</em> Determines the caller's class.
@@ -81,12 +80,12 @@ public class StackLocator {
         return walker.walk(s -> s.skip(depth).findFirst()).map(StackWalker.StackFrame::getDeclaringClass).orElse(null);
     }
 
-    public Stack<Class<?>> getCurrentStackTrace() {
+    public Deque<Class<?>> getCurrentStackTrace() {
         // benchmarks show that using the SecurityManager is much faster than looping through getCallerClass(int)
         if (PrivateSecurityManagerStackTraceUtil.isEnabled()) {
             return PrivateSecurityManagerStackTraceUtil.getCurrentStackTrace();
         }
-        Stack<Class<?>> stack = new Stack<Class<?>>();
+        Deque<Class<?>> stack = new ArrayDeque<Class<?>>();
         List<Class<?>> classes = walker.walk(s -> s.map(f -> f.getDeclaringClass()).collect(Collectors.toList()));
         stack.addAll(classes);
         return stack;

--- a/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/StackLocatorTest.java
+++ b/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/StackLocatorTest.java
@@ -19,6 +19,7 @@ package org.apache.logging.log4j.util.java9;
 import org.apache.logging.log4j.util.StackLocator;
 import org.junit.jupiter.api.Test;
 
+import java.util.Deque;
 import java.util.Stack;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -43,10 +44,10 @@ public class StackLocatorTest {
     @Test
     public void testGetCurrentStackTrace() {
         final StackLocator stackLocator = StackLocator.getInstance();
-        final Stack<Class<?>> classes = stackLocator.getCurrentStackTrace();
+        final Deque<Class<?>> classes = stackLocator.getCurrentStackTrace();
         final Stack<Class<?>> reversed = new Stack<>();
         reversed.ensureCapacity(classes.size());
-        while (!classes.empty()) {
+        while (!classes.isEmpty()) {
             reversed.push(classes.pop());
         }
         while (reversed.peek() != StackLocator.class) {


### PR DESCRIPTION
Fixes a regression introduced by 97f3153b73ab071a69c2e61e0130fd0104d45407 which did not update mr-jar implementation for java 9+