### PR TITLE
LOG4J2-3476 ignore JUL ApiLogger.setLevel without error

### DIFF
--- a/log4j-jul/src/main/java/org/apache/logging/log4j/jul/ApiLogger.java
+++ b/log4j-jul/src/main/java/org/apache/logging/log4j/jul/ApiLogger.java
@@ -93,7 +93,7 @@ public class ApiLogger extends Logger {
     @Override
     public void setLevel(final Level newLevel) throws SecurityException {
         StatusLogger.getLogger().error("Cannot set JUL log level through log4j-api: " +
-                "ignoring call to Logger.setLevel(" + newLevel + ")");
+                "ignoring call to Logger.setLevel({})", newLevel);
     }
 
     /**

--- a/log4j-jul/src/main/java/org/apache/logging/log4j/jul/ApiLogger.java
+++ b/log4j-jul/src/main/java/org/apache/logging/log4j/jul/ApiLogger.java
@@ -27,6 +27,7 @@ import java.util.logging.Logger;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.spi.ExtendedLogger;
+import org.apache.logging.log4j.status.StatusLogger;
 
 /**
  * Log4j API implementation of the JUL {@link Logger} class. <strong>Note that this implementation does
@@ -91,7 +92,8 @@ public class ApiLogger extends Logger {
 
     @Override
     public void setLevel(final Level newLevel) throws SecurityException {
-        throw new UnsupportedOperationException("Cannot set level through log4j-api");
+        StatusLogger.getLogger().error("Cannot set JUL log level through log4j-api: " +
+                "ignoring call to Logger.setLevel(" + newLevel + ")");
     }
 
     /**


### PR DESCRIPTION
This PR implements the change discussed in https://issues.apache.org/jira/browse/LOG4J2-3476:

When JUL ApiLogger.setLevel is called, do not throw an UnsupportedOperationException, but instead log an error in the status logger.