### PR TITLE
fix typo in method name getRequesteApiVersion()

### DIFF
--- a/log4j-slf4j18-impl/src/main/java/org/apache/logging/slf4j/SLF4JServiceProvider.java
+++ b/log4j-slf4j18-impl/src/main/java/org/apache/logging/slf4j/SLF4JServiceProvider.java
@@ -44,7 +44,7 @@ public class SLF4JServiceProvider implements org.slf4j.spi.SLF4JServiceProvider 
     }
 
     @Override
-    public String getRequesteApiVersion() {
+    public String getRequestedApiVersion() {
         return REQUESTED_API_VERSION;
     }
 


### PR DESCRIPTION
SLF4JServiceProvider defines the `getRequestedApiVersion()` method, but this class has a typo, the method is incorrectly named `getRequesteApiVersion()` which causes the following error message to be reported when using this library:

```
Unexpected problem occured during version sanity check
Reported exception:
java.lang.AbstractMethodError: Receiver class org.apache.logging.slf4j.SLF4JServiceProvider does not define or inherit an implementation of the resolved method 'abstract java.lang.String getRequestedApiVersion()' of interface org.slf4j.spi.SLF4JServiceProvider.
```