### PR TITLE
Adds a shorthand method to specify components names

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -524,8 +524,8 @@ public final class PropertiesUtil {
         final List<String> keys = new ArrayList<>();
 
         for (final String key : properties.stringPropertyNames()) {
-            if (key.startsWith(prefixToMatch)) {
-                subset.setProperty(key.substring(prefixToMatch.length()), properties.getProperty(key));
+            if (key.startsWith(prefixToMatch) || key.equals(prefix)) {
+                subset.setProperty(key.substring(Math.min(key.length(), prefixToMatch.length())), properties.getProperty(key));
                 keys.add(key);
             }
         }
@@ -541,23 +541,26 @@ public final class PropertiesUtil {
     }
 
     /**
-     * Partitions a properties map based on common key prefixes up to the first period.
+     * Partitions a properties map based on common key prefixes up to the first
+     * period. If the key does not contain periods, the whole key is taken as
+     * prefix.
      *
-     * @param properties properties to partition
-     * @return the partitioned properties where each key is the common prefix (minus the period) and the values are
-     * new property maps without the prefix and period in the key
+     * @param properties
+     *            properties to partition
+     * @return the partitioned properties where each key is the common prefix
+     *         (minus the period) and the values are new property maps without
+     *         the prefix and period in the key
      * @since 2.6
      */
     public static Map<String, Properties> partitionOnCommonPrefixes(final Properties properties) {
         final Map<String, Properties> parts = new ConcurrentHashMap<>();
         for (final String key : properties.stringPropertyNames()) {
             final int idx = key.indexOf('.');
-            if (idx < 0) continue;
-            final String prefix = key.substring(0, idx);
+            final String prefix = idx < 0 ? key : key.substring(0, idx);
             if (!parts.containsKey(prefix)) {
                 parts.put(prefix, new Properties());
             }
-            parts.get(prefix).setProperty(key.substring(idx + 1), properties.getProperty(key));
+            parts.get(prefix).setProperty(idx < 0 ? "" : key.substring(idx + 1), properties.getProperty(key));
         }
         return parts;
     }

--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/PropertiesUtilTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/PropertiesUtilTest.java
@@ -45,18 +45,22 @@ public class PropertiesUtilTest {
         assertHasAllProperties(PropertiesUtil.extractSubset(properties, "b."));
         assertHasAllProperties(PropertiesUtil.extractSubset(properties, "c.1"));
         assertHasAllProperties(PropertiesUtil.extractSubset(properties, "dd"));
-        // One invalid entry remains
-        assertEquals(1, properties.size());
+        assertEquals(2, properties.size());
+        // this one does not start with 'b.'
+        assertTrue(properties.containsKey("b"));
+        assertTrue(properties.containsKey("e"));
     }
 
     @Test
     public void testPartitionOnCommonPrefix() {
         final Map<String, Properties> parts = PropertiesUtil.partitionOnCommonPrefixes(properties);
-        assertEquals(4, parts.size());
+        assertEquals(5, parts.size());
         assertHasAllProperties(parts.get("a"));
         assertHasAllProperties(parts.get("b"));
         assertHasAllProperties(PropertiesUtil.partitionOnCommonPrefixes(parts.get("c")).get("1"));
         assertHasAllProperties(parts.get("dd"));
+        assertTrue(parts.containsKey("e"));
+        assertTrue(parts.get("e").containsKey(""));
     }
 
     private static void assertHasAllProperties(final Properties properties) {

--- a/log4j-api/src/test/resources/PropertiesUtilTest.properties
+++ b/log4j-api/src/test/resources/PropertiesUtilTest.properties
@@ -18,9 +18,11 @@
 a.1 = 1
 a.2 = 2
 a.3 = 3
+a = empty key
 b.1 = 1
 b.2 = 2
 b.3 = 3
+b = does not start with 'b.'
 c.1.1 = 1
 c.1.2 = 2
 c.1.3 = 3
@@ -28,5 +30,4 @@ dd.1 = 1
 dd.2 = 2
 dd.3 = 3
 
-# Dotless entry, should be ignored
-a = invalid
+e = only empty key

--- a/log4j-core/src/test/resources/LoggerLevelAppenderTest.properties
+++ b/log4j-core/src/test/resources/LoggerLevelAppenderTest.properties
@@ -17,8 +17,7 @@
 
 status = off
 name = LoggerLevelAppenderTest
-logger.core-config-properties.name = org.apache.logging.log4j.core.config.properties
 # whitespace added for testing trimming
-logger.core-config-properties = INFO , first , second
+logger.org-apache-logging-log4j-core-config-properties = INFO , first , second
 appender.first.type = List
 appender.second.type = List

--- a/src/site/xdoc/manual/configuration.xml.vm
+++ b/src/site/xdoc/manual/configuration.xml.vm
@@ -942,16 +942,20 @@ Configuration:
             </p>
             <p>
               As of version 2.17.2,
-              appenders can use the wrapper element as the implicit name of the component.
+              components can use the wrapper element as the implicit name of the component. If the name contains
+              dots, they must be replaced with dashes.
               If no name is specified, the grouping element is used as the name. For example, the following
               two properties snippets are equivalent.
             </p>
             <pre class="prettyprint linenums">
 appender.STDOUT.type = Console
+logger.org-apache-logging-log4j.level = INFO
             </pre>
             <pre class="prettyprint linenums">
 appender.console.type = Console
 appender.console.name = STDOUT
+logger.1.level = INFO
+logger.1.name = org.apache.logging.log4j
             </pre>
             <p>
               As of version 2.17.2,


### PR DESCRIPTION
As an extension of #733, this PR allows to specify the name of any component in its key. Dots in components names are escaped using dashes `-`. Since this is not the only way to specify a components name, there is **no** shorthand for names with dashes.

After this change, only one property is needed to specify a logger, e.g.:

`logger.org-apache-logging-log4j=DEBUG, Console`

Some changes were necessary in two helper functions in `PropertiesUtil`:

 - `extractSubset` didn't extract the property **equal** to the given prefix, although the Javadoc says it should,
 - `partitionOnCommonPrefixes` ignored properties that didn't contain a dot (or threw an exception before #729 ). Now it detects also dotless properties.