### PR TITLE
LOG4J2-3477 JsonLayout template doesn't contain the context stack

### DIFF
--- a/log4j-layout-template-json/src/main/resources/JsonLayout.json
+++ b/log4j-layout-template-json/src/main/resources/JsonLayout.json
@@ -45,7 +45,7 @@
     }
   },
   "contextStack": {
-    "$resolver": "ndc"
+    "$resolver": "mdc"
   },
   "endOfBatch": {
     "$resolver": "endOfBatch"


### PR DESCRIPTION
There is a typo in definition of context stack resolver. Should be **mdc** what stands for Mapped Diagnostic Context, was **ndc** by mistake.