### PR TITLE
[LOG4J2-3440] Synchronize Log4j 1.x and Log4j 2.x appenders

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/AppenderAdapter.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/AppenderAdapter.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.util.Strings;
 
 /**
  * Binds a Log4j 1.x Appender to Log4j 2.
@@ -62,7 +63,11 @@ public class AppenderAdapter {
     private AppenderAdapter(Appender appender) {
         this.appender = appender;
         final org.apache.logging.log4j.core.Filter appenderFilter = FilterAdapter.adapt(appender.getFilter());
-        this.adapter = new Adapter(appender.getName(), appenderFilter, null, true, null);
+        String name = appender.getName();
+        if (Strings.isEmpty(name)) {
+            name = String.format("0x%08x", appender.hashCode());
+        }
+        this.adapter = new Adapter(name, appenderFilter, null, true, null);
     }
 
     public Adapter getAdapter() {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/CategoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/CategoryTest.java
@@ -18,16 +18,21 @@
 package org.apache.log4j;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+import org.apache.log4j.bridge.AppenderAdapter;
+import org.apache.log4j.bridge.AppenderWrapper;
+import org.apache.log4j.spi.LoggingEvent;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -52,11 +57,15 @@ public class CategoryTest {
 
     static ConfigurationFactory cf = new BasicConfigurationFactory();
 
-    private static ListAppender appender = new ListAppender("List");
+    private static final String VERSION1_APPENDER_NAME = "Version1List";
+    private static final String VERSION2_APPENDER_NAME = "List";
+    private static ListAppender appender = new ListAppender(VERSION2_APPENDER_NAME);
+    private static org.apache.log4j.ListAppender version1Appender = new org.apache.log4j.ListAppender();
 
     @BeforeClass
     public static void setupClass() {
         appender.start();
+        version1Appender.setName(VERSION1_APPENDER_NAME);
         ConfigurationFactory.setConfigurationFactory(cf);
         LoggerContext.getContext().reconfigure();
     }
@@ -333,6 +342,75 @@ public class CategoryTest {
         final M typedMessage = (M) message;
         messageTester.accept(typedMessage);
 
+    }
+
+    @Test
+    public void testAddAppender() {
+        try {
+            final Logger rootLogger = LogManager.getRootLogger();
+            int count = version1Appender.getEvents().size();
+            rootLogger.addAppender(version1Appender);
+            final Logger logger = LogManager.getLogger(CategoryTest.class);
+            final org.apache.log4j.ListAppender appender = new org.apache.log4j.ListAppender();
+            appender.setName("appender2");
+            logger.addAppender(appender);
+            // Root logger
+            rootLogger.info("testAddLogger");
+            assertEquals("adding at root works", ++count, version1Appender.getEvents().size());
+            assertEquals("adding at child works", 0, appender.getEvents().size());
+            // Another logger
+            logger.info("testAddLogger2");
+            assertEquals("adding at root works", ++count, version1Appender.getEvents().size());
+            assertEquals("adding at child works", 1, appender.getEvents().size());
+            // Call appenders
+            final LoggingEvent event = new LoggingEvent();
+            logger.callAppenders(event);
+            assertEquals("callAppenders", ++count, version1Appender.getEvents().size());
+            assertEquals("callAppenders", 2, appender.getEvents().size());
+        } finally {
+            LogManager.resetConfiguration();
+        }
+    }
+
+    @Test
+    public void testGetAppender() {
+        try {
+            final Logger rootLogger = LogManager.getRootLogger();
+            final org.apache.logging.log4j.core.Logger v2RootLogger = (org.apache.logging.log4j.core.Logger) rootLogger
+                    .getLogger();
+            v2RootLogger.addAppender(AppenderAdapter.adapt(version1Appender));
+            v2RootLogger.addAppender(appender);
+            final List<Appender> rootAppenders = Collections.list(rootLogger.getAllAppenders());
+            assertEquals("only v1 appenders", 1, rootAppenders.size());
+            assertTrue("appender is a v1 ListAppender", rootAppenders.get(0) instanceof org.apache.log4j.ListAppender);
+            assertEquals("explicitly named appender", VERSION1_APPENDER_NAME,
+                    rootLogger.getAppender(VERSION1_APPENDER_NAME).getName());
+            Appender v2ListAppender = rootLogger.getAppender(VERSION2_APPENDER_NAME);
+            assertTrue("explicitly named appender", v2ListAppender instanceof AppenderWrapper);
+            assertTrue("appender is a v2 ListAppender",
+                    ((AppenderWrapper) v2ListAppender).getAppender() instanceof ListAppender);
+
+            final Logger logger = LogManager.getLogger(CategoryTest.class);
+            final org.apache.logging.log4j.core.Logger v2Logger = (org.apache.logging.log4j.core.Logger) logger
+                    .getLogger();
+            final org.apache.log4j.ListAppender loggerAppender = new org.apache.log4j.ListAppender();
+            loggerAppender.setName("appender2");
+            v2Logger.addAppender(AppenderAdapter.adapt(loggerAppender));
+            final List<Appender> appenders = Collections.list(logger.getAllAppenders());
+            assertEquals("no parent appenders", 1, appenders.size());
+            assertEquals(loggerAppender, appenders.get(0));
+            assertNull("no parent appenders", logger.getAppender(VERSION1_APPENDER_NAME));
+            assertNull("no parent appenders", logger.getAppender(VERSION2_APPENDER_NAME));
+
+            final Logger childLogger = LogManager.getLogger(CategoryTest.class.getName() + ".child");
+            final Enumeration<Appender> childAppenders = childLogger.getAllAppenders();
+            assertFalse("no parent appenders", childAppenders.hasMoreElements());
+            assertNull("no parent appenders", childLogger.getAppender("appender2"));
+            assertNull("no parent appenders", childLogger.getAppender(VERSION1_APPENDER_NAME));
+            assertNull("no parent appenders", childLogger.getAppender(VERSION2_APPENDER_NAME));
+        } finally {
+            LogManager.resetConfiguration();
+        }
     }
 
     /**

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/ListAppender.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/ListAppender.java
@@ -80,4 +80,8 @@ public class ListAppender extends AppenderSkeleton {
         }
         return getMessages();
     }
+
+    public String toString() {
+        return String.format("ListAppender[%s]", getName());
+    }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesReconfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesReconfigurationTest.java
@@ -128,24 +128,15 @@ public class PropertiesReconfigurationTest {
     }
 
     private void checkCustomAppender(final String appenderName, final boolean expectBoolean, final int expectInt, final String expectString) {
-        final Logger logger = LogManager.getLogger("test");
+        final Logger logger = LogManager.getRootLogger();
         final org.apache.log4j.Appender appender = logger.getAppender(appenderName);
         assertNotNull(appender);
         assertCustomNoopAppender(appender, expectBoolean, expectInt, expectString);
         assertCustomNoopAppender(getAppenderFromContext(appenderName), expectBoolean, expectInt, expectString);
     }
 
-    private void checkCustomFileAppender(final boolean expectAppend, final Appender appender) {
-        assertNotNull(appender);
-        final FileAppender fileAppender = (FileAppender) appender;
-        @SuppressWarnings("resource")
-        final FileManager manager = fileAppender.getManager();
-        assertNotNull(manager);
-        assertEquals(expectAppend, manager.isAppend());
-    }
-
     private void checkCustomFileAppender(final String appenderName, final boolean expectBoolean, final int expectInt, final String expectString) {
-        final Logger logger = LogManager.getLogger("test");
+        final Logger logger = LogManager.getRootLogger();
         final org.apache.log4j.Appender appender = logger.getAppender(appenderName);
         assertNotNull(appender);
         assertCustomFileAppender(appender, expectBoolean, expectInt, expectString);
@@ -153,13 +144,14 @@ public class PropertiesReconfigurationTest {
     }
 
     private void checkFileAppender(final boolean expectAppend, final String appenderName) {
-        final Logger logger = LogManager.getLogger("test");
+        final Logger logger = LogManager.getRootLogger();
         final org.apache.log4j.Appender appender = logger.getAppender(appenderName);
         assertNotNull(appender);
         final AppenderWrapper appenderWrapper = (AppenderWrapper) appender;
         checkCoreFileAppender(expectAppend, appenderWrapper.getAppender());
     }
 
+    @SuppressWarnings("unchecked")
     private <T extends org.apache.log4j.Appender> T getAppenderFromContext(final String appenderName) {
         final LoggerContext context = (LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
         final LoggerConfig loggerConfig = context.getConfiguration().getRootLogger();


### PR DESCRIPTION
Forwards the `addAppender`, `callAppenders`, `getAllAppenders` and `getAppender` calls the the corresponding Log4j 2.x objects if Log4j 2.x Core is present.

The `getAllAppenders` method only returns those appenders, which are attached to homonymous logger config and are native Log4j 1.x appenders.