### PR TITLE
LOG4J2-3333: Fix ThreadContextDataInjector classloader deadlock

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
@@ -41,11 +41,9 @@ import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.config.NullConfiguration;
 import org.apache.logging.log4j.core.config.Reconfigurable;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
-import org.apache.logging.log4j.core.impl.ThreadContextDataInjector;
 import org.apache.logging.log4j.core.jmx.Server;
 import org.apache.logging.log4j.core.util.Cancellable;
 import org.apache.logging.log4j.core.util.ExecutorServices;
-import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.core.util.NetUtils;
 import org.apache.logging.log4j.core.util.ShutdownCallbackRegistry;
 import org.apache.logging.log4j.message.MessageFactory;
@@ -67,15 +65,6 @@ import org.apache.logging.log4j.util.PropertiesUtil;
 public class LoggerContext extends AbstractLifeCycle
         implements org.apache.logging.log4j.spi.LoggerContext, AutoCloseable, Terminable, ConfigurationListener,
         LoggerContextShutdownEnabled {
-
-    static {
-        try {
-            // LOG4J2-1642 preload ExecutorServices as it is used in shutdown hook
-            Loader.loadClass(ExecutorServices.class.getName());
-        } catch (final Exception e) {
-            LOGGER.error("Failed to preload ExecutorServices class.", e);
-        }
-    }
 
     /**
      * Property name of the property change event fired if the configuration is changed.
@@ -135,9 +124,6 @@ public class LoggerContext extends AbstractLifeCycle
             externalMap.put(EXTERNAL_CONTEXT_KEY, externalContext);
         }
         this.configLocation = configLocn;
-        Thread runner = new Thread(new ThreadContextDataTask(), "Thread Context Data Task");
-        runner.setDaemon(true);
-        runner.start();
     }
 
     /**
@@ -166,9 +152,6 @@ public class LoggerContext extends AbstractLifeCycle
         } else {
             configLocation = null;
         }
-        Thread runner = new Thread(new ThreadContextDataTask(), "Thread Context Data Task");
-        runner.setDaemon(true);
-        runner.start();
     }
 
     @Override
@@ -308,6 +291,8 @@ public class LoggerContext extends AbstractLifeCycle
             final LoggerContextFactory factory = LogManager.getFactory();
             if (factory instanceof ShutdownCallbackRegistry) {
                 LOGGER.debug(SHUTDOWN_HOOK_MARKER, "Shutdown hook enabled. Registering a new one.");
+                // LOG4J2-1642 preload ExecutorServices as it is used in shutdown hook
+                ExecutorServices.ensureInitialized();
                 try {
                     final long shutdownTimeoutMillis = this.configuration.getShutdownTimeoutMillis();
                     this.shutdownCallback = ((ShutdownCallbackRegistry) factory).addShutdownCallback(new Runnable() {
@@ -785,15 +770,5 @@ public class LoggerContext extends AbstractLifeCycle
     // LOG4J2-151: changed visibility from private to protected
     protected Logger newInstance(final LoggerContext ctx, final String name, final MessageFactory messageFactory) {
         return new Logger(ctx, name, messageFactory);
-    }
-
-    private class ThreadContextDataTask implements Runnable {
-
-        @Override
-        public void run() {
-            LOGGER.debug("Initializing Thread Context Data Service Providers");
-            ThreadContextDataInjector.initServiceProviders();
-            LOGGER.debug("Thread Context Data Service Provider initialization complete");
-        }
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThreadContextDataInjector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThreadContextDataInjector.java
@@ -63,6 +63,13 @@ public class ThreadContextDataInjector {
 
     private static final List<ContextDataProvider> SERVICE_PROVIDERS = getServiceProviders();
 
+    /**
+     * Previously this method allowed ContextDataProviders to be loaded eagerly, now they
+     * are loaded when this class is initialized.
+     *
+     * @deprecated no-op
+     */
+    @Deprecated
     public static void initServiceProviders() {}
 
     private static List<ContextDataProvider> getServiceProviders() {
@@ -269,7 +276,6 @@ public class ThreadContextDataInjector {
     }
 
     private static List<ContextDataProvider> getProviders() {
-        initServiceProviders();
         final List<ContextDataProvider> providers =
                 new ArrayList<>(contextDataProviders.size() + SERVICE_PROVIDERS.size());
         providers.addAll(contextDataProviders);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThreadContextDataInjector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThreadContextDataInjector.java
@@ -18,13 +18,12 @@ package org.apache.logging.log4j.core.impl;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
@@ -62,21 +61,9 @@ public class ThreadContextDataInjector {
     public static Collection<ContextDataProvider> contextDataProviders =
             new ConcurrentLinkedDeque<>();
 
-    private static volatile List<ContextDataProvider> serviceProviders = null;
-    private static final Lock providerLock = new ReentrantLock();
+    private static final List<ContextDataProvider> SERVICE_PROVIDERS = getServiceProviders();
 
-    public static void initServiceProviders() {
-        if (serviceProviders == null) {
-            providerLock.lock();
-            try {
-                if (serviceProviders == null) {
-                    serviceProviders = getServiceProviders();
-                }
-            } finally {
-                providerLock.unlock();
-            }
-        }
-    }
+    public static void initServiceProviders() {}
 
     private static List<ContextDataProvider> getServiceProviders() {
         List<ContextDataProvider> providers = new ArrayList<>();
@@ -91,7 +78,7 @@ public class ThreadContextDataInjector {
                 LOGGER.debug("Unable to access Context Data Providers {}", ex.getMessage());
             }
         }
-        return providers;
+        return Collections.unmodifiableList(providers);
     }
 
     /**
@@ -283,10 +270,10 @@ public class ThreadContextDataInjector {
 
     private static List<ContextDataProvider> getProviders() {
         initServiceProviders();
-        final List<ContextDataProvider> providers = new ArrayList<>(contextDataProviders);
-        if (serviceProviders != null) {
-            providers.addAll(serviceProviders);
-        }
+        final List<ContextDataProvider> providers =
+                new ArrayList<>(contextDataProviders.size() + SERVICE_PROVIDERS.size());
+        providers.addAll(contextDataProviders);
+        providers.addAll(SERVICE_PROVIDERS);
         return providers;
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/ExecutorServices.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/ExecutorServices.java
@@ -78,4 +78,6 @@ public class ExecutorServices {
         return true;
     }
 
+    /** no-op method which can be invoked to ensure this class has been initialized per jls-12.4.2. */
+    public static void ensureInitialized() {}
 }


### PR DESCRIPTION
draft, I need to validate performance related to the original reason this ran on another thread:  https://issues.apache.org/jira/browse/LOG4J2-2867

Now that the serviceloader is guarded by class init, it should be less costly, however I wonder if we can deduplicate out some parent classloaders from loaderutil.