### PR TITLE
[LOG4J2-3040][2.x] Avoid ClassCastException in JeroMqManager with custom LoggerContextFactory

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqManager.java
@@ -61,7 +61,7 @@ public class JeroMqManager extends AbstractManager {
 
         final boolean enableShutdownHook = PropertiesUtil.getProperties().getBooleanProperty(
             SYS_PROPERTY_ENABLE_SHUTDOWN_HOOK, true);
-        if (enableShutdownHook) {
+        if (enableShutdownHook && LogManager.getFactory() instanceof ShutdownCallbackRegistry) {
             SHUTDOWN_HOOK = ((ShutdownCallbackRegistry) LogManager.getFactory()).addShutdownCallback(CONTEXT::close);
         } else {
             SHUTDOWN_HOOK = null;


### PR DESCRIPTION
Signed-off-by: Grzegorz Grzybek <gr.grzybek@gmail.com>