### PR TITLE
[LOG4J2-3040] Avoid ClassCastException in JeroMqManager with custom LoggerContextFactory

### DIFF
--- a/log4j-jeromq/src/main/java/org/apache/logging/log4j/jeromq/appender/JeroMqManager.java
+++ b/log4j-jeromq/src/main/java/org/apache/logging/log4j/jeromq/appender/JeroMqManager.java
@@ -61,7 +61,7 @@ public class JeroMqManager extends AbstractManager {
 
         final boolean enableShutdownHook = PropertiesUtil.getProperties().getBooleanProperty(
             SYS_PROPERTY_ENABLE_SHUTDOWN_HOOK, true);
-        if (enableShutdownHook) {
+        if (enableShutdownHook && LogManager.getFactory() instanceof ShutdownCallbackRegistry) {
             SHUTDOWN_HOOK = ((ShutdownCallbackRegistry) LogManager.getFactory()).addShutdownCallback(CONTEXT::close);
         } else {
             SHUTDOWN_HOOK = null;


### PR DESCRIPTION
Signed-off-by: Grzegorz Grzybek <gr.grzybek@gmail.com>

I tried using `org.apache.logging.log4j.test.junit.LoggerContextFactoryExtension`, but somehow I couldn't make it work (maybe incompatible with `org.apache.logging.log4j.core.test.junit.LoggerContextRule`?