### PR TITLE
LOG4J2-3350: Lookup recursion is not allowed, except through config properties

### DIFF
--- a/log4j-core/revapi.json
+++ b/log4j-core/revapi.json
@@ -49,6 +49,33 @@
         "old": "method void org.apache.logging.log4j.core.script.ScriptManager::addScript(org.apache.logging.log4j.core.script.AbstractScript)",
         "new": "method boolean org.apache.logging.log4j.core.script.ScriptManager::addScript(org.apache.logging.log4j.core.script.AbstractScript)",
         "justification": "LOG4J2-2486 - Require enabled script languages to be specified in a system property"
+      },
+      {
+        "code": "java.method.returnTypeChanged",
+        "old": "method java.lang.String org.apache.logging.log4j.core.lookup.StrSubstitutor::resolveVariable(org.apache.logging.log4j.core.LogEvent, java.lang.String, java.lang.StringBuilder, int, int)",
+        "new": "method org.apache.logging.log4j.core.lookup.LookupResult org.apache.logging.log4j.core.lookup.StrSubstitutor::resolveVariable(org.apache.logging.log4j.core.LogEvent, java.lang.String, java.lang.StringBuilder, int, int)",
+        "justification": "LOG4J2-3317: Fix RoutingAppender backcompat while improving lookup security"
+      },
+      {
+        "code": "java.annotation.removed",
+        "old": "parameter org.apache.logging.log4j.core.config.Property org.apache.logging.log4j.core.config.Property::createProperty(===java.lang.String===, java.lang.String)",
+        "new": "parameter org.apache.logging.log4j.core.config.Property org.apache.logging.log4j.core.config.Property::createProperty(===java.lang.String===, java.lang.String)",
+        "annotation": "@org.apache.logging.log4j.core.config.plugins.PluginAttribute(\"name\")",
+        "justification": "LOG4J2-3317: Fix RoutingAppender backcompat while improving lookup security"
+      },
+      {
+        "code": "java.annotation.removed",
+        "old": "parameter org.apache.logging.log4j.core.config.Property org.apache.logging.log4j.core.config.Property::createProperty(java.lang.String, ===java.lang.String===)",
+        "new": "parameter org.apache.logging.log4j.core.config.Property org.apache.logging.log4j.core.config.Property::createProperty(java.lang.String, ===java.lang.String===)",
+        "annotation": "@org.apache.logging.log4j.core.config.plugins.PluginValue(\"value\")",
+        "justification": "LOG4J2-3317: Fix RoutingAppender backcompat while improving lookup security"
+      },
+      {
+        "code": "java.annotation.removed",
+        "old": "method org.apache.logging.log4j.core.config.Property org.apache.logging.log4j.core.config.Property::createProperty(java.lang.String, java.lang.String)",
+        "new": "method org.apache.logging.log4j.core.config.Property org.apache.logging.log4j.core.config.Property::createProperty(java.lang.String, java.lang.String)",
+        "annotation": "@org.apache.logging.log4j.core.config.plugins.PluginFactory",
+        "justification": "LOG4J2-3317: Fix RoutingAppender backcompat while improving lookup security"
       }
     ]
   }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/HttpURLConnectionManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/HttpURLConnectionManager.java
