### PR TITLE
[LOG4J2-3341] Support logger level and appender refs shorthand

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
@@ -17,11 +17,8 @@
 
 package org.apache.logging.log4j.core.config.properties;
 
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationException;
@@ -42,8 +39,14 @@ import org.apache.logging.log4j.core.config.builder.api.ScriptComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ScriptFileComponentBuilder;
 import org.apache.logging.log4j.core.filter.AbstractFilter.AbstractFilterBuilder;
 import org.apache.logging.log4j.core.util.Builder;
+import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.Strings;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Helper builder for parsing properties files into a PropertiesConfiguration.
@@ -53,6 +56,7 @@ import org.apache.logging.log4j.util.Strings;
 public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
     implements Builder<PropertiesConfiguration> {
 
+    private static final Logger LOGGER = StatusLogger.getLogger();
     private static final String ADVERTISER_KEY = "advertiser";
     private static final String STATUS_KEY = "status";
     private static final String SHUTDOWN_HOOK = "shutdownHook";
@@ -170,17 +174,20 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
                 }
             }
         } else {
-            final Map<String, Properties> loggers = PropertiesUtil
-                    .partitionOnCommonPrefixes(PropertiesUtil.extractSubset(rootProperties, "logger"));
+            final Properties context = PropertiesUtil.extractSubset(rootProperties, "logger");
+            final Map<String, Properties> loggers = PropertiesUtil.partitionOnCommonPrefixes(context);
             for (final Map.Entry<String, Properties> entry : loggers.entrySet()) {
                 final String name = entry.getKey().trim();
                 if (!name.equals(LoggerConfig.ROOT)) {
-                    builder.add(createLogger(name, entry.getValue()));
+                    final Properties loggerProps = entry.getValue();
+                    useSyntheticLevelAndAppenderRefs(name, loggerProps, context);
+                    builder.add(createLogger(name, loggerProps));
                 }
             }
         }
 
         final Properties props = PropertiesUtil.extractSubset(rootProperties, "rootLogger");
+        useSyntheticLevelAndAppenderRefs("rootLogger", props, rootProperties);
         if (props.size() > 0) {
             builder.add(createRootLogger(props));
         }
@@ -188,6 +195,23 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
         builder.setLoggerContext(loggerContext);
 
         return builder.build(false);
+    }
+
+    private static void useSyntheticLevelAndAppenderRefs(final String propertyName, final Properties loggerProps, final Properties context) {
+        final String propertyValue = (String) context.remove(propertyName);
+        if (propertyValue != null) {
+            final String[] parts = propertyValue.split(",");
+            if (parts.length > 0) {
+                final String level = parts[0].trim();
+                loggerProps.setProperty("level", level);
+                LOGGER.debug("Using log level '{}' for logger '{}'", level, propertyName);
+                for (int i = 1; i < parts.length; i++) {
+                    final String appenderRef = parts[i].trim();
+                    LOGGER.debug("Adding synthetic appender ref '{}' for logger '{}'", appenderRef, propertyName);
+                    loggerProps.setProperty("appenderRef.$" + i + ".ref", appenderRef);
+                }
+            }
+        }
     }
 
     private ScriptComponentBuilder createScript(final Properties properties) {
@@ -207,7 +231,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
     }
 
     private AppenderComponentBuilder createAppender(final String key, final Properties properties) {
-        final String name = (String) properties.remove(CONFIG_NAME);
+        final String name = Objects.toString(properties.remove(CONFIG_NAME), key);
         if (Strings.isEmpty(name)) {
             throw new ConfigurationException("No name attribute provided for Appender " + key);
         }

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationTest.java
@@ -22,12 +22,17 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LifeCycle;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.junit.LoggerContextSource;
+import org.apache.logging.log4j.junit.Named;
+import org.apache.logging.log4j.test.appender.ListAppender;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -105,5 +110,24 @@ class PropertiesConfigurationTest {
         assertEquals(Level.DEBUG, logger.getLevel(), "Incorrect level " + logger.getLevel());
 
         logger.debug("Welcome to Log4j!");
+    }
+
+    @Test
+    @LoggerContextSource("RootLoggerLevelAppenderTest.properties")
+    void testRootLoggerLevelAppender(final LoggerContext context, @Named final ListAppender app) {
+        context.getRootLogger().info("Hello world!");
+        final List<LogEvent> events = app.getEvents();
+        assertEquals(1, events.size());
+        assertEquals("Hello world!", events.get(0).getMessage().getFormattedMessage());
+    }
+
+    @Test
+    @LoggerContextSource("LoggerLevelAppenderTest.properties")
+    void testLoggerLevelAppender(final LoggerContext context, @Named final ListAppender first, @Named final ListAppender second) {
+        context.getLogger(getClass()).atInfo().log("message");
+        final List<LogEvent> firstEvents = first.getEvents();
+        final List<LogEvent> secondEvents = second.getEvents();
+        assertEquals(firstEvents, secondEvents);
+        assertEquals(1, firstEvents.size());
     }
 }

