### PR TITLE
Remove the revapi plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,6 @@
     <release.plugin.version>2.5.3</release.plugin.version>
     <scm.plugin.version>1.9.5</scm.plugin.version>
     <jxr.plugin.version>3.1.1</jxr.plugin.version>
-    <revapi.plugin.version>0.14.6</revapi.plugin.version>
     <revapi.skip>false</revapi.skip>
     <clirr.plugin.version>2.8</clirr.plugin.version>
     <site.plugin.version>3.11.0</site.plugin.version>
@@ -1837,113 +1836,6 @@
       <activation>
         <jdk>[1.8,)</jdk>
       </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.revapi</groupId>
-            <artifactId>revapi-maven-plugin</artifactId>
-            <version>${revapi.plugin.version}</version>
-            <dependencies>
-              <dependency>
-                <groupId>org.revapi</groupId>
-                <artifactId>revapi-java</artifactId>
-                <version>0.26.1</version>
-              </dependency>
-            </dependencies>
-            <executions>
-              <execution>
-                <goals><goal>check</goal></goals>
-                <configuration>
-                  <checkDependencies>false</checkDependencies>
-                  <skip>${revapi.skip}</skip>
-                  <failOnMissingConfigurationFiles>false</failOnMissingConfigurationFiles>
-                  <analysisConfigurationFiles>
-                    <path>revapi.json</path>
-                  </analysisConfigurationFiles>
-                  <analysisConfiguration><![CDATA[
-[  {
-     "extension": "revapi.filter",
-      "configuration": {
-      "elements": {
-        "include": [
-         {
-           "matcher": "java-package",
-           "match": "/org\\.apache\\.logging\\.log4j(\\..*)?/"
-         }
-        ]
-      }
-    }
-  },
-  {
-     "extension": "revapi.java",
-     "configuration": {
-       "missing-classes": {
-         "behavior": "report",
-         "ignoreMissingAnnotations": false
-       },
-       "reportUsesFor": [
-          "java.missing.newClass",
-          "java.class.nonPublicPartOfAPI"
-       ]
-     }
-  },
-  {
-    "extension": "revapi.ignore",
-    "configuration": [
-      {
-  		"code": "java.method.returnTypeTypeParametersChanged",
-  		"old": "method org.apache.logging.log4j.core.appender.OutputStreamAppender.Builder org.apache.logging.log4j.core.appender.OutputStreamAppender::newBuilder()",
-  		"new": "method <B extends org.apache.logging.log4j.core.appender.OutputStreamAppender.Builder<B extends org.apache.logging.log4j.core.appender.OutputStreamAppender.Builder<B>>> B org.apache.logging.log4j.core.appender.OutputStreamAppender::newBuilder()",
-  		"justification": "The compiler erases types (https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.6)"
-	  },
-      {
-        "code": "java.generics.elementNowParameterized",
-        "old": "method org.apache.logging.log4j.core.appender.OutputStreamAppender.Builder org.apache.logging.log4j.core.appender.OutputStreamAppender::newBuilder()",
-        "new": "method <B extends org.apache.logging.log4j.core.appender.OutputStreamAppender.Builder<B extends org.apache.logging.log4j.core.appender.OutputStreamAppender.Builder<B>>> B org.apache.logging.log4j.core.appender.OutputStreamAppender::newBuilder()",
-        "justification": "The compiler erases types (https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.6)"
-      },
-      {
-        "code": "java.generics.formalTypeParameterAdded",
-        "old": "method org.apache.logging.log4j.core.appender.OutputStreamAppender.Builder org.apache.logging.log4j.core.appender.OutputStreamAppender::newBuilder()",
-        "new": "method <B extends org.apache.logging.log4j.core.appender.OutputStreamAppender.Builder<B extends org.apache.logging.log4j.core.appender.OutputStreamAppender.Builder<B>>> B org.apache.logging.log4j.core.appender.OutputStreamAppender::newBuilder()",
-        "typeParameter": "B extends org.apache.logging.log4j.core.appender.OutputStreamAppender.Builder<B extends org.apache.logging.log4j.core.appender.OutputStreamAppender.Builder<B>>",
-        "justification": "The compiler erases types (https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.6)"
-      }
-    ]
-  }
-]
-              ]]></analysisConfiguration>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-      <reporting>
-        <plugins>
-          <plugin>
-            <groupId>org.revapi</groupId>
-            <artifactId>revapi-maven-plugin</artifactId>
-            <version>${revapi.plugin.version}</version>
-            <configuration>
-              <skip>${revapi.skip}</skip>
-            </configuration>
-            <reportSets>
-              <reportSet>
-                <inherited>false</inherited>
-                <reports>
-                  <report>report-aggregate</report>
-                </reports>
-              </reportSet>
-              <reportSet>
-                <reports>
-                  <report>report</report>
-                </reports>
-              </reportSet>
-            </reportSets>
-          </plugin>
-        </plugins>
-      </reporting>
     </profile>
     <profile>
       <id>java8-doclint-disabled</id>


### PR DESCRIPTION
We should enable it again, however at the moment it's causing
all builds to fail.