### PR TITLE
LOG4J2-3019: Fix HtmlLayoutTest on Windows

### DIFF
--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/HtmlLayoutTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/HtmlLayoutTest.java
@@ -24,6 +24,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
@@ -267,7 +268,8 @@ public class HtmlLayoutTest {
         // Pattern letter 'X' (upper case) will output 'Z' when the offset to be output would be zero,
         // whereas pattern letter 'x' (lower case) will output '+00', '+0000', or '+00:00'. Log4j2 needs x.
         DateTimeFormatter dateTimeFormatter =
-            DateTimeFormatter.ofPattern(format.getPattern().replace('n', 'S').replace('X', 'x'));
+            DateTimeFormatter.ofPattern(format.getPattern().replace('n', 'S').replace('X', 'x'),
+                    Locale.getDefault());
         String expected = zonedDateTime.format(dateTimeFormatter);
 
         assertEquals("<td>" + expected + "</td>", actual,


### PR DESCRIPTION
This PR fixes the [issue](https://issues.apache.org/jira/browse/LOG4J2-3019) that `HtmlLayoutTest.testLayoutWithDatePatternFixedFormat` test fails on Windows. 

AFAIK, this test only fails in a special case on Windows, that is, the _Windows display language_ and _Regional format_ are inconsistent. For example, my settings are:
```
Windows display language: zh_CN
Regional format: en_NL
```
the result will be: `[ERROR]   HtmlLayoutTest.testLayoutWithDatePatternFixedFormat:245->testLayoutWithDatePatternFixedFormat:277 Incorrect date=<td>02 十一月 2012 21:34:02,123</td>, format=DATE, timezone=GMT+8 ==> expected: <<td>02 Nov 2012 21:32,123</td>> but was: <<td>02 十一月 2012 21:34:02,123</td>>`

---------

I think the reason is that 
- the actual value that generated from `layout` at [line 255](https://github.com/apache/logging-log4j2/blob/release-2.x/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/HtmlLayoutTest.java#L255) using `Locale.getDefault()` (zh_CN, which causes `02 十一月`), 
- the expected value that generated from `DateTimeFormatter.ofPattern()` at [line 269](https://github.com/apache/logging-log4j2/blob/release-2.x/log4j-core/src/test/java/org/apache/logging/log4j/core/layout/HtmlLayoutTest.java#L269) using `Locale.Category.FORMAT` (en_NL, which causes `02 Nov`). 
 
It is easy to avoid this issue by manually setting the `locale` argument for `DateTimeFormatter.ofPattern()`, and the results will use the `Locale.getDefault()`.