### PR TITLE
[LOG4J2-3415] Support JSON configuration using embedded JSON parser

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/JsonReaderTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/JsonReaderTest.java
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.layout.template.json.util;
+package org.apache.logging.log4j.util;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -24,6 +24,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 class JsonReaderTest {
 
@@ -373,6 +374,11 @@ class JsonReaderTest {
                                     put("k2", "v2");
                                     put("k3", Collections.singletonMap("k4", "v4"));
                                 }})));
+    }
+
+    @Test
+    void test_comments() {
+        test("/*comment1*/{\"foo\": /* comment two */\"bar\"}", Map.of("foo", "bar"));
     }
 
     private void test(final String json, final Object expected) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/JsonReader.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/JsonReader.java
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.layout.template.json.util;
+package org.apache.logging.log4j.util;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -185,10 +185,24 @@ public final class JsonReader {
     }
 
     private void skipWhiteSpace() {
+        boolean inComment = false;
         do {
-            if (!Character.isWhitespace(readChar)) {
+            if (!inComment && readChar == '/') {
+                if (readChar() == '*') {
+                    inComment = true;
+                } else {
+                    unreadChar();
+                }
+            } else if (inComment && readChar == '*') {
+                if (readChar() == '/') {
+                    inComment = false;
+                } else {
+                    unreadChar();
+                }
+            } else if (!inComment && !Character.isWhitespace(readChar)) {
                 break;
             }
+
         } while (readChar() != CharacterIterator.DONE);
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/arbiters/BasicArbiterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/arbiters/BasicArbiterTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class BasicArbiterTest {
 
-    static final String CONFIG = "log4j2-arbiters.xml";
+    static final String CONFIG = "log4j2-arbiters.json";
     static LoggerContext loggerContext = null;
 
     @AfterEach

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/JsonReaderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/JsonReaderTest.java
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.util;
+package org.apache.logging.log4j.core.util;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/log4j-core-test/src/test/resources/log4j2-arbiters.json
+++ b/log4j-core-test/src/test/resources/log4j2-arbiters.json
@@ -1,0 +1,42 @@
+{
+  "name": "ConfigTest",
+  "status": "ERROR",
+  "monitorInterval": 5,
+  "Appenders": {
+    "SystemPropertyArbiter": [
+      {
+        "propertyName": "env",
+        "propertyValue": "dev",
+        "Console": {
+          "name": "Out",
+          "PatternLayout": {
+            "pattern": "%m%n"
+          }
+        }
+      },
+      {
+        "propertyName": "env",
+        "propertyValue": "prod",
+        "List": {
+          "name": "Out"
+        }
+      }
+    ]
+  },
+  "Loggers": {
+    "Logger": {
+      "name": "org.apache.test",
+      "level": "trace",
+      "additivity": false,
+      "AppenderRef": {
+        "ref": "Out"
+      }
+    },
+    "Root": {
+      "level": "error",
+      "AppenderRef": {
+        "ref": "Out"
+      }
+    }
+  }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/jason/JsonConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/jason/JsonConfiguration.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.core.config.jason;
+
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.AbstractConfiguration;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.Reconfigurable;
+import org.apache.logging.log4j.core.config.status.StatusConfiguration;
+import org.apache.logging.log4j.core.util.Patterns;
+import org.apache.logging.log4j.plugins.Node;
+import org.apache.logging.log4j.plugins.util.PluginType;
+import org.apache.logging.log4j.plugins.util.ResolverUtil;
+import org.apache.logging.log4j.plugins.util.TypeUtil;
+import org.apache.logging.log4j.util.JsonReader;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class JsonConfiguration extends AbstractConfiguration implements Reconfigurable {
+    private static final String[] VERBOSE_CLASSES = new String[] { ResolverUtil.class.getName() };
+
+    private final List<Status> statuses = new ArrayList<>();
+    private Map<String, Object> root;
+
+    public JsonConfiguration(final LoggerContext loggerContext, final ConfigurationSource configurationSource) {
+        super(loggerContext, configurationSource);
+        try {
+            final byte[] bytes;
+            try (final var configStream = configurationSource.getInputStream()) {
+                bytes = configStream.readAllBytes();
+                root = TypeUtil.cast(JsonReader.read(new String(bytes, StandardCharsets.UTF_8)));
+            }
+            if (root.size() == 1) {
+                for (final Object value : root.values()) {
+                    root = TypeUtil.cast(value);
+                }
+            }
+            processAttributes(rootNode, root);
+            final StatusConfiguration statusConfig = new StatusConfiguration().setVerboseClasses(VERBOSE_CLASSES)
+                    .setStatus(getDefaultStatus());
+            final AtomicInteger monitorIntervalSeconds = new AtomicInteger();
+
+            rootNode.getAttributes().forEach((key, value) -> {
+                if ("status".equalsIgnoreCase(key)) {
+                    statusConfig.setStatus(value);
+                } else if ("dest".equalsIgnoreCase(key)) {
+                    statusConfig.setDestination(value);
+                } else if ("shutdownHook".equalsIgnoreCase(key)) {
+                    isShutdownHookEnabled = !"disable".equalsIgnoreCase(value);
+                } else if ("shutdownTimeout".equalsIgnoreCase(key)) {
+                    shutdownTimeoutMillis = Long.parseLong(value);
+                } else if ("verbose".equalsIgnoreCase(key)) {
+                    statusConfig.setVerbosity(value);
+                } else if ("packages".equalsIgnoreCase(key)) {
+                    pluginPackages.addAll(Arrays.asList(value.split(Patterns.COMMA_SEPARATOR)));
+                } else if ("name".equalsIgnoreCase(key)) {
+                    setName(value);
+                } else if ("monitorInterval".equalsIgnoreCase(key)) {
+                    monitorIntervalSeconds.setOpaque(Integer.parseInt(value));
+                } else if ("advertiser".equalsIgnoreCase(key)) {
+                    createAdvertiser(value, configurationSource, bytes, "application/json");
+                }
+            });
+            initializeWatchers(this, configurationSource, monitorIntervalSeconds.getOpaque());
+            statusConfig.initialize();
+            if (getName() == null) {
+                setName(configurationSource.getLocation());
+            }
+        } catch (final Exception e) {
+            LOGGER.error("Error parsing {}", configurationSource.getLocation(), e);
+        }
+    }
+
+    @Override
+    public void setup() {
+        final List<Node> children = rootNode.getChildren();
+        root.forEach((key, value) -> {
+            if (value instanceof Map) {
+                LOGGER.debug("Processing node for object {}", key);
+                children.add(constructNode(key, rootNode, TypeUtil.cast(value)));
+            }
+        });
+        LOGGER.debug("Completed parsing configuration");
+        if (statuses.size() > 0) {
+            for (final var s : statuses) {
+                LOGGER.error("Error processing element {}: {}", s.name, s.errorType);
+            }
+        }
+    }
+
+    private Node constructNode(final String key, final Node parent, final Map<String, Object> value) {
+        final PluginType<?> pluginType = pluginManager.getPluginType(key);
+        final Node node = new Node(parent, key, pluginType);
+        processAttributes(node, value);
+        final List<Node> children = node.getChildren();
+
+        value.forEach((k, v) -> {
+            if (isValueType(v)) {
+                LOGGER.debug("Node {} is of type {}", k, v != null ? v.getClass() : null);
+                return;
+            }
+            if (pluginType == null) {
+                statuses.add(new Status(v, k, ErrorType.CLASS_NOT_FOUND));
+                return;
+            }
+            if (v instanceof List<?>) {
+                LOGGER.debug("Processing node for array {}", k);
+                ((List<?>) v).forEach(object -> {
+                    if (object instanceof Map<?, ?>) {
+                        final Map<String, Object> map = TypeUtil.cast(object);
+                        final String type = getType(map).orElse(k);
+                        final PluginType<?> entryType = pluginManager.getPluginType(type);
+                        final Node child = new Node(node, k, entryType);
+                        processAttributes(child, map);
+                        if (type.equalsIgnoreCase(k)) {
+                            LOGGER.debug("Processing {}[{}]", k, children.size());
+                        } else {
+                            LOGGER.debug("Processing {} {}[{}]", type, k, children.size());
+                        }
+                        final List<Node> grandchildren = child.getChildren();
+                        map.forEach((itemKey, itemValue) -> {
+                            if (itemValue instanceof Map<?, ?>) {
+                                LOGGER.debug("Processing node for object {}", itemKey);
+                                grandchildren.add(constructNode(itemKey, child, TypeUtil.cast(itemValue)));
+                            } else if (itemValue instanceof List<?>) {
+                                final List<?> list = (List<?>) itemValue;
+                                LOGGER.debug("Processing array for object {}", itemKey);
+                                list.forEach(subValue -> grandchildren.add(
+                                        constructNode(itemKey, child, TypeUtil.cast(subValue))));
+                            }
+                        });
+                        children.add(child);
+                    }
+                });
+            } else {
+                LOGGER.debug("Processing node for object {}", k);
+                children.add(constructNode(k, node, TypeUtil.cast(v)));
+            }
+        });
+
+        final String t;
+        if (pluginType == null) {
+            t = "null";
+        } else {
+            t = pluginType.getElementName() + ':' + pluginType.getPluginClass();
+        }
+
+        final String p = node.getParent() == null ? "null"
+                : node.getParent().getName() == null ? LoggerConfig.ROOT : node.getParent().getName();
+        LOGGER.debug("Returning {} with parent {} of type {}", node.getName(), p, t);
+        return node;
+    }
+
+    @Override
+    public Configuration reconfigure() {
+        try {
+            final ConfigurationSource configurationSource = getConfigurationSource().resetInputStream();
+            if (configurationSource == null) {
+                return null;
+            }
+            return new JsonConfiguration(getLoggerContext(), configurationSource);
+        } catch (final IOException e) {
+            LOGGER.error("Cannot locate file {}", getConfigurationSource(), e);
+        }
+        return null;
+    }
+
+    private static boolean isValueType(final Object value) {
+        return !(value instanceof Map<?, ?> || value instanceof List<?>);
+    }
+
+    private static void processAttributes(final Node parent, final Map<String, Object> node) {
+        final Map<String, String> attributes = parent.getAttributes();
+        node.forEach((key, value) -> {
+            if (!key.equalsIgnoreCase("type") && isValueType(value)) {
+                attributes.put(key, String.valueOf(value));
+            }
+        });
+    }
+
+    private static Optional<String> getType(final Map<String, Object> node) {
+        for (final Map.Entry<String, Object> entry : node.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase("type")) {
+                final Object value = entry.getValue();
+                if (isValueType(value)) {
+                    return Optional.of(String.valueOf(value));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * The error that occurred.
+     */
+    private enum ErrorType {
+        CLASS_NOT_FOUND
+    }
+
+    /**
+     * Status for recording errors.
+     */
+    private static class Status {
+        private final Object node;
+        private final String name;
+        private final ErrorType errorType;
+
+        private Status(final Object node, final String name, final ErrorType errorType) {
+            this.node = node;
+            this.name = name;
+            this.errorType = errorType;
+        }
+
+        @Override
+        public String toString() {
+            return "Status{" +
+                    "node=" + node +
+                    ", name='" + name + '\'' +
+                    ", errorType=" + errorType +
+                    '}';
+        }
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/jason/JsonConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/jason/JsonConfiguration.java
@@ -24,12 +24,12 @@ import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.Reconfigurable;
 import org.apache.logging.log4j.core.config.status.StatusConfiguration;
+import org.apache.logging.log4j.core.util.JsonReader;
 import org.apache.logging.log4j.core.util.Patterns;
 import org.apache.logging.log4j.plugins.Node;
 import org.apache.logging.log4j.plugins.util.PluginType;
 import org.apache.logging.log4j.plugins.util.ResolverUtil;
 import org.apache.logging.log4j.plugins.util.TypeUtil;
-import org.apache.logging.log4j.util.JsonReader;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/jason/JsonConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/jason/JsonConfigurationFactory.java
@@ -14,14 +14,18 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.config.json;
+
+package org.apache.logging.log4j.core.config.jason;
 
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
-import org.apache.logging.log4j.core.util.Loader;
+import org.apache.logging.log4j.core.config.Order;
+import org.apache.logging.log4j.plugins.Plugin;
 
+@Plugin(name = "JsonConfigurationFactory", category = ConfigurationFactory.CATEGORY)
+@Order(6)
 public class JsonConfigurationFactory extends ConfigurationFactory {
 
     /**
@@ -29,40 +33,13 @@ public class JsonConfigurationFactory extends ConfigurationFactory {
      */
     private static final String[] SUFFIXES = new String[] {".json", ".jsn"};
 
-    private static final String[] dependencies = new String[] {
-            "com.fasterxml.jackson.databind.ObjectMapper",
-            "com.fasterxml.jackson.databind.JsonNode",
-            "com.fasterxml.jackson.core.JsonParser"
-    };
-
-    private final boolean isActive;
-
-    public JsonConfigurationFactory() {
-        for (final String dependency : dependencies) {
-            if (!Loader.isClassAvailable(dependency)) {
-                LOGGER.debug("Missing dependencies for Json support, ConfigurationFactory {} is inactive", getClass().getName());
-                isActive = false;
-                return;
-            }
-        }
-        isActive = true;
-    }
-
     @Override
-    protected boolean isActive() {
-        return isActive;
+    protected String[] getSupportedTypes() {
+        return SUFFIXES;
     }
 
     @Override
     public Configuration getConfiguration(final LoggerContext loggerContext, final ConfigurationSource source) {
-        if (!isActive) {
-            return null;
-        }
         return new JsonConfiguration(loggerContext, source);
-    }
-
-    @Override
-    public String[] getSupportedTypes() {
-        return SUFFIXES;
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/JsonReader.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/JsonReader.java
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.util;
+package org.apache.logging.log4j.core.util;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/JsonReader.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/JsonReader.java
@@ -187,22 +187,25 @@ public final class JsonReader {
     private void skipWhiteSpace() {
         boolean inComment = false;
         do {
-            if (!inComment && readChar == '/') {
-                if (readChar() == '*') {
-                    inComment = true;
-                } else {
-                    unreadChar();
-                }
-            } else if (inComment && readChar == '*') {
-                if (readChar() == '/') {
-                    inComment = false;
-                } else {
-                    unreadChar();
-                }
-            } else if (!inComment && !Character.isWhitespace(readChar)) {
-                break;
+            if (inComment) {
+                if (readChar == '*') {
+                    if (readChar() == '/') {
+                        inComment = false;
+                    } else {
+                        unreadChar();
+                    }
+                } // else continue
+            } else {
+                if (readChar == '/') {
+                    if (readChar() == '*') {
+                        inComment = true;
+                    } else {
+                        unreadChar();
+                    }
+                } else if (!Character.isWhitespace(readChar)) {
+                    break;
+                } // else continue
             }
-
         } while (readChar() != CharacterIterator.DONE);
     }
 

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/CaseConverterResolver.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/CaseConverterResolver.java
@@ -17,9 +17,9 @@
 package org.apache.logging.log4j.layout.template.json.resolver;
 
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.util.JsonReader;
 import org.apache.logging.log4j.layout.template.json.JsonTemplateLayoutDefaults;
 import org.apache.logging.log4j.layout.template.json.util.JsonWriter;
-import org.apache.logging.log4j.util.JsonReader;
 
 import java.util.Locale;
 import java.util.function.Function;

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/CaseConverterResolver.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/CaseConverterResolver.java
@@ -18,8 +18,8 @@ package org.apache.logging.log4j.layout.template.json.resolver;
 
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.layout.template.json.JsonTemplateLayoutDefaults;
-import org.apache.logging.log4j.layout.template.json.util.JsonReader;
 import org.apache.logging.log4j.layout.template.json.util.JsonWriter;
+import org.apache.logging.log4j.util.JsonReader;
 
 import java.util.Locale;
 import java.util.function.Function;

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/EventAdditionalFieldInterceptor.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/EventAdditionalFieldInterceptor.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.layout.template.json.resolver;
 
+import org.apache.logging.log4j.layout.template.json.JsonTemplateLayout.EventTemplateAdditionalField;
 import org.apache.logging.log4j.plugins.Plugin;
 import org.apache.logging.log4j.plugins.PluginFactory;
-import org.apache.logging.log4j.layout.template.json.JsonTemplateLayout.EventTemplateAdditionalField;
-import org.apache.logging.log4j.layout.template.json.util.JsonReader;
+import org.apache.logging.log4j.util.JsonReader;
 
 import java.util.Map;
 

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/EventAdditionalFieldInterceptor.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/EventAdditionalFieldInterceptor.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.layout.template.json.resolver;
 
+import org.apache.logging.log4j.core.util.JsonReader;
 import org.apache.logging.log4j.layout.template.json.JsonTemplateLayout.EventTemplateAdditionalField;
 import org.apache.logging.log4j.plugins.Plugin;
 import org.apache.logging.log4j.plugins.PluginFactory;
-import org.apache.logging.log4j.util.JsonReader;
 
 import java.util.Map;
 

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/TemplateResolvers.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/TemplateResolvers.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.layout.template.json.resolver;
 
-import org.apache.logging.log4j.layout.template.json.util.JsonReader;
 import org.apache.logging.log4j.layout.template.json.util.JsonWriter;
+import org.apache.logging.log4j.util.JsonReader;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/TemplateResolvers.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/TemplateResolvers.java
@@ -16,8 +16,8 @@
  */
 package org.apache.logging.log4j.layout.template.json.resolver;
 
+import org.apache.logging.log4j.core.util.JsonReader;
 import org.apache.logging.log4j.layout.template.json.util.JsonWriter;
-import org.apache.logging.log4j.util.JsonReader;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutAdditionalFieldTest.java
+++ b/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutAdditionalFieldTest.java
@@ -21,7 +21,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
-import org.apache.logging.log4j.layout.template.json.util.JsonReader;
+import org.apache.logging.log4j.util.JsonReader;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;

--- a/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutAdditionalFieldTest.java
+++ b/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutAdditionalFieldTest.java
@@ -21,7 +21,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
-import org.apache.logging.log4j.util.JsonReader;
+import org.apache.logging.log4j.core.util.JsonReader;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;

--- a/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/TestHelpers.java
+++ b/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/TestHelpers.java
@@ -27,9 +27,9 @@ import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
 import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.util.JsonReader;
 import org.apache.logging.log4j.layout.template.json.util.JsonWriter;
 import org.apache.logging.log4j.layout.template.json.util.MapAccessor;
-import org.apache.logging.log4j.util.JsonReader;
 
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/TestHelpers.java
+++ b/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/TestHelpers.java
@@ -27,9 +27,9 @@ import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
 import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.layout.template.json.util.JsonReader;
 import org.apache.logging.log4j.layout.template.json.util.JsonWriter;
 import org.apache.logging.log4j.layout.template.json.util.MapAccessor;
+import org.apache.logging.log4j.util.JsonReader;
 
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/CounterResolverTest.java
+++ b/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/CounterResolverTest.java
@@ -18,8 +18,8 @@ package org.apache.logging.log4j.layout.template.json.resolver;
 
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.core.util.JsonReader;
 import org.apache.logging.log4j.layout.template.json.JsonTemplateLayout;
-import org.apache.logging.log4j.util.JsonReader;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;

--- a/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/CounterResolverTest.java
+++ b/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/CounterResolverTest.java
@@ -19,7 +19,7 @@ package org.apache.logging.log4j.layout.template.json.resolver;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.layout.template.json.JsonTemplateLayout;
-import org.apache.logging.log4j.layout.template.json.util.JsonReader;
+import org.apache.logging.log4j.util.JsonReader;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;

--- a/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/MessageResolverTest.java
+++ b/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/MessageResolverTest.java
@@ -18,15 +18,15 @@ package org.apache.logging.log4j.layout.template.json.resolver;
 
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
 import org.apache.logging.log4j.layout.template.json.JsonTemplateLayout;
-import org.apache.logging.log4j.layout.template.json.util.JsonReader;
-import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ObjectMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.message.StringMapMessage;
+import org.apache.logging.log4j.util.JsonReader;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/MessageResolverTest.java
+++ b/log4j-layout-template-json/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/MessageResolverTest.java
@@ -21,12 +21,12 @@ import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
+import org.apache.logging.log4j.core.util.JsonReader;
 import org.apache.logging.log4j.layout.template.json.JsonTemplateLayout;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ObjectMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.message.StringMapMessage;
-import org.apache.logging.log4j.util.JsonReader;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutBenchmarkReport.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutBenchmarkReport.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.layout.template.json;
 
-import org.apache.logging.log4j.util.JsonReader;
+import org.apache.logging.log4j.core.util.JsonReader;
 import org.apache.logging.log4j.util.Strings;
 
 import java.io.File;

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutBenchmarkReport.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutBenchmarkReport.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.layout.template.json;
 
-import org.apache.logging.log4j.layout.template.json.util.JsonReader;
+import org.apache.logging.log4j.util.JsonReader;
 import org.apache.logging.log4j.util.Strings;
 
 import java.io.File;


### PR DESCRIPTION
* Moves `JsonReader` from log4j-layout-json-template to log4j-api.
* Adds support for comments in parsing JSON for compatibility with existing Jackson usage.
* Adds new default `JsonConfigurationFactory` implementation using this.