### PR TITLE
Expand test suite for DateLookup

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/DateLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/DateLookup.java
@@ -28,7 +28,8 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.status.StatusLogger;
 
 /**
- * Formats the current date or the date in the LogEvent. The "key" is used as the format String.
+ * Formats the current date or the date in the LogEvent. The "key" is used as the format String,
+ * following the java.text.SimpleDateFormat date and time pattern strings.
  */
 @Plugin(name = "date", category = StrLookup.CATEGORY)
 public class DateLookup implements StrLookup {
@@ -37,9 +38,9 @@ public class DateLookup implements StrLookup {
     private static final Marker LOOKUP = MarkerManager.getMarker("LOOKUP");
 
     /**
-     * Looks up the value of the environment variable.
+     * Looks up the current date.
      * @param key the format to use. If null, the default DateFormat will be used.
-     * @return The value of the environment variable.
+     * @return The formatted current date, never null.
      */
     @Override
     public String lookup(final String key) {
@@ -47,10 +48,10 @@ public class DateLookup implements StrLookup {
     }
 
     /**
-     * Looks up the value of the environment variable.
+     * Looks up the the current date or the date in the LogEvent.
      * @param event The LogEvent for which the date is returned. If null, current date is returned.
      * @param key the format to use. If null, the default DateFormat will be used.
-     * @return The value of the environment variable.
+     * @return The formatted date, never null.
      */
     @Override
     public String lookup(final LogEvent event, final String key) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/DateLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/DateLookup.java
@@ -48,7 +48,7 @@ public class DateLookup implements StrLookup {
 
     /**
      * Looks up the value of the environment variable.
-     * @param event The current LogEvent (is ignored by this StrLookup).
+     * @param event The LogEvent for which the date is returned. If null, current date is returned.
      * @param key the format to use. If null, the default DateFormat will be used.
      * @return The value of the environment variable.
      */

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/DateLookupTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/DateLookupTest.java
@@ -23,31 +23,42 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DateLookupTest {
 
-
     @Test
-    public void testLookup() {
-        final StrLookup lookup = new DateLookup();
-        final LogEvent event = new MyLogEvent();
-        final String value = lookup.lookup(event, "MM/dd/yyyy");
-        assertNotNull(value);
-        assertEquals("12/30/2011", value);
+    public void testDateLookupInEvent() {
+        final LogEvent mockedEvent = mock(LogEvent.class);
+        final Calendar cal = Calendar.getInstance();
+        cal.set(2011, Calendar.DECEMBER, 30, 10, 56, 35);
+        when(mockedEvent.getTimeMillis()).thenReturn(cal.getTimeInMillis());
+
+        final String actualDate = new DateLookup().lookup(mockedEvent, "MM/dd/yyyy");
+        assertEquals("12/30/2011", actualDate);
     }
 
-    private static class MyLogEvent extends AbstractLogEvent {
-        /**
-         * Generated serial version ID.
-         */
-        private static final long serialVersionUID = -2663819677970643109L;
+    @Test
+    public void testDateLookUpNoEvent() {
+        final String dateFormat = "MM/dd/yyyy";
+        final String actualDate = new DateLookup().lookup(null, dateFormat);
+        // we don't know current time, so check length of format instead.
+        assertEquals(actualDate.length(), dateFormat.length());
+    }
 
-        @Override
-        public long getTimeMillis() {
-            final Calendar cal = Calendar.getInstance();
-            cal.set(2011, Calendar.DECEMBER, 30, 10, 56, 35);
-            return cal.getTimeInMillis();
-        }
+    @Test
+    public void testNullDateLookupYieldsCurrentTime() {
+        final String currentTime = new DateLookup().lookup(null, null);
+        assertNotNull(currentTime);
+        // we don't know current time nor format, so just check length of date string.
+        assertTrue(currentTime.length() > 0);
+    }
 
+    @Test
+    public void testInvalidFormatYieldsDefaultFormat() {
+        final String currentTime = new DateLookup().lookup(null, "bananas");
+        // we don't know current time nor format, so just check length of date string.
+        assertTrue(currentTime.length() > 0);
     }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/DateLookupTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/DateLookupTest.java
@@ -16,11 +16,15 @@
  */
 package org.apache.logging.log4j.core.lookup;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
-import org.apache.logging.log4j.core.AbstractLogEvent;
 import org.apache.logging.log4j.core.LogEvent;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -29,36 +33,39 @@ import static org.mockito.Mockito.when;
 public class DateLookupTest {
 
     @Test
-    public void testDateLookupInEvent() {
+    public void testCorrectEvent() {
         final LogEvent mockedEvent = mock(LogEvent.class);
         final Calendar cal = Calendar.getInstance();
         cal.set(2011, Calendar.DECEMBER, 30, 10, 56, 35);
         when(mockedEvent.getTimeMillis()).thenReturn(cal.getTimeInMillis());
 
-        final String actualDate = new DateLookup().lookup(mockedEvent, "MM/dd/yyyy");
-        assertEquals("12/30/2011", actualDate);
+        final String lookupDate = new DateLookup().lookup(mockedEvent, "MM/dd/yyyy");
+        assertEquals("12/30/2011", lookupDate);
     }
 
     @Test
-    public void testDateLookUpNoEvent() {
+    public void testValidKeyWithoutEvent() {
         final String dateFormat = "MM/dd/yyyy";
-        final String actualDate = new DateLookup().lookup(null, dateFormat);
-        // we don't know current time, so check length of format instead.
-        assertEquals(actualDate.length(), dateFormat.length());
+
+        final Calendar cal = Calendar.getInstance();
+        final DateFormat formatter = new SimpleDateFormat(dateFormat);
+        cal.setTimeInMillis(System.currentTimeMillis());
+        final String today = formatter.format(cal.getTime());
+        cal.add(Calendar.DATE, 1);
+        final String tomorrow = formatter.format(cal.getTime());
+
+        final String lookupTime = new DateLookup().lookup(null, dateFormat);
+        // lookup gives current time, which by now could be tomorrow at midnight sharp
+        assertTrue(lookupTime.equals(today) || lookupTime.equals(tomorrow));
     }
 
-    @Test
-    public void testNullDateLookupYieldsCurrentTime() {
-        final String currentTime = new DateLookup().lookup(null, null);
-        assertNotNull(currentTime);
-        // we don't know current time nor format, so just check length of date string.
-        assertTrue(currentTime.length() > 0);
-    }
-
-    @Test
-    public void testInvalidFormatYieldsDefaultFormat() {
-        final String currentTime = new DateLookup().lookup(null, "bananas");
-        // we don't know current time nor format, so just check length of date string.
-        assertTrue(currentTime.length() > 0);
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = { "bananas" })
+    public void testInvalidKey(String key) {
+        // For invalid keys without event, the current time in default format should be returned.
+        // Checking this may depend on locale and exact time, and could become flaky.
+        // Therefore we just check that the result isn't null and that (formatting) exceptions are caught.
+        assertNotNull(new DateLookup().lookup(null, key));
     }
 }


### PR DESCRIPTION
This commit strengthens the test suite for the `DateLookup` class so that it achieves full branch coverage.

The javadoc for the `lookup(event, key)` method incorrectly stated that the key was ignored.
This has been updated to clarify that the date of the event is shown.

The PR replaces the hand-written `MyLogEvent` with a mockito mock class.