@@ -92,7 +92,7 @@ public class HttpURLConnectionManager extends HttpManager {
         for (final Property header : headers) {
             urlConnection.setRequestProperty(
                 header.getName(),
-                header.isValueNeedsLookup() ? getConfiguration().getStrSubstitutor().replace(event, header.getValue()) : header.getValue());
+                header.evaluate(getConfiguration().getStrSubstitutor()));
         }
         if (sslConfiguration != null) {
             ((HttpsURLConnection)urlConnection).setSSLSocketFactory(sslConfiguration.getSslSocketFactory());

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLogger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLogger.java
@@ -496,9 +496,7 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
             if (contextData.getValue(prop.getName()) != null) {
                 continue; // contextMap overrides config properties
             }
-            final String value = prop.isValueNeedsLookup() //
-                    ? privateConfig.config.getStrSubstitutor().replace(event, prop.getValue()) //
-                    : prop.getValue();
+            final String value = prop.evaluate(privateConfig.config.getStrSubstitutor());
             contextData.putValue(prop.getName(), value);
         }
         event.setContextData(contextData);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -454,10 +454,8 @@ public class LoggerConfig extends AbstractFilterable implements LocationAware {
                 .build();
         for (int i = 0; i < props.size(); i++) {
             final Property prop = props.get(i);
-            final String value = prop.isValueNeedsLookup() // since LOG4J2-1575
-                    ? config.getStrSubstitutor().replace(event, prop.getValue()) //
-                    : prop.getValue();
-            results.add(Property.createProperty(prop.getName(), value));
+            final String value = prop.evaluate(config.getStrSubstitutor()); // since LOG4J2-1575
+            results.add(Property.createProperty(prop.getName(), prop.getRawValue(), value));
         }
         return results;
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/PluginValue.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/PluginValue.java
@@ -37,4 +37,7 @@ import org.apache.logging.log4j.core.config.plugins.visitors.PluginValueVisitor;
 public @interface PluginValue {
 
     String value();
+
+    /** If false, standard configuration value substitution is not done on the referenced value. */
+    boolean substitute() default true;
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginValueVisitor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginValueVisitor.java
@@ -49,7 +49,9 @@ public class PluginValueVisitor extends AbstractPluginVisitor<PluginValue> {
         } else {
             rawValue = removeAttributeValue(node.getAttributes(), name);
         }
-        final String value = this.substitutor.replace(event, rawValue);
+        final String value = this.annotation.substitute()
+                ? this.substitutor.replace(event, rawValue)
+                : rawValue;
         StringBuilders.appendKeyDqValue(log, name, value);
         return value;
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/ConfigurationStrSubstitutor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/ConfigurationStrSubstitutor.java
@@ -46,17 +46,6 @@ public final class ConfigurationStrSubstitutor extends StrSubstitutor {
     }
 
     @Override
-    boolean isRecursiveEvaluationAllowed() {
-        return true;
-    }
-
-    @Override
-    void setRecursiveEvaluationAllowed(final boolean recursiveEvaluationAllowed) {
-        throw new UnsupportedOperationException(
-                "recursiveEvaluationAllowed cannot be modified within ConfigurationStrSubstitutor");
-    }
-
-    @Override
     public String toString() {
         return "ConfigurationStrSubstitutor{" + super.toString() + "}";
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/DefaultLookupResult.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/DefaultLookupResult.java
@@ -14,33 +14,32 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
+
 package org.apache.logging.log4j.core.lookup;
 
-/**
- * A default lookup for others to extend.
- *
- * @since 2.1
- */
-public abstract class AbstractLookup implements StrLookup {
+import java.util.Objects;
 
-    /**
-     * Calls {@code lookup(null, key)} in the implementation.
-     *
-     * @see StrLookup#lookup(LogEvent, String)
-     */
-    @Override
-    public String lookup(final String key) {
-        return lookup(null, key);
+/** Default internal implementation of {@link LookupResult}. */
+final class DefaultLookupResult implements LookupResult {
+
+    private final String value;
+
+    DefaultLookupResult(String value) {
+        this.value = Objects.requireNonNull(value, "value is required");
     }
 
-    /**
-     * Calls {@code evaluate(null, key)} in the implementation.
-     *
-     * @see StrLookup#evaluate(LogEvent, String)
-     */
     @Override
-    public LookupResult evaluate(final String key) {
-        return evaluate(null, key);
+    public String value() {
+        return value;
     }
 
+    @Override
+    public boolean isLookupEvaluationAllowedInValue() {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultLookupResult{value='" + value + "'}";
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
@@ -154,6 +154,25 @@ public class Interpolator extends AbstractConfigurationAwareLookup {
      */
     @Override
     public String lookup(final LogEvent event, String var) {
+        LookupResult result = evaluate(event, var);
+        return result == null ? null : result.value();
+    }
+
+    /**
+     * Resolves the specified variable. This implementation will try to extract
+     * a variable prefix from the given variable name (the first colon (':') is
+     * used as prefix separator). It then passes the name of the variable with
+     * the prefix stripped to the lookup object registered for this prefix. If
+     * no prefix can be found or if the associated lookup object cannot resolve
+     * this variable, the default lookup object will be used.
+     *
+     * @param event The current LogEvent or null.
+     * @param var the name of the variable whose value is to be looked up
+     * @return the value of this variable or <b>null</b> if it cannot be
+     * resolved
+     */
+    @Override
+    public LookupResult evaluate(final LogEvent event, String var) {
         if (var == null) {
             return null;
         }
@@ -166,9 +185,9 @@ public class Interpolator extends AbstractConfigurationAwareLookup {
             if (lookup instanceof ConfigurationAware) {
                 ((ConfigurationAware) lookup).setConfiguration(configuration);
             }
-            String value = null;
+            LookupResult value = null;
             if (lookup != null) {
-                value = event == null ? lookup.lookup(name) : lookup.lookup(event, name);
+                value = event == null ? lookup.evaluate(name) : lookup.evaluate(event, name);
             }
 
             if (value != null) {
@@ -177,7 +196,7 @@ public class Interpolator extends AbstractConfigurationAwareLookup {
             var = var.substring(prefixPos + 1);
         }
         if (defaultLookup != null) {
-            return event == null ? defaultLookup.lookup(var) : defaultLookup.lookup(event, var);
+            return event == null ? defaultLookup.evaluate(var) : defaultLookup.evaluate(event, var);
         }
         return null;
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/LookupResult.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/LookupResult.java
@@ -14,33 +14,22 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
+
 package org.apache.logging.log4j.core.lookup;
 
-/**
- * A default lookup for others to extend.
- *
- * @since 2.1
- */
-public abstract class AbstractLookup implements StrLookup {
+public interface LookupResult {
+
+    /** Value of the lookup result. Never null. */
+    String value();
 
     /**
-     * Calls {@code lookup(null, key)} in the implementation.
-     *
-     * @see StrLookup#lookup(LogEvent, String)
+     * True if the {@link #value()} should be re-evaluated for other lookups.
+     * This is used by {@link PropertiesLookup} to allow properties to be evaluated against other properties,
+     * because the configuration properties are completely trusted and designed with lookups in mind. It is
+     * unsafe to return true in most cases because it may allow unintended lookups to evaluate other lookups.
      */
-    @Override
-    public String lookup(final String key) {
-        return lookup(null, key);
-    }
-
-    /**
-     * Calls {@code evaluate(null, key)} in the implementation.
-     *
-     * @see StrLookup#evaluate(LogEvent, String)
-     */
-    @Override
-    public LookupResult evaluate(final String key) {
-        return evaluate(null, key);
+    default boolean isLookupEvaluationAllowedInValue() {
+        return false;
     }
 
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/PropertiesLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/PropertiesLookup.java
@@ -17,9 +17,12 @@
 package org.apache.logging.log4j.core.lookup;
 
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.Property;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A lookup designed for {@code Properties} defined in the configuration. This is similar
@@ -29,10 +32,20 @@ import java.util.Map;
  */
 public final class PropertiesLookup implements StrLookup {
 
-    /**
-     * Configuration from which to read properties.
-     */
-    private final Map<String, String> properties;
+    /** Logger context properties. */
+    private final Map<String, String> contextProperties;
+
+    /** Configuration properties. */
+    private final Map<String, ConfigurationPropertyResult> configurationProperties;
+
+    public PropertiesLookup(final Property[] configProperties, final Map<String, String> contextProperties) {
+        this.contextProperties = contextProperties == null
+                ? Collections.emptyMap()
+                : contextProperties;
+        this.configurationProperties = configProperties == null
+                ? Collections.emptyMap()
+                : createConfigurationPropertyMap(configProperties);
+    }
 
     /**
      * Constructs a new instance for the given map.
@@ -40,18 +53,7 @@ public final class PropertiesLookup implements StrLookup {
      * @param properties map these.
      */
     public PropertiesLookup(final Map<String, String> properties) {
-        this.properties = properties == null
-                ? Collections.emptyMap()
-                : properties;
-    }
-
-    /**
-     * Gets the property map.
-     *
-     * @return the property map.
-     */
-    public Map<String, String> getProperties() {
-        return properties;
+        this(Property.EMPTY_ARRAY, properties);
     }
 
     @Override
@@ -70,12 +72,100 @@ public final class PropertiesLookup implements StrLookup {
      */
     @Override
     public String lookup(final String key) {
-        return key == null ? null : properties.get(key);
+        LookupResult result = evaluate(key);
+        return result == null ? null : result.value();
+    }
+
+    @Override
+    public LookupResult evaluate(String key) {
+        if (key == null) {
+            return null;
+        }
+        LookupResult configResult = configurationProperties.get(key);
+        if (configResult != null) {
+            return configResult;
+        }
+        // Allow the context map to be mutated after this lookup has been initialized.
+        String contextResult = contextProperties.get(key);
+        return contextResult == null ? null : new ContextPropertyResult(contextResult);
+    }
+
+    @Override
+    public LookupResult evaluate(@SuppressWarnings("ignored") final LogEvent event, final String key) {
+        return evaluate(key);
     }
 
     @Override
     public String toString() {
-        return "PropertiesLookup{properties=" + properties + '}';
+        return "PropertiesLookup{" +
+                "contextProperties=" + contextProperties +
+                ", configurationProperties=" + configurationProperties +
+                '}';
     }
 
+    private static Map<String, ConfigurationPropertyResult> createConfigurationPropertyMap(Property[] props) {
+        // The raw property values must be used without the substitution handled by the plugin framework
+        // which calls this method, otherwise we risk re-interpolating through unexpected data.
+        // The PropertiesLookup is unique in that results from this lookup support recursive evaluation.
+        Map<String, ConfigurationPropertyResult> result = new HashMap<>(props.length);
+        for (Property property : props) {
+            result.put(property.getName(), new ConfigurationPropertyResult(property.getRawValue()));
+        }
+        return result;
+    }
+
+    private static final class ConfigurationPropertyResult implements LookupResult {
+
+        private final String value;
+
+        ConfigurationPropertyResult(String value) {
+            this.value = Objects.requireNonNull(value, "value is required");
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+
+        /**
+         * Properties are a special case in which lookups contained
+         * within the properties map are allowed for recursive evaluation.
+         */
+        @Override
+        public boolean isLookupEvaluationAllowedInValue() {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "ConfigurationPropertyResult{'" + value + "'}";
+        }
+    }
+
+    private static final class ContextPropertyResult implements LookupResult {
+
+        private final String value;
+
+        ContextPropertyResult(String value) {
+            this.value = Objects.requireNonNull(value, "value is required");
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+
+        /**
+         * Unlike configuration properties, context properties are not built around lookup syntax.
+         */
+        @Override
+        public boolean isLookupEvaluationAllowedInValue() {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "ContextPropertyResult{'" + value + "'}";
+        }
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/RuntimeStrSubstitutor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/RuntimeStrSubstitutor.java
@@ -44,17 +44,6 @@ public final class RuntimeStrSubstitutor extends StrSubstitutor {
     }
 
     @Override
-    boolean isRecursiveEvaluationAllowed() {
-        return false;
-    }
-
-    @Override
-    void setRecursiveEvaluationAllowed(final boolean recursiveEvaluationAllowed) {
-        throw new UnsupportedOperationException(
-                "recursiveEvaluationAllowed cannot be modified within RuntimeStrSubstitutor");
-    }
-
-    @Override
     public String toString() {
         return "RuntimeStrSubstitutor{" + super.toString() + "}";
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/StrLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/StrLookup.java
@@ -99,4 +99,26 @@ public interface StrLookup {
      * @return the matching value, null if no match
      */
     String lookup(LogEvent event, String key);
+
+    /**
+     * Same as {@link #lookup(String)}, but provides additional metadata describing the result.
+     * Returns null if the key cannot be evaluated, otherwise a {@link LookupResult} wrapping the non-null string value.
+     */
+    default LookupResult evaluate(String key) {
+        String value = lookup(key);
+        return value == null
+                ? null
+                : new DefaultLookupResult(value);
+    }
+
+    /**
+     * Same as {@link #lookup(LogEvent, String)}, but provides additional metadata describing the result.
+     * Returns null if the key cannot be evaluated, otherwise a {@link LookupResult} wrapping the non-null string value.
+     */
+    default LookupResult evaluate(LogEvent event, String key) {
+        String value = lookup(event, key);
+        return value == null
+                ? null
+                : new DefaultLookupResult(value);
+    }
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender3350Test.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender3350Test.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.appender.routing;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.apache.logging.log4j.message.StringMapMessage;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class RoutingAppender3350Test {
+    private static final String CONFIG = "log4j-routing3350.xml";
+    private static final String LOG_FILE = "target/tmp/test.log";
+
+    private final LoggerContextRule loggerContextRule = new LoggerContextRule(CONFIG);
+
+    @Rule
+    public RuleChain rules = loggerContextRule.withCleanFilesRule(LOG_FILE);
+
+    @After
+    public void tearDown() throws Exception {
+        this.loggerContextRule.getLoggerContext().stop();
+    }
+
+    @Test
+    public void routingTest() throws IOException {
+        String expected = "expectedValue";
+        StringMapMessage message = new StringMapMessage().with("data", expected);
+        Logger logger = loggerContextRule.getLoggerContext().getLogger(getClass());
+        logger.error(message);
+        File file = new File(LOG_FILE);
+        try (InputStream inputStream = new FileInputStream(file);
+             InputStreamReader streamReader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+             BufferedReader reader = new BufferedReader(streamReader)) {
+            String actual = reader.readLine();
+            assertEquals(expected, actual);
+        }
+    }
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/PropertiesPluginTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/PropertiesPluginTest.java
@@ -14,33 +14,23 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.lookup;
 
-/**
- * A default lookup for others to extend.
- *
- * @since 2.1
- */
-public abstract class AbstractLookup implements StrLookup {
+package org.apache.logging.log4j.core.config;
 
-    /**
-     * Calls {@code lookup(null, key)} in the implementation.
-     *
-     * @see StrLookup#lookup(LogEvent, String)
-     */
-    @Override
-    public String lookup(final String key) {
-        return lookup(null, key);
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PropertiesPluginTest {
+
+    @Test
+    public void testUnescape() {
+        assertEquals("${foo}", PropertiesPlugin.unescape("$${foo}"));
     }
 
-    /**
-     * Calls {@code evaluate(null, key)} in the implementation.
-     *
-     * @see StrLookup#evaluate(LogEvent, String)
-     */
-    @Override
-    public LookupResult evaluate(final String key) {
-        return evaluate(null, key);
+    @Test
+    public void testUnescapeNotEscapedWithDefault() {
+        String value = "${foo:-bar}";
+        assertEquals(value, PropertiesPlugin.unescape(value));
     }
-
 }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/PropertiesLookupTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/lookup/PropertiesLookupTest.java
@@ -17,10 +17,16 @@
 
 package org.apache.logging.log4j.core.lookup;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
+import org.apache.logging.log4j.core.config.Property;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -29,9 +35,63 @@ import org.junit.jupiter.api.Test;
 public class PropertiesLookupTest {
 
     @Test
-    public void testGetProperties() {
-        final HashMap<String, String> properties = new HashMap<>();
-        properties.put("A", "1");
-        assertEquals(properties, new PropertiesLookup(properties).getProperties());
+    public void testLookupContextProperty() {
+        final StrLookup propertiesLookup = new PropertiesLookup(
+                Property.EMPTY_ARRAY, Collections.singletonMap("A", "1"));
+        assertEquals("1", propertiesLookup.lookup("A"));
+        final LookupResult lookupResult = propertiesLookup.evaluate("A");
+        assertEquals("1", lookupResult.value());
+        assertFalse(lookupResult.isLookupEvaluationAllowedInValue());
+    }
+
+    @Test
+    public void testLookupConfigProperty() {
+        final StrLookup propertiesLookup = new PropertiesLookup(
+                new Property[] {Property.createProperty("A", "1")},
+                Collections.emptyMap());
+        assertEquals("1", propertiesLookup.lookup("A"));
+        final LookupResult lookupResult = propertiesLookup.evaluate("A");
+        assertEquals("1", lookupResult.value());
+        assertTrue(lookupResult.isLookupEvaluationAllowedInValue());
+    }
+
+    @Test
+    public void testConfigPropertiesPreferredOverContextProperties() {
+        final StrLookup propertiesLookup = new PropertiesLookup(
+                new Property[] {Property.createProperty("A", "1")},
+                Collections.singletonMap("A", "2"));
+        assertEquals("1", propertiesLookup.lookup("A"));
+        final LookupResult lookupResult = propertiesLookup.evaluate("A");
+        assertEquals("1", lookupResult.value());
+        assertTrue(lookupResult.isLookupEvaluationAllowedInValue());
+    }
+
+    @Test
+    public void testEvaluateResultsSupportRecursiveEvaluation() {
+        PropertiesLookup lookup = new PropertiesLookup(Collections.singletonMap("key", "value"));
+        assertFalse(lookup.evaluate("key").isLookupEvaluationAllowedInValue());
+    }
+
+    @Test
+    public void testEvaluateReturnsNullWhenKeyIsNotFound() {
+        PropertiesLookup lookup = new PropertiesLookup(Collections.emptyMap());
+        assertNull(lookup.evaluate("key"));
+    }
+
+    @Test
+    public void testEvaluateReturnsNullWhenKeyIsNull() {
+        PropertiesLookup lookup = new PropertiesLookup(Collections.emptyMap());
+        assertNull(lookup.evaluate(null));
+    }
+
+    @Test
+    public void testContextPropertiesAreMutable() {
+        Map<String, String> contextProperties = new HashMap<>();
+        PropertiesLookup lookup = new PropertiesLookup(Property.EMPTY_ARRAY, contextProperties);
+        assertNull(lookup.evaluate("key"));
+        contextProperties.put("key", "value");
+        LookupResult result = lookup.evaluate("key");
+        assertEquals("value", result.value());
+        assertFalse(result.isLookupEvaluationAllowedInValue());
     }
 }

--- a/log4j-core/src/test/resources/log4j-routing-purge.xml
+++ b/log4j-core/src/test/resources/log4j-routing-purge.xml
@@ -17,6 +17,10 @@
 
 -->
 <Configuration status="OFF" name="RoutingTest">
+  <Properties>
+    <Property name="filename-idle">target/routing-purge-idle/routingtest-$${sd:id}.log</Property>
+    <Property name="filename-manual">target/routing-purge-manual/routingtest-$${sd:id}.log</Property>
+  </Properties>
   <ThresholdFilter level="debug"/>
 
   <Appenders>
@@ -30,7 +34,7 @@
     <Routing name="RoutingPurgeIdle">
       <Routes pattern="$${sd:id}">
         <Route>
-          <File name="Routing-${sd:id}" fileName="target/routing-purge-idle/routingtest-${sd:id}.log">
+          <File name="Routing-${sd:id}" fileName="${filename-idle}">
             <PatternLayout>
               <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
             </PatternLayout>
@@ -54,7 +58,7 @@
     <Routing name="RoutingPurgeManual">
       <Routes pattern="$${sd:id}">
         <Route>
-          <File name="Routing-${sd:id}" fileName="target/routing-purge-manual/routingtest-${sd:id}.log">
+          <File name="Routing-${sd:id}" fileName="${filename-manual}">
             <PatternLayout>
               <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
             </PatternLayout>

--- a/log4j-core/src/test/resources/log4j-routing.json
+++ b/log4j-core/src/test/resources/log4j-routing.json
@@ -15,6 +15,9 @@
  * limitations under the license.
  */
 { "configuration": { "status": "error", "name": "RoutingTest",
+    "properties": {
+      "property": { "name": "filename", "value" : "target/rolling1/rollingtest-$${sd:type}.log" }
+    },
     "ThresholdFilter": { "level": "debug" },
     "appenders": {
       "Console": { "name": "STDOUT",
@@ -28,7 +31,7 @@
           "Route": [
             {
               "RollingFile": {
-                "name": "Rolling-${sd:type}", "fileName": "target/rolling1/rollingtest-${sd:type}.log",
+                "name": "Rolling-${sd:type}", "fileName": "${filename}",
                 "filePattern": "target/rolling1/test1-${sd:type}.%i.log.gz",
                 "PatternLayout": {"pattern": "%d %p %C{1.} [%t] %m%n"},
                 "SizeBasedTriggeringPolicy": { "size": "500" }

--- a/log4j-core/src/test/resources/log4j-routing.properties
+++ b/log4j-core/src/test/resources/log4j-routing.properties
@@ -16,6 +16,8 @@
 status = error
 name = RoutingTest
 
+property.filename = target/routing1/routingtestProps-$${sd:type}.log
+
 filter.threshold.type = ThresholdFilter
 filter.threshold.level = debug
 
@@ -31,7 +33,7 @@ appender.routing.routes.pattern = $${sd:type}
 appender.routing.routes.route1.type = Route
 appender.routing.routes.route1.rolling.type = RollingFile
 appender.routing.routes.route1.rolling.name = Routing-${sd:type}
-appender.routing.routes.route1.rolling.fileName = target/routing1/routingtestProps-${sd:type}.log
+appender.routing.routes.route1.rolling.fileName = ${filename}
 appender.routing.routes.route1.rolling.filePattern = target/routing1/test1-${sd:type}.%i.log.gz
 appender.routing.routes.route1.rolling.layout.type = PatternLayout
 appender.routing.routes.route1.rolling.layout.pattern = %d %p %C{1.} [%t] %m%n

--- a/log4j-core/src/test/resources/log4j-routing.xml
+++ b/log4j-core/src/test/resources/log4j-routing.xml
@@ -17,6 +17,9 @@
 
 -->
 <Configuration status="OFF" name="RoutingTest">
+  <Properties>
+    <Property name="filename">target/routing1/routingtest-$${sd:type}.log</Property>
+  </Properties>
   <ThresholdFilter level="debug"/>
 
   <Appenders>
@@ -29,7 +32,7 @@
     <Routing name="Routing">
       <Routes pattern="$${sd:type}">
         <Route>
-          <RollingFile name="Routing-${sd:type}" fileName="target/routing1/routingtest-${sd:type}.log"
+          <RollingFile name="Routing-${sd:type}" fileName="${filename}"
                        filePattern="target/routing1/test1-${sd:type}.%i.log.gz">
             <PatternLayout>
               <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>

--- a/log4j-core/src/test/resources/log4j-routing2.json
+++ b/log4j-core/src/test/resources/log4j-routing2.json
@@ -15,6 +15,9 @@
  * limitations under the license.
  */
 { "configuration": { "status": "error", "name": "RoutingTest",
+    "properties": {
+      "property": { "name": "filename", "value" : "target/rolling1/rollingtest-$${sd:type}.log" }
+    },
     "ThresholdFilter": { "level": "debug" },
     "appenders": {
       "appender": [
@@ -25,7 +28,7 @@
             "Route": [
               {
                 "RollingFile": {
-                  "name": "Rolling-${sd:type}", "fileName": "target/rolling1/rollingtest-${sd:type}.log",
+                  "name": "Rolling-${sd:type}", "fileName": "${filename}",
                   "filePattern": "target/rolling1/test1-${sd:type}.%i.log.gz",
                   "PatternLayout": {"pattern": "%d %p %C{1.} [%t] %m%n"},
                   "SizeBasedTriggeringPolicy": { "size": "500" }

--- a/log4j-core/src/test/resources/log4j-routing3350.xml
+++ b/log4j-core/src/test/resources/log4j-routing3350.xml
@@ -16,24 +16,24 @@
  limitations under the License.
 
 -->
-<Configuration status="WARN" name="RoutingTest">
+<Configuration status="OFF" name="Routing3350">
   <Properties>
-    <Property name="filename">target/routing1/routingtest-$${sd:type}.log</Property>
+    <Property name="pcode">def</Property>
+    <Property name="drive">target</Property>
+    <Property name="path">/tmp/</Property>
+    <Property name="name">test.log</Property>
+    <Property name="filename">${drive}${path}${name}</Property>
+    <Property name="filepattern">${filename}.%i.backup</Property>
   </Properties>
-
   <Appenders>
-    <Console name="STDOUT">
-      <PatternLayout pattern="%m%n"/>
-    </Console>
     <Routing name="Routing">
-      <Routes>
+      <Routes pattern="$${map:pcode}">
         <Route>
-          <RollingFile name="Routing-${sd:type}" fileName="${filename}"
-                       filePattern="target/routing1/test1-${sd:type}.%i.log.gz">
+          <RollingFile name="Rolling" fileName="${filename}" filePattern="${filepattern}">
             <PatternLayout>
-              <Pattern>%d %p %C{1.} [%t] %m%n</Pattern>
+              <pattern>%map{data}%n</pattern>
             </PatternLayout>
-            <SizeBasedTriggeringPolicy size="500" />
+            <SizeBasedTriggeringPolicy size="500"/>
           </RollingFile>
         </Route>
       </Routes>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -31,6 +31,9 @@
     -->
     <release version="2.17.2" date="20YY-MM-DD" description="GA Release 2.17.2">
       <!-- FIXES -->
+      <action issue="LOG4J2-3317" dev="ckozak" type="fix">
+        Fix RoutingAppender backcompat and disallow recursive evaluation of lookup results outside of configuration properties.
+      </action>
       <action issue="LOG4J2-3333" dev="ckozak" type="fix">
         Fix ThreadContextDataInjector initialization deadlock
       </action>


### PR DESCRIPTION
Previously lookups between configuration properties weren't evaluated
until they were used in the configuration, which resulted in
behavior more prohibitive for RoutingAppenders than anticipated.

This attempts to provide a safer, more compatible lookup strategy
with consistent behavior between users.

**TODO(ckozak): needs additional test coverage, but I'd like to share the concept first**

## How does property substitution work on `release-2.x`?

```xml
<Configuration>
  <Properties>
    <Property name="path">/tmp/</Property>
    <Property name="name">test.${lower:LOG}</Property>
    <Property name="filename">${path}${name}</Property>
    <Property name="pattern">%m%n</Property>
  </Properties>
  <Appenders>
    <RollingFile name="rolling" fileName="${filename}">
      <PatternLayout>
        <pattern>$${filename} ${pattern}</pattern>
      </PatternLayout>
    </RollingFile>
  </Appenders>
</Configuration> 
```

When this configuration is read, we end up with a Substitutor based on the properties defined in the top of the file.
It is build using standard PluginBuilder components, so the plugin value component undergoes substitution using the initial StrSubstitutor, however it's not yet aware of other properties because we're still parsing them. So, we evaluate the properties in order:

* `path`: `/tmp/` (unmodified)
* `name`: `test.${lower:LOG}` -> `test.log` due to `Interpolator.lookup("lower:LOG")` -> `LowerLookup.lookup("LOG")` -> `"log"`
* `filename`: `${path}${name}` (unmodified) the substitutor knows nothing of `path` or `name` when it calls `PropertiesPlugin.configureSubstitutor` and cannot find replacements.
* `pattern`: `%m%n` (unmodified)

This leaves us in an odd state, some data in the properties map is fully interpolated, while other data is incomplete. A reasonable user would expect the value of `filename` to be `/tmp/test.log`, but we're pretty far off.

This presents itself in 2.17.1, where  we limited runtime lookup recursion, because the escaped `$${filename}` component in our pattern is unescaped when the PluginBuilder renders the pattern value as `${filename} %m%n`, which results in `LiteralPatternConverter` being used to evaluate the runtime lookup for `${filename}` for each log line.
Given `log.info("Hello");` we get output `${path}${name} Hello` where the user would want `/tmp/test.log Hello`, which was the behavior prior to 2.17.1 because the resulting lookups where evaluated.

## How does this PR improve matters?

Given the same configuration as above, we handle properties differently from _all_ other lookups: Properties themselves can be evaluated recursively, while the results of other lookups cannot. Properties are defined in a way that's already aware of lookups, so this is safe, while environment variables, jvm system properties, etc are not designed with lookups in mind.

Given the example configuration above, we construct our lookups using the raw values with no substitution. This is important because any amount of substitution prior to the final evaluation will taint values such that we no longer know whether the value contains a lookup that we should evaluate, or referenced untrusted data which may or may not contain lookups.
* `path`: `/tmp/` (unmodified)
* `name`: `test.${lower:LOG}`  (unmodified)
* `filename`: `${path}${name}`  (unmodified)
* `pattern`: `%m%n` (unmodified)

Now, this data is also an unexpected state, but it cannot be observed because of changes to the way we're handling lookup recursion:
In 2.17.1 we eliminated runtime recursive evaluation, here we're eliminating configuration-time recursive evaluation as well, but allowing the results of property lookups to be recursively evaluated.

Given the `log.info("Hello");` example from earlier, we once again get output `/tmp/test.log Hello` because `${filename}` -> `${path}${name}` -> `/tmp/${name}` -> `/tmp/test.${lower:LOG}` -> `/tmp/test.log`

## What about Spring Boot `sys:NAME` lookups?

The [spring boot configuration](https://github.com/spring-projects/spring-boot/blob/8125b46ed5b904801153eab8394272888c09b611/spring-boot-project/spring-boot/src/main/resources/org/springframework/boot/logging/log4j2/log4j2.xml) uses properties which can be overridden by setting jvm system properties `java -DCONSOLE_LOG_PATTERN=<value>`

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Configuration status="WARN">
	<Properties>
		<Property name="LOG_EXCEPTION_CONVERSION_WORD">%xwEx</Property>
		<Property name="LOG_LEVEL_PATTERN">%5p</Property>
		<Property name="LOG_DATEFORMAT_PATTERN">yyyy-MM-dd HH:mm:ss.SSS</Property>
		<Property name="CONSOLE_LOG_PATTERN">%clr{%d{${sys:LOG_DATEFORMAT_PATTERN}}}{faint} %clr{${sys:LOG_LEVEL_PATTERN}} %clr{%pid}{magenta} %clr{---}{faint} %clr{[%15.15t]}{faint} %clr{%-40.40c{1.}}{cyan} %clr{:}{faint} %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
		<Property name="FILE_LOG_PATTERN">%d{${LOG_DATEFORMAT_PATTERN}} ${LOG_LEVEL_PATTERN} %pid --- [%t] %-40.40c{1.} : %m%n${sys:LOG_EXCEPTION_CONVERSION_WORD}</Property>
	</Properties>
	<Appenders>
		<Console name="Console" target="SYSTEM_OUT" follow="true">
			<PatternLayout pattern="${sys:CONSOLE_LOG_PATTERN}" charset="${sys:CONSOLE_LOG_CHARSET}"/>
		</Console>
	</Appenders>
   <!-- loggers, etc -->
</Configuration>
```

These weren't impacted by the 2.17.1 changes, but they _could_ be impacted by this PR.
In the default configuration, there's no change because whether or not recursion is allowed on values depends on the source of the value, not the structure of the lookup (e.g. `Interpolator` failing to find a `sys` value for `CONSOLE_LOG_PATTERN` will fall back to the default `PropertiesLookup`). However, there's an oddity in which overriding a property with a jvm system property, with exactly the same value, will prevent nested lookups from being evaluated, when they would be in all versions up to 2.17.1. It would be fair to classify this as a bug, the behavior we provide isn't meant to recursively evaluate through system properties, environment variables, etc, but we cannot prove that no users rely on it.

## Other Risks and Caveats

Primary risk is that changes in edge-case behavior impact the entire configuration surface, and are not isolated to the more obscure runtime consumers.

For example, a property defined thusly (note the escaped lookup)
`<property name="foo">Date is $${date:YYYY-MM-dd}</property>`
When used via `${foo}` would result in `Date is ${date:YYYY-MM-dd}`
rather than `Date is 2022-01-27`, because initially when
the configuration is parsed, lookups aren't evaluated on properties,
which previously stripped one level of escapement.
The new behavior is easier to understand, but may result in some
friction for consumers.

**Temporal Risk**: rather than simple lookups executing immediately when the configuration is loaded, they may be re-evaluated later on, expanding through the property each time the property is read, where it's possible that the value may change in ways that were previously memoized by substitution within `<property/>` plugin object construction.