### PR TITLE
Remote pluginRepositories compatibility issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,20 +311,6 @@
     <javaTargetVersion>1.8</javaTargetVersion>
     <module.name />
   </properties>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>apache</id>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
-    </pluginRepository>
-<!--     <pluginRepository> -->
-<!--       <id>apache.snapshots</id> -->
-<!--       <name>Apache snapshots repository</name> -->
-<!--       <url>http://repository.apache.org/content/groups/snapshots</url> -->
-<!--       <snapshots> -->
-<!--         <enabled>true</enabled> -->
-<!--       </snapshots> -->
-<!--     </pluginRepository>     -->
-  </pluginRepositories>
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
The pluginRepositories conflict with that in the Apache Maven. 
The private repository address configured in the Apache Maven is not preferentially used. 
Is it compatible to use the user's private warehouse configuration?