### PR TITLE
LOG4J2-3388 custom levels configured using log4j2.properies is giving number format exception.

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
@@ -124,7 +124,10 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
         final Properties levelProps = PropertiesUtil.extractSubset(rootProperties, "customLevel");
         if (levelProps.size() > 0) {
             for (final String key : levelProps.stringPropertyNames()) {
+             if(key.endsWith("intLevel"))
                 builder.add(builder.newCustomLevel(key, Integer.parseInt(levelProps.getProperty(key))));
+             else
+                builder.add(builder.newCustomLevel(key, levelProps.getProperty(key)));
             }
         }
 


### PR DESCRIPTION
 LOG4J2-3388  if we have below properties configured in log4j2.properies files, when we will hit NumberFormatException or there will be no logs for custom level.  This issue is happening because we are trying to convert string "VERBOSE" into integer which is not expected.  It is expected to covert the values which is there in property called intLevel only. 

customLevels = V
customLevel.V.name = VERBOSE
customLevel.V.intLevel = 525