### PR TITLE
[LOG4J2-3427] Replace ServiceLoader calls with ServiceLoaderUtil

### DIFF
--- a/log4j-api-java9/pom.xml
+++ b/log4j-api-java9/pom.xml
@@ -36,6 +36,10 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/log4j-api-java9/src/assembly/java9.xml
+++ b/log4j-api-java9/src/assembly/java9.xml
@@ -34,8 +34,12 @@
       <excludes>
         <exclude>**/Dummy.class</exclude>
         <exclude>**/spi/Provider.class</exclude>
+        <exclude>**/status/StatusLogger.class</exclude>
+        <exclude>**/util/EnvironmentPropertySource.class</exclude>
+        <exclude>**/util/LoaderUtil.class</exclude>
         <exclude>**/util/PropertySource.class</exclude>
         <exclude>**/util/PrivateSecurityManagerStackTraceUtil.class</exclude>
+        <exclude>**/util/SystemPropertiesPropertySource.class</exclude>
         <exclude>**/message/ThreadDumpMessage.class</exclude>
         <exclude>**/message/ThreadDumpMessage$ThreadInfoFactory.class</exclude>
       </excludes>

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -14,23 +14,25 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-import org.apache.logging.log4j.util.EnvironmentPropertySource;
-import org.apache.logging.log4j.util.PropertySource;
-import org.apache.logging.log4j.util.SystemPropertiesPropertySource;
+package org.apache.logging.log4j.status;
 
