### PR TITLE
Make ConfigurationFactory injectable

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
@@ -27,14 +27,13 @@ import org.apache.log4j.rewrite.RewritePolicy;
 import org.apache.log4j.spi.Filter;
 import org.apache.log4j.xml.XmlConfiguration;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.plugins.util.PluginManager;
 import org.apache.logging.log4j.plugins.util.PluginType;
+import org.apache.logging.log4j.plugins.util.PluginUtil;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
 import org.w3c.dom.Element;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -50,9 +49,7 @@ public class BuilderManager {
     private final Map<String, PluginType<?>> plugins;
 
     public BuilderManager() {
-        final PluginManager manager = new PluginManager(CATEGORY);
-        manager.collectPlugins();
-        plugins = manager.getPlugins();
+        plugins = PluginUtil.collectPluginsByCategory(CATEGORY);
     }
 
     public Appender parseAppender(String className, Element appenderElement, XmlConfiguration config) {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/CategoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/CategoryTest.java
@@ -19,7 +19,6 @@ package org.apache.log4j;
 
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
@@ -47,21 +46,18 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class CategoryTest {
 
-    static ConfigurationFactory cf = new BasicConfigurationFactory();
-
     private static ListAppender appender = new ListAppender("List");
 
     @BeforeAll
     public static void setupClass() {
         appender.start();
-        ConfigurationFactory.setConfigurationFactory(cf);
-        LoggerContext.getContext().reconfigure();
+        System.setProperty(ConfigurationFactory.CONFIGURATION_FACTORY_PROPERTY, BasicConfigurationFactory.class.getName());
     }
 
     @AfterAll
     public static void cleanupClass() {
-        ConfigurationFactory.removeConfigurationFactory(cf);
         appender.stop();
+        System.clearProperty(ConfigurationFactory.CONFIGURATION_FACTORY_PROPERTY);
     }
 
     @BeforeEach

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LogWithRouteTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LogWithRouteTest.java
@@ -16,40 +16,39 @@
  */
 package org.apache.log4j;
 
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.test.junit.UsingThreadContextMap;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test passing MDC values to the Routing appender.
  */
+@UsingThreadContextMap
 public class LogWithRouteTest {
 
     private static final String CONFIG = "log-RouteWithMDC.xml";
 
-    @ClassRule
-    public static final LoggerContextRule CTX = new LoggerContextRule(CONFIG);
-
     @Test
-    public void testMDC() throws Exception {
+    @LoggerContextSource(CONFIG)
+    public void testMDC(final Configuration configuration) throws Exception {
         MDC.put("Type", "Service");
         MDC.put("Name", "John Smith");
         try {
             final Logger logger = Logger.getLogger("org.apache.test.logging");
             logger.debug("This is a test");
-            final ListAppender listApp = (ListAppender) CTX.getAppender("List");
+            final ListAppender listApp = configuration.getAppender("List");
             assertNotNull(listApp);
             final List<String> msgs = listApp.getMessages();
-            assertNotNull("No messages received", msgs);
-            assertTrue(msgs.size() == 1);
-            assertTrue("Type is missing", msgs.get(0).contains("Type=Service"));
-            assertTrue("Name is missing", msgs.get(0).contains("Name=John Smith"));
+            assertNotNull(msgs, "No messages received");
+            assertEquals(1, msgs.size());
+            assertTrue(msgs.get(0).contains("Type=Service"), "Type is missing");
+            assertTrue(msgs.get(0).contains("Name=John Smith"), "Name is missing");
         } finally {
             MDC.remove("Type");
             MDC.remove("Name");

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LoggingTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LoggingTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.log4j;
 
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  *
@@ -29,15 +29,13 @@ public class LoggingTest {
 
     private static final String CONFIG = "log4j2-config.xml";
 
-    @ClassRule
-    public static final LoggerContextRule CTX = new LoggerContextRule(CONFIG);
-
     @Test
+    @LoggerContextSource(CONFIG)
     public void testParent() {
         final Logger logger = Logger.getLogger("org.apache.test.logging.Test");
         final Category parent = logger.getParent();
-        assertNotNull("No parent Logger", parent);
-        assertEquals("Incorrect parent logger", "org.apache.test.logging", parent.getName());
+        assertNotNull(parent, "No parent Logger");
+        assertEquals("org.apache.test.logging", parent.getName(), "Incorrect parent logger");
     }
 
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AutoConfigTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AutoConfigTest.java
@@ -23,34 +23,26 @@ import org.apache.log4j.bridge.AppenderAdapter;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.spi.LoggerContext;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test configuration from XML.
  */
 public class AutoConfigTest {
 
-    @BeforeClass
-    public static void beforeClass() {
-        System.setProperty(ConfigurationFactory.LOG4J1_EXPERIMENTAL, "true");
-    }
-
     @Test
-    public void testListAppender() {
+    @LoggerContextSource(value = "log4j.xml", v1config = true)
+    public void testListAppender(final org.apache.logging.log4j.core.LoggerContext context) {
         Logger logger = LogManager.getLogger("test");
         logger.debug("This is a test of the root logger");
-        LoggerContext loggerContext = org.apache.logging.log4j.LogManager.getContext(false);
-        Configuration configuration = ((org.apache.logging.log4j.core.LoggerContext) loggerContext).getConfiguration();
+        Configuration configuration = context.getConfiguration();
         Map<String, Appender> appenders = configuration.getAppenders();
         ListAppender eventAppender = null;
         ListAppender messageAppender = null;
@@ -61,12 +53,12 @@ public class AutoConfigTest {
                 eventAppender = (ListAppender) ((AppenderAdapter.Adapter) entry.getValue()).getAppender();
             }
         }
-        assertNotNull("No Event Appender", eventAppender);
-        assertNotNull("No Message Appender", messageAppender);
+        assertNotNull(eventAppender, "No Event Appender");
+        assertNotNull(messageAppender, "No Message Appender");
         List<LoggingEvent> events = eventAppender.getEvents();
-        assertTrue("No events", events != null && events.size() > 0);
+        assertTrue(events != null && events.size() > 0, "No events");
         List<String> messages = messageAppender.getMessages();
-        assertTrue("No messages", messages != null && messages.size() > 0);
+        assertTrue(messages != null && messages.size() > 0, "No messages");
     }
 
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -16,27 +16,19 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.apache.log4j.layout.Log4j1XmlLayout;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
 import java.net.URL;
 
-import org.apache.log4j.layout.Log4j1XmlLayout;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.Layout;
-import org.apache.logging.log4j.core.appender.ConsoleAppender;
-import org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
-import org.apache.logging.log4j.core.appender.FileAppender;
-import org.apache.logging.log4j.core.appender.NullAppender;
-import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.layout.PatternLayout;
-import org.junit.Ignore;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationTest {
 
@@ -45,7 +37,7 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
     @Override
     protected Configuration getConfiguration(final String configResource) throws URISyntaxException {
         final URL configLocation = ClassLoader.getSystemResource(configResource + SUFFIX);
-        assertNotNull(configResource, configLocation);
+        assertNotNull(configLocation, configResource);
         final Configuration configuration = new Log4j1ConfigurationFactory().getConfiguration(null, "test", configLocation.toURI());
         assertNotNull(configuration);
         return configuration;
@@ -55,7 +47,8 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
         final Configuration configuration = getConfiguration(configResource);
         final String name = "Console";
         final ConsoleAppender appender = configuration.getAppender(name);
-        assertNotNull("Missing appender '" + name + "' in configuration " + configResource + " → " + configuration, appender);
+        assertNotNull(appender,
+                "Missing appender '" + name + "' in configuration " + configResource + " → " + configuration);
         assertEquals(Target.SYSTEM_ERR, appender.getTarget());
         //
         final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/MapRewriteAppenderTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/MapRewriteAppenderTest.java
@@ -21,39 +21,27 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.log4j.bridge.AppenderAdapter;
 import org.apache.log4j.spi.LoggingEvent;
-import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.test.junit.UsingThreadContextMap;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test RewriteAppender
  */
+@UsingThreadContextMap
 public class MapRewriteAppenderTest {
 
-    @BeforeClass
-    public static void beforeClass() {
-        System.setProperty(ConfigurationFactory.LOG4J1_CONFIGURATION_FILE_PROPERTY, "target/test-classes/log4j1-mapRewrite.xml");
-    }
-
-    @After
-    public void after() {
-        ThreadContext.clearMap();
-    }
-
     @Test
+    @LoggerContextSource(value = "log4j1-mapRewrite.xml", v1config = true)
     public void testRewrite() throws Exception {
         Logger logger = LogManager.getLogger("test");
         Map<String, String> map = new HashMap<>();
@@ -69,11 +57,11 @@ public class MapRewriteAppenderTest {
                 eventAppender = (ListAppender) ((AppenderAdapter.Adapter) entry.getValue()).getAppender();
             }
         }
-        assertNotNull("No Event Appender", eventAppender);
+        assertNotNull(eventAppender, "No Event Appender");
         List<LoggingEvent> events = eventAppender.getEvents();
-        assertTrue("No events", events != null && events.size() > 0);
-        assertNotNull("No properties in the event", events.get(0).getProperties());
-        assertTrue("Key was not inserted", events.get(0).getProperties().containsKey("hello"));
-        assertEquals("Key value is incorrect", "world", events.get(0).getProperties().get("hello"));
+        assertTrue(events != null && events.size() > 0, "No events");
+        assertNotNull(events.get(0).getProperties(), "No properties in the event");
+        assertTrue(events.get(0).getProperties().containsKey("hello"), "Key was not inserted");
+        assertEquals("world", events.get(0).getProperties().get("hello"), "Key value is incorrect");
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -16,17 +16,6 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URISyntaxException;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.log4j.ListAppender;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -43,8 +32,16 @@ import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.filter.CompositeFilter;
 import org.apache.logging.log4j.core.filter.Filterable;
 import org.apache.logging.log4j.core.filter.LevelRangeFilter;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test configuration from Properties.
@@ -61,7 +58,7 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
         final ConfigurationSource source = new ConfigurationSource(inputStream);
         final LoggerContext context = LoggerContext.getContext(false);
         final Configuration configuration = new PropertiesConfigurationFactory().getConfiguration(context, source);
-        assertNotNull("No configuration created", configuration);
+        assertNotNull(configuration, "No configuration created");
         configuration.initialize();
         return configuration;
     }
@@ -140,12 +137,12 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
                     eventAppender = (ListAppender) ((AppenderAdapter.Adapter) entry.getValue()).getAppender();
                 }
             }
-            assertNotNull("No Event Appender", eventAppender);
-            assertNotNull("No Message Appender", messageAppender);
+            assertNotNull(eventAppender, "No Event Appender");
+            assertNotNull(messageAppender, "No Message Appender");
             final List<LoggingEvent> events = eventAppender.getEvents();
-            assertTrue("No events", events != null && events.size() > 0);
+            assertTrue(events != null && events.size() > 0, "No events");
             final List<String> messages = messageAppender.getMessages();
-            assertTrue("No messages", messages != null && messages.size() > 0);
+            assertTrue(messages != null && messages.size() > 0, "No messages");
         }
     }
 
@@ -155,11 +152,11 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
             final Logger logger = LogManager.getLogger("test");
             logger.debug("This is a test of the root logger");
             File file = new File("target/temp.A1");
-            assertTrue("File A1 was not created", file.exists());
-            assertTrue("File A1 is empty", file.length() > 0);
+            assertTrue(file.exists(), "File A1 was not created");
+            assertTrue(file.length() > 0, "File A1 is empty");
             file = new File("target/temp.A2");
-            assertTrue("File A2 was not created", file.exists());
-            assertTrue("File A2 is empty", file.length() > 0);
+            assertTrue(file.exists(), "File A2 was not created");
+            assertTrue(file.length() > 0, "File A2 is empty");
         }
     }
 
@@ -173,8 +170,8 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
             assertNotNull(configuration);
             final String name = "FILE_APPENDER";
             final Appender appender = configuration.getAppender(name);
-            assertNotNull(name, appender);
-            assertTrue(appender.getClass().getName(), appender instanceof FileAppender);
+            assertNotNull(appender, name);
+            assertTrue(appender instanceof FileAppender, appender.getClass().getName());
             final FileAppender fileAppender = (FileAppender) appender;
             // Two slashes because that's how the config file is setup.
             assertEquals(testPathLocation + "/hadoop.log", fileAppender.getFileName());

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesRollingWithPropertiesTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesRollingWithPropertiesTest.java
@@ -16,43 +16,42 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertTrue;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.test.junit.CleanUpDirectories;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
-import org.apache.logging.log4j.core.test.SystemPropertyTestRule;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestRule;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test configuration from Properties.
  */
 public class PropertiesRollingWithPropertiesTest {
 
-    private static final String TEST_DIR = "target/" + PropertiesRollingWithPropertiesTest.class.getSimpleName();
+    private static final String TEST_DIR = "target/PropertiesRollingWithPropertiesTest";
 
-    @ClassRule
-    public static TestRule SP_RULE = RuleChain.emptyRuleChain()
-    //@formatter:off
-        .around(SystemPropertyTestRule.create("test.directory", TEST_DIR))
-        .around(SystemPropertyTestRule.create("log4j.configuration", "target/test-classes/log4j1-rolling-properties.properties"));
-    //@formatter:on
+    @BeforeAll
+    static void beforeAll() {
+        System.setProperty("test.directory", TEST_DIR);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        System.clearProperty("test.directory");
+    }
 
     @Test
-    public void testProperties() throws Exception {
-        final Path path = Paths.get(TEST_DIR, "somefile.log");
-        Files.deleteIfExists(path);
-        final Logger logger = LogManager.getLogger("test");
+    @CleanUpDirectories(TEST_DIR)
+    @LoggerContextSource(value = "log4j1-rolling-properties.properties", v1config = true)
+    public void testProperties(final LoggerContext context) throws Exception {
+        final Logger logger = context.getLogger("test");
         logger.debug("This is a test of the root logger");
-        assertTrue("Log file was not created", Files.exists(path));
-        assertTrue("Log file is empty", Files.size(path) > 0);
-
+        assertThat(Paths.get(TEST_DIR, "somefile.log")).exists().isNotEmptyFile();
     }
 
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/RewriteAppenderTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/RewriteAppenderTest.java
@@ -25,41 +25,29 @@ import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.test.junit.UsingThreadContextMap;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test RewriteAppender
  */
+@UsingThreadContextMap
 public class RewriteAppenderTest {
 
-    @BeforeClass
-    public static void beforeClass() {
-        System.setProperty(ConfigurationFactory.LOG4J1_CONFIGURATION_FILE_PROPERTY, "target/test-classes/log4j1-rewrite.xml");
-    }
-
-    @After
-    public void after() {
-        ThreadContext.clearMap();
-    }
-
     @Test
-    public void testRewrite() throws Exception {
+    @LoggerContextSource(value = "log4j1-rewrite.xml", v1config = true)
+    public void testRewrite(final LoggerContext context) throws Exception {
         Logger logger = LogManager.getLogger("test");
         ThreadContext.put("key1", "This is a test");
         ThreadContext.put("hello", "world");
         long logTime = System.currentTimeMillis();
         logger.debug("Say hello");
-        LoggerContext context = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
         Configuration configuration = context.getConfiguration();
         Map<String, Appender> appenders = configuration.getAppenders();
         ListAppender eventAppender = null;
@@ -68,12 +56,12 @@ public class RewriteAppenderTest {
                 eventAppender = (ListAppender) ((AppenderAdapter.Adapter) entry.getValue()).getAppender();
             }
         }
-        assertNotNull("No Event Appender", eventAppender);
+        assertNotNull(eventAppender, "No Event Appender");
         List<LoggingEvent> events = eventAppender.getEvents();
-        assertTrue("No events", events != null && events.size() > 0);
-        assertNotNull("No properties in the event", events.get(0).getProperties());
-        assertTrue("Key was not inserted", events.get(0).getProperties().containsKey("key2"));
-        assertEquals("Key value is incorrect", "Log4j", events.get(0).getProperties().get("key2"));
-        assertTrue("Timestamp is before point of logging", events.get(0).getTimeStamp() >= logTime);
+        assertTrue(events != null && events.size() > 0, "No events");
+        assertNotNull(events.get(0).getProperties(), "No properties in the event");
+        assertTrue(events.get(0).getProperties().containsKey("key2"), "Key was not inserted");
+        assertEquals("Log4j", events.get(0).getProperties().get("key2"), "Key value is incorrect");
+        assertTrue(events.get(0).getTimeStamp() >= logTime, "Timestamp is before point of logging");
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -16,17 +16,6 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URISyntaxException;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.log4j.ListAppender;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -36,11 +25,23 @@ import org.apache.log4j.xml.XmlConfigurationFactory;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.spi.LoggerContextFactory;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.apache.logging.log4j.util.LazyValue;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test configuration from XML.
@@ -55,8 +56,11 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
         final InputStream inputStream = ClassLoader.getSystemResourceAsStream(configResource);
         final ConfigurationSource source = new ConfigurationSource(inputStream);
         final LoggerContext context = LoggerContext.getContext(false);
-        final Configuration configuration = new XmlConfigurationFactory().getConfiguration(context, source);
-        assertNotNull("No configuration created", configuration);
+        final Configuration configuration = context.getInjector()
+                .registerBinding(ConfigurationFactory.KEY, new LazyValue<>(XmlConfigurationFactory::new))
+                .getInstance(ConfigurationFactory.KEY)
+                .getConfiguration(context, source);
+        assertNotNull(configuration, "No configuration created");
         configuration.initialize();
         return configuration;
     }
@@ -67,11 +71,11 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
         Logger logger = LogManager.getLogger("test");
         logger.debug("This is a test of the root logger");
         File file = new File("target/temp.A1");
-        assertTrue("File A1 was not created", file.exists());
-        assertTrue("File A1 is empty", file.length() > 0);
+        assertTrue(file.exists(), "File A1 was not created");
+        assertTrue(file.length() > 0, "File A1 is empty");
         file = new File("target/temp.A2");
-        assertTrue("File A2 was not created", file.exists());
-        assertTrue("File A2 is empty", file.length() > 0);
+        assertTrue(file.exists(), "File A2 was not created");
+        assertTrue(file.length() > 0, "File A2 is empty");
     }
 
     @Test
@@ -90,12 +94,12 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
                 eventAppender = (ListAppender) ((AppenderAdapter.Adapter) entry.getValue()).getAppender();
             }
         }
-        assertNotNull("No Event Appender", eventAppender);
-        assertNotNull("No Message Appender", messageAppender);
+        assertNotNull(eventAppender, "No Event Appender");
+        assertNotNull(messageAppender, "No Message Appender");
         List<LoggingEvent> events = eventAppender.getEvents();
-        assertTrue("No events", events != null && events.size() > 0);
+        assertTrue(events != null && events.size() > 0, "No events");
         List<String> messages = messageAppender.getMessages();
-        assertTrue("No messages", messages != null && messages.size() > 0);
+        assertTrue(messages != null && messages.size() > 0, "No messages");
     }
 
     private LoggerContext configure(String configLocation) throws Exception {
@@ -105,7 +109,7 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
         LoggerContextFactory factory = org.apache.logging.log4j.LogManager.getFactory();
         LoggerContext context = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
         Configuration configuration = new XmlConfigurationFactory().getConfiguration(context, source);
-        assertNotNull("No configuration created", configuration);
+        assertNotNull(configuration, "No configuration created");
         Configurator.reconfigure(configuration);
         return context;
     }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlRollingWithPropertiesTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlRollingWithPropertiesTest.java
@@ -16,43 +16,43 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertTrue;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.test.junit.CleanUpDirectories;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
-import org.apache.logging.log4j.core.test.SystemPropertyTestRule;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestRule;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test configuration from Properties.
  */
 public class XmlRollingWithPropertiesTest {
 
-    private static final String TEST_DIR = "target/" + XmlRollingWithPropertiesTest.class.getSimpleName();
+    private static final String TEST_DIR = "target/XmlRollingWithPropertiesTest";
 
-    @ClassRule
-    public static TestRule SP_RULE = RuleChain.emptyRuleChain()
-    //@formatter:off
-        .around(SystemPropertyTestRule.create("test.directory", TEST_DIR))
-        .around(SystemPropertyTestRule.create("log4j.configuration", "target/test-classes/log4j1-rolling-properties.xml"));
-    //@formatter:on
+    @BeforeAll
+    static void beforeAll() {
+        System.setProperty("test.directory", TEST_DIR);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        System.clearProperty("test.directory");
+    }
 
     @Test
-    public void testProperties() throws Exception {
+    @CleanUpDirectories(TEST_DIR)
+    @LoggerContextSource(value = "log4j1-rolling-properties.xml", v1config = true)
+    public void testProperties(final LoggerContext context) {
         // ${test.directory}/logs/etl.log
-        final Path path = Paths.get(TEST_DIR, "logs/etl.log");
-        Files.deleteIfExists(path);
-        final Logger logger = LogManager.getLogger("test");
+        final Logger logger = context.getLogger("test");
         logger.debug("This is a test of the root logger");
-        assertTrue("Log file was not created " + path, Files.exists(path));
-        assertTrue("Log file is empty " + path, Files.size(path) > 0);
+        assertThat(Paths.get(TEST_DIR, "logs/etl.log")).exists().isNotEmptyFile();
     }
 
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingDirectTimeNewDirectoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingDirectTimeNewDirectoryTest.java
@@ -32,7 +32,7 @@ import org.opentest4j.AssertionFailedError;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,7 +45,7 @@ public class RollingDirectTimeNewDirectoryTest implements RolloverListener {
     // Note that the path is hardcoded in the configuration!
     private static final String DIR = "target/rolling-folder-direct";
     private final AtomicLong currentTimeMillis = new AtomicLong(System.currentTimeMillis());
-    private final CountDownLatch latch = new CountDownLatch(2);
+    private final Phaser phaser = new Phaser(3);
 
     @Factory
     Clock clock() {
@@ -70,7 +70,7 @@ public class RollingDirectTimeNewDirectoryTest implements RolloverListener {
             logger.info("nHq6p9kgfvWfjzDRYbZp");
         }
 
-        latch.await();
+        phaser.arriveAndAwaitAdvance();
 
         File logDir = new File(DIR);
         File[] logFolders = logDir.listFiles();
@@ -116,6 +116,6 @@ public class RollingDirectTimeNewDirectoryTest implements RolloverListener {
 
     @Override
     public void rolloverComplete(final String fileName) {
-        latch.countDown();
+        phaser.arriveAndDeregister();
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/RequiredValidatorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/RequiredValidatorTest.java
@@ -20,8 +20,8 @@ import org.apache.logging.log4j.plugins.Node;
 import org.apache.logging.log4j.plugins.di.DI;
 import org.apache.logging.log4j.plugins.di.Keys;
 import org.apache.logging.log4j.plugins.test.validation.ValidatingPlugin;
-import org.apache.logging.log4j.plugins.util.PluginManager;
 import org.apache.logging.log4j.plugins.util.PluginType;
+import org.apache.logging.log4j.plugins.util.PluginUtil;
 import org.apache.logging.log4j.test.junit.StatusLoggerLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,9 +38,7 @@ public class RequiredValidatorTest {
     @SuppressWarnings("unchecked")
     @BeforeEach
     public void setUp() throws Exception {
-        final PluginManager manager = new PluginManager("Test");
-        manager.collectPlugins();
-        PluginType<ValidatingPlugin> plugin = (PluginType<ValidatingPlugin>) manager.getPluginType("Validator");
+        PluginType<ValidatingPlugin> plugin = (PluginType<ValidatingPlugin>) PluginUtil.collectPluginsByCategory("Test").get("validator");
         assertNotNull(plugin, "Rebuild this module to make sure annotation processing kicks in.");
         node = new Node(null, "Validator", plugin);
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidHostValidatorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidHostValidatorTest.java
@@ -20,8 +20,8 @@ import org.apache.logging.log4j.plugins.Node;
 import org.apache.logging.log4j.plugins.di.DI;
 import org.apache.logging.log4j.plugins.di.Keys;
 import org.apache.logging.log4j.plugins.test.validation.HostAndPort;
-import org.apache.logging.log4j.plugins.util.PluginManager;
 import org.apache.logging.log4j.plugins.util.PluginType;
+import org.apache.logging.log4j.plugins.util.PluginUtil;
 import org.apache.logging.log4j.test.junit.StatusLoggerLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,9 +39,7 @@ public class ValidHostValidatorTest {
     @SuppressWarnings("unchecked")
     @BeforeEach
     public void setUp() throws Exception {
-        final PluginManager manager = new PluginManager("Test");
-        manager.collectPlugins();
-        plugin = (PluginType<HostAndPort>) manager.getPluginType("HostAndPort");
+        plugin = (PluginType<HostAndPort>) PluginUtil.collectPluginsByCategory("Test").get("hostandport");
         assertNotNull(plugin, "Rebuild this module to ensure annotation processing has been done.");
         node = new Node(null, "HostAndPort", plugin);
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidPortValidatorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidPortValidatorTest.java
@@ -20,8 +20,8 @@ import org.apache.logging.log4j.plugins.Node;
 import org.apache.logging.log4j.plugins.di.DI;
 import org.apache.logging.log4j.plugins.di.Keys;
 import org.apache.logging.log4j.plugins.test.validation.HostAndPort;
-import org.apache.logging.log4j.plugins.util.PluginManager;
 import org.apache.logging.log4j.plugins.util.PluginType;
+import org.apache.logging.log4j.plugins.util.PluginUtil;
 import org.apache.logging.log4j.test.junit.StatusLoggerLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,9 +39,7 @@ public class ValidPortValidatorTest {
     @SuppressWarnings("unchecked")
     @BeforeEach
     public void setUp() throws Exception {
-        final PluginManager manager = new PluginManager("Test");
-        manager.collectPlugins();
-        plugin = (PluginType<HostAndPort>) manager.getPluginType("HostAndPort");
+        plugin = (PluginType<HostAndPort>) PluginUtil.collectPluginsByCategory("Test").get("hostandport");
         assertNotNull(plugin, "Rebuild this module to ensure annotation processing has been done.");
         node = new Node(null, "HostAndPort", plugin);
         node.getAttributes().put("host", "localhost");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidatingPluginWithFailoverTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidatingPluginWithFailoverTest.java
@@ -28,8 +28,8 @@ import org.apache.logging.log4j.plugins.di.DI;
 import org.apache.logging.log4j.plugins.di.Injector;
 import org.apache.logging.log4j.plugins.di.Key;
 import org.apache.logging.log4j.plugins.di.Keys;
-import org.apache.logging.log4j.plugins.util.PluginManager;
 import org.apache.logging.log4j.plugins.util.PluginType;
+import org.apache.logging.log4j.plugins.util.PluginUtil;
 import org.apache.logging.log4j.status.StatusData;
 import org.apache.logging.log4j.status.StatusListener;
 import org.apache.logging.log4j.status.StatusLogger;
@@ -37,6 +37,8 @@ import org.apache.logging.log4j.test.junit.StatusLoggerLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+import java.util.Map;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -51,15 +53,14 @@ public class ValidatingPluginWithFailoverTest {
     @SuppressWarnings("unchecked")
     @BeforeEach
     public void setUp() throws Exception {
-        final PluginManager manager = new PluginManager(Core.CATEGORY_NAME);
-        manager.collectPlugins();
-        PluginType<FailoverAppender> plugin = (PluginType<FailoverAppender>) manager.getPluginType("failover");
+        final Map<String, PluginType<?>> plugins = PluginUtil.collectPluginsByCategory(Core.CATEGORY_NAME);
+        PluginType<FailoverAppender> plugin = (PluginType<FailoverAppender>) plugins.get("Failover".toLowerCase(Locale.ROOT));
         assertNotNull(plugin, "Rebuild this module to make sure annotation processing kicks in.");
 
         AppenderRef appenderRef = AppenderRef.createAppenderRef("List", Level.ALL, null);
         node = new Node(null, "failover", plugin);
-        Node failoversNode = new Node(node, "Failovers", manager.getPluginType("Failovers"));
-        Node appenderRefNode  = new Node(failoversNode, "appenderRef", manager.getPluginType("appenderRef"));
+        Node failoversNode = new Node(node, "Failovers", plugins.get("Failovers".toLowerCase(Locale.ROOT)));
+        Node appenderRefNode  = new Node(failoversNode, "appenderRef", plugins.get("appenderRef".toLowerCase(Locale.ROOT)));
         appenderRefNode.getAttributes().put("ref", "file");
         appenderRefNode.setObject(appenderRef);
         failoversNode.getChildren().add(appenderRefNode);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidatingPluginWithGenericBuilderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidatingPluginWithGenericBuilderTest.java
@@ -20,12 +20,14 @@ import org.apache.logging.log4j.plugins.Node;
 import org.apache.logging.log4j.plugins.di.DI;
 import org.apache.logging.log4j.plugins.di.Keys;
 import org.apache.logging.log4j.plugins.test.validation.ValidatingPluginWithGenericBuilder;
-import org.apache.logging.log4j.plugins.util.PluginManager;
 import org.apache.logging.log4j.plugins.util.PluginType;
+import org.apache.logging.log4j.plugins.util.PluginUtil;
 import org.apache.logging.log4j.test.junit.StatusLoggerLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+import java.util.Map;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -38,10 +40,9 @@ public class ValidatingPluginWithGenericBuilderTest {
     @SuppressWarnings("unchecked")
     @BeforeEach
     public void setUp() throws Exception {
-        final PluginManager manager = new PluginManager("Test");
-        manager.collectPlugins();
-        PluginType<ValidatingPluginWithGenericBuilder> plugin =
-                (PluginType<ValidatingPluginWithGenericBuilder>) manager.getPluginType("ValidatingPluginWithGenericBuilder");
+        final Map<String, PluginType<?>> plugins = PluginUtil.collectPluginsByCategory("Test");
+        final var plugin = (PluginType<ValidatingPluginWithGenericBuilder>)
+                plugins.get("ValidatingPluginWithGenericBuilder".toLowerCase(Locale.ROOT));
         assertNotNull(plugin, "Rebuild this module to make sure annotation processing kicks in.");
         node = new Node(null, "Validator", plugin);
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidatingPluginWithGenericSubclassFoo1BuilderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidatingPluginWithGenericSubclassFoo1BuilderTest.java
@@ -20,12 +20,13 @@ import org.apache.logging.log4j.plugins.Node;
 import org.apache.logging.log4j.plugins.di.DI;
 import org.apache.logging.log4j.plugins.di.Keys;
 import org.apache.logging.log4j.plugins.test.validation.PluginWithGenericSubclassFoo1Builder;
-import org.apache.logging.log4j.plugins.util.PluginManager;
 import org.apache.logging.log4j.plugins.util.PluginType;
+import org.apache.logging.log4j.plugins.util.PluginUtil;
 import org.apache.logging.log4j.test.junit.StatusLoggerLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -38,11 +39,8 @@ public class ValidatingPluginWithGenericSubclassFoo1BuilderTest {
     @SuppressWarnings("unchecked")
     @BeforeEach
     public void setUp() throws Exception {
-        final PluginManager manager = new PluginManager("Test");
-        manager.collectPlugins();
-        PluginType<PluginWithGenericSubclassFoo1Builder> plugin =
-                (PluginType<PluginWithGenericSubclassFoo1Builder>) manager.getPluginType(
-                        "PluginWithGenericSubclassFoo1Builder");
+        final var plugin = (PluginType<PluginWithGenericSubclassFoo1Builder>) PluginUtil.collectPluginsByCategory("Test")
+                .get("PluginWithGenericSubclassFoo1Builder".toLowerCase(Locale.ROOT));
         assertNotNull(plugin, "Rebuild this module to make sure annotation processing kicks in.");
         node = new Node(null, "Validator", plugin);
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidatingPluginWithTypedBuilderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/validation/validators/ValidatingPluginWithTypedBuilderTest.java
@@ -20,12 +20,13 @@ import org.apache.logging.log4j.plugins.Node;
 import org.apache.logging.log4j.plugins.di.DI;
 import org.apache.logging.log4j.plugins.di.Keys;
 import org.apache.logging.log4j.plugins.test.validation.ValidatingPluginWithTypedBuilder;
-import org.apache.logging.log4j.plugins.util.PluginManager;
 import org.apache.logging.log4j.plugins.util.PluginType;
+import org.apache.logging.log4j.plugins.util.PluginUtil;
 import org.apache.logging.log4j.test.junit.StatusLoggerLevel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -38,10 +39,8 @@ public class ValidatingPluginWithTypedBuilderTest {
     @SuppressWarnings("unchecked")
     @BeforeEach
     public void setUp() throws Exception {
-        final PluginManager manager = new PluginManager("Test");
-        manager.collectPlugins();
-        PluginType<ValidatingPluginWithTypedBuilder> plugin = (PluginType<ValidatingPluginWithTypedBuilder>) manager
-                .getPluginType("ValidatingPluginWithTypedBuilder");
+        final var plugin = (PluginType<ValidatingPluginWithTypedBuilder>) PluginUtil.collectPluginsByCategory("Test")
+                .get("ValidatingPluginWithTypedBuilder".toLowerCase(Locale.ROOT));
         assertNotNull(plugin, "Rebuild this module to make sure annotation processing kicks in.");
         node = new Node(null, "Validator", plugin);
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/GelfLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/GelfLayoutTest.java
@@ -20,16 +20,20 @@ import com.fasterxml.jackson.core.io.JsonStringEncoder;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.ThreadContext;
-import org.apache.logging.log4j.core.*;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.layout.GelfLayout.CompressionType;
 import org.apache.logging.log4j.core.lookup.JavaLookup;
 import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
+import org.apache.logging.log4j.core.test.appender.EncodingListAppender;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.util.KeyValuePair;
 import org.apache.logging.log4j.core.util.NetUtils;
 import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
-import org.apache.logging.log4j.core.test.appender.EncodingListAppender;
-import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.util.LazyValue;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -42,12 +46,10 @@ import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
 import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @UsingAnyThreadContext
 public class GelfLayoutTest {
-
-    static ConfigurationFactory configFactory = new BasicConfigurationFactory();
 
     private static final String HOSTNAME = "TheHost";
     private static final String KEY1 = "Key1";
@@ -63,13 +65,13 @@ public class GelfLayoutTest {
 
     @AfterAll
     public static void cleanupClass() {
-        ConfigurationFactory.removeConfigurationFactory(configFactory);
+        LoggerContext.getContext().getInjector().removeBinding(ConfigurationFactory.KEY);
     }
 
     @BeforeAll
     public static void setupClass() {
-        ConfigurationFactory.setConfigurationFactory(configFactory);
         final LoggerContext ctx = LoggerContext.getContext();
+        ctx.getInjector().registerBinding(ConfigurationFactory.KEY, new LazyValue<>(BasicConfigurationFactory::new));
         ctx.reconfigure();
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/HtmlLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/HtmlLayoutTest.java
@@ -16,10 +16,26 @@
  */
 package org.apache.logging.log4j.core.layout;
 
-import static org.apache.logging.log4j.core.time.internal.format.FixedDateFormat.FixedFormat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.AbstractLogEvent;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.time.Instant;
+import org.apache.logging.log4j.core.time.MutableInstant;
+import org.apache.logging.log4j.core.time.internal.format.FixedDateFormat;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.apache.logging.log4j.util.LazyValue;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.lang.management.ManagementFactory;
 import java.nio.charset.StandardCharsets;
@@ -31,25 +47,8 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.ThreadContext;
-import org.apache.logging.log4j.core.AbstractLogEvent;
-import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.time.Instant;
-import org.apache.logging.log4j.core.time.MutableInstant;
-import org.apache.logging.log4j.core.time.internal.format.FixedDateFormat;
-import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
-import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.message.SimpleMessage;
-import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import static org.apache.logging.log4j.core.time.internal.format.FixedDateFormat.FixedFormat;
+import static org.junit.jupiter.api.Assertions.*;
 
 @UsingAnyThreadContext
 public class HtmlLayoutTest {
@@ -85,18 +84,16 @@ public class HtmlLayoutTest {
     private final LoggerContext ctx = LoggerContext.getContext();
     private final Logger root = ctx.getRootLogger();
 
-    static ConfigurationFactory cf = new BasicConfigurationFactory();
-
     @BeforeAll
     public static void setupClass() {
-        ConfigurationFactory.setConfigurationFactory(cf);
         final LoggerContext ctx = LoggerContext.getContext();
+        ctx.getInjector().registerBinding(ConfigurationFactory.KEY, new LazyValue<>(BasicConfigurationFactory::new));
         ctx.reconfigure();
     }
 
     @AfterAll
     public static void cleanupClass() {
-        ConfigurationFactory.removeConfigurationFactory(cf);
+        LoggerContext.getContext().getInjector().removeBinding(ConfigurationFactory.KEY);
     }
 
     private static final String body = "<tr><td bgcolor=\"#993300\" style=\"color:White; font-size : small;\" colspan=\"6\">java.lang.NullPointerException: test";

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/PatternLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/PatternLayoutTest.java
@@ -16,14 +16,9 @@
  */
 package org.apache.logging.log4j.core.layout;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.ThreadContext;
-import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
@@ -31,11 +26,17 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.lookup.MainMapLookup;
-import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
 import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.apache.logging.log4j.util.LazyValue;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -46,21 +47,12 @@ public class PatternLayoutTest {
             return new String(layout.toByteArray(event));
         }
     }
-    static ConfigurationFactory cf = new BasicConfigurationFactory();
-    static String msgPattern = "%m%n";
-    static String OUTPUT_FILE = "target/output/PatternParser";
     static final String regexPattern = "%replace{%logger %msg}{\\.}{/}";
-
-    static String WITNESS_FILE = "witness/PatternParser";
-
-    public static void cleanupClass() {
-        ConfigurationFactory.removeConfigurationFactory(cf);
-    }
 
     @BeforeAll
     public static void setupClass() {
-        ConfigurationFactory.setConfigurationFactory(cf);
         final LoggerContext ctx = LoggerContext.getContext();
+        ctx.getInjector().registerBinding(ConfigurationFactory.KEY, new LazyValue<>(BasicConfigurationFactory::new));
         ctx.reconfigure();
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/Rfc5424LayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/Rfc5424LayoutTest.java
@@ -16,31 +16,32 @@
  */
 package org.apache.logging.log4j.core.layout;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.net.Facility;
+import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.util.KeyValuePair;
-import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.apache.logging.log4j.core.util.ProcessIdUtil;
 import org.apache.logging.log4j.message.StructuredDataCollectionMessage;
 import org.apache.logging.log4j.message.StructuredDataMessage;
 import org.apache.logging.log4j.status.StatusLogger;
-import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.util.ProcessIdUtil;
+import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.apache.logging.log4j.util.LazyValue;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -69,19 +70,17 @@ public class Rfc5424LayoutTest {
     private static final String collectionEndOfLine = "Transfer Complete";
 
 
-    static ConfigurationFactory cf = new BasicConfigurationFactory();
-
     @BeforeAll
     public static void setupClass() {
         StatusLogger.getLogger().setLevel(Level.OFF);
-        ConfigurationFactory.setConfigurationFactory(cf);
         final LoggerContext ctx = LoggerContext.getContext();
+        ctx.getInjector().registerBinding(ConfigurationFactory.KEY, new LazyValue<>(BasicConfigurationFactory::new));
         ctx.reconfigure();
     }
 
     @AfterAll
     public static void cleanupClass() {
-        ConfigurationFactory.removeConfigurationFactory(cf);
+        LoggerContext.getContext().getInjector().removeBinding(ConfigurationFactory.KEY);
     }
 
     /**

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/SyslogLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/SyslogLayoutTest.java
@@ -16,26 +16,27 @@
  */
 package org.apache.logging.log4j.core.layout;
 
-import java.util.List;
-import java.util.Locale;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.net.Facility;
-import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
-import org.apache.logging.log4j.message.StructuredDataMessage;
+import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.message.StructuredDataMessage;
+import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.apache.logging.log4j.util.LazyValue;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @UsingAnyThreadContext
 public class SyslogLayoutTest {
@@ -53,14 +54,14 @@ public class SyslogLayoutTest {
 
     @BeforeAll
     public static void setupClass() {
-        ConfigurationFactory.setConfigurationFactory(cf);
         final LoggerContext ctx = LoggerContext.getContext();
+        ctx.getInjector().registerBinding(ConfigurationFactory.KEY, new LazyValue<>(BasicConfigurationFactory::new));
         ctx.reconfigure();
     }
 
     @AfterAll
     public static void cleanupClass() {
-        ConfigurationFactory.removeConfigurationFactory(cf);
+        LoggerContext.getContext().getInjector().removeBinding(ConfigurationFactory.KEY);
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
@@ -297,7 +297,7 @@ public class LoggerContext extends AbstractLifeCycle
         if (configLock.tryLock()) {
             try {
                 if (this.isInitialized() || this.isStopped()) {
-                    if (this.configuration.isShutdownHookEnabled()) {
+                    if (config.isShutdownHookEnabled()) {
                         setUpShutdownHook();
                     }
                     this.setStarted();
@@ -714,7 +714,8 @@ public class LoggerContext extends AbstractLifeCycle
         final ClassLoader cl = externalContext instanceof ClassLoader ? (ClassLoader) externalContext : null;
         LOGGER.debug("Reconfiguration started for {} at URI {} with optional ClassLoader: {}",
                 this, configURI, cl);
-        final Configuration instance = ConfigurationFactory.getInstance().getConfiguration(this, contextName, configURI, cl);
+        final Configuration instance =
+                injector.getInstance(ConfigurationFactory.KEY).getConfiguration(this, contextName, configURI, cl);
         if (instance == null) {
             LOGGER.error("Reconfiguration failed: No configuration found for '{}' at '{}' in '{}'", contextName, configURI, cl);
         } else {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
@@ -20,7 +20,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
-import org.apache.logging.log4j.core.config.composite.CompositeConfiguration;
 import org.apache.logging.log4j.core.lookup.ConfigurationStrSubstitutor;
 import org.apache.logging.log4j.core.lookup.Interpolator;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
@@ -28,32 +27,18 @@ import org.apache.logging.log4j.core.net.UrlConnectionFactory;
 import org.apache.logging.log4j.core.util.AuthorizationProvider;
 import org.apache.logging.log4j.core.util.BasicAuthorizationProvider;
 import org.apache.logging.log4j.core.util.FileUtils;
-import org.apache.logging.log4j.core.util.Loader;
-import org.apache.logging.log4j.core.util.NetUtils;
-import org.apache.logging.log4j.plugins.util.PluginManager;
-import org.apache.logging.log4j.plugins.util.PluginType;
+import org.apache.logging.log4j.plugins.di.Injector;
+import org.apache.logging.log4j.plugins.di.Key;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.PropertiesUtil;
-import org.apache.logging.log4j.util.ReflectionUtil;
-import org.apache.logging.log4j.util.Strings;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Factory class for parsed {@link Configuration} objects from a configuration file.
@@ -62,10 +47,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * <ol>
  * <li>A system property named "log4j.configurationFactory" can be set with the
  * name of the ConfigurationFactory to be used.</li>
- * <li>
- * {@linkplain #setConfigurationFactory(ConfigurationFactory)} can be called
- * with the instance of the ConfigurationFactory to be used. This must be called
- * before any other calls to Log4j.</li>
+ * <li>An {@link Injector} binding for ConfigurationFactory may be registered.</li>
  * <li>
  * A ConfigurationFactory implementation can be added to the classpath and configured as a plugin in the
  * {@link #CATEGORY ConfigurationFactory} category. The {@link Order} annotation should be used to configure the
@@ -99,8 +81,6 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
 
     public static final String LOG4J1_EXPERIMENTAL = "log4j1.compatibility";
 
-    public static final String AUTHORIZATION_PROVIDER = "authorizationProvider";
-
     /**
      * Plugin category used to inject a ConfigurationFactory {@link org.apache.logging.log4j.plugins.Plugin}
      * class.
@@ -108,6 +88,8 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
      * @since 2.1
      */
     public static final String CATEGORY = "ConfigurationFactory";
+
+    public static final Key<ConfigurationFactory> KEY = new Key<>() {};
 
     /**
      * Allows subclasses access to the status logger without creating another instance.
@@ -137,71 +119,15 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
      */
     private static final String CLASS_PATH_SCHEME = "classpath";
 
-    private static final String OVERRIDE_PARAM = "override";
-
-    private static volatile List<ConfigurationFactory> factories;
-
-    private static volatile ConfigurationFactory configFactory;
-
-    protected final StrSubstitutor substitutor = new ConfigurationStrSubstitutor(new Interpolator());
-
-    private static final Lock LOCK = new ReentrantLock();
-
-    private static final String HTTPS = "https";
-    private static final String HTTP = "http";
-
     private static final String[] PREFIXES = {"log4j2.", "log4j2.Configuration."};
 
-    private static volatile AuthorizationProvider authorizationProvider;
-
-    /**
-     * Returns the ConfigurationFactory.
-     * @return the ConfigurationFactory.
-     */
+    @Deprecated(since = "3.0.0", forRemoval = true)
     public static ConfigurationFactory getInstance() {
-        if (factories == null) {
-            LOCK.lock();
-            try {
-                if (factories == null) {
-                    final List<ConfigurationFactory> list = new ArrayList<>();
-                    final PropertiesUtil props = PropertiesUtil.getProperties();
-                    final String factoryClass = props.getStringProperty(CONFIGURATION_FACTORY_PROPERTY);
-                    if (factoryClass != null) {
-                        addFactory(list, factoryClass);
-                    }
-                    final PluginManager manager = new PluginManager(CATEGORY);
-                    manager.collectPlugins();
-                    final Map<String, PluginType<?>> plugins = manager.getPlugins();
-                    final List<Class<? extends ConfigurationFactory>> ordered = new ArrayList<>(plugins.size());
-                    for (final PluginType<?> type : plugins.values()) {
-                        try {
-                            ordered.add(type.getPluginClass().asSubclass(ConfigurationFactory.class));
-                        } catch (final Exception ex) {
-                            LOGGER.warn("Unable to add class {}", type.getPluginClass(), ex);
-                        }
-                    }
-                    ordered.sort(OrderComparator.getInstance());
-                    for (final Class<? extends ConfigurationFactory> clazz : ordered) {
-                        addFactory(list, clazz);
-                    }
-                    factories = Collections.unmodifiableList(list);
-                    authorizationProvider = authorizationProvider(props);
-                    // late init here to avoid potential class loader deadlock referencing subclass
-                    if (configFactory == null) {
-                        configFactory = new Factory();
-                    }
-                }
-            } finally {
-                LOCK.unlock();
-            }
-        }
-
-        LOGGER.debug("Using configurationFactory {}", configFactory);
-        return configFactory;
+        return null;
     }
 
     public static AuthorizationProvider authorizationProvider(final PropertiesUtil props) {
-        final String authClass = props.getStringProperty(PREFIXES, AUTHORIZATION_PROVIDER, null);
+        final String authClass = props.getStringProperty(PREFIXES, "authorizationProvider", null);
         AuthorizationProvider provider = null;
         if (authClass != null) {
             try {
@@ -221,52 +147,7 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
         return provider;
     }
 
-    public static AuthorizationProvider getAuthorizationProvider() {
-        return authorizationProvider;
-    }
-
-    private static void addFactory(final Collection<ConfigurationFactory> list, final String factoryClass) {
-        try {
-            addFactory(list, Loader.loadClass(factoryClass).asSubclass(ConfigurationFactory.class));
-        } catch (final Exception ex) {
-            LOGGER.error("Unable to load class {}", factoryClass, ex);
-        }
-    }
-
-    private static void addFactory(final Collection<ConfigurationFactory> list,
-                                   final Class<? extends ConfigurationFactory> factoryClass) {
-        try {
-            list.add(ReflectionUtil.instantiate(factoryClass));
-        } catch (final Exception ex) {
-            LOGGER.error("Unable to create instance of {}", factoryClass.getName(), ex);
-        }
-    }
-
-    /**
-     * Sets the configuration factory. This method is not intended for general use and may not be thread safe.
-     * @param factory the ConfigurationFactory.
-     */
-    public static void setConfigurationFactory(final ConfigurationFactory factory) {
-        configFactory = factory;
-    }
-
-    /**
-     * Resets the ConfigurationFactory to the default. This method is not intended for general use and may
-     * not be thread safe.
-     */
-    public static void resetConfigurationFactory() {
-        configFactory = new Factory();
-    }
-
-    /**
-     * Removes the ConfigurationFactory. This method is not intended for general use and may not be thread safe.
-     * @param factory The factory to remove.
-     */
-    public static void removeConfigurationFactory(final ConfigurationFactory factory) {
-        if (configFactory == factory) {
-            configFactory = new Factory();
-        }
-    }
+    protected final StrSubstitutor substitutor = new ConfigurationStrSubstitutor(new Interpolator());
 
     protected abstract String[] getSupportedTypes();
 
@@ -381,254 +262,4 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
         }
     }
 
-    /**
-     * Default Factory.
-     */
-    private static class Factory extends ConfigurationFactory {
-
-        private static final String ALL_TYPES = "*";
-
-        /**
-         * Default Factory Constructor.
-         * @param name The configuration name.
-         * @param configLocation The configuration location.
-         * @return The Configuration.
-         */
-        @Override
-        public Configuration getConfiguration(final LoggerContext loggerContext, final String name, final URI configLocation) {
-
-            if (configLocation == null) {
-                final String configLocationStr = this.substitutor.replace(PropertiesUtil.getProperties()
-                        .getStringProperty(CONFIGURATION_FILE_PROPERTY));
-                if (configLocationStr != null) {
-                    final String[] sources = parseConfigLocations(configLocationStr);
-                    if (sources.length > 1) {
-                        final List<AbstractConfiguration> configs = new ArrayList<>();
-                        for (final String sourceLocation : sources) {
-                            final Configuration config = getConfiguration(loggerContext, sourceLocation.trim());
-                            if (config != null) {
-                                if (config instanceof AbstractConfiguration) {
-                                    configs.add((AbstractConfiguration) config);
-                                } else {
-                                    LOGGER.error("Failed to created configuration at {}", sourceLocation);
-                                    return null;
-                                }
-                            } else {
-                                LOGGER.warn("Unable to create configuration for {}, ignoring", sourceLocation);
-                            }
-                        }
-                        if (configs.size() > 1) {
-                            return new CompositeConfiguration(configs);
-                        } else if (configs.size() == 1) {
-                            return configs.get(0);
-                        }
-                    }
-                    return getConfiguration(loggerContext, configLocationStr);
-                } else {
-                    final String log4j1ConfigStr = this.substitutor.replace(PropertiesUtil.getProperties()
-                            .getStringProperty(LOG4J1_CONFIGURATION_FILE_PROPERTY));
-                    if (log4j1ConfigStr != null) {
-                        System.setProperty(LOG4J1_EXPERIMENTAL, "true");
-                        return getConfiguration(LOG4J1_VERSION, loggerContext, log4j1ConfigStr);
-                    }
-                }
-                for (final ConfigurationFactory factory : getFactories()) {
-                    final String[] types = factory.getSupportedTypes();
-                    if (types != null) {
-                        for (final String type : types) {
-                            if (type.equals(ALL_TYPES)) {
-                                final Configuration config = factory.getConfiguration(loggerContext, name, configLocation);
-                                if (config != null) {
-                                    return config;
-                                }
-                            }
-                        }
-                    }
-                }
-            } else {
-                // configLocation != null
-                final String[] sources = parseConfigLocations(configLocation);
-                if (sources.length > 1) {
-                    final List<AbstractConfiguration> configs = new ArrayList<>();
-                    for (final String sourceLocation : sources) {
-                        final Configuration config = getConfiguration(loggerContext, sourceLocation.trim());
-                        if (config instanceof AbstractConfiguration) {
-                            configs.add((AbstractConfiguration) config);
-                        } else {
-                            LOGGER.error("Failed to created configuration at {}", sourceLocation);
-                            return null;
-                        }
-                    }
-                    return new CompositeConfiguration(configs);
-                }
-                final String configLocationStr = configLocation.toString();
-                for (final ConfigurationFactory factory : getFactories()) {
-                    final String[] types = factory.getSupportedTypes();
-                    if (types != null) {
-                        for (final String type : types) {
-                            if (type.equals(ALL_TYPES) || configLocationStr.endsWith(type)) {
-                                final Configuration config = factory.getConfiguration(loggerContext, name, configLocation);
-                                if (config != null) {
-                                    return config;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            Configuration config = getConfiguration(loggerContext, true, name);
-            if (config == null) {
-                config = getConfiguration(loggerContext, true, null);
-                if (config == null) {
-                    config = getConfiguration(loggerContext, false, name);
-                    if (config == null) {
-                        config = getConfiguration(loggerContext, false, null);
-                    }
-                }
-            }
-            if (config != null) {
-                return config;
-            }
-            LOGGER.warn("No Log4j 2 configuration file found. " +
-                    "Using default configuration (logging only errors to the console), " +
-                    "or user programmatically provided configurations. " +
-                    "Set system property 'log4j2.debug' " +
-                    "to show Log4j 2 internal initialization logging. " +
-                    "See https://logging.apache.org/log4j/2.x/manual/configuration.html for instructions on how to configure Log4j 2");
-            return new DefaultConfiguration();
-        }
-
-        private Configuration getConfiguration(final LoggerContext loggerContext, final String configLocationStr) {
-            return getConfiguration(null, loggerContext, configLocationStr);
-        }
-
-        private Configuration getConfiguration(final String requiredVersion, final LoggerContext loggerContext,
-                final String configLocationStr) {
-            ConfigurationSource source = null;
-            try {
-                source = ConfigurationSource.fromUri(NetUtils.toURI(configLocationStr));
-            } catch (final Exception ex) {
-                // Ignore the error and try as a String.
-                LOGGER.catching(Level.DEBUG, ex);
-            }
-            if (source == null) {
-                final ClassLoader loader = LoaderUtil.getThreadContextClassLoader();
-                source = getInputFromString(configLocationStr, loader);
-            }
-            if (source != null) {
-                for (final ConfigurationFactory factory : getFactories()) {
-                    if (requiredVersion != null && !factory.getVersion().equals(requiredVersion)) {
-                        continue;
-                    }
-                    final String[] types = factory.getSupportedTypes();
-                    if (types != null) {
-                        for (final String type : types) {
-                            if (type.equals(ALL_TYPES) || configLocationStr.endsWith(type)) {
-                                final Configuration config = factory.getConfiguration(loggerContext, source);
-                                if (config != null) {
-                                    return config;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            return null;
-        }
-
-        private Configuration getConfiguration(final LoggerContext loggerContext, final boolean isTest, final String name) {
-            final boolean named = Strings.isNotEmpty(name);
-            final ClassLoader loader = LoaderUtil.getThreadContextClassLoader();
-            for (final ConfigurationFactory factory : getFactories()) {
-                String configName;
-                final String prefix = isTest ? factory.getTestPrefix() : factory.getDefaultPrefix();
-                final String [] types = factory.getSupportedTypes();
-                if (types == null) {
-                    continue;
-                }
-
-                for (final String suffix : types) {
-                    if (suffix.equals(ALL_TYPES)) {
-                        continue;
-                    }
-                    configName = named ? prefix + name + suffix : prefix + suffix;
-
-                    final ConfigurationSource source = ConfigurationSource.fromResource(configName, loader);
-                    if (source != null) {
-                        if (!factory.isActive()) {
-                            LOGGER.warn("Found configuration file {} for inactive ConfigurationFactory {}", configName, factory.getClass().getName());
-                        }
-                        return factory.getConfiguration(loggerContext, source);
-                    }
-                }
-            }
-            return null;
-        }
-
-        @Override
-        public String[] getSupportedTypes() {
-            return null;
-        }
-
-        @Override
-        public Configuration getConfiguration(final LoggerContext loggerContext, final ConfigurationSource source) {
-            if (source != null) {
-                final String config = source.getLocation();
-                for (final ConfigurationFactory factory : getFactories()) {
-                    final String[] types = factory.getSupportedTypes();
-                    if (types != null) {
-                        for (final String type : types) {
-                            if (type.equals(ALL_TYPES) || config != null && config.endsWith(type)) {
-                                final Configuration c = factory.getConfiguration(loggerContext, source);
-                                if (c != null) {
-                                    LOGGER.debug("Loaded configuration from {}", source);
-                                    return c;
-                                }
-                                LOGGER.error("Cannot determine the ConfigurationFactory to use for {}", config);
-                                return null;
-                            }
-                        }
-                    }
-                }
-            }
-            LOGGER.error("Cannot process configuration, input source is null");
-            return null;
-        }
-
-        private String[] parseConfigLocations(final URI configLocations) {
-            final String[] uris = configLocations.toString().split("\\?");
-            final List<String> locations = new ArrayList<>();
-            if (uris.length > 1) {
-                locations.add(uris[0]);
-                final String[] pairs = configLocations.getQuery().split("&");
-                for (final String pair : pairs) {
-                    final int idx = pair.indexOf("=");
-                    final String key = idx > 0 ? URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8) : pair;
-                    if (key.equalsIgnoreCase(OVERRIDE_PARAM)) {
-                        locations.add(URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8));
-                    }
-                }
-                return locations.toArray(new String[0]);
-            }
-            return new String[] {uris[0]};
-        }
-
-        private String[] parseConfigLocations(final String configLocations) {
-            final String[] uris = configLocations.split(",");
-            if (uris.length > 1) {
-                return uris;
-            }
-            try {
-                return parseConfigLocations(new URI(configLocations));
-            } catch (final URISyntaxException ex) {
-                LOGGER.warn("Error parsing URI {}", configLocations);
-            }
-            return new String[] {configLocations};
-        }
-    }
-
-    static List<ConfigurationFactory> getFactories() {
-        return factories;
-    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
@@ -123,7 +123,7 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
 
     @Deprecated(since = "3.0.0", forRemoval = true)
     public static ConfigurationFactory getInstance() {
-        return null;
+        return LoggerContext.getContext(false).getInjector().getInstance(KEY);
     }
 
     public static AuthorizationProvider authorizationProvider(final PropertiesUtil props) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/DefaultConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/DefaultConfigurationFactory.java
@@ -1,0 +1,353 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.core.config;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.composite.CompositeConfiguration;
+import org.apache.logging.log4j.core.util.Loader;
+import org.apache.logging.log4j.core.util.NetUtils;
+import org.apache.logging.log4j.plugins.Inject;
+import org.apache.logging.log4j.plugins.Named;
+import org.apache.logging.log4j.plugins.di.Injector;
+import org.apache.logging.log4j.plugins.di.Key;
+import org.apache.logging.log4j.plugins.util.PluginManager;
+import org.apache.logging.log4j.util.LazyValue;
+import org.apache.logging.log4j.util.LoaderUtil;
+import org.apache.logging.log4j.util.PropertiesUtil;
+import org.apache.logging.log4j.util.Strings;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Default factory for using a plugin selected based on the configuration source.
+ */
+public class DefaultConfigurationFactory extends ConfigurationFactory {
+
+    private static final String ALL_TYPES = "*";
+    private static final String OVERRIDE_PARAM = "override";
+
+    private final Supplier<List<ConfigurationFactory>> configurationFactories;
+
+    @Inject
+    public DefaultConfigurationFactory(final Injector injector) {
+        configurationFactories = new LazyValue<>(() -> loadConfigurationFactories(injector));
+    }
+
+    /**
+     * Default Factory Constructor.
+     *
+     * @param name           The configuration name.
+     * @param configLocation The configuration location.
+     * @return The Configuration.
+     */
+    @Override
+    public Configuration getConfiguration(final LoggerContext loggerContext, final String name, final URI configLocation) {
+
+        if (configLocation == null) {
+            final PropertiesUtil properties = PropertiesUtil.getProperties();
+            final String configLocationStr = substitutor.replace(properties.getStringProperty(CONFIGURATION_FILE_PROPERTY));
+            if (configLocationStr != null) {
+                final String[] sources = parseConfigLocations(configLocationStr);
+                if (sources.length > 1) {
+                    final List<AbstractConfiguration> configs = new ArrayList<>();
+                    for (final String sourceLocation : sources) {
+                        final Configuration config = getConfiguration(loggerContext, sourceLocation.trim());
+                        if (config != null) {
+                            if (config instanceof AbstractConfiguration) {
+                                configs.add((AbstractConfiguration) config);
+                            } else {
+                                LOGGER.error("Failed to created configuration at {}", sourceLocation);
+                                return null;
+                            }
+                        } else {
+                            LOGGER.warn("Unable to create configuration for {}, ignoring", sourceLocation);
+                        }
+                    }
+                    if (configs.size() > 1) {
+                        return new CompositeConfiguration(configs);
+                    } else if (configs.size() == 1) {
+                        return configs.get(0);
+                    }
+                }
+                return getConfiguration(loggerContext, configLocationStr);
+            } else {
+                final String log4j1ConfigStr =
+                        substitutor.replace(properties.getStringProperty(LOG4J1_CONFIGURATION_FILE_PROPERTY));
+                if (log4j1ConfigStr != null) {
+                    System.setProperty(LOG4J1_EXPERIMENTAL, "true");
+                    return getConfiguration(LOG4J1_VERSION, loggerContext, log4j1ConfigStr);
+                }
+            }
+            for (final ConfigurationFactory factory : configurationFactories.get()) {
+                final String[] types = factory.getSupportedTypes();
+                if (types != null) {
+                    for (final String type : types) {
+                        if (type.equals(ALL_TYPES)) {
+                            final Configuration config = factory.getConfiguration(loggerContext, name, null);
+                            if (config != null) {
+                                return config;
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            // configLocation != null
+            final String[] sources = parseConfigLocations(configLocation);
+            if (sources.length > 1) {
+                final List<AbstractConfiguration> configs = new ArrayList<>();
+                for (final String sourceLocation : sources) {
+                    final Configuration config = getConfiguration(loggerContext, sourceLocation.trim());
+                    if (config instanceof AbstractConfiguration) {
+                        configs.add((AbstractConfiguration) config);
+                    } else {
+                        LOGGER.error("Failed to created configuration at {}", sourceLocation);
+                        return null;
+                    }
+                }
+                return new CompositeConfiguration(configs);
+            }
+            final String configLocationStr = configLocation.toString();
+            for (final ConfigurationFactory factory : configurationFactories.get()) {
+                final String[] types = factory.getSupportedTypes();
+                if (types != null) {
+                    for (final String type : types) {
+                        if (type.equals(ALL_TYPES) || configLocationStr.endsWith(type)) {
+                            final Configuration config = factory.getConfiguration(loggerContext, name, configLocation);
+                            if (config != null) {
+                                return config;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Configuration config = getConfiguration(loggerContext, true, name);
+        if (config == null) {
+            config = getConfiguration(loggerContext, true, null);
+            if (config == null) {
+                config = getConfiguration(loggerContext, false, name);
+                if (config == null) {
+                    config = getConfiguration(loggerContext, false, null);
+                }
+            }
+        }
+        if (config != null) {
+            return config;
+        }
+        LOGGER.warn("No Log4j 2 configuration file found. " +
+                "Using default configuration (logging only errors to the console), " +
+                "or user programmatically provided configurations. " +
+                "Set system property 'log4j2.debug' " +
+                "to show Log4j 2 internal initialization logging. " +
+                "See https://logging.apache.org/log4j/2.x/manual/configuration.html for instructions on how to configure Log4j 2");
+        return new DefaultConfiguration();
+    }
+
+    private Configuration getConfiguration(final LoggerContext loggerContext, final String configLocationStr) {
+        return getConfiguration(null, loggerContext, configLocationStr);
+    }
+
+    private Configuration getConfiguration(
+            final String requiredVersion, final LoggerContext loggerContext,
+            final String configLocationStr) {
+        ConfigurationSource source = null;
+        try {
+            source = ConfigurationSource.fromUri(NetUtils.toURI(configLocationStr));
+        } catch (final Exception ex) {
+            // Ignore the error and try as a String.
+            LOGGER.catching(Level.DEBUG, ex);
+        }
+        if (source == null) {
+            final ClassLoader loader = LoaderUtil.getThreadContextClassLoader();
+            source = getInputFromString(configLocationStr, loader);
+        }
+        if (source != null) {
+            for (final ConfigurationFactory factory : configurationFactories.get()) {
+                if (requiredVersion != null && !factory.getVersion().equals(requiredVersion)) {
+                    continue;
+                }
+                final String[] types = factory.getSupportedTypes();
+                if (types != null) {
+                    for (final String type : types) {
+                        if (type.equals(ALL_TYPES) || configLocationStr.endsWith(type)) {
+                            final Configuration config = factory.getConfiguration(loggerContext, source);
+                            if (config != null) {
+                                return config;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private Configuration getConfiguration(final LoggerContext loggerContext, final boolean isTest, final String name) {
+        final boolean named = Strings.isNotEmpty(name);
+        final ClassLoader loader = LoaderUtil.getThreadContextClassLoader();
+        for (final ConfigurationFactory factory : configurationFactories.get()) {
+            String configName;
+            final String prefix = isTest ? factory.getTestPrefix() : factory.getDefaultPrefix();
+            final String[] types = factory.getSupportedTypes();
+            if (types == null) {
+                continue;
+            }
+
+            for (final String suffix : types) {
+                if (suffix.equals(ALL_TYPES)) {
+                    continue;
+                }
+                configName = named ? prefix + name + suffix : prefix + suffix;
+
+                final ConfigurationSource source = ConfigurationSource.fromResource(configName, loader);
+                if (source != null) {
+                    if (!factory.isActive()) {
+                        LOGGER.warn("Found configuration file {} for inactive ConfigurationFactory {}", configName,
+                                factory.getClass().getName());
+                    }
+                    return factory.getConfiguration(loggerContext, source);
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String[] getSupportedTypes() {
+        return null;
+    }
+
+    @Override
+    public Configuration getConfiguration(final LoggerContext loggerContext, final ConfigurationSource source) {
+        if (source != null) {
+            final String config = source.getLocation();
+            for (final ConfigurationFactory factory : configurationFactories.get()) {
+                final String[] types = factory.getSupportedTypes();
+                if (types != null) {
+                    for (final String type : types) {
+                        if (type.equals(ALL_TYPES) || config != null && config.endsWith(type)) {
+                            final Configuration c = factory.getConfiguration(loggerContext, source);
+                            if (c != null) {
+                                LOGGER.debug("Loaded configuration from {}", source);
+                                return c;
+                            }
+                            LOGGER.error("Cannot determine the ConfigurationFactory to use for {}", config);
+                            return null;
+                        }
+                    }
+                }
+            }
+        }
+        LOGGER.error("Cannot process configuration, input source is null");
+        return null;
+    }
+
+    private String[] parseConfigLocations(final URI configLocations) {
+        final String[] uris = configLocations.toString().split("\\?");
+        final List<String> locations = new ArrayList<>();
+        if (uris.length > 1) {
+            locations.add(uris[0]);
+            final String[] pairs = configLocations.getQuery().split("&");
+            for (final String pair : pairs) {
+                final int idx = pair.indexOf("=");
+                final String key = idx > 0 ? URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8) : pair;
+                if (key.equalsIgnoreCase(OVERRIDE_PARAM)) {
+                    locations.add(URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8));
+                }
+            }
+            return locations.toArray(new String[0]);
+        }
+        return new String[] { uris[0] };
+    }
+
+    private String[] parseConfigLocations(final String configLocations) {
+        final String[] uris = configLocations.split(",");
+        if (uris.length > 1) {
+            return uris;
+        }
+        try {
+            return parseConfigLocations(new URI(configLocations));
+        } catch (final URISyntaxException ex) {
+            LOGGER.warn("Error parsing URI {}", configLocations);
+        }
+        return new String[] { configLocations };
+    }
+
+    private static List<ConfigurationFactory> loadConfigurationFactories(final Injector injector) {
+        final Stream<? extends ConfigurationFactory> primaryConfigurationFactoryStream =
+                Optional.ofNullable(PropertiesUtil.getProperties().getStringProperty(CONFIGURATION_FACTORY_PROPERTY))
+                        .flatMap(DefaultConfigurationFactory::tryLoadFactoryClass)
+                        .map(clazz -> {
+                            try {
+                                return injector.getInstance(clazz);
+                            } catch (final Exception ex) {
+                                LOGGER.error("Unable to create instance of {}", clazz, ex);
+                                return null;
+                            }
+                        })
+                        .stream();
+
+        final PluginManager manager = injector.getInstance(new @Named(CATEGORY) Key<>() {});
+        manager.collectPlugins();
+        final Stream<? extends ConfigurationFactory> pluginConfigurationFactoryStream = manager.getPlugins()
+                .values()
+                .stream()
+                .flatMap(type -> {
+                    try {
+                        final Class<? extends ConfigurationFactory> clazz =
+                                type.getPluginClass().asSubclass(ConfigurationFactory.class);
+                        return Stream.of(clazz);
+                    } catch (final Exception ex) {
+                        LOGGER.warn("Unable to add class {}", type.getPluginClass(), ex);
+                        return Stream.empty();
+                    }
+                })
+                .sorted(OrderComparator.getInstance())
+                .flatMap(clazz -> {
+                    try {
+                        return Stream.of(injector.getInstance(clazz));
+                    } catch (final Exception ex) {
+                        LOGGER.error("Unable to create instance of {}", clazz, ex);
+                        return Stream.empty();
+                    }
+                });
+
+        return Stream.concat(primaryConfigurationFactoryStream, pluginConfigurationFactoryStream).collect(Collectors.toList());
+    }
+
+    private static Optional<Class<? extends ConfigurationFactory>> tryLoadFactoryClass(final String factoryClass) {
+        try {
+            return Optional.of(Loader.loadClass(factoryClass).asSubclass(ConfigurationFactory.class));
+        } catch (final Exception ex) {
+            LOGGER.error("Unable to load ConfigurationFactory class {}", factoryClass, ex);
+            return Optional.empty();
+        }
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/CompositeConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/CompositeConfiguration.java
@@ -16,19 +16,11 @@
  */
 package org.apache.logging.log4j.core.config.composite;
 
-import java.lang.reflect.InvocationTargetException;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.AbstractConfiguration;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
-import org.apache.logging.log4j.plugins.Node;
 import org.apache.logging.log4j.core.config.Reconfigurable;
 import org.apache.logging.log4j.core.config.status.StatusConfiguration;
 import org.apache.logging.log4j.core.util.Loader;
@@ -36,8 +28,16 @@ import org.apache.logging.log4j.core.util.Patterns;
 import org.apache.logging.log4j.core.util.Source;
 import org.apache.logging.log4j.core.util.WatchManager;
 import org.apache.logging.log4j.core.util.Watcher;
-import org.apache.logging.log4j.util.PropertiesUtil;
+import org.apache.logging.log4j.plugins.Node;
 import org.apache.logging.log4j.plugins.util.ResolverUtil;
+import org.apache.logging.log4j.util.PropertiesUtil;
+
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 /**
  * A Composite Configuration.
@@ -142,7 +142,7 @@ public class CompositeConfiguration extends AbstractConfiguration implements Rec
     public Configuration reconfigure() {
         LOGGER.debug("Reconfiguring composite configuration");
         final List<AbstractConfiguration> configs = new ArrayList<>();
-        final ConfigurationFactory factory = ConfigurationFactory.getInstance();
+        final ConfigurationFactory factory = injector.getInstance(ConfigurationFactory.KEY);
         for (final AbstractConfiguration config : configurations) {
             final ConfigurationSource source = config.getConfigurationSource();
             final URI sourceURI = source.getURI();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/DefaultCallback.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/DefaultCallback.java
@@ -21,6 +21,8 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.ContextDataInjector;
+import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.apache.logging.log4j.core.config.DefaultConfigurationFactory;
 import org.apache.logging.log4j.core.selector.ClassLoaderContextSelector;
 import org.apache.logging.log4j.core.selector.ContextSelector;
 import org.apache.logging.log4j.core.time.Clock;
@@ -117,6 +119,7 @@ public class DefaultCallback implements InjectorCallback {
                         () -> loader.getInstance(Constants.LOG4J_LOG_EVENT_FACTORY, LogEventFactory.class,
                                 () -> Constants.ENABLE_THREADLOCALS ? ReusableLogEventFactory.class :
                                         DefaultLogEventFactory.class))
+                .registerBindingIfAbsent(ConfigurationFactory.KEY, injector.getFactory(DefaultConfigurationFactory.class))
                 .registerBindingIfAbsent(Constants.DEFAULT_STATUS_LEVEL_KEY, () -> {
                     final String statusLevel =
                             properties.getStringProperty(Constants.LOG4J_DEFAULT_STATUS_LEVEL, Level.ERROR.name());

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jContextFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jContextFactory.java
@@ -184,7 +184,7 @@ public class Log4jContextFactory implements LoggerContextFactory, ShutdownCallba
         if (ctx.getState() == LifeCycle.State.INITIALIZED) {
             if (source != null) {
                 ContextAnchor.THREAD_CONTEXT.set(ctx);
-                final Configuration config = ConfigurationFactory.getInstance().getConfiguration(ctx, source);
+                final Configuration config = injector.getInstance(ConfigurationFactory.KEY).getConfiguration(ctx, source);
                 LOGGER.debug("Starting {} from configuration {}", ctx, source);
                 ctx.start(config);
                 ContextAnchor.THREAD_CONTEXT.remove();
@@ -245,7 +245,8 @@ public class Log4jContextFactory implements LoggerContextFactory, ShutdownCallba
         if (ctx.getState() == LifeCycle.State.INITIALIZED) {
             if (configLocation != null || name != null) {
                 ContextAnchor.THREAD_CONTEXT.set(ctx);
-                final Configuration config = ConfigurationFactory.getInstance().getConfiguration(ctx, name, configLocation);
+                final Configuration config =
+                        injector.getInstance(ConfigurationFactory.KEY).getConfiguration(ctx, name, configLocation);
                 LOGGER.debug("Starting {} from configuration at {}", ctx, configLocation);
                 ctx.start(config);
                 ContextAnchor.THREAD_CONTEXT.remove();
@@ -265,7 +266,8 @@ public class Log4jContextFactory implements LoggerContextFactory, ShutdownCallba
         if (ctx.getState() == LifeCycle.State.INITIALIZED) {
             if (configLocation != null || name != null) {
                 ContextAnchor.THREAD_CONTEXT.set(ctx);
-                final Configuration config = ConfigurationFactory.getInstance().getConfiguration(ctx, name, configLocation);
+                final Configuration config =
+                        injector.getInstance(ConfigurationFactory.KEY).getConfiguration(ctx, name, configLocation);
                 LOGGER.debug("Starting {} from configuration at {}", ctx, configLocation);
                 ctx.start(config);
                 ContextAnchor.THREAD_CONTEXT.remove();
@@ -291,7 +293,7 @@ public class Log4jContextFactory implements LoggerContextFactory, ShutdownCallba
                 ContextAnchor.THREAD_CONTEXT.set(ctx);
                 final List<AbstractConfiguration> configurations = new ArrayList<>(configLocations.size());
                 for (final URI configLocation : configLocations) {
-                    final Configuration currentReadConfiguration = ConfigurationFactory.getInstance()
+                    final Configuration currentReadConfiguration = injector.getInstance(ConfigurationFactory.KEY)
                             .getConfiguration(ctx, name, configLocation);
                     if (currentReadConfiguration != null) {
                         if (currentReadConfiguration instanceof DefaultConfiguration) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/LoggerContextAdmin.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/LoggerContextAdmin.java
@@ -16,6 +16,18 @@
  */
 package org.apache.logging.log4j.core.jmx;
 
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.util.Closer;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Strings;
+
+import javax.management.MBeanNotificationInfo;
+import javax.management.Notification;
+import javax.management.NotificationBroadcasterSupport;
+import javax.management.ObjectName;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.ByteArrayInputStream;
@@ -35,19 +47,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
-
-import javax.management.MBeanNotificationInfo;
-import javax.management.Notification;
-import javax.management.NotificationBroadcasterSupport;
-import javax.management.ObjectName;
-
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.config.ConfigurationSource;
-import org.apache.logging.log4j.core.util.Closer;
-import org.apache.logging.log4j.status.StatusLogger;
-import org.apache.logging.log4j.util.Strings;
 
 /**
  * Implementation of the {@code LoggerContextAdminMBean} interface.
@@ -132,7 +131,8 @@ public class LoggerContextAdmin extends NotificationBroadcasterSupport implement
             LOGGER.debug("Opening config URL {}", configURL);
             configSource = new ConfigurationSource(configURL.openStream(), configURL);
         }
-        final Configuration config = ConfigurationFactory.getInstance().getConfiguration(loggerContext, configSource);
+        final Configuration config =
+                loggerContext.getInjector().getInstance(ConfigurationFactory.KEY).getConfiguration(loggerContext, configSource);
         loggerContext.start(config);
         LOGGER.debug("Completed remote request to reconfigure.");
     }
@@ -197,7 +197,8 @@ public class LoggerContextAdmin extends NotificationBroadcasterSupport implement
         try {
             final InputStream in = new ByteArrayInputStream(configText.getBytes(charsetName));
             final ConfigurationSource source = new ConfigurationSource(in);
-            final Configuration updated = ConfigurationFactory.getInstance().getConfiguration(loggerContext, source);
+            final Configuration updated =
+                    loggerContext.getInjector().getInstance(ConfigurationFactory.KEY).getConfiguration(loggerContext, source);
             loggerContext.start(updated);
             LOGGER.debug("Completed remote request to reconfigure from config text.");
         } catch (final Exception ex) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.plugins.di.Key;
 import org.apache.logging.log4j.plugins.util.PluginManager;
 import org.apache.logging.log4j.plugins.util.PluginType;
+import org.apache.logging.log4j.plugins.util.PluginUtil;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.ReflectionUtil;
 
@@ -73,9 +74,8 @@ public class Interpolator extends AbstractConfigurationAwareLookup {
      */
     public Interpolator(final StrLookup defaultLookup, final List<String> pluginPackages) {
         this.defaultLookup = defaultLookup == null ? new PropertiesLookup(Map.of()) : defaultLookup;
-        final PluginManager manager = new PluginManager(CATEGORY);
-        manager.collectPlugins(pluginPackages);
-        final Map<String, PluginType<?>> plugins = manager.getPlugins();
+        final Map<String, PluginType<?>> plugins =
+                PluginUtil.collectPluginsByCategoryAndPackage(CATEGORY, pluginPackages);
 
         for (final Map.Entry<String, PluginType<?>> entry : plugins.entrySet()) {
             try {

--- a/log4j-csv/src/test/java/org/apache/logging/log4j/csv/layout/CsvLogEventLayoutTest.java
+++ b/log4j-csv/src/test/java/org/apache/logging/log4j/csv/layout/CsvLogEventLayoutTest.java
@@ -16,50 +16,43 @@
  */
 package org.apache.logging.log4j.csv.layout;
 
-import static org.junit.Assert.assertEquals;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.apache.logging.log4j.util.LazyValue;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.csv.CSVFormat;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.test.junit.ThreadContextRule;
-import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@link AbstractCsvLayout}.
  *
  * @since 2.4
  */
-@Category(Layouts.Csv.class)
+@UsingAnyThreadContext
 public class CsvLogEventLayoutTest {
-    static ConfigurationFactory cf = new BasicConfigurationFactory();
 
-    @Rule
-    public final ThreadContextRule threadContextRule = new ThreadContextRule();
-
-    @AfterClass
+    @AfterAll
     public static void cleanupClass() {
-        ConfigurationFactory.removeConfigurationFactory(cf);
+        LoggerContext.getContext().getInjector().removeBinding(ConfigurationFactory.KEY);
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setupClass() {
-        ConfigurationFactory.setConfigurationFactory(cf);
         final LoggerContext ctx = LoggerContext.getContext();
+        ctx.getInjector().registerBinding(ConfigurationFactory.KEY, new LazyValue<>(BasicConfigurationFactory::new));
         ctx.reconfigure();
     }
 
@@ -123,28 +116,28 @@ public class CsvLogEventLayoutTest {
         final String event0 = list.get(0 + headerOffset);
         final String event1 = list.get(1 + headerOffset);
         final char del = format.getDelimiter();
-        Assert.assertTrue(event0, event0.contains(del + "DEBUG" + del));
+        assertTrue(event0.contains(del + "DEBUG" + del), event0);
         final String quote = del == ',' ? "\"" : "";
-        Assert.assertTrue(event0, event0.contains(del + quote + "one=1, two=2, three=3" + quote + del));
-        Assert.assertTrue(event1, event1.contains(del + "INFO" + del));
+        assertTrue(event0.contains(del + quote + "one=1, two=2, three=3" + quote + del), event0);
+        assertTrue(event1.contains(del + "INFO" + del), event1);
 
         if (hasHeaderSerializer && header == null) {
-            Assert.fail();
+            fail();
         }
         if (!hasHeaderSerializer && header != null) {
-            Assert.fail();
+            fail();
         }
         if (hasFooterSerializer && footer == null) {
-            Assert.fail();
+            fail();
         }
         if (!hasFooterSerializer && footer != null) {
-            Assert.fail();
+            fail();
         }
         if (hasHeaderSerializer) {
-            Assert.assertEquals(list.toString(), header, list.get(0));
+            assertEquals(header, list.get(0), list.toString());
         }
         if (hasFooterSerializer) {
-            Assert.assertEquals(list.toString(), footer, list.get(list.size() - 1));
+            assertEquals(footer, list.get(list.size() - 1), list.toString());
         }
     }
 

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumePersistentManager.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumePersistentManager.java
@@ -16,24 +16,6 @@
  */
 package org.apache.logging.log4j.flume.appender;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.File;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import javax.crypto.Cipher;
-import javax.crypto.SecretKey;
-
 import com.sleepycat.je.Cursor;
 import com.sleepycat.je.CursorConfig;
 import com.sleepycat.je.Database;
@@ -56,9 +38,27 @@ import org.apache.logging.log4j.core.util.FileUtils;
 import org.apache.logging.log4j.core.util.Log4jThread;
 import org.apache.logging.log4j.core.util.Log4jThreadFactory;
 import org.apache.logging.log4j.core.util.SecretKeyProvider;
-import org.apache.logging.log4j.plugins.util.PluginManager;
 import org.apache.logging.log4j.plugins.util.PluginType;
+import org.apache.logging.log4j.plugins.util.PluginUtil;
 import org.apache.logging.log4j.util.Strings;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Manager that persists data to Berkeley DB before passing it on to Flume.
@@ -429,9 +429,7 @@ public class FlumePersistentManager extends FlumeAvroManager {
                     }
                 }
                 if (key != null) {
-                    final PluginManager manager = new PluginManager("KeyProvider");
-                    manager.collectPlugins();
-                    final Map<String, PluginType<?>> plugins = manager.getPlugins();
+                    final Map<String, PluginType<?>> plugins = PluginUtil.collectPluginsByCategory("KeyProvider");
                     if (plugins != null) {
                         boolean found = false;
                         for (final Map.Entry<String, PluginType<?>> entry : plugins.entrySet()) {

--- a/log4j-layout-jackson-json/src/test/java/org/apache/logging/log4j/jackson/json/MarkerMixInJsonTest.java
+++ b/log4j-layout-jackson-json/src/test/java/org/apache/logging/log4j/jackson/json/MarkerMixInJsonTest.java
@@ -17,13 +17,9 @@
 
 package org.apache.logging.log4j.jackson.json;
 
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.apache.logging.log4j.jackson.AbstractMarkerMixInTest;
-import org.junit.experimental.categories.Category;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.jackson.AbstractMarkerMixInTest;
 
-@Category(Layouts.Json.class)
 public class MarkerMixInJsonTest extends AbstractMarkerMixInTest {
 
     @Override

--- a/log4j-layout-jackson-xml/src/test/java/org/apache/logging/log4j/jackson/xml/MarkerMixInXmlTest.java
+++ b/log4j-layout-jackson-xml/src/test/java/org/apache/logging/log4j/jackson/xml/MarkerMixInXmlTest.java
@@ -17,13 +17,9 @@
 
 package org.apache.logging.log4j.jackson.xml;
 
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.apache.logging.log4j.jackson.AbstractMarkerMixInTest;
-import org.junit.experimental.categories.Category;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.jackson.AbstractMarkerMixInTest;
 
-@Category(Layouts.Xml.class)
 public class MarkerMixInXmlTest extends AbstractMarkerMixInTest {
 
     @Override

--- a/log4j-layout-jackson-yaml/src/test/java/org/apache/logging/log4j/jackson/yaml/LevelMixInYamlTest.java
+++ b/log4j-layout-jackson-yaml/src/test/java/org/apache/logging/log4j/jackson/yaml/LevelMixInYamlTest.java
@@ -17,13 +17,9 @@
 
 package org.apache.logging.log4j.jackson.yaml;
 
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.apache.logging.log4j.jackson.LevelMixInTest;
-import org.junit.experimental.categories.Category;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.jackson.LevelMixInTest;
 
-@Category(Layouts.Yaml.class)
 public class LevelMixInYamlTest extends LevelMixInTest {
 
     @Override

--- a/log4j-layout-jackson-yaml/src/test/java/org/apache/logging/log4j/jackson/yaml/MarkerMixInYamlTest.java
+++ b/log4j-layout-jackson-yaml/src/test/java/org/apache/logging/log4j/jackson/yaml/MarkerMixInYamlTest.java
@@ -17,13 +17,9 @@
 
 package org.apache.logging.log4j.jackson.yaml;
 
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.apache.logging.log4j.jackson.AbstractMarkerMixInTest;
-import org.junit.experimental.categories.Category;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.jackson.AbstractMarkerMixInTest;
 
-@Category(Layouts.Yaml.class)
 public class MarkerMixInYamlTest extends AbstractMarkerMixInTest {
 
     @Override

--- a/log4j-layout-jackson-yaml/src/test/java/org/apache/logging/log4j/jackson/yaml/StackTraceElementYamlMixInTest.java
+++ b/log4j-layout-jackson-yaml/src/test/java/org/apache/logging/log4j/jackson/yaml/StackTraceElementYamlMixInTest.java
@@ -16,35 +16,28 @@
  */
 package org.apache.logging.log4j.jackson.yaml;
 
-import java.io.IOException;
-
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.apache.logging.log4j.jackson.Log4jStackTraceElementDeserializer;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import org.apache.logging.log4j.jackson.Log4jStackTraceElementDeserializer;
+import org.junit.jupiter.api.Test;
 
-@Category(Layouts.Json.class)
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class StackTraceElementYamlMixInTest {
 
     protected String aposToQuotes(final String json) {
         return json.replace("'", "\"");
     }
 
-    private void roundtrip(final ObjectMapper mapper)
-            throws JsonProcessingException, IOException, JsonParseException, JsonMappingException {
+    private void roundtrip(final ObjectMapper mapper) throws IOException {
         final StackTraceElement expected = new StackTraceElement("package.SomeClass", "someMethod", "SomeClass.java",
                 123);
         final String s = mapper.writeValueAsString(expected);
         final StackTraceElement actual = mapper.readValue(s, StackTraceElement.class);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -59,7 +52,7 @@ public class StackTraceElementYamlMixInTest {
         final StackTraceElement actual = mapper.readValue(
                 "---\nclass: package.SomeClass\nmethod: someMethod\nfile: SomeClass.java\nline: 123\n...",
                 StackTraceElement.class);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -73,7 +66,7 @@ public class StackTraceElementYamlMixInTest {
         final StackTraceElement actual = mapper.readValue(
                 "---\nclass: package.SomeClass\nmethod: someMethod\nfile: SomeClass.java\nline: 123\n...",
                 StackTraceElement.class);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/log4j-layout-jackson/src/test/java/org/apache/logging/log4j/jackson/AbstractMarkerMixInTest.java
+++ b/log4j-layout-jackson/src/test/java/org/apache/logging/log4j/jackson/AbstractMarkerMixInTest.java
@@ -16,19 +16,19 @@
 */
 package org.apache.logging.log4j.jackson;
 
-import java.io.IOException;
-
-import org.apache.logging.log4j.Marker;
-import org.apache.logging.log4j.MarkerManager;
-import org.apache.logging.log4j.MarkerManager.Log4jMarker;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+import org.apache.logging.log4j.MarkerManager.Log4jMarker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests {@link MarkerMixIn}.
@@ -42,7 +42,7 @@ public abstract class AbstractMarkerMixInTest {
 
     protected abstract ObjectMapper newObjectMapper();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         final ObjectMapper log4jObjectMapper = newObjectMapper();
         writer = log4jObjectMapper.writer();
@@ -54,9 +54,9 @@ public abstract class AbstractMarkerMixInTest {
     public void testNameOnly() throws IOException {
         final Marker expected = MarkerManager.getMarker("A");
         final String str = writeValueAsString(expected);
-        Assert.assertFalse(str.contains("parents"));
+        assertFalse(str.contains("parents"));
         final Marker actual = reader.readValue(str);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -65,9 +65,9 @@ public abstract class AbstractMarkerMixInTest {
         final Marker parent = MarkerManager.getMarker("PARENT_MARKER");
         expected.addParents(parent);
         final String str = writeValueAsString(expected);
-        Assert.assertTrue(str.contains("PARENT_MARKER"));
+        assertTrue(str.contains("PARENT_MARKER"));
         final Marker actual = reader.readValue(str);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -78,10 +78,10 @@ public abstract class AbstractMarkerMixInTest {
         expected.addParents(parent1);
         expected.addParents(parent2);
         final String str = writeValueAsString(expected);
-        Assert.assertTrue(str.contains("PARENT_MARKER1"));
-        Assert.assertTrue(str.contains("PARENT_MARKER2"));
+        assertTrue(str.contains("PARENT_MARKER1"));
+        assertTrue(str.contains("PARENT_MARKER2"));
         final Marker actual = reader.readValue(str);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     /**

--- a/log4j-layout-jackson/src/test/java/org/apache/logging/log4j/jackson/LevelMixInTest.java
+++ b/log4j-layout-jackson/src/test/java/org/apache/logging/log4j/jackson/LevelMixInTest.java
@@ -16,24 +16,22 @@
  */
 package org.apache.logging.log4j.jackson;
 
-import java.io.IOException;
-
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@link LevelMixIn}.
  */
-@Category(Layouts.Json.class)
 public abstract class LevelMixInTest {
 
     static class Fixture {
@@ -78,7 +76,7 @@ public abstract class LevelMixInTest {
 
     protected abstract ObjectMapper newObjectMapper();
 
-    @Before
+    @BeforeEach
     public void setUp() {
         log4jObjectMapper = newObjectMapper();
         writer = log4jObjectMapper.writer();
@@ -89,18 +87,18 @@ public abstract class LevelMixInTest {
     public void testContainer() throws IOException {
         final Fixture expected = new Fixture();
         final String str = writer.writeValueAsString(expected);
-        Assert.assertTrue(str.contains("DEBUG"));
+        assertTrue(str.contains("DEBUG"));
         final ObjectReader fixtureReader = log4jObjectMapper.readerFor(Fixture.class);
         final Fixture actual = fixtureReader.readValue(str);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void testNameOnly() throws IOException {
         final Level expected = Level.getLevel("DEBUG");
         final String str = writer.writeValueAsString(expected);
-        Assert.assertTrue(str.contains("DEBUG"));
+        assertTrue(str.contains("DEBUG"));
         final Level actual = reader.readValue(str);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/log4j-plugins/src/main/java/org/apache/logging/log4j/plugins/convert/TypeConverterRegistry.java
+++ b/log4j-plugins/src/main/java/org/apache/logging/log4j/plugins/convert/TypeConverterRegistry.java
@@ -17,8 +17,8 @@
 package org.apache.logging.log4j.plugins.convert;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.plugins.util.PluginManager;
 import org.apache.logging.log4j.plugins.util.PluginType;
+import org.apache.logging.log4j.plugins.util.PluginUtil;
 import org.apache.logging.log4j.plugins.util.TypeUtil;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LazyValue;
@@ -99,9 +99,7 @@ public class TypeConverterRegistry {
 
     private TypeConverterRegistry() {
         LOGGER.trace("TypeConverterRegistry initializing.");
-        final PluginManager manager = new PluginManager(TypeConverters.CATEGORY);
-        manager.collectPlugins();
-        loadKnownTypeConverters(manager.getPlugins().values());
+        loadKnownTypeConverters(PluginUtil.collectPluginsByCategory(TypeConverters.CATEGORY).values());
         registerPrimitiveTypes();
     }
 

--- a/log4j-spring-boot/src/main/java/org/apache/logging/log4j/spring/boot/Log4j2CloudConfigLoggingSystem.java
+++ b/log4j-spring-boot/src/main/java/org/apache/logging/log4j/spring/boot/Log4j2CloudConfigLoggingSystem.java
@@ -16,22 +16,6 @@
  */
 package org.apache.logging.log4j.spring.boot;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.net.URLDecoder;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Properties;
-import javax.net.ssl.HttpsURLConnection;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -44,7 +28,6 @@ import org.apache.logging.log4j.core.net.ssl.LaxHostnameVerifier;
 import org.apache.logging.log4j.core.net.ssl.SslConfiguration;
 import org.apache.logging.log4j.core.net.ssl.SslConfigurationFactory;
 import org.apache.logging.log4j.core.util.AuthorizationProvider;
-import org.apache.logging.log4j.core.util.BasicAuthorizationProvider;
 import org.apache.logging.log4j.core.util.FileUtils;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.PropertiesUtil;
@@ -55,6 +38,21 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ResourceUtils;
 
+import javax.net.ssl.HttpsURLConnection;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
 /**
  * Override Spring's implementation of the Log4j 2 Logging System to properly support Spring Cloud Config.
  */
@@ -62,7 +60,7 @@ public class Log4j2CloudConfigLoggingSystem extends Log4J2LoggingSystem {
     private static final String HTTPS = "https";
     public static final String ENVIRONMENT_KEY = "SpringEnvironment";
     private static final String OVERRIDE_PARAM = "override";
-    private static Logger LOGGER = StatusLogger.getLogger();
+    private static final Logger LOGGER = StatusLogger.getLogger();
 
     public Log4j2CloudConfigLoggingSystem(ClassLoader loader) {
         super(loader);
@@ -116,20 +114,21 @@ public class Log4j2CloudConfigLoggingSystem extends Log4J2LoggingSystem {
     protected void loadConfiguration(String location, LogFile logFile) {
         Assert.notNull(location, "Location must not be null");
         try {
-            LoggerContext ctx = getLoggerContext();
-            String[] locations = parseConfigLocations(location);
+            final LoggerContext ctx = getLoggerContext();
+            final ConfigurationFactory factory = ctx.getInjector().getInstance(ConfigurationFactory.KEY);
+            final String[] locations = parseConfigLocations(location);
             if (locations.length == 1) {
                 final URL url = ResourceUtils.getURL(location);
                 final ConfigurationSource source = getConfigurationSource(url);
                 if (source != null) {
-                    ctx.start(ConfigurationFactory.getInstance().getConfiguration(ctx, source));
+                    ctx.start(factory.getConfiguration(ctx, source));
                 }
             } else {
                 final List<AbstractConfiguration> configs = new ArrayList<>();
                 for (final String sourceLocation : locations) {
                     final ConfigurationSource source = getConfigurationSource(ResourceUtils.getURL(sourceLocation));
                     if (source != null) {
-                        final Configuration config = ConfigurationFactory.getInstance().getConfiguration(ctx, source);
+                        final Configuration config = factory.getConfiguration(ctx, source);
                         if (config instanceof AbstractConfiguration) {
                             configs.add((AbstractConfiguration) config);
                         } else {
@@ -167,13 +166,9 @@ public class Log4j2CloudConfigLoggingSystem extends Log4J2LoggingSystem {
                 final String[] pairs = url.getQuery().split("&");
                 for (String pair : pairs) {
                     final int idx = pair.indexOf("=");
-                    try {
-                        final String key = idx > 0 ? URLDecoder.decode(pair.substring(0, idx), "UTF-8") : pair;
-                        if (key.equalsIgnoreCase(OVERRIDE_PARAM)) {
-                            locations.add(URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
-                        }
-                    } catch (UnsupportedEncodingException ex) {
-                        LOGGER.warn("Bad data in configuration string: {}", pair);
+                    final String key = idx > 0 ? URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8) : pair;
+                    if (key.equalsIgnoreCase(OVERRIDE_PARAM)) {
+                        locations.add(URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8));
                     }
                 }
                 return locations.toArray(new String[0]);

--- a/log4j-spring-boot/src/main/resources/META-INF/spring.factories
+++ b/log4j-spring-boot/src/main/resources/META-INF/spring.factories
@@ -14,4 +14,4 @@
 # See the license for the specific language governing permissions and
 # limitations under the license.
 #
-org.springframework.boot.logging.LoggingSystem=org.apache.logging.log4j.spring.boot.Log4j2CloudConfigLoggingSystem
+org.springframework.boot.logging.LoggingSystemFactory=org.apache.logging.log4j.spring.boot.Log4j2CloudConfigLoggingSystem.Factory

--- a/log4j-spring-boot/src/test/java/org/apache/logging/log4j/spring/boot/Log4j2CloudConfigLoggingSystemTest.java
+++ b/log4j-spring-boot/src/test/java/org/apache/logging/log4j/spring/boot/Log4j2CloudConfigLoggingSystemTest.java
@@ -19,23 +19,41 @@ package org.apache.logging.log4j.spring.boot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.spi.LoggerContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetSystemProperty;
+import org.springframework.boot.logging.LoggingSystem;
+import org.springframework.boot.logging.log4j2.Log4J2LoggingSystem;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
-
-import static org.junit.Assert.assertTrue;
 
 public class Log4j2CloudConfigLoggingSystemTest {
 
     @Test
     public void getStandardConfigLocations() {
         String customLog4j2Location = "classpath:my_custom_log4j2.properties";
-        LoggerContext lc = LogManager.getContext(); // Initialize LogManager to here to prevent a failure trying to initialize it from StatusLogger.
+        LoggerContext lc = LogManager.getContext(); // Initialize LogManager to here to prevent a failure trying to
+                                                    // initialize it from StatusLogger.
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, customLog4j2Location);
-        Log4j2CloudConfigLoggingSystem cloudLoggingSystem = new Log4j2CloudConfigLoggingSystem(this.getClass().getClassLoader());
+        Log4j2CloudConfigLoggingSystem cloudLoggingSystem = new Log4j2CloudConfigLoggingSystem(
+                this.getClass().getClassLoader());
         List<String> standardConfigLocations = Arrays.asList(cloudLoggingSystem.getStandardConfigLocations());
         assertTrue(standardConfigLocations.contains(customLog4j2Location));
 
+    }
+
+    @Test
+    @SetSystemProperty(key = Log4j2CloudConfigLoggingSystem.LOG4J2_DISABLE_CLOUD_CONFIG_LOGGING_SYSTEM, value = "true")
+    public void testUseLog4j2LoggingSystem() {
+        LoggingSystem loggingSystem = LoggingSystem.get(getClass().getClassLoader());
+        assertTrue(loggingSystem.getClass().equals(Log4J2LoggingSystem.class));
+    }
+
+    @Test
+    public void testLoggingSystemEnabled() {
+        LoggingSystem loggingSystem = LoggingSystem.get(getClass().getClassLoader());
+        assertTrue(loggingSystem.getClass().equals(Log4j2CloudConfigLoggingSystem.class));
     }
 }


### PR DESCRIPTION
This allows for a ConfigurationFactory binding to be registered as well as generally participate in dependency injection.

Signed-off-by: Matt Sicker <mattsicker@apache.org>