### PR TITLE
LOG4J2-3350: Evaluate configuration property substitutions eagerly

### DIFF
--- a/log4j-core/revapi.json
+++ b/log4j-core/revapi.json
@@ -192,6 +192,27 @@
         "code": "java.method.removed",
         "old": "method java.util.List<java.lang.String> org.apache.logging.log4j.core.util.NetUtils::getLocalIps()",
         "justification": "method is no longer used."
+      },
+      {
+        "code": "java.annotation.removed",
+        "old": "parameter org.apache.logging.log4j.core.config.Property org.apache.logging.log4j.core.config.Property::createProperty(===java.lang.String===, java.lang.String)",
+        "new": "parameter org.apache.logging.log4j.core.config.Property org.apache.logging.log4j.core.config.Property::createProperty(===java.lang.String===, java.lang.String)",
+        "annotation": "@org.apache.logging.log4j.core.config.plugins.PluginAttribute(\"name\")",
+        "justification": "Plugin system uses the new constructor"
+      },
+      {
+        "code": "java.annotation.removed",
+        "old": "parameter org.apache.logging.log4j.core.config.Property org.apache.logging.log4j.core.config.Property::createProperty(java.lang.String, ===java.lang.String===)",
+        "new": "parameter org.apache.logging.log4j.core.config.Property org.apache.logging.log4j.core.config.Property::createProperty(java.lang.String, ===java.lang.String===)",
+        "annotation": "@org.apache.logging.log4j.core.config.plugins.PluginValue(\"value\")",
+        "justification": "Plugin system uses the new constructor"
+      },
+      {
+        "code": "java.annotation.removed",
+        "old": "method org.apache.logging.log4j.core.config.Property org.apache.logging.log4j.core.config.Property::createProperty(java.lang.String, java.lang.String)",
+        "new": "method org.apache.logging.log4j.core.config.Property org.apache.logging.log4j.core.config.Property::createProperty(java.lang.String, java.lang.String)",
+        "annotation": "@org.apache.logging.log4j.core.config.plugins.PluginFactory",
+        "justification": "Plugin system uses the new constructor"
       }
     ]
   }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/PluginValue.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/PluginValue.java
@@ -37,4 +37,7 @@ import org.apache.logging.log4j.core.config.plugins.visitors.PluginValueVisitor;
 public @interface PluginValue {
 
     String value();
+
+    /** If false, standard configuration value substitution is not done on the referenced value. */
+    boolean substitute() default true;
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginValueVisitor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginValueVisitor.java
@@ -49,7 +49,9 @@ public class PluginValueVisitor extends AbstractPluginVisitor<PluginValue> {
         } else {
             rawValue = removeAttributeValue(node.getAttributes(), name);
         }
-        final String value = this.substitutor.replace(event, rawValue);
+        final String value = this.annotation.substitute()
+                ? this.substitutor.replace(event, rawValue)
+                : rawValue;
         StringBuilders.appendKeyDqValue(log, name, value);
         return value;
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
@@ -104,7 +104,7 @@ public class Interpolator extends AbstractConfigurationAwareLookup {
         strLookupMap.put("sys", new SystemPropertiesLookup());
         strLookupMap.put("env", new EnvironmentLookup());
         strLookupMap.put("main", MainMapLookup.MAIN_SINGLETON);
-        strLookupMap.put("map", new MapLookup(properties));
+        strLookupMap.put("map", new MapLookup());
         strLookupMap.put("marker", new MarkerLookup());
         strLookupMap.put("java", new JavaLookup());
         strLookupMap.put("lower", new LowerLookup());

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender3350Test.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender3350Test.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.appender.routing;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.apache.logging.log4j.message.StringMapMessage;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class RoutingAppender3350Test {
+    private static final String CONFIG = "log4j-routing3350.xml";
+    private static final String LOG_FILE = "target/tmp/test.log";
+
+    private final LoggerContextRule loggerContextRule = new LoggerContextRule(CONFIG);
+
+    @Rule
+    public RuleChain rules = loggerContextRule.withCleanFilesRule(LOG_FILE);
+
+    @After
+    public void tearDown() throws Exception {
+        this.loggerContextRule.getLoggerContext().stop();
+    }
+
+    @Test
+    public void routingTest() throws IOException {
+        String expected = "expectedValue";
+        StringMapMessage message = new StringMapMessage().with("data", expected);
+        Logger logger = loggerContextRule.getLoggerContext().getLogger(getClass());
+        logger.error(message);
+        File file = new File(LOG_FILE);
+        try (InputStream inputStream = new FileInputStream(file);
+             InputStreamReader streamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+             BufferedReader reader = new BufferedReader(streamReader)) {
+            String actual = reader.readLine();
+            assertEquals(expected, actual);
+        }
+    }
+}

--- a/log4j-core/src/test/resources/log4j-routing3350.xml
+++ b/log4j-core/src/test/resources/log4j-routing3350.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration status="OFF" name="Routing3350">
+  <Properties>
+    <Property name="pcode">def</Property>
+    <Property name="drive">target</Property>
+    <Property name="path">/tmp/</Property>
+    <Property name="name">test.log</Property>
+    <Property name="filename">${drive}${path}${name}</Property>
+    <Property name="filepattern">${filename}.%i.backup</Property>
+  </Properties>
+  <Appenders>
+    <Routing name="Routing">
+      <Routes pattern="$${map:pcode}">
+        <Route>
+          <RollingFile name="Rolling" fileName="${filename}" filePattern="${filepattern}">
+            <PatternLayout>
+              <pattern>%map{data}%n</pattern>
+            </PatternLayout>
+            <SizeBasedTriggeringPolicy size="500"/>
+          </RollingFile>
+        </Route>
+      </Routes>
+    </Routing>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="EventLogger" level="info" additivity="false">
+      <AppenderRef ref="Routing"/>
+    </Logger>
+
+    <Root level="info">
+      <AppenderRef ref="Routing"/>
+    </Root>
+  </Loggers>
+
+</Configuration>


### PR DESCRIPTION
Previously lookups between configuration properties weren't evaluated
until they were used in the configuration, which resulted in
behavior more prohibitive for RoutingAppenders than anticipated.

This attempts to pre-compute the values of top-level configuration
properties so they don't have to be re-evaluated on an as-needed
basis.