### PR TITLE
LOG4J2-3407 Log4j 1.2 bridge Check for non-existent appender when parsing properties

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/PropertiesConfiguration.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/PropertiesConfiguration.java
@@ -436,6 +436,10 @@ public class PropertiesConfiguration extends Log4j1Configuration {
         final String layoutPrefix = prefix + ".layout";
         final String filterPrefix = APPENDER_PREFIX + appenderName + ".filter.";
         final String className = OptionConverter.findAndSubst(prefix, props);
+        if (className == null) {
+            LOGGER.debug("Appender \"" + appenderName + "\" does not exist.");
+            return null;
+        }
         appender = manager.parseAppender(appenderName, className, prefix, layoutPrefix, filterPrefix, props, this);
         if (appender == null) {
             appender = buildAppender(appenderName, className, prefix, layoutPrefix, filterPrefix, props);
@@ -505,7 +509,7 @@ public class PropertiesConfiguration extends Log4j1Configuration {
         final ErrorHandler eh = newInstanceOf(errorHandlerClass, "ErrorHandler");
         final String[] keys = new String[] {
             // @formatter:off
-            errorHandlerPrefix + "." + ROOT_REF, 
+            errorHandlerPrefix + "." + ROOT_REF,
             errorHandlerPrefix + "." + LOGGER_REF,
             errorHandlerPrefix + "." + APPENDER_REF_TAG};
             // @formatter:on

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -106,7 +106,7 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
             assertTrue(filter.getFilter() instanceof NeutralFilterFixture);
         }
     }
-    
+
     @Test
     public void testConsoleAppenderLevelRangeFilter() throws Exception {
         PluginManager.addPackage("org.apache.log4j.builders.filter");
@@ -123,6 +123,15 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
             final LevelRangeFilter defaultFilter = (LevelRangeFilter) ((FilterWrapper) ((FilterAdapter) filters[1]).getFilter()).getFilter();
             assertEquals(Level.TRACE, defaultFilter.getMinLevel());
       }
+    }
+
+    @Test
+    public void testConfigureAppenderDoesNotExist() throws Exception {
+        // Verify that we tolerate a logger which specifies an appender that does not exist.
+        try (LoggerContext loggerContext = TestConfigurator.configure("target/test-classes/LOG4J2-3407.properties")) {
+            final Configuration configuration = loggerContext.getConfiguration();
+            assertNotNull(configuration);
+        }
     }
 
     @Test

--- a/log4j-1.2-api/src/test/resources/LOG4J2-3407.properties
+++ b/log4j-1.2-api/src/test/resources/LOG4J2-3407.properties
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.filter.1=org.apache.log4j.config.NeutralFilterFixture
+log4j.appender.CONSOLE.filter.1.onMatch=neutral
+log4j.appender.CONSOLE.Target=System.out
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+log4j.logger.org.apache.log4j.xml=trace, A1
+log4j.rootLogger=trace, CONSOLE


### PR DESCRIPTION
This change will make `PropertiesConfiguration` tolerant of attempts to resolve a non-existent Appender. See JIRA ticket for details.