### PR TITLE
Move performance tests to `log4j-perf`

### DIFF
--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -176,13 +176,6 @@
       <version>3.5.7</version>
       <scope>test</scope>
     </dependency>
-    <!-- Log4j 1.2 tests -->
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-      <scope>test</scope>
-    </dependency>
     <!-- SLF4J tests -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -348,11 +341,6 @@
     <dependency>
       <groupId>com.google.code.java-allocation-instrumenter</groupId>
       <artifactId>java-allocation-instrumenter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hdrhistogram</groupId>
-      <artifactId>HdrHistogram</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppenderTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppenderTest.java
@@ -36,8 +36,8 @@ import java.util.concurrent.TimeoutException;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.log4j.MDC;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.categories.Appenders;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LogEvent;
@@ -61,7 +61,7 @@ public class KafkaAppenderTest {
 
 			Future<RecordMetadata> retVal = super.send(record);
 
-			boolean isRetryTest = "true".equals(MDC.get("KafkaAppenderWithRetryCount"));
+			boolean isRetryTest = "true".equals(ThreadContext.get("KafkaAppenderWithRetryCount"));
 			if (isRetryTest) {
 				try {
 					throw new TimeoutException();
@@ -179,7 +179,7 @@ public class KafkaAppenderTest {
 	@Test
 	public void testAppendWithRetryCount() {
 		try {
-			MDC.put("KafkaAppenderWithRetryCount", "true");
+			ThreadContext.put("KafkaAppenderWithRetryCount", "true");
 			final Appender appender = ctx.getRequiredAppender("KafkaAppenderWithRetryCount");
 			final LogEvent logEvent = createLogEvent();
 			appender.append(logEvent);
@@ -189,7 +189,7 @@ public class KafkaAppenderTest {
 		} catch (Exception e) {
 			e.printStackTrace();
 		} finally {
-			MDC.clear();
+			ThreadContext.clearMap();
 		}
 
 	}

--- a/log4j-perf/pom.xml
+++ b/log4j-perf/pom.xml
@@ -65,6 +65,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <type>test-jar</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-jpa</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -156,6 +162,10 @@
     <dependency>
       <groupId>co.elastic.logging</groupId>
       <artifactId>log4j2-ecs-layout</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hdrhistogram</groupId>
+      <artifactId>HdrHistogram</artifactId>
     </dependency>
   </dependencies>
 

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/AbstractRunQueue.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/AbstractRunQueue.java
@@ -14,12 +14,12 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 
-import org.apache.logging.log4j.core.async.perftest.ResponseTimeTest.PrintingAsyncQueueFullPolicy;
+import org.apache.logging.log4j.perf.async.ResponseTimeTest.PrintingAsyncQueueFullPolicy;
 
 public abstract class AbstractRunQueue implements IPerfTestRunner {
 

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/Histogram.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/Histogram.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/IPerfTestRunner.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/IPerfTestRunner.java
@@ -14,18 +14,18 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
-import java.util.concurrent.BlockingQueue;
+public interface IPerfTestRunner {
+    String LINE100 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!\"#$%&'()-=^~|\\@`[]{};:+*,.<>/?_123456";
+    String THROUGHPUT_MSG = LINE100 + LINE100 + LINE100 + LINE100
+            + LINE100;
+    String LATENCY_MSG = "Short msg";
 
-import org.apache.logging.log4j.core.async.DisruptorBlockingQueueFactory;
+    void runThroughputTest(int lines, Histogram histogram);
 
-import com.conversantmedia.util.concurrent.SpinPolicy;
-
-public class RunConversant extends AbstractRunQueue {
-
-    @Override
-    BlockingQueue<String> createQueue(final int capacity) {
-        return DisruptorBlockingQueueFactory.<String>createFactory(SpinPolicy.SPINNING).create(capacity);
-    }
+    void runLatencyTest(int samples, Histogram histogram, long nanoTimeCost,
+            int threadCount);
+    void shutdown();
+    void log(String finalMessage);
 }

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/IdleStrategy.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/IdleStrategy.java
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
 /**
  * Idle strategy for use by threads when they do not have work to do.

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/MultiThreadPerfTest.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/MultiThreadPerfTest.java
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/NoOpIdleStrategy.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/NoOpIdleStrategy.java
@@ -14,18 +14,24 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
-public interface IPerfTestRunner {
-    String LINE100 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!\"#$%&'()-=^~|\\@`[]{};:+*,.<>/?_123456";
-    String THROUGHPUT_MSG = LINE100 + LINE100 + LINE100 + LINE100
-            + LINE100;
-    String LATENCY_MSG = "Short msg";
+/**
+ * No operation idle strategy.
+ * <p>
+ * This idle strategy should be prevented from being inlined by using a Hotspot compiler command as a JVM argument e.g:
+ * <code>-XX:CompileCommand=dontinline,org.apache.logging.log4j.core.async.perftest.NoOpIdleStrategy::idle</code>
+ * </p>
+ */
+class NoOpIdleStrategy implements IdleStrategy {
 
-    void runThroughputTest(int lines, Histogram histogram);
+    /**
+     * <b>Note</b>: this implementation will result in no safepoint poll once inlined.
+     *
+     * @see IdleStrategy
+     */
+    @Override
+    public void idle() {
 
-    void runLatencyTest(int samples, Histogram histogram, long nanoTimeCost,
-            int threadCount);
-    void shutdown();
-    void log(String finalMessage);
+    }
 }

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/PerfTest.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/PerfTest.java
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
 import java.io.FileWriter;
 import java.io.IOException;
@@ -28,8 +28,8 @@ import org.apache.logging.log4j.core.util.Loader;
  * Single-threaded performance test. Usually invoked from PerfTestDriver as part of a series of tests.
  * <p>
  * To run a single instance of this class for the log4j2 test runner:<br>
- * java -Dlog4j.configurationFile=mylog4j2.xml org.apache.logging.log4j.core.async.perftest.PerfTest \
- * org.apache.logging.log4j.core.async.perftest.RunLog4j2 <name> <resultfile.txt> <-verbose> <-throughput>
+ * java -Dlog4j.configurationFile=mylog4j2.xml org.apache.logging.log4j.perf.async.PerfTest \
+ * org.apache.logging.log4j.perf.async.RunLog4j2 <name> <resultfile.txt> <-verbose> <-throughput>
  */
 public class PerfTest {
 

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/PerfTestDriver.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/PerfTestDriver.java
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/PerfTestResultFormatter.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/PerfTestResultFormatter.java
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/ResponseTimeTest.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/ResponseTimeTest.java
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -84,14 +84,14 @@ import org.apache.logging.log4j.core.util.Loader;
 // RUN
 // java -XX:+UnlockDiagnosticVMOptions -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintTenuringDistribution
 // -XX:+PrintGCApplicationConcurrentTime -XX:+PrintGCApplicationStoppedTime -XX:GuaranteedSafepointInterval=500000
-// -XX:CompileCommand=dontinline,org.apache.logging.log4j.core.async.perftest.NoOpIdleStrategy::idle
+// -XX:CompileCommand=dontinline,org.apache.logging.log4j.perf.async.NoOpIdleStrategy::idle
 // -cp HdrHistogram-2.1.8.jar:disruptor-3.3.4.jar:log4j-api-2.6-SNAPSHOT.jar:log4j-core-2.6-SNAPSHOT.jar:log4j-core-2.6-SNAPSHOT-tests.jar
 // -DAsyncLogger.WaitStrategy=busyspin -DLog4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
 // -Dlog4j2.enable.threadlocals=true -Dlog4j2.enable.direct.encoders=true
-//  -Xms1G -Xmx1G org.apache.logging.log4j.core.async.perftest.ResponseTimeTest 1 100000
+//  -Xms1G -Xmx1G org.apache.logging.log4j.perf.async.ResponseTimeTest 1 100000
 //
 // RUN recording in Java Flight Recorder:
-// %JAVA_HOME%\bin\java -XX:+UnlockCommercialFeatures -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:+FlightRecorder -XX:StartFlightRecording=duration=10m,filename=replayStats-2.6-latency.jfr -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationConcurrentTime -XX:+PrintGCApplicationStoppedTime -XX:CompileCommand=dontinline,org.apache.logging.log4j.core.async.perftest.NoOpIdleStrategy::idle -DAsyncLogger.WaitStrategy=yield  -Dorg.apache.logging.log4j.simplelog.StatusLogger.level=TRACE -cp .;HdrHistogram-2.1.8.jar;disruptor-3.3.4.jar;log4j-api-2.6-SNAPSHOT.jar;log4j-core-2.6-SNAPSHOT.jar;log4j-core-2.6-SNAPSHOT-tests.jar org.apache.logging.log4j.core.async.perftest.ResponseTimeTest 1 50000
+// %JAVA_HOME%\bin\java -XX:+UnlockCommercialFeatures -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:+FlightRecorder -XX:StartFlightRecording=duration=10m,filename=replayStats-2.6-latency.jfr -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationConcurrentTime -XX:+PrintGCApplicationStoppedTime -XX:CompileCommand=dontinline,org.apache.logging.log4j.perf.async.NoOpIdleStrategy::idle -DAsyncLogger.WaitStrategy=yield  -Dorg.apache.logging.log4j.simplelog.StatusLogger.level=TRACE -cp .;HdrHistogram-2.1.8.jar;disruptor-3.3.4.jar;log4j-api-2.6-SNAPSHOT.jar;log4j-core-2.6-SNAPSHOT.jar;log4j-core-2.6-SNAPSHOT-tests.jar org.apache.logging.log4j.perf.async.ResponseTimeTest 1 50000
 public class ResponseTimeTest {
     private static final String LATENCY_MSG = new String(new char[64]);
 
@@ -119,7 +119,7 @@ public class ResponseTimeTest {
 
         // initialize the logger
         final String wrapper = loggerLib.startsWith("Run") ? loggerLib : "Run" + loggerLib;
-        final String loggerWrapperClass = "org.apache.logging.log4j.core.async.perftest." + wrapper;
+        final String loggerWrapperClass = "org.apache.logging.log4j.perf.async." + wrapper;
         final IPerfTestRunner logger = Loader.newCheckedInstanceOf(loggerWrapperClass, IPerfTestRunner.class);
         logger.log("Starting..."); // ensure initialized
         Thread.sleep(100);

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/RunConversant.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/RunConversant.java
@@ -14,19 +14,18 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
 import java.util.concurrent.BlockingQueue;
 
-import org.apache.logging.log4j.core.async.JCToolsBlockingQueueFactory;
-import org.apache.logging.log4j.core.async.JCToolsBlockingQueueFactory.WaitStrategy;
+import org.apache.logging.log4j.core.async.DisruptorBlockingQueueFactory;
 
-public class RunJCTools extends AbstractRunQueue {
+import com.conversantmedia.util.concurrent.SpinPolicy;
+
+public class RunConversant extends AbstractRunQueue {
 
     @Override
     BlockingQueue<String> createQueue(final int capacity) {
-        return JCToolsBlockingQueueFactory.<String>createFactory(WaitStrategy.SPIN).create(capacity);
+        return DisruptorBlockingQueueFactory.<String>createFactory(SpinPolicy.SPINNING).create(capacity);
     }
-
-
 }

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/RunJCTools.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/RunJCTools.java
@@ -14,24 +14,19 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
-/**
- * No operation idle strategy.
- * <p>
- * This idle strategy should be prevented from being inlined by using a Hotspot compiler command as a JVM argument e.g:
- * <code>-XX:CompileCommand=dontinline,org.apache.logging.log4j.core.async.perftest.NoOpIdleStrategy::idle</code>
- * </p>
- */
-class NoOpIdleStrategy implements IdleStrategy {
+import java.util.concurrent.BlockingQueue;
 
-    /**
-     * <b>Note</b>: this implementation will result in no safepoint poll once inlined.
-     *
-     * @see IdleStrategy
-     */
+import org.apache.logging.log4j.core.async.JCToolsBlockingQueueFactory;
+import org.apache.logging.log4j.core.async.JCToolsBlockingQueueFactory.WaitStrategy;
+
+public class RunJCTools extends AbstractRunQueue {
+
     @Override
-    public void idle() {
-
+    BlockingQueue<String> createQueue(final int capacity) {
+        return JCToolsBlockingQueueFactory.<String>createFactory(WaitStrategy.SPIN).create(capacity);
     }
+
+
 }

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/RunLog4j1.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/RunLog4j1.java
@@ -14,13 +14,13 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.CoreLoggerContexts;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
 
-public class RunLog4j2 implements IPerfTestRunner {
+public class RunLog4j1 implements IPerfTestRunner {
+
     final Logger LOGGER = LogManager.getLogger(getClass());
 
     @Override
@@ -34,7 +34,6 @@ public class RunLog4j2 implements IPerfTestRunner {
         final long opsPerSec = (1000L * 1000L * 1000L * lines) / (s2 - s1);
         histogram.addObservation(opsPerSec);
     }
-
 
     @Override
     public void runLatencyTest(final int samples, final Histogram histogram,
@@ -57,12 +56,10 @@ public class RunLog4j2 implements IPerfTestRunner {
         }
     }
 
-
     @Override
     public void shutdown() {
-        CoreLoggerContexts.stopLoggerContext(); // stop async thread
+        LogManager.shutdown();
     }
-
 
     @Override
     public void log(final String finalMessage) {

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/RunLog4j2.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/RunLog4j2.java
@@ -14,13 +14,13 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.CoreLoggerContexts;
 
-public class RunLog4j1 implements IPerfTestRunner {
-
+public class RunLog4j2 implements IPerfTestRunner {
     final Logger LOGGER = LogManager.getLogger(getClass());
 
     @Override
@@ -34,6 +34,7 @@ public class RunLog4j1 implements IPerfTestRunner {
         final long opsPerSec = (1000L * 1000L * 1000L * lines) / (s2 - s1);
         histogram.addObservation(opsPerSec);
     }
+
 
     @Override
     public void runLatencyTest(final int samples, final Histogram histogram,
@@ -56,10 +57,12 @@ public class RunLog4j1 implements IPerfTestRunner {
         }
     }
 
+
     @Override
     public void shutdown() {
-        LogManager.shutdown();
+        CoreLoggerContexts.stopLoggerContext(); // stop async thread
     }
+
 
     @Override
     public void log(final String finalMessage) {

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/RunLogback.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/RunLogback.java
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
 import org.slf4j.LoggerFactory;
 

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/SimplePerfTest.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/SimplePerfTest.java
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/YieldIdleStrategy.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/async/YieldIdleStrategy.java
@@ -14,7 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-package org.apache.logging.log4j.core.async.perftest;
+package org.apache.logging.log4j.perf.async;
 
 /**
  * Idle strategy that yields the thread.


### PR DESCRIPTION
By moving the performance tests from `log4j-core` to `log4j-perf`, we can drop the `log4j:log4j` dependency