### PR TITLE
Increase to 50 dependabot proposals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,17 @@
 #
 version: 2
 updates:
+# No more than 10 PRs for dependencies with a `test` scope
 - package-ecosystem: maven
   directory: "/"
   schedule:
     interval: daily
-    time: '04:00'
+  allow: development
   open-pull-requests-limit: 10
+# 50 PRs for the remaining dependencies (`compile` and Maven plugins)
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+  allow: production
+  open-pull-requests-limit: 50


### PR DESCRIPTION
We have 38 upgradeable dependencies. In order to limit the annoyance from Dependabot PRs, I propose to limit the number of `test` scope upgrade proposals to 10 and to give a larger number (50) for the remaining ones.

Another solution would be to prioritize the number of upgrade proposals for `log4j-api` and `log4j-core` and limit those for the remaining modules.