### PR TITLE
Adds Log4j 1.x global threshold

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationParser.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationParser.java
@@ -25,8 +25,10 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.TreeMap;
 
+import org.apache.log4j.LogManager;
 import org.apache.log4j.helpers.OptionConverter;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Filter.Result;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.appender.NullAppender;
@@ -36,10 +38,12 @@ import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder
 import org.apache.logging.log4j.core.config.builder.api.ComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
+import org.apache.logging.log4j.core.config.builder.api.FilterComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.LayoutComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.LoggerComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.RootLoggerComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
 
@@ -102,6 +106,13 @@ public class Log4j1ConfigurationParser {
             final String debugValue = getLog4jValue("debug");
             if (Boolean.parseBoolean(debugValue)) {
                 builder.setStatusLevel(Level.DEBUG);
+            }
+            // global threshold
+            final String threshold = OptionConverter.findAndSubst(PropertiesConfiguration.THRESHOLD_KEY, properties);
+            if (threshold != null) {
+                final Level level = OptionConverter.convertLevel(threshold.trim(), Level.ALL);
+                builder.add(builder.newFilter("ThresholdFilter", Result.NEUTRAL, Result.DENY)
+                        .addAttribute("level", level));
             }
             // Root
             buildRootLogger(getLog4jValue(ROOTCATEGORY));

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/PropertiesConfiguration.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/PropertiesConfiguration.java
@@ -39,11 +39,14 @@ import org.apache.log4j.bridge.FilterAdapter;
 import org.apache.log4j.helpers.OptionConverter;
 import org.apache.log4j.spi.ErrorHandler;
 import org.apache.log4j.spi.Filter;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Filter.Result;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.status.StatusConfiguration;
+import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.util.LoaderUtil;
 
 /**
@@ -66,6 +69,7 @@ public class PropertiesConfiguration extends Log4j1Configuration {
      */
     private static final String RESET_KEY = "log4j.reset";
 
+    public static final String THRESHOLD_KEY = "log4j.threshold";
     public static final String DEBUG_KEY = "log4j.debug";
 
     private static final String INTERNAL_ROOT_NAME = "root";
@@ -311,6 +315,12 @@ public class PropertiesConfiguration extends Log4j1Configuration {
         final String reset = properties.getProperty(RESET_KEY);
         if (reset != null && OptionConverter.toBoolean(reset, false)) {
             LogManager.resetConfiguration();
+        }
+
+        final String threshold = OptionConverter.findAndSubst(THRESHOLD_KEY, properties);
+        if (threshold != null) {
+            final Level level = OptionConverter.convertLevel(threshold.trim(), Level.ALL);
+            addFilter(ThresholdFilter.createFilter(level, Result.NEUTRAL, Result.DENY));
         }
 
         configureRoot(properties);

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfiguration.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfiguration.java
@@ -43,10 +43,12 @@ import org.apache.log4j.spi.AppenderAttachable;
 import org.apache.log4j.spi.ErrorHandler;
 import org.apache.log4j.spi.Filter;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.Filter.Result;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.status.StatusConfiguration;
+import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
 import org.w3c.dom.Document;
@@ -87,6 +89,7 @@ public class XmlConfiguration extends Log4j1Configuration {
     private static final String ADDITIVITY_ATTR = "additivity";
     private static final String CONFIG_DEBUG_ATTR = "configDebug";
     private static final String INTERNAL_DEBUG_ATTR = "debug";
+    private static final String THRESHOLD_ATTR = "threshold";
     private static final String EMPTY_STR = "";
     private static final Class<?>[] ONE_STRING_PARAM = new Class[] { String.class };
     private static final String dbfKey = "javax.xml.parsers.DocumentBuilderFactory";
@@ -740,6 +743,13 @@ public class XmlConfiguration extends Log4j1Configuration {
 
         final StatusConfiguration statusConfig = new StatusConfiguration().withStatus(status);
         statusConfig.initialize();
+
+        final String threshold = subst(element.getAttribute(THRESHOLD_ATTR));
+        if (threshold != null) {
+            final org.apache.logging.log4j.Level level = OptionConverter.convertLevel(threshold.trim(),
+                    org.apache.logging.log4j.Level.ALL);
+            addFilter(ThresholdFilter.createFilter(level, Result.NEUTRAL, Result.DENY));
+        }
 
         forEachElement(element.getChildNodes(), currentElement -> {
             switch (currentElement.getTagName()) {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -29,11 +29,14 @@ import java.net.URL;
 import org.apache.log4j.layout.Log4j1XmlLayout;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.junit.Test;
 
@@ -170,6 +173,19 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
             config.stop();
         } catch (NoClassDefFoundError e) {
             fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGlobalThreshold() throws Exception {
+        try (final LoggerContext ctx = configure("config-1.2/log4j-global-threshold")) {
+            final Configuration config = ctx.getConfiguration();
+            final Filter filter = config.getFilter();
+            assertTrue(filter instanceof ThresholdFilter);
+            ThresholdFilter thresholdFilter = (ThresholdFilter)filter;
+            assertEquals(Level.INFO, thresholdFilter.getLevel());
+            assertEquals(Filter.Result.NEUTRAL, thresholdFilter.getOnMatch());
+            assertEquals(Filter.Result.DENY, thresholdFilter.getOnMismatch());
         }
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -302,4 +302,10 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
         }
     }
 
+    @Override
+    @Test
+    public void testGlobalThreshold() throws Exception {
+        super.testGlobalThreshold();
+    }
+
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -172,4 +172,10 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
         super.testMultipleFilters();
     }
 
+    @Override
+    @Test
+    public void testGlobalThreshold() throws Exception {
+        super.testGlobalThreshold();
+    }
+
 }

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-global-threshold.properties
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-global-threshold.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.threshold = info
+log4j.appender.LIST = org.apache.log4j.ListAppender
+log4j.rootLogger = debug, LIST

--- a/log4j-1.2-api/src/test/resources/config-1.2/log4j-global-threshold.xml
+++ b/log4j-1.2-api/src/test/resources/config-1.2/log4j-global-threshold.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" threshold="info">
+  <appender name="LIST" class="org.apache.log4j.ListAppender" />
+
+  <root>
+    <priority value="debug" />
+    <appender-ref ref="LIST" />
+  </root>
+</log4j:configuration>


### PR DESCRIPTION
The `log4j.threshold` configuration key was not translated into its Log4j 2.x equivalent global filter.