### PR TITLE
Adds a Tomcat lookup

### DIFF
--- a/log4j-appserver/src/main/java/org/apache/logging/log4j/appserver/tomcat/TomcatLookup.java
+++ b/log4j-appserver/src/main/java/org/apache/logging/log4j/appserver/tomcat/TomcatLookup.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.appserver.tomcat;
+
+import org.apache.juli.WebappProperties;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.lookup.StrLookup;
+
+/**
+ * Resolves the names specific to Tomcat's internal component structure. The
+ * names of the properties starting with {@code classloader.} are kept for
+ * compatibility with the original Tomcat JULI implementation.
+ */
+@Plugin(name = "tomcat", category = StrLookup.CATEGORY)
+public class TomcatLookup implements StrLookup {
+
+    private static final String SERVICE_LOGGER_FORMAT = "org.apache.catalina.core.ContainerBase.[%s]";
+    private static final String HOST_LOGGER_FORMAT = "org.apache.catalina.core.ContainerBase.[%s].[%s]";
+    private static final String CONTEXT_LOGGER_FORMAT = "org.apache.catalina.core.ContainerBase.[%s].[%s].[%s]";
+
+    @Override
+    public String lookup(String key) {
+        final ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl instanceof WebappProperties) {
+            final WebappProperties props = (WebappProperties) cl;
+            switch (key) {
+                case "catalina.engine.name":
+                case "classloader.serviceName":
+                    return props.getServiceName();
+                case "catalina.engine.logger":
+                    return String.format(SERVICE_LOGGER_FORMAT, props.getServiceName());
+                case "catalina.host.name":
+                case "classloader.hostName":
+                    return props.getHostName();
+                case "catalina.host.logger":
+                    return String.format(HOST_LOGGER_FORMAT, props.getServiceName(), props.getHostName());
+                case "catalina.context.name":
+                case "classloader.webappName":
+                    return props.getWebappName();
+                case "catalina.context.logger":
+                    return String.format(CONTEXT_LOGGER_FORMAT, props.getServiceName(), props.getHostName(),
+                            props.getWebappName());
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String lookup(LogEvent event, String key) {
+        return lookup(key);
+    }
+}

--- a/log4j-appserver/src/main/java/org/apache/logging/log4j/appserver/tomcat/TomcatLookup.java
+++ b/log4j-appserver/src/main/java/org/apache/logging/log4j/appserver/tomcat/TomcatLookup.java
@@ -36,7 +36,7 @@ public class TomcatLookup implements StrLookup {
     @Override
     public String lookup(String key) {
         final ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        if (cl instanceof WebappProperties) {
+        if (cl instanceof WebappProperties && key != null) {
             final WebappProperties props = (WebappProperties) cl;
             switch (key) {
                 case "catalina.engine.name":

--- a/log4j-appserver/src/test/java/org/apache/logging/log4j/appserver/tomcat/TomcatLoggerTest.java
+++ b/log4j-appserver/src/test/java/org/apache/logging/log4j/appserver/tomcat/TomcatLoggerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.appserver.tomcat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.junit.LoggerContextSource;
+import org.apache.logging.log4j.junit.Named;
+import org.apache.logging.log4j.test.appender.ListAppender;
+import org.junit.jupiter.api.Test;
+
+@LoggerContextSource("log4j2-listAppender.xml")
+public class TomcatLoggerTest {
+
+    private static final String MESSAGE = "Hello world!";
+
+    @Test
+    public void testMessageForwarding(@Named("List") final ListAppender app) {
+        final Log juliLog = LogFactory.getLog(TomcatLoggerTest.class);
+        juliLog.debug(MESSAGE);
+        List<LogEvent> events = app.getEvents();
+        assertEquals(1, events.size());
+        Object[] parameters = events.get(0).getMessage().getParameters();
+        assertEquals(1, parameters.length);
+        assertEquals(MESSAGE, parameters[0]);
+    }
+
+}

--- a/log4j-appserver/src/test/java/org/apache/logging/log4j/appserver/tomcat/TomcatLookupTest.java
+++ b/log4j-appserver/src/test/java/org/apache/logging/log4j/appserver/tomcat/TomcatLookupTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.appserver.tomcat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.catalina.loader.WebappClassLoader;
+import org.apache.logging.log4j.core.lookup.StrLookup;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class TomcatLookupTest {
+
+    private static ClassLoader originalTccl;
+
+    private static final String ENGINE_NAME = "Catalina";
+    private static final String HOST_NAME = "localhost";
+    private static final String CONTEXT_NAME = "/myapp";
+
+    @BeforeAll
+    public static void setupContextClassloader() {
+        originalTccl = Thread.currentThread().getContextClassLoader();
+        WebappClassLoader tccl = Mockito.mock(WebappClassLoader.class);
+        Mockito.when(tccl.getServiceName()).thenReturn(ENGINE_NAME);
+        Mockito.when(tccl.getHostName()).thenReturn(HOST_NAME);
+        Mockito.when(tccl.getWebappName()).thenReturn(CONTEXT_NAME);
+        Thread.currentThread().setContextClassLoader(tccl);
+    }
+
+    @AfterAll
+    public static void clearContextClassloader() {
+        Thread.currentThread().setContextClassLoader(originalTccl);
+    }
+
+    @Test
+    public void lookupWorksProperly() {
+        final StrLookup lookup = new TomcatLookup();
+        assertEquals(ENGINE_NAME, lookup.lookup("classloader.serviceName"));
+        assertEquals(ENGINE_NAME, lookup.lookup("catalina.engine.name"));
+        assertEquals(HOST_NAME, lookup.lookup("classloader.hostName"));
+        assertEquals(HOST_NAME, lookup.lookup("catalina.host.name"));
+        assertEquals(CONTEXT_NAME, lookup.lookup("classloader.webappName"));
+        assertEquals(CONTEXT_NAME, lookup.lookup("catalina.context.name"));
+        assertEquals("org.apache.catalina.core.ContainerBase.[Catalina]", lookup.lookup("catalina.engine.logger"));
+        assertEquals("org.apache.catalina.core.ContainerBase.[Catalina].[localhost]",
+                lookup.lookup("catalina.host.logger"));
+        assertEquals("org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/myapp]",
+                lookup.lookup("catalina.context.logger"));
+    }
+}

--- a/log4j-appserver/src/test/resources/log4j2-listAppender.xml
+++ b/log4j-appserver/src/test/resources/log4j2-listAppender.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="ERROR">
+  <Appenders>
+    <List name="List" />
+  </Appenders>
+  <Loggers>
+    <Root level="ALL">
+      <AppenderRef ref="List" />
+    </Root>
+  </Loggers>
+</Configuration>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -168,6 +168,7 @@
         <item name="Spring" href="/manual/lookups.html#SpringLookup"/>
         <item name="Structured Data" href="/manual/lookups.html#StructuredDataLookup"/>
         <item name="System Properties" href="/manual/lookups.html#SystemPropertiesLookup"/>
+        <item name="Tomcat" href="/manual/lookups.html#TomcatLookup"/>
         <item name="Upper" href="/manual/lookups.html#UpperLookup"/>
         <item name="Web" href="/manual/lookups.html#WebLookup"/>
       </item>

--- a/src/site/xdoc/manual/lookups.xml
+++ b/src/site/xdoc/manual/lookups.xml
@@ -650,7 +650,6 @@ logger.info(PERFORMANCE, "Message in Performance.log");]]></pre>
   <File name="ApplicationLog" fileName="${sys:logPath:-/var/logs}/app.log"/>
 </Appenders>]]></pre>            
         </subsection>
-        <a name="UpperLookup"/>
         <a name="TomcatLookup"/>
         <subsection name="Tomcat Lookup">
           <p>
@@ -694,6 +693,7 @@ logger.info(PERFORMANCE, "Message in Performance.log");]]></pre>
             </tr>
           </table>
         </subsection>
+        <a name="UpperLookup"/>
         <subsection name="Upper Lookup">
           <p>
             The UpperLookup converts the passed in argument to upper case. Presumably the value will be the

--- a/src/site/xdoc/manual/lookups.xml
+++ b/src/site/xdoc/manual/lookups.xml
@@ -651,6 +651,49 @@ logger.info(PERFORMANCE, "Message in Performance.log");]]></pre>
 </Appenders>]]></pre>            
         </subsection>
         <a name="UpperLookup"/>