--- a/log4j-core/src/test/resources/LoggerLevelAppenderTest.properties
+++ b/log4j-core/src/test/resources/LoggerLevelAppenderTest.properties
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache license, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the license for the specific language governing permissions and
+# limitations under the license.
+#
+
+status = off
+name = LoggerLevelAppenderTest
+logger.core-config-properties.name = org.apache.logging.log4j.core.config.properties
+# whitespace added for testing trimming
+logger.core-config-properties = INFO , first , second
+appender.first.type = List
+appender.second.type = List

--- a/log4j-core/src/test/resources/RootLoggerLevelAppenderTest.properties
+++ b/log4j-core/src/test/resources/RootLoggerLevelAppenderTest.properties
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache license, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the license for the specific language governing permissions and
+# limitations under the license.
+#
+
+status = off
+name = RootLoggerLevelAppenderTest
+rootLogger = INFO,app
+appender.app.type = List

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -184,6 +184,9 @@
       <action type="add" dev="ggregory" due-to="Gary Gregory">
         Add Configurator.setLevel(Logger, Level), setLevel(String, String), and setLevel(Class, Level).
       </action>
+      <action type="add" dev="mattsicker" issue="LOG4J2-3341">
+        Add shorthand syntax for properties configuration format for specifying a logger level and appender refs and implicit appender names for when no name is specified.
+      </action>
       <!-- UPDATES -->
       <action dev="ggregory" type="udpate" due-to="Dependabot">
         Bump mongodb3.version from 3.12.4 to 3.12.10 #605.

--- a/src/site/xdoc/manual/configuration.xml.vm
+++ b/src/site/xdoc/manual/configuration.xml.vm
@@ -941,11 +941,51 @@ Configuration:
               wrapper element, as the TimeBasedTriggeringPolicy and SizeBasedTriggeringPolicy are defined below.
             </p>
             <p>
+              As of version 2.17.2,
+              appenders can use the wrapper element as the implicit name of the component.
+              If no name is specified, the grouping element is used as the name. For example, the following
+              two properties snippets are equivalent.
+            </p>
+            <pre class="prettyprint linenums">
+appender.STDOUT.type = Console
+            </pre>
+            <pre class="prettyprint linenums">
+appender.console.type = Console
+appender.console.name = STDOUT
+            </pre>
+            <p>
+              As of version 2.17.2,
+              <tt>rootLogger</tt> and <tt>logger.<var>key</var></tt> properties can be specified to set the
+              level and zero or more appender refs to create for that logger. The level and appender refs are
+              separated by comma <tt>,</tt> characters with optional whitespace surrounding the comma. The
+              following example demonstrates how the shorthand is expanded when reading properties configurations.
+            </p>
+            <pre class="prettyprint linenums">
+appender.stdout.type = Console
+# ... other appender properties
+appender.file.type = File
+# ... other appender properties
+logger.app = INFO, stdout, file
+logger.app.name = com.example.app
+
+# expanded to:
+appender.stdout.type = Console
+appender.stdout.name = stdout
+# ...
+appender.file.type = File
+appender.file.name = file
+# ...
+logger.app.name = com.example.app
+logger.app.level = INFO
+logger.app.appenderRef.$1.ref = stdout
+logger.app.appenderRef.$2.ref = file
+            </pre>
+            <p>
               Properties configuration files support the advertiser, monitorInterval, name, packages, shutdownHook,
               shutdownTimeout, status, verbose, and dest attributes. See <a href="#ConfigurationSyntax">Configuration Syntax</a>
               for the definitions of these attributes.
             </p>
-          <pre class="prettyprint linenums">
+            <pre class="prettyprint linenums">
 status = error
 dest = err
 name = PropertiesConfig
@@ -964,7 +1004,7 @@ appender.console.filter.threshold.level = error
 
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile
-appender.rolling.fileName = ${filename}
+appender.rolling.fileName = ${dollar}{filename}
 appender.rolling.filePattern = target/rolling2/test1-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz
 appender.rolling.layout.type = PatternLayout
 appender.rolling.layout.pattern = %d %p %C{1.} [%t] %m%n
@@ -977,13 +1017,15 @@ appender.rolling.policies.size.size=100MB
 appender.rolling.strategy.type = DefaultRolloverStrategy
 appender.rolling.strategy.max = 5
 
+logger.rolling = debug, RollingFile
 logger.rolling.name = com.example.my.app
-logger.rolling.level = debug
 logger.rolling.additivity = false
-logger.rolling.appenderRef.rolling.ref = RollingFile
 
-rootLogger.level = info
-rootLogger.appenderRef.stdout.ref = STDOUT
+rootLogger = info, STDOUT
+
+# or using a grouping element:
+# rootLogger.level = info
+# rootLogger.appenderRef.stdout.ref = STDOUT
           </pre>
           <a name="Loggers"/>
           <h4>Configuring Loggers</h4>


### PR DESCRIPTION
This adds a properties format feature where the property names "rootLogger" and "logger.<key>" can be set to a level and one or more appender refs.

https://issues.apache.org/jira/browse/LOG4J2-3341