### PR TITLE
[LOG4J2-3439] Corrects default SSL configuration

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/AbstractKeyStoreConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/AbstractKeyStoreConfiguration.java
@@ -33,6 +33,8 @@ import org.apache.logging.log4j.core.util.NetUtils;
  * Configuration of the KeyStore
  */
 public class AbstractKeyStoreConfiguration extends StoreConfiguration<KeyStore> {
+    static final char[] DEFAULT_PASSWORD = "changeit".toCharArray();
+
     private final KeyStore keyStore;
     private final String keyStoreType;
 
@@ -73,7 +75,7 @@ public class AbstractKeyStoreConfiguration extends StoreConfiguration<KeyStore> 
                 final KeyStore ks = KeyStore.getInstance(this.keyStoreType);
                 final char[] password = this.getPasswordAsCharArray();
                 try {
-                    ks.load(fin, password);
+                    ks.load(fin, password != null ? password : DEFAULT_PASSWORD);
                 } finally {
                     if (password != null) {
                         Arrays.fill(password, '\0');

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/KeyStoreConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/KeyStoreConfiguration.java
@@ -169,7 +169,7 @@ public class KeyStoreConfiguration extends AbstractKeyStoreConfiguration {
         final KeyManagerFactory kmFactory = KeyManagerFactory.getInstance(this.keyManagerFactoryAlgorithm);
         final char[] password = this.getPasswordAsCharArray();
         try {
-            kmFactory.init(this.getKeyStore(), password);
+            kmFactory.init(this.getKeyStore(), password != null ? password : DEFAULT_PASSWORD);
         } finally {
             if (password != null) {
                 Arrays.fill(password, '\0');

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/SslConfigurationDefaults.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/SslConfigurationDefaults.java
@@ -16,12 +16,15 @@
  */
 package org.apache.logging.log4j.core.net.ssl;
 
+import java.security.KeyStore;
+
 /**
  *
  */
 public class SslConfigurationDefaults {
 
-    public static final String KEYSTORE_TYPE = "JKS";
-    public static final String PROTOCOL = "SSL";
+    public static final String KEYSTORE_TYPE = KeyStore.getDefaultType();
+    // "TLS" uses all protocols available except those excluded in "jdk.tls.disabledAlgorithms"
+    public static final String PROTOCOL = "TLS";
 
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/SslConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/SslConfigurationFactory.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.util.PropertiesUtil;
 public class SslConfigurationFactory {
 
     private static final Logger LOGGER = StatusLogger.getLogger();
-    private static SslConfiguration sslConfiguration = null;
+    private static SslConfiguration sslConfiguration = createSslConfiguration(PropertiesUtil.getProperties());
 
     private static final String trustStorelocation = "log4j2.trustStoreLocation";
     private static final String trustStorePassword = "log4j2.trustStorePassword";
@@ -42,8 +42,7 @@ public class SslConfigurationFactory {
     private static final String keyStoreKeyManagerFactoryAlgorithm = "log4j2.keyStoreKeyManagerFactoryAlgorithm";
     private static final String verifyHostName = "log4j2.sslVerifyHostName";
 
-    static {
-        PropertiesUtil props = PropertiesUtil.getProperties();
+    static SslConfiguration createSslConfiguration(PropertiesUtil props) {
         KeyStoreConfiguration keyStoreConfiguration = null;
         TrustStoreConfiguration trustStoreConfiguration = null;
         String location = props.getStringProperty(trustStorelocation);
@@ -80,9 +79,10 @@ public class SslConfigurationFactory {
         }
         if (trustStoreConfiguration != null || keyStoreConfiguration != null) {
             boolean isVerifyHostName = props.getBooleanProperty(verifyHostName, false);
-            sslConfiguration = SslConfiguration.createSSLConfiguration("https", keyStoreConfiguration,
+            return SslConfiguration.createSSLConfiguration(null, keyStoreConfiguration,
                 trustStoreConfiguration, isVerifyHostName);
         }
+        return null;
     }
 
     public static SslConfiguration getSslConfiguration() {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/net/ssl/SslConfigurationFactoryTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/net/ssl/SslConfigurationFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.net.ssl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Properties;
+
+import org.apache.logging.log4j.util.PropertiesUtil;
+import org.junit.jupiter.api.Test;
+
+public class SslConfigurationFactoryTest {
+
+    private static void addKeystoreConfiguration(Properties props) {
+        props.setProperty("log4j2.keyStoreLocation", TestConstants.KEYSTORE_FILE_RESOURCE);
+        props.setProperty("log4j2.keyStoreKeyStoreType", TestConstants.KEYSTORE_TYPE);
+    }
+
+    private static void addTruststoreConfiguration(Properties props) {
+        props.setProperty("log4j2.trustStoreLocation", TestConstants.TRUSTSTORE_FILE_RESOURCE);
+        props.setProperty("log4j2.trustStoreKeyStoreType", TestConstants.TRUSTSTORE_TYPE);
+    }
+
+    @Test
+    public void testStaticConfiguration() {
+        final Properties props = new Properties();
+        final PropertiesUtil util = new PropertiesUtil(props);
+        // No keystore and truststore -> no SslConfiguration
+        SslConfiguration sslConfiguration = SslConfigurationFactory.createSslConfiguration(util);
+        assertNull(sslConfiguration);
+        // Only keystore
+        props.clear();
+        addKeystoreConfiguration(props);
+        util.reload();
+        sslConfiguration = SslConfigurationFactory.createSslConfiguration(util);
+        assertNotNull(sslConfiguration);
+        assertNotNull(sslConfiguration.getKeyStoreConfig());
+        assertNull(sslConfiguration.getTrustStoreConfig());
+        // Only truststore
+        props.clear();
+        addTruststoreConfiguration(props);
+        util.reload();
+        sslConfiguration = SslConfigurationFactory.createSslConfiguration(util);
+        assertNotNull(sslConfiguration);
+        assertNull(sslConfiguration.getKeyStoreConfig());
+        assertNotNull(sslConfiguration.getTrustStoreConfig());
+        // Both
+        props.clear();
+        addKeystoreConfiguration(props);
+        addTruststoreConfiguration(props);
+        util.reload();
+        sslConfiguration = SslConfigurationFactory.createSslConfiguration(util);
+        assertNotNull(sslConfiguration);
+        assertNotNull(sslConfiguration.getKeyStoreConfig());
+        assertNotNull(sslConfiguration.getTrustStoreConfig());
+    }
+}

--- a/src/site/xdoc/manual/appenders.xml
+++ b/src/site/xdoc/manual/appenders.xml
@@ -5003,8 +5003,10 @@ public class JpaLogEntity extends AbstractLogEventWrapperEntity {
           <tr>
             <td>protocol</td>
             <td>String</td>
-            <td><code>SSL</code> if omitted.
-            See also <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#SSLContext">Standard names</a>.</td>
+            <td>The SSL protocol to use, <code>TLS</code> if omitted. A single value may enable multiple protocols,
+              see the <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/security/StandardNames.html#SSLContext">JVM documentation</a>
+              for details.
+            </td>
           </tr>
           <tr>
             <td>KeyStore</td>


### PR DESCRIPTION
Replaces an invalid `SSLContext` algorithm name with Log4j's default and adds unit tests.