### PR TITLE
LOG4J2-3366 Fixes order of property sources

### DIFF
--- a/log4j-api/pom.xml
+++ b/log4j-api/pom.xml
@@ -61,6 +61,10 @@
       <artifactId>junit-jupiter-engine</artifactId>
     </dependency>
     <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-jupiter</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/EnvironmentPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/EnvironmentPropertySource.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.util;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -30,11 +31,17 @@ import java.util.Map;
 public class EnvironmentPropertySource implements PropertySource {
 
 	private static final String PREFIX = "LOG4J_";
-	private static final int DEFAULT_PRIORITY = -100;
+	private static final int DEFAULT_PRIORITY = 100;
 
 	@Override
 	public int getPriority() {
 		return DEFAULT_PRIORITY;
+	}
+
+	private void logException(SecurityException e) {
+		// There is no status logger yet.
+		LowLevelLogUtil.logException(
+				"The system environment variables are not available to Log4j due to security restrictions: " + e, e);
 	}
 
 	@Override
@@ -43,10 +50,7 @@ public class EnvironmentPropertySource implements PropertySource {
 		try {
 			getenv = System.getenv();
 		} catch (final SecurityException e) {
-			// There is no status logger yet.
-			LowLevelLogUtil.logException(
-					"The system environment variables are not available to Log4j due to security restrictions: " + e,
-					e);
+			logException(e);
 			return;
 		}
 		for (final Map.Entry<String, String> entry : getenv.entrySet()) {
@@ -68,4 +72,35 @@ public class EnvironmentPropertySource implements PropertySource {
 		}
 		return sb.toString();
 	}
+
+	@Override
+	public Collection<String> getPropertyNames() {
+		try {
+			return System.getenv().keySet();
+		} catch (final SecurityException e) {
+			logException(e);
+			return PropertySource.super.getPropertyNames();
+		}
+	}
+
+	@Override
+	public String getProperty(String key) {
+		try {
+			return System.getenv(key);
+		} catch (final SecurityException e) {
+			logException(e);
+			return PropertySource.super.getProperty(key);
+		}
+	}
+
+	@Override
+	public boolean containsProperty(String key) {
+		try {
+			return System.getenv().containsKey(key);
+		} catch (final SecurityException e) {
+			logException(e);
+			return PropertySource.super.containsProperty(key);
+		}
+	}
+
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.util;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
@@ -27,17 +29,24 @@ import java.util.Properties;
  */
 public class PropertiesPropertySource implements PropertySource {
 
+    private static final int DEFAULT_PRIORITY = 200;
     private static final String PREFIX = "log4j2.";
 
     private final Properties properties;
+    private final int priority;
 
     public PropertiesPropertySource(final Properties properties) {
+        this(properties, DEFAULT_PRIORITY);
+    }
+
+    public PropertiesPropertySource(final Properties properties, final int priority) {
         this.properties = properties;
+        this.priority = priority;
     }
 
     @Override
     public int getPriority() {
-        return 0;
+        return priority;
     }
 
     @Override
@@ -51,4 +60,20 @@ public class PropertiesPropertySource implements PropertySource {
     public CharSequence getNormalForm(final Iterable<? extends CharSequence> tokens) {
         return PREFIX + Util.joinAsCamelCase(tokens);
     }
+
+    @Override
+    public Collection<String> getPropertyNames() {
+        return properties.stringPropertyNames();
+    }
+
+    @Override
+    public String getProperty(String key) {
+        return properties.getProperty(key);
+    }
+
+    @Override
+    public boolean containsProperty(String key) {
+        return getProperty(key) != null;
+    }
+
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -25,8 +25,10 @@ import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.ServiceLoader;
@@ -61,7 +63,7 @@ public final class PropertiesUtil {
      * @param props the Properties to use by default
      */
     public PropertiesUtil(final Properties props) {
-        this.environment = new Environment(new PropertiesPropertySource(props));
+        this(new PropertiesPropertySource(props));
     }
 
     /**
@@ -75,7 +77,15 @@ public final class PropertiesUtil {
     }
 
     private PropertiesUtil(final String propertiesFileName, final boolean useTccl) {
-        this.environment = new Environment(new PropertyFilePropertySource(propertiesFileName, useTccl));
+        this(new PropertyFilePropertySource(propertiesFileName, useTccl));
+    }
+
+    /**
+     * Constructs a PropertiesUtil for a give property source as source of additional properties.
+     * @param source a property source
+     */
+    PropertiesUtil(final PropertySource source) {
+        this.environment = new Environment(source);
     }
 
     /**
@@ -424,8 +434,15 @@ public final class PropertiesUtil {
     private static class Environment {
 
         private final Set<PropertySource> sources = new TreeSet<>(new PropertySource.Comparator());
-        private final Map<CharSequence, String> literal = new ConcurrentHashMap<>();
-        private final Map<CharSequence, String> normalized = new ConcurrentHashMap<>();
+        /**
+         * Maps a key to its value in the lowest priority source that contains it.
+         */
+        private final Map<String, String> literal = new ConcurrentHashMap<>();
+        /**
+         * Maps a key to the value associated to its normalization in the lowest
+         * priority source that contains it.
+         */
+        private final Map<String, String> normalized = new ConcurrentHashMap<>();
         private final Map<List<CharSequence>, String> tokenized = new ConcurrentHashMap<>();
 
         private Environment(final PropertySource propertySource) {
@@ -451,28 +468,36 @@ public final class PropertiesUtil {
             literal.clear();
             normalized.clear();
             tokenized.clear();
-            for (final PropertySource source : sources) {
-                source.forEach((key, value) -> {
-                    if (key != null && value != null) {
-                        literal.put(key, value);
-                        final List<CharSequence> tokens = PropertySource.Util.tokenize(key);
-                        if (tokens.isEmpty()) {
-                            normalized.put(source.getNormalForm(Collections.singleton(key)), value);
-                        } else {
-                            normalized.put(source.getNormalForm(tokens), value);
-                            tokenized.put(tokens, value);
+            // 1. Collects all property keys from enumerable sources.
+            final Set<String> keys = new HashSet<>();
+            sources.stream()
+                   .map(PropertySource::getPropertyNames)
+                   .reduce(keys, (left, right) -> {
+                       left.addAll(right);
+                       return left;
+                   });
+            // 2. Fills the property caches. Sources with higher priority values don't override the previous ones.
+            keys.stream()
+                .filter(Objects::nonNull)
+                .forEach(key -> {
+                    final List<CharSequence> tokens = PropertySource.Util.tokenize(key);
+                    sources.forEach(source -> {
+                        final String value = source.getProperty(key);
+                        if (value != null) {
+                            literal.putIfAbsent(key, value);
+                            if (!tokens.isEmpty()) {
+                                tokenized.putIfAbsent(tokens, value);
+                            }
                         }
-                    }
+                        final CharSequence normalKey = source.getNormalForm(tokens);
+                        if (normalKey != null) {
+                            final String normalValue = source.getProperty(normalKey.toString());
+                            if (normalValue != null) {
+                                normalized.putIfAbsent(key, normalValue);
+                            }
+                        }
+                    });
                 });
-            }
-        }
-
-        private static boolean hasSystemProperty(final String key) {
-            try {
-                return System.getProperties().containsKey(key);
-            } catch (final SecurityException ignored) {
-                return false;
-            }
         }
 
         private String get(final String key) {
@@ -482,22 +507,33 @@ public final class PropertiesUtil {
             if (literal.containsKey(key)) {
                 return literal.get(key);
             }
-            if (hasSystemProperty(key)) {
-                return System.getProperty(key);
-            }
+            final List<CharSequence> tokens = PropertySource.Util.tokenize(key);
             for (final PropertySource source : sources) {
+                final String normalKey = Objects.toString(source.getNormalForm(tokens), null);
+                if (normalKey != null && source.containsProperty(normalKey)) {
+                    final String normalValue = source.getProperty(normalKey);
+                    // Caching previously unknown keys breaks many tests which set and unset system properties
+                    // normalized.put(key, normalValue);
+                    return normalValue;
+                }
                 if (source.containsProperty(key)) {
-                    return source.getProperty(key);
+                    final String value = source.getProperty(key);
+                    // literal.put(key, value);
+                    return value;
                 }
             }
-            return tokenized.get(PropertySource.Util.tokenize(key));
+            return tokenized.get(tokens);
         }
 
         private boolean containsKey(final String key) {
+            List<CharSequence> tokens = PropertySource.Util.tokenize(key);
             return normalized.containsKey(key) ||
-                literal.containsKey(key) ||
-                hasSystemProperty(key) ||
-                tokenized.containsKey(PropertySource.Util.tokenize(key));
+                   literal.containsKey(key) ||
+                   tokenized.containsKey(tokens) ||
+                   sources.stream().anyMatch(s -> {
+                        final CharSequence normalizedKey = s.getNormalForm(tokens);
+                        return s.containsProperty(key) || normalizedKey != null && s.containsProperty(normalizedKey.toString());
+                   });
         }
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyFilePropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyFilePropertySource.java
@@ -48,9 +48,4 @@ public class PropertyFilePropertySource extends PropertiesPropertySource {
         return props;
     }
 
-    @Override
-    public int getPriority() {
-        return 0;
-    }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
@@ -19,6 +19,8 @@ package org.apache.logging.log4j.util;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,7 +37,7 @@ public interface PropertySource {
 
     /**
      * Returns the order in which this PropertySource has priority. A higher value means that the source will be
-     * applied later so as to take precedence over other property sources.
+     * searched later and can be overridden by other property sources.
      *
      * @return priority value
      */
@@ -47,6 +49,15 @@ public interface PropertySource {
      * @param action action to perform on each key/value pair
      */
     default void forEach(BiConsumer<String, String> action) {
+    }
+
+    /**
+     * Returns the list of all property names.
+     * 
+     * @return list of property names
+     */
+    default Collection<String> getPropertyNames() {
+        return Collections.emptySet();
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/SystemPropertiesPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/SystemPropertiesPropertySource.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.util;
 
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Properties;
 
@@ -28,7 +29,7 @@ import java.util.Properties;
  */
 public class SystemPropertiesPropertySource implements PropertySource {
 
-	private static final int DEFAULT_PRIORITY = 100;
+	private static final int DEFAULT_PRIORITY = 0;
 	private static final String PREFIX = "log4j2.";
 
 	@Override
@@ -66,6 +67,29 @@ public class SystemPropertiesPropertySource implements PropertySource {
 	@Override
 	public CharSequence getNormalForm(final Iterable<? extends CharSequence> tokens) {
 		return PREFIX + Util.joinAsCamelCase(tokens);
+	}
+
+	@Override
+	public Collection<String> getPropertyNames() {
+		try {
+			return System.getProperties().stringPropertyNames();
+		} catch (final SecurityException e) {
+			return PropertySource.super.getPropertyNames();
+		}
+	}
+
+	@Override
+	public String getProperty(String key) {
+		try {
+			return System.getProperty(key);
+		} catch (final SecurityException e) {
+			return PropertySource.super.getProperty(key);
+		}
+	}
+
+	@Override
+	public boolean containsProperty(String key) {
+		return getProperty(key) != null;
 	}
 
 }

--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/PropertiesUtilOrderTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/PropertiesUtilOrderTest.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
+
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
+
+@ExtendWith(SystemStubsExtension.class)
+@ResourceLock(value = Resources.SYSTEM_PROPERTIES)
+public class PropertiesUtilOrderTest {
+
+    public static class NonEnumerablePropertySource implements PropertySource {
+
+        private final Properties props;
+
+        public NonEnumerablePropertySource(final Properties props) {
+            this.props = props;
+        }
+
+        @Override
+        public int getPriority() {
+            return Integer.MIN_VALUE;
+        }
+
+        @Override
+        public CharSequence getNormalForm(Iterable<? extends CharSequence> tokens) {
+            return "log4j2." + PropertySource.Util.joinAsCamelCase(tokens);
+        }
+
+        @Override
+        public String getProperty(String key) {
+            return props.getProperty(key);
+        }
+
+        @Override
+        public boolean containsProperty(String key) {
+            return getProperty(key) != null;
+        }
+
+    }
+
+    public static class NullPropertySource implements PropertySource {
+
+        @Override
+        public int getPriority() {
+            return Integer.MIN_VALUE;
+        }
+
+    }
+
+    private final Properties properties = new Properties();
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        properties.load(ClassLoader.getSystemResourceAsStream("PropertiesUtilOrderTest.properties"));
+    }
+
+    @Test
+    public void normalizedOverrideLegacy() {
+        final PropertiesUtil util = new PropertiesUtil(properties);
+        final String legacy = "props.legacy";
+        final String normalized = "props.normalized";
+        assertEquals(legacy, properties.getProperty("log4j.legacyProperty"));
+        assertTrue(util.hasProperty("log4j.legacyProperty"));
+        assertEquals(normalized, util.getStringProperty("log4j.legacyProperty"));
+        assertEquals(legacy, properties.getProperty("org.apache.logging.log4j.legacyProperty2"));
+        assertTrue(util.hasProperty("log4j.legacyProperty2"));
+        assertEquals(normalized, util.getStringProperty("org.apache.logging.log4j.legacyProperty2"));
+        assertEquals(legacy, properties.getProperty("Log4jLegacyProperty3"));
+        assertTrue(util.hasProperty("log4j.legacyProperty3"));
+        assertEquals(normalized, util.getStringProperty("Log4jLegacyProperty3"));
+        // non-overridden legacy property
+        assertTrue(util.hasProperty("log4j.nonOverriddenLegacy"));
+        assertEquals(legacy, util.getStringProperty("log4j.nonOverriddenLegacy"));
+    }
+
+    @Test
+    public void fallsBackToTokenMatching() {
+        final PropertiesUtil util = new PropertiesUtil(properties);
+        for (int i = 1; i <= 4; i++) {
+            final String key = "log4j2.tokenBasedProperty" + i;
+            assertTrue(util.hasProperty(key));
+            assertEquals("props.token", util.getStringProperty(key));
+        }
+        // No fall back (a normalized property is present)
+        assertTrue(util.hasProperty("log4j2.normalizedProperty"));
+        assertEquals("props.normalized", util.getStringProperty("log4j2.normalizedProperty"));
+    }
+
+    @Test
+    public void orderOfNormalizedProperties(EnvironmentVariables env, SystemProperties sysProps) {
+        properties.remove("log4j2.normalizedProperty");
+        properties.remove("LOG4J_normalized.property");
+        final PropertiesUtil util = new PropertiesUtil(properties);
+        // Same result for both a legacy property and a normalized property
+        assertFalse(util.hasProperty("Log4jNormalizedProperty"));
+        assertEquals(null, util.getStringProperty("Log4jNormalizedProperty"));
+        assertFalse(util.hasProperty("log4j2.normalizedProperty"));
+        assertEquals(null, util.getStringProperty("log4j2.normalizedProperty"));
+
+        properties.setProperty("log4j2.normalizedProperty", "props.normalized");
+        util.reload();
+        assertTrue(util.hasProperty("Log4jNormalizedProperty"));
+        assertEquals("props.normalized", util.getStringProperty("Log4jNormalizedProperty"));
+        assertTrue(util.hasProperty("log4j2.normalizedProperty"));
+        assertEquals("props.normalized", util.getStringProperty("log4j2.normalizedProperty"));
+
+        env.set("LOG4J_NORMALIZED_PROPERTY", "env");
+        util.reload();
+        assertTrue(util.hasProperty("Log4jNormalizedProperty"));
+        assertEquals("env", util.getStringProperty("Log4jNormalizedProperty"));
+        assertTrue(util.hasProperty("log4j2.normalizedProperty"));
+        assertEquals("env", util.getStringProperty("log4j2.normalizedProperty"));
+
+        sysProps.set("log4j2.normalizedProperty", "sysProps");
+        util.reload();
+        assertTrue(util.hasProperty("Log4jNormalizedProperty"));
+        assertEquals("sysProps", util.getStringProperty("Log4jNormalizedProperty"));
+        assertTrue(util.hasProperty("log4j2.normalizedProperty"));
+        assertEquals("sysProps", util.getStringProperty("log4j2.normalizedProperty"));
+    }
+
+    @Test
+    public void highPriorityNonEnumerableSource(SystemProperties sysProps) {
+        // In both datasources
+        assertNotNull(properties.getProperty("log4j2.normalizedProperty"));
+        assertNotNull(properties.getProperty("log4j.onlyLegacy"));
+        sysProps.set("log4j2.normalizedProperty", "sysProps.normalized");
+        sysProps.set("log4j.onlyLegacy", "sysProps.legazy");
+        // Only system properties
+        assertNull(properties.getProperty("log4j2.normalizedPropertySysProps"));
+        assertNull(properties.getProperty("log4j.onlyLegacySysProps"));
+        sysProps.set("log4j2.normalizedPropertySysProps", "sysProps.normalized");
+        sysProps.set("log4j.onlyLegacySysProps", "sysProps.legacy");
+        // Only the non enumerable source
+        assertNotNull(properties.getProperty("log4j2.normalizedPropertyProps"));
+        assertNotNull(properties.getProperty("log4j.onlyLegacyProps"));
+
+        final PropertiesUtil util = new PropertiesUtil(new NonEnumerablePropertySource(properties));
+        assertTrue(util.hasProperty("log4j2.normalizedProperty"));
+        assertEquals("props.normalized", util.getStringProperty("log4j2.normalizedProperty"));
+        assertTrue(util.hasProperty("log4j.onlyLegacy"));
+        assertEquals("props.legacy", util.getStringProperty("log4j.onlyLegacy"));
+        assertTrue(util.hasProperty("log4j2.normalizedPropertySysProps"));
+        assertEquals("sysProps.normalized", util.getStringProperty("log4j2.normalizedPropertySysProps"));
+        assertTrue(util.hasProperty("log4j.onlyLegacySysProps"));
+        assertEquals("sysProps.legacy", util.getStringProperty("log4j.onlyLegacySysProps"));
+        assertTrue(util.hasProperty("log4j2.normalizedPropertyProps"));
+        assertEquals("props.normalized", util.getStringProperty("log4j2.normalizedPropertyProps"));
+        assertTrue(util.hasProperty("log4j.onlyLegacyProps"));
+        assertEquals("props.legacy", util.getStringProperty("log4j.onlyLegacyProps"));
+    }
+
+    /**
+     * Checks the for missing null checks. The {@link NullPropertySource} returns
+     * {@code null} in almost every call.
+     * 
+     * @param sysProps
+     */
+    @Test
+    public void nullChecks(SystemProperties sysProps) {
+        sysProps.set("log4j2.someProperty", "sysProps");
+        sysProps.set("Log4jLegacyProperty", "sysProps");
+        final PropertiesUtil util = new PropertiesUtil(new NullPropertySource());
+        assertTrue(util.hasProperty("log4j2.someProperty"));
+        assertEquals("sysProps", util.getStringProperty("log4j2.someProperty"));
+        assertTrue(util.hasProperty("Log4jLegacyProperty"));
+        assertEquals("sysProps", util.getStringProperty("Log4jLegacyProperty"));
+        assertTrue(util.hasProperty("log4j.legacyProperty"));
+        assertEquals("sysProps", util.getStringProperty("log4j.legacyProperty"));
+        assertFalse(util.hasProperty("log4j2.nonExistentProperty"));
+        assertNull(util.getStringProperty("log4j2.nonExistentProperty"));
+    }
+}

--- a/log4j-api/src/test/resources/PropertiesUtilOrderTest.properties
+++ b/log4j-api/src/test/resources/PropertiesUtilOrderTest.properties
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache license, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the license for the specific language governing permissions and
+# limitations under the license.
+#
+
+###
+# Legacy properties
+log4j.legacyProperty=props.legacy
+org.apache.logging.log4j.legacyProperty2=props.legacy
+Log4jLegacyProperty3=props.legacy
+log4j.nonOverriddenLegacy=props.legacy
+log4j.onlyLegacy=props.legacy
+log4j.onlyLegacyProps=props.legacy
+
+###
+# Their equivalent normalized versions
+log4j2.legacyProperty=props.normalized
+log4j2.legacyProperty2=props.normalized
+log4j2.legacyProperty3=props.normalized
+
+###
+# Token-based matching
+LOG4J_token.based.property1=props.token
+LOG4J_token-based-property2=props.token
+LOG4J_token/based/property3=props.token
+LOG4J_tokenBasedProperty4=props.token
+
+##
+LOG4J_normalized.property=props.token
+log4j2.normalizedProperty=props.normalized
+log4j2.normalizedPropertyProps=props.normalized

--- a/log4j-spring-boot/src/main/java/org/apache/logging/log4j/spring/boot/SpringPropertySource.java
+++ b/log4j-spring-boot/src/main/java/org/apache/logging/log4j/spring/boot/SpringPropertySource.java
@@ -24,6 +24,8 @@ import org.springframework.core.env.Environment;
  */
 public class SpringPropertySource extends SpringEnvironmentHolder implements PropertySource {
 
+    private static final int DEFAULT_PRIORITY = -100;
+
     /**
      * System properties take precendence followed by properties in Log4j properties files. Spring properties
      * follow.
@@ -31,7 +33,7 @@ public class SpringPropertySource extends SpringEnvironmentHolder implements Pro
      */
     @Override
     public int getPriority() {
-        return -50;
+        return DEFAULT_PRIORITY ;
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -814,6 +814,13 @@
         <version>${junitJupiterVersion}</version>
         <scope>test</scope>
       </dependency>
+      <!-- Environment and system properties support for Jupiter -->
+      <dependency>
+        <groupId>uk.org.webcompere</groupId>
+        <artifactId>system-stubs-jupiter</artifactId>
+        <version>2.0.1</version>
+        <scope>test</scope>
+      </dependency>
       <!-- JUnit 4 API dependency -->
       <dependency>
         <groupId>junit</groupId>

--- a/src/site/xdoc/manual/configuration.xml.vm
+++ b/src/site/xdoc/manual/configuration.xml.vm
@@ -1866,8 +1866,27 @@ public class AwesomeTest {
               <th>Description</th>
             </tr>
             <tr>
-              <td>Environment Variables</td>
+              <td>Spring Boot Properties</td>
               <td>-100</td>
+              <td>
+                This property source is enabled only if the Java application uses Spring Boot and the
+                <code>log4j-spring</code> module is present. It resolves properties using a Spring
+                <a href="https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/env/Environment.html">Environment</a>. 
+              </td>
+            </tr>
+            <tr>
+              <td>System Properties</td>
+              <td>0</td>
+              <td>
+                All properties can be set using normal system property patterns. These have the lowest numerical priority 
+                among commonly available property sources and can override properties files or environment variables.
+                If a <code>log4j2.system.properties</code> file is available on the classpath its contents are
+                sourced into Java system properties at Log4j startup.
+              </td>
+            </tr>
+            <tr>
+              <td>Environment Variables</td>
+              <td>100</td>
               <td>
                 Environment variables are all prefixed with <code>LOG4J_</code>, are in all caps, and words are all
                 separated by underscores. Only this naming scheme is support for environment variables as there were
@@ -1876,19 +1895,11 @@ public class AwesomeTest {
             </tr>
             <tr>
               <td><code>log4j2.component.properties</code> file</td>
-              <td>0</td>
+              <td>200</td>
               <td>
                 Including this file on the classpath can be used as an alternative to providing properties as system
-                properties. This has priority over system properties, but they can be overridden by environment
-                variables as described above.
-              </td>
-            </tr>
-            <tr>
-              <td>System Properties</td>
-              <td>100</td>
-              <td>
-                All properties can be set using normal system property patterns. These have the lowest priority and
-                can be overridden by included properties files or environment variables.
+                properties. This is the property source with highest numerical priority and can be used to provide
+                default values that can be overridden by the system administrator.
               </td>
             </tr>
           </table>


### PR DESCRIPTION
This PR fixes the order of the property sources to:

1. Spring Boot properties with lowest numerical priority (overrides all others). In a Spring Boot application with `log4j-spring` present it will use in order: the servlet context init parameters, JNDI environment entries (from `java:comp/env` exclusively), Java system properties and system environment variables (among others, cf. [the complete list](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.external-config)).
2. Java system properties,
3. OS environment variables,
4. `log4j2.component.properties` to allow devs to provide some defaults.

Due to some issues with the previous implementation, the logic of the `Environment` class has been rewritten:

- the `normalized` map maps **any** key to the value of its normalization in the highest priority property source. E.g.: the key `log4j.configurationFile` will contain the value of the `log4j2.configurationFile` property (remark the `2`) in Java's system properties or the value of the `LOG4J_CONFIGURATION_FILE` environment variable. Previously it contained two separate mappings: `log4j2.configurationFile` -> value in Java's system properties, `LOG4J_CONFIGURATION_FILE` -> value of the environment variable. This caused a miss for 95% of the `PropertiesUtil#getStringProperty` calls, which usually use the legacy property name.
- the three caches (`normalized`, `literal` and `tokenized`) are filled in two steps: first we recover all the keys from **enumerable** sources and then we query **all** sources to retrieve the appropriate values. Previously non-enumerable sources didn't get a chance to provide a value in these caches (the Spring Boot property source is non-enumerable).
