### PR TITLE
Fix minor typo

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/AbstractWatcher.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/AbstractWatcher.java
@@ -39,7 +39,7 @@ public abstract class AbstractWatcher implements Watcher {
         this.reconfigurable = reconfigurable;
         this.configurationListeners = configurationListeners;
         this.threadFactory = configurationListeners != null ?
-            Log4jThreadFactory.createDaemonThreadFactory("ConfiguratonFileWatcher") : null;
+            Log4jThreadFactory.createDaemonThreadFactory("ConfigurationFileWatcher") : null;
     }
 
     @Override

--- a/src/site/xdoc/manual/configuration.xml.vm
+++ b/src/site/xdoc/manual/configuration.xml.vm
@@ -368,7 +368,7 @@ public class Bar {
           </p>
         </subsection>
         <a name="Configuration From a URI"/>
-        <subsection name="Configuraton From a URI">
+        <subsection name="Configuration From a URI">
           <p>
             When <code>log4j2.configurationFile</code> references a URL Log4j will first determine if the URL reference
             a file using the file protocol. If it does Log4j will validate that the file url is valid and continue


### PR DESCRIPTION
This commit fixes a simple typo in [AbstractWatcher.java](https://github.com/apache/logging-log4j2/blob/release-2.x/log4j-core/src/main/java/org/apache/logging/log4j/core/util/AbstractWatcher.java), `ConfiguratonFileWatcher` to `ConfigurationFileWatcher`. I think the contributor for this [commit](https://github.com/apache/logging-log4j2/commit/22a0ca71e6220b37ce0c76bc8ab3399c8fb6012f) just forget to fix this.

Also, find a similar typo in the doc.