### PR TITLE
Update Spring to 5.3.18 which fixes CVE-2022-22965 aka "Spring4shell".

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
     <jackson1Version>1.9.13</jackson1Version>
     <jackson2Version>2.13.2</jackson2Version>
     <spring-boot.version>2.5.7</spring-boot.version>
-    <springVersion>5.3.17</springVersion>
+    <springVersion>5.3.18</springVersion>
     <kubernetes-client.version>5.12.1</kubernetes-client.version>
     <flumeVersion>1.9.0</flumeVersion>
     <disruptorVersion>3.4.4</disruptorVersion>


### PR DESCRIPTION
See details: https://tanzu.vmware.com/security/cve-2022-22965