+        <a name="TomcatLookup"/>
+        <subsection name="Tomcat Lookup">
+          <p>
+            The TomcatLookup allows applications running on Tomcat to retrieve the names of the component hierarchy
+            containing the application. The keys in parentheses are kept for compatibility with Tomcat JULI.
+          </p>
+          <table>
+            <tr>
+              <th>Key</th>
+              <th>Description</th>
+            </tr>
+            <tr>
+              <td>catalina.engine.name<br/>(classloader.serviceName)</td>
+              <td>Returns the name of the current
+                <a href="https://tomcat.apache.org/tomcat-8.5-doc/config/engine.html">Engine</a>
+              </td>
+            </tr>
+            <tr>
+              <td>catalina.host.name<br/>(classloader.hostName)</td>
+              <td>Returns the name of the current
+                <a href="https://tomcat.apache.org/tomcat-8.5-doc/config/host.html">Host</a>
+              </td>
+            </tr>
+            <tr>
+              <td>catalina.context.name<br/>(classloader.webappName)</td>
+              <td>Returns the name of the current
+                <a href="https://tomcat.apache.org/tomcat-8.5-doc/config/context.html">Context</a>
+              </td>
+            </tr>
+            <tr>
+              <td>catalina.engine.logger</td>
+              <td>Returns the logger name of the current engine.</td>
+            </tr>
+            <tr>
+              <td>catalina.host.logger</td>
+              <td>Returns the logger name of the current host.</td>
+            </tr>
+            <tr>
+              <td>catalina.context.logger</td>
+              <td>Returns the logger name of the current context.</td>
+            </tr>
+          </table>
+        </subsection>
         <subsection name="Upper Lookup">
           <p>
             The UpperLookup converts the passed in argument to upper case. Presumably the value will be the


### PR DESCRIPTION
The `TomcatLookup` can be used to retrieve the engine, host and context names under which the application is running. These are also provided by the original Tomcat JULI implementation (cf. [ClassLoaderLogManager#replaceWebApplicationProperties](https://github.com/apache/tomcat/blob/a05603de0fc5ae1ee60d41ea8677f96818a9b11f/java/org/apache/juli/ClassLoaderLogManager.java#L654)).

It also provides three helper properties `*.logger` that resolve to the logger name used by `ServletContext#log`.