### PR TITLE
trim MaxBackupIndex if last char is blank

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DefaultRolloverStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DefaultRolloverStrategy.java
@@ -134,7 +134,7 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
                 }
                 maxIndex = DEFAULT_WINDOW_SIZE;
                 if (max != null) {
-                    maxIndex = Integer.parseInt(max);
+                    maxIndex = Integer.parseInt(max.trim());
                     if (maxIndex < minIndex) {
                         maxIndex = minIndex < DEFAULT_WINDOW_SIZE ? DEFAULT_WINDOW_SIZE : minIndex;
                         LOGGER.error("Maximum window size must be greater than the minimum windows size. Set to " + maxIndex);


### PR DESCRIPTION
using log4j1.2-api-2.x bridge with log4j.properties a blank after MaxBackupIndex=<value> stops creating the appender and logging is disabled