-module org.apache.logging.log4j {
-    requires java.base;
+import java.util.concurrent.atomic.AtomicInteger;
 
-    exports org.apache.logging.log4j;
-    exports org.apache.logging.log4j.message;
-    exports org.apache.logging.log4j.simple;
-    exports org.apache.logging.log4j.spi;
-    exports org.apache.logging.log4j.status;
-    exports org.apache.logging.log4j.util;
+/**
+ * This is a dummy class and is only here to allow module-info.java to compile.
+ * It will not be copied into the log4j-api module.
+ */
+public final class StatusLogger {
 
-    uses org.apache.logging.log4j.spi.Provider;
-    uses org.apache.logging.log4j.util.PropertySource;
-    uses org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
+    private static final StatusLogger STATUS_LOGGER = new StatusLogger();
 
-    provides PropertySource with EnvironmentPropertySource, SystemPropertiesPropertySource;
+    public void error(String message, Object p0, Object p1) {
+    }
+
+    public void warn(String message, Object p0, Object p1) {
+    }
+
+    public static StatusLogger getLogger() {
+        return STATUS_LOGGER;
+    }
 }

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/EnvironmentPropertySource.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/EnvironmentPropertySource.java
@@ -14,23 +14,11 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-import org.apache.logging.log4j.util.EnvironmentPropertySource;
-import org.apache.logging.log4j.util.PropertySource;
-import org.apache.logging.log4j.util.SystemPropertiesPropertySource;
+package org.apache.logging.log4j.util;
 
-module org.apache.logging.log4j {
-    requires java.base;
-
-    exports org.apache.logging.log4j;
-    exports org.apache.logging.log4j.message;
-    exports org.apache.logging.log4j.simple;
-    exports org.apache.logging.log4j.spi;
-    exports org.apache.logging.log4j.status;
-    exports org.apache.logging.log4j.util;
-
-    uses org.apache.logging.log4j.spi.Provider;
-    uses org.apache.logging.log4j.util.PropertySource;
-    uses org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
-
-    provides PropertySource with EnvironmentPropertySource, SystemPropertiesPropertySource;
+/**
+ * This is a dummy class and is only here to allow module-info.java to compile. It will not
+ * be copied into the log4j-api module.
+ */
+public class EnvironmentPropertySource implements PropertySource {
 }

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
@@ -14,23 +14,15 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-import org.apache.logging.log4j.util.EnvironmentPropertySource;
-import org.apache.logging.log4j.util.PropertySource;
-import org.apache.logging.log4j.util.SystemPropertiesPropertySource;
+package org.apache.logging.log4j.util;
 
-module org.apache.logging.log4j {
-    requires java.base;
+/**
+ * This is a dummy class and is only here to allow module-info.java to compile. It will not
+ * be copied into the log4j-api module.
+ */
+public final class LoaderUtil {
 
-    exports org.apache.logging.log4j;
-    exports org.apache.logging.log4j.message;
-    exports org.apache.logging.log4j.simple;
-    exports org.apache.logging.log4j.spi;
-    exports org.apache.logging.log4j.status;
-    exports org.apache.logging.log4j.util;
-
-    uses org.apache.logging.log4j.spi.Provider;
-    uses org.apache.logging.log4j.util.PropertySource;
-    uses org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
-
-    provides PropertySource with EnvironmentPropertySource, SystemPropertiesPropertySource;
+    public static ClassLoader getThreadContextClassLoader() {
+        return LoaderUtil.class.getClassLoader();
+    }
 }

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/PropertySource.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/PropertySource.java
@@ -14,23 +14,21 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-import org.apache.logging.log4j.util.EnvironmentPropertySource;
-import org.apache.logging.log4j.util.PropertySource;
-import org.apache.logging.log4j.util.SystemPropertiesPropertySource;
+package org.apache.logging.log4j.util;
 
-module org.apache.logging.log4j {
-    requires java.base;
+import java.lang.invoke.MethodHandles;
+import java.util.stream.Stream;
 
-    exports org.apache.logging.log4j;
-    exports org.apache.logging.log4j.message;
-    exports org.apache.logging.log4j.simple;
-    exports org.apache.logging.log4j.spi;
-    exports org.apache.logging.log4j.status;
-    exports org.apache.logging.log4j.util;
+/**
+ * This is a dummy class and is only here to allow module-info.java to compile. It will not
+ * be copied into the log4j-api module.
+ */
+public interface PropertySource {
 
-    uses org.apache.logging.log4j.spi.Provider;
-    uses org.apache.logging.log4j.util.PropertySource;
-    uses org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
-
-    provides PropertySource with EnvironmentPropertySource, SystemPropertiesPropertySource;
+    /**
+     * This method's only purpose is to test {@link ServiceLoaderUtil} from inside the module.
+     */
+    public static Stream<PropertySource> loadPropertySources() {
+        return ServiceLoaderUtil.loadServices(PropertySource.class, MethodHandles.lookup());
+    }
 }

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/SystemPropertiesPropertySource.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/SystemPropertiesPropertySource.java
@@ -14,23 +14,11 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-import org.apache.logging.log4j.util.EnvironmentPropertySource;
-import org.apache.logging.log4j.util.PropertySource;
-import org.apache.logging.log4j.util.SystemPropertiesPropertySource;
+package org.apache.logging.log4j.util;
 
-module org.apache.logging.log4j {
-    requires java.base;
-
-    exports org.apache.logging.log4j;
-    exports org.apache.logging.log4j.message;
-    exports org.apache.logging.log4j.simple;
-    exports org.apache.logging.log4j.spi;
-    exports org.apache.logging.log4j.status;
-    exports org.apache.logging.log4j.util;
-
-    uses org.apache.logging.log4j.spi.Provider;
-    uses org.apache.logging.log4j.util.PropertySource;
-    uses org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
-
-    provides PropertySource with EnvironmentPropertySource, SystemPropertiesPropertySource;
+/**
+ * This is a dummy class and is only here to allow module-info.java to compile. It will not
+ * be copied into the log4j-api module.
+ */
+public class SystemPropertiesPropertySource implements PropertySource {
 }

--- a/log4j-api-java9/src/test/java/module-info.java
+++ b/log4j-api-java9/src/test/java/module-info.java
@@ -14,11 +14,21 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.util;
+import org.apache.logging.log4j.util.java9.test.BetterService;
+import org.apache.logging.log4j.util.java9.test.Service;
+import org.apache.logging.log4j.util.java9.test.Service1;
+import org.apache.logging.log4j.util.java9.test.Service2;
 
-/**
- * This is a dummy class and is only here to allow module-info.java to compile. It will not
- * be copied into the log4j-api module.
- */
-public class PropertySource {
+open module org.apache.logging.log4j.java9test {
+    exports org.apache.logging.log4j.util.java9;
+
+    requires org.apache.logging.log4j;
+    requires transitive org.junit.jupiter.engine;
+    requires transitive org.junit.jupiter.api;
+
+    uses Service;
+    uses BetterService;
+
+    provides Service with Service1, Service2;
+    provides BetterService with Service2;
 }

--- a/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/ServiceLoaderUtilTest.java
+++ b/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/ServiceLoaderUtilTest.java
@@ -16,13 +16,11 @@
  */
 package org.apache.logging.log4j.util.java9;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.lang.invoke.MethodHandles;
-import java.util.Collections;
 import java.util.List;
-import java.util.ServiceConfigurationError;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.util.PropertySource;
@@ -35,43 +33,21 @@ public class ServiceLoaderUtilTest {
 
     @Test
     public void testServiceResolution() {
-        // Run only if we are a module
-        if (ServiceLoaderUtil.class.getModule().isNamed()) {
-            List<Object> services = Collections.emptyList();
-            // Service from test module
-            try {
-                services = ServiceLoaderUtil.loadServices(Service.class, MethodHandles.lookup())
-                        .collect(Collectors.toList());
-            } catch (ServiceConfigurationError e) {
-                fail(e);
-            }
-            assertEquals(2, services.size(), "Service services");
-            // BetterService from test module
-            services.clear();
-            try {
-                services = ServiceLoaderUtil.loadServices(BetterService.class, MethodHandles.lookup())
-                        .collect(Collectors.toList());
-            } catch (ServiceConfigurationError e) {
-                fail(e);
-            }
-            assertEquals(1, services.size(), "BetterService services");
-            // PropertySource from org.apache.logging.log4j module from this module
-            services.clear();
-            try {
-                services = ServiceLoaderUtil.loadServices(PropertySource.class, MethodHandles.lookup())
-                        .collect(Collectors.toList());
-            } catch (ServiceConfigurationError e) {
-                fail(e);
-            }
-            assertEquals(0, services.size(), "PropertySource services");
-            // PropertySource from within org.apache.logging.log4j module
-            services.clear();
-            try {
-                services = PropertySource.loadPropertySources().collect(Collectors.toList());
-            } catch (ServiceConfigurationError e) {
-                fail(e);
-            }
-            assertEquals(2, services.size(), "PropertySource services");
-        }
+        List<Object> services;
+        // Service from test module
+        services = assertDoesNotThrow(() -> ServiceLoaderUtil.loadServices(Service.class, MethodHandles.lookup())
+                .collect(Collectors.toList()));
+        assertThat(services).hasSize(2);
+        // BetterService from test module
+        services = assertDoesNotThrow(() -> ServiceLoaderUtil.loadServices(BetterService.class, MethodHandles.lookup())
+                .collect(Collectors.toList()));
+        assertThat(services).hasSize(1);
+        // PropertySource from org.apache.logging.log4j module from this module
+        services = assertDoesNotThrow(() -> ServiceLoaderUtil.loadServices(PropertySource.class, MethodHandles.lookup())
+                .collect(Collectors.toList()));
+        assertThat(services).hasSize(0);
+        // PropertySource from within org.apache.logging.log4j module
+        services = assertDoesNotThrow(() -> PropertySource.loadPropertySources().collect(Collectors.toList()));
+        assertThat(services).hasSize(2);
     }
 }

--- a/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/ServiceLoaderUtilTest.java
+++ b/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/ServiceLoaderUtilTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.util.java9;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceConfigurationError;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.util.PropertySource;
+import org.apache.logging.log4j.util.ServiceLoaderUtil;
+import org.apache.logging.log4j.util.java9.test.BetterService;
+import org.apache.logging.log4j.util.java9.test.Service;
+import org.junit.jupiter.api.Test;
+
+public class ServiceLoaderUtilTest {
+
+    @Test
+    public void testServiceResolution() {
+        // Run only if we are a module
+        if (ServiceLoaderUtil.class.getModule().isNamed()) {
+            List<Object> services = Collections.emptyList();
+            // Service from test module
+            try {
+                services = ServiceLoaderUtil.loadServices(Service.class, MethodHandles.lookup())
+                        .collect(Collectors.toList());
+            } catch (ServiceConfigurationError e) {
+                fail(e);
+            }
+            assertEquals(2, services.size(), "Service services");
+            // BetterService from test module
+            services.clear();
+            try {
+                services = ServiceLoaderUtil.loadServices(BetterService.class, MethodHandles.lookup())
+                        .collect(Collectors.toList());
+            } catch (ServiceConfigurationError e) {
+                fail(e);
+            }
+            assertEquals(1, services.size(), "BetterService services");
+            // PropertySource from org.apache.logging.log4j module from this module
+            services.clear();
+            try {
+                services = ServiceLoaderUtil.loadServices(PropertySource.class, MethodHandles.lookup())
+                        .collect(Collectors.toList());
+            } catch (ServiceConfigurationError e) {
+                fail(e);
+            }
+            assertEquals(0, services.size(), "PropertySource services");
+            // PropertySource from within org.apache.logging.log4j module
+            services.clear();
+            try {
+                services = PropertySource.loadPropertySources().collect(Collectors.toList());
+            } catch (ServiceConfigurationError e) {
+                fail(e);
+            }
+            assertEquals(2, services.size(), "PropertySource services");
+        }
+    }
+}

--- a/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/test/BetterService.java
+++ b/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/test/BetterService.java
@@ -14,23 +14,8 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-import org.apache.logging.log4j.util.EnvironmentPropertySource;
-import org.apache.logging.log4j.util.PropertySource;
-import org.apache.logging.log4j.util.SystemPropertiesPropertySource;
 
-module org.apache.logging.log4j {
-    requires java.base;
+package org.apache.logging.log4j.util.java9.test;
 
-    exports org.apache.logging.log4j;
-    exports org.apache.logging.log4j.message;
-    exports org.apache.logging.log4j.simple;
-    exports org.apache.logging.log4j.spi;
-    exports org.apache.logging.log4j.status;
-    exports org.apache.logging.log4j.util;
-
-    uses org.apache.logging.log4j.spi.Provider;
-    uses org.apache.logging.log4j.util.PropertySource;
-    uses org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
-
-    provides PropertySource with EnvironmentPropertySource, SystemPropertiesPropertySource;
+public interface BetterService extends Service {
 }

--- a/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/test/Service.java
+++ b/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/test/Service.java
@@ -14,23 +14,8 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-import org.apache.logging.log4j.util.EnvironmentPropertySource;
-import org.apache.logging.log4j.util.PropertySource;
-import org.apache.logging.log4j.util.SystemPropertiesPropertySource;
 
-module org.apache.logging.log4j {
-    requires java.base;
+package org.apache.logging.log4j.util.java9.test;
 
-    exports org.apache.logging.log4j;
-    exports org.apache.logging.log4j.message;
-    exports org.apache.logging.log4j.simple;
-    exports org.apache.logging.log4j.spi;
-    exports org.apache.logging.log4j.status;
-    exports org.apache.logging.log4j.util;
-
-    uses org.apache.logging.log4j.spi.Provider;
-    uses org.apache.logging.log4j.util.PropertySource;
-    uses org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
-
-    provides PropertySource with EnvironmentPropertySource, SystemPropertiesPropertySource;
+public interface Service {
 }

--- a/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/test/Service1.java
+++ b/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/test/Service1.java
@@ -14,23 +14,8 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-import org.apache.logging.log4j.util.EnvironmentPropertySource;
-import org.apache.logging.log4j.util.PropertySource;
-import org.apache.logging.log4j.util.SystemPropertiesPropertySource;
 
-module org.apache.logging.log4j {
-    requires java.base;
+package org.apache.logging.log4j.util.java9.test;
 
-    exports org.apache.logging.log4j;
-    exports org.apache.logging.log4j.message;
-    exports org.apache.logging.log4j.simple;
-    exports org.apache.logging.log4j.spi;
-    exports org.apache.logging.log4j.status;
-    exports org.apache.logging.log4j.util;
-
-    uses org.apache.logging.log4j.spi.Provider;
-    uses org.apache.logging.log4j.util.PropertySource;
-    uses org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
-
-    provides PropertySource with EnvironmentPropertySource, SystemPropertiesPropertySource;
+public class Service1 implements Service {
 }

--- a/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/test/Service2.java
+++ b/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/test/Service2.java
@@ -14,23 +14,8 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-import org.apache.logging.log4j.util.EnvironmentPropertySource;
-import org.apache.logging.log4j.util.PropertySource;
-import org.apache.logging.log4j.util.SystemPropertiesPropertySource;
 
-module org.apache.logging.log4j {
-    requires java.base;
+package org.apache.logging.log4j.util.java9.test;
 
-    exports org.apache.logging.log4j;
-    exports org.apache.logging.log4j.message;
-    exports org.apache.logging.log4j.simple;
-    exports org.apache.logging.log4j.spi;
-    exports org.apache.logging.log4j.status;
-    exports org.apache.logging.log4j.util;
-
-    uses org.apache.logging.log4j.spi.Provider;
-    uses org.apache.logging.log4j.util.PropertySource;
-    uses org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
-
-    provides PropertySource with EnvironmentPropertySource, SystemPropertiesPropertySource;
+public class Service2 implements BetterService {
 }

--- a/log4j-api-java9/src/test/java9/module-info.java
+++ b/log4j-api-java9/src/test/java9/module-info.java
@@ -14,9 +14,22 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
+import org.apache.logging.log4j.util.java9.test.BetterService;
+import org.apache.logging.log4j.util.java9.test.Service;
+import org.apache.logging.log4j.util.java9.test.Service1;
+import org.apache.logging.log4j.util.java9.test.Service2;
+
 open module org.apache.logging.log4j.java9test {
     exports org.apache.logging.log4j.util.java9;
+
     requires org.apache.logging.log4j;
     requires transitive org.junit.jupiter.engine;
     requires transitive org.junit.jupiter.api;
+    requires transitive org.assertj.core;
+
+    uses Service;
+    uses BetterService;
+
+    provides Service with Service1, Service2;
+    provides BetterService with Service2;
 }

--- a/log4j-api/pom.xml
+++ b/log4j-api/pom.xml
@@ -95,10 +95,6 @@
       <groupId>org.junit-pioneer</groupId>
       <artifactId>junit-pioneer</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>osgi-resource-locator</artifactId>
-    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -215,7 +211,7 @@
             </goals>
             <configuration>
               <archive>
-                <manifestFile>${manifestfile}</manifestFile>
+                <manifestFile>${project.build.testOutputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                 <manifestEntries>
                   <Specification-Title>${project.name}</Specification-Title>
                   <Specification-Version>${project.version}</Specification-Version>
@@ -250,18 +246,48 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Export-Package>org.apache.logging.log4j.*</Export-Package>
-            <Import-Package>
-              sun.reflect;resolution:=optional,
-              org.glassfish.hk2.osgiresourcelocator;version="[2.5,3.0)";resolution:=optional,
-              *
-            </Import-Package>
-            <Bundle-Activator>org.apache.logging.log4j.util.Activator</Bundle-Activator>
-            <_fixupmessages>"Classes found in the wrong directory";is:=warning</_fixupmessages>
-          </instructions>
-        </configuration>
+        <executions>
+          <execution>
+            <id>default-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <instructions>
+                <Export-Package>org.apache.logging.log4j.*</Export-Package>
+                <Import-Package>
+                  sun.reflect;resolution:=optional,
+                  *
+                </Import-Package>
+                <Bundle-Activator>org.apache.logging.log4j.util.Activator</Bundle-Activator>
+                <_fixupmessages>"Classes found in the wrong directory";is:=warning</_fixupmessages>
+              </instructions>
+            </configuration>
+          </execution>
+          <execution>
+            <id>default-test-manifest</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+            <configuration>
+              <classifier>tests</classifier>
+              <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+              <manifestLocation>${project.build.testOutputDirectory}/META-INF</manifestLocation>
+              <instructions>
+                <Bundle-SymbolicName>${maven-symbolicname}.tests</Bundle-SymbolicName>
+                <Fragment-Host>org.apache.logging.log4j.api</Fragment-Host>
+                <Export-Package>org.apache.logging.log4j.*</Export-Package>
+                <Import-Package></Import-Package>
+              </instructions>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-scr-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/OsgiServiceLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/OsgiServiceLocator.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.util;
+
+import java.lang.invoke.MethodHandles.Lookup;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.status.StatusLogger;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+public class OsgiServiceLocator {
+
+    private static final boolean OSGI_AVAILABLE = checkOsgiAvailable();
+
+    private static boolean checkOsgiAvailable() {
+        try {
+            Class.forName("org.osgi.framework.Bundle");
+            return true;
+        } catch (final ClassNotFoundException | LinkageError e) {
+            return false;
+        } catch (final Throwable e) {
+            LowLevelLogUtil.logException("Unknown error checking for existence of class: org.osgi.framework.Bundle", e);
+            return false;
+        }
+    }
+
+    public static boolean isAvailable() {
+        return OSGI_AVAILABLE;
+    }
+
+    public static <T> Stream<T> loadServices(final Class<T> serviceType, final Lookup lookup) {
+        return loadServices(serviceType, lookup, true);
+    }
+
+    public static <T> Stream<T> loadServices(final Class<T> serviceType, final Lookup lookup, final boolean verbose) {
+        final Bundle bundle = FrameworkUtil.getBundle(lookup.lookupClass());
+        if (bundle != null) {
+            final BundleContext ctx = bundle.getBundleContext();
+            try {
+                return ctx.getServiceReferences(serviceType, null)
+                        .stream()
+                        .map(ctx::getService);
+            } catch (Throwable e) {
+                if (verbose) {
+                    StatusLogger.getLogger().error("Unable to load OSGI services for service {}", serviceType, e);
+                }
+            }
+        }
+        return Stream.empty();
+    }
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyFilePropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyFilePropertySource.java
@@ -29,12 +29,16 @@ import java.util.Properties;
 public class PropertyFilePropertySource extends PropertiesPropertySource {
 
     public PropertyFilePropertySource(final String fileName) {
-        super(loadPropertiesFile(fileName));
+        this(fileName, true);
     }
 
-    private static Properties loadPropertiesFile(final String fileName) {
+    public PropertyFilePropertySource(final String fileName, final boolean useTccl) {
+        super(loadPropertiesFile(fileName, useTccl));
+    }
+
+    private static Properties loadPropertiesFile(final String fileName, final boolean useTccl) {
         final Properties props = new Properties();
-        for (final URL url : LoaderUtil.findResources(fileName)) {
+        for (final URL url : LoaderUtil.findResources(fileName, useTccl)) {
             try (final InputStream in = url.openStream()) {
                 props.load(in);
             } catch (final IOException e) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ServiceLoaderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ServiceLoaderUtil.java
@@ -86,6 +86,9 @@ public final class ServiceLoaderUtil {
                         loadClassloaderServices(serviceType, lookup, contextClassLoader, verbose));
             }
         }
+        if (OsgiServiceLocator.isAvailable()) {
+            services = Stream.concat(services, OsgiServiceLocator.loadServices(serviceType, lookup, verbose));
+        }
         final Set<Class<?>> classes = new HashSet<>();
         // only the first occurrence of a class
         return services.filter(service -> classes.add(service.getClass()));

--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/OsgiServiceLocatorTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/OsgiServiceLocatorTest.java
@@ -14,21 +14,26 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-import org.apache.logging.log4j.util.java9.test.BetterService;
-import org.apache.logging.log4j.util.java9.test.Service;
-import org.apache.logging.log4j.util.java9.test.Service1;
-import org.apache.logging.log4j.util.java9.test.Service2;
+package org.apache.logging.log4j.util;
 
-open module org.apache.logging.log4j.java9test {
-    exports org.apache.logging.log4j.util.java9;
+import java.lang.invoke.MethodHandles;
+import java.util.stream.Stream;
 
-    requires org.apache.logging.log4j;
-    requires transitive org.junit.jupiter.engine;
-    requires transitive org.junit.jupiter.api;
+import org.apache.logging.log4j.spi.Provider;
 
-    uses Service;
-    uses BetterService;
+public class OsgiServiceLocatorTest {
 
-    provides Service with Service1, Service2;
-    provides BetterService with Service2;
+    /**
+     * Used by OSGI {@link AbstractLoadBundleTest} to preserve caller
+     * sensitivity.
+     * 
+     * @return
+     */
+    public static Stream<Provider> loadProviders() {
+        return OsgiServiceLocator.loadServices(Provider.class, MethodHandles.lookup());
+    }
+
+    public static Stream<PropertySource> loadPropertySources() {
+        return OsgiServiceLocator.loadServices(PropertySource.class, MethodHandles.lookup());
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThreadContextDataInjector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThreadContextDataInjector.java
@@ -16,13 +16,13 @@
  */
 package org.apache.logging.log4j.core.impl;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
 import org.apache.logging.log4j.Logger;
@@ -32,8 +32,8 @@ import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.util.ContextDataProvider;
 import org.apache.logging.log4j.spi.ReadOnlyThreadContextMap;
 import org.apache.logging.log4j.status.StatusLogger;
-import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.apache.logging.log4j.util.ServiceLoaderUtil;
 import org.apache.logging.log4j.util.StringMap;
 
 /**
@@ -74,17 +74,8 @@ public class ThreadContextDataInjector {
 
     private static List<ContextDataProvider> getServiceProviders() {
         List<ContextDataProvider> providers = new ArrayList<>();
-        for (final ClassLoader classLoader : LoaderUtil.getClassLoaders()) {
-            try {
-                for (final ContextDataProvider provider : ServiceLoader.load(ContextDataProvider.class, classLoader)) {
-                    if (providers.stream().noneMatch(p -> p.getClass().isAssignableFrom(provider.getClass()))) {
-                        providers.add(provider);
-                    }
-                }
-            } catch (final Throwable ex) {
-                LOGGER.debug("Unable to access Context Data Providers {}", ex.getMessage());
-            }
-        }
+        ServiceLoaderUtil.loadServices(ContextDataProvider.class, MethodHandles.lookup(), false)
+                .forEach(providers::add);
         return Collections.unmodifiableList(providers);
     }
 

--- a/log4j-osgi/pom.xml
+++ b/log4j-osgi/pom.xml
@@ -68,10 +68,6 @@
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>osgi-resource-locator</artifactId>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -505,12 +505,6 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.glassfish.hk2</groupId>
-        <artifactId>osgi-resource-locator</artifactId>
-        <version>2.5.0-b42</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>org.fusesource.jansi</groupId>
         <artifactId>jansi</artifactId>
         <version>2.4.0</version>


### PR DESCRIPTION
In an attempt to uniformize the calls to `ServiceLoader` and work around its limitations, this replaces the `ServiceLoader#load` call sites with `ServiceLoaderUtil#loadServices`.

`ServiceLoaderUtil` is also modified to return `Stream` instead of a `List`, hence allowing for a more comfortable filtering and sorting of the results.