### PR TITLE
Fixes a StringIndexOutOfBoundsException

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -551,11 +551,13 @@ public final class PropertiesUtil {
     public static Map<String, Properties> partitionOnCommonPrefixes(final Properties properties) {
         final Map<String, Properties> parts = new ConcurrentHashMap<>();
         for (final String key : properties.stringPropertyNames()) {
-            final String prefix = key.substring(0, key.indexOf('.'));
+            final int idx = key.indexOf('.');
+            if (idx < 0) continue;
+            final String prefix = key.substring(0, idx);
             if (!parts.containsKey(prefix)) {
                 parts.put(prefix, new Properties());
             }
-            parts.get(prefix).setProperty(key.substring(key.indexOf('.') + 1), properties.getProperty(key));
+            parts.get(prefix).setProperty(key.substring(idx + 1), properties.getProperty(key));
         }
         return parts;
     }

--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/PropertiesUtilTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/PropertiesUtilTest.java
@@ -45,7 +45,8 @@ public class PropertiesUtilTest {
         assertHasAllProperties(PropertiesUtil.extractSubset(properties, "b."));
         assertHasAllProperties(PropertiesUtil.extractSubset(properties, "c.1"));
         assertHasAllProperties(PropertiesUtil.extractSubset(properties, "dd"));
-        assertEquals(0, properties.size());
+        // One invalid entry remains
+        assertEquals(1, properties.size());
     }
 
     @Test

--- a/log4j-api/src/test/resources/PropertiesUtilTest.properties
+++ b/log4j-api/src/test/resources/PropertiesUtilTest.properties
@@ -27,3 +27,6 @@ c.1.3 = 3
 dd.1 = 1
 dd.2 = 2
 dd.3 = 3
+
+# Dotless entry, should be ignored
+a = invalid


### PR DESCRIPTION
`PropertiesUtilTest#partitionOnCommonPrefixes` fails if a property does not contain any dots.

The bug appears when parsing a `log4j2.properties` like in [this StackOverflow question](https://stackoverflow.com/q/70851549/11748454).

I modified the data used by `PropertiesUtilTest` to fail with a `StringIndexOutOfBoundsException`.