### PR TITLE
[LOG4J2-2921] Parallel execution for JUnit5 tests

### DIFF
--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -444,6 +444,30 @@
             <org.apache.activemq.SERIALIZABLE_PACKAGES>*</org.apache.activemq.SERIALIZABLE_PACKAGES>
           </systemPropertyVariables>
         </configuration>
+        <executions>
+            <execution>
+                <id>default-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                   <includeJUnit5Engines>junit-jupiter</includeJUnit5Engines>
+                   <forkCount>1C</forkCount>
+                   <runOrder>random</runOrder>
+                </configuration>
+            </execution>
+            <execution>
+                <id>junit4-test</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                    <excludeJUnit5Engines>junit-jupiter</excludeJUnit5Engines>
+                </configuration>
+            </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/log4j-core/src/test/java/org/apache/logging/log4j/junit/PrivateDir.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/junit/PrivateDir.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.junit;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Provides a private directory for the test and registers it with the 'test'
+ * lookup as ${test:privateDir}.
+ *
+ * @see TempDir
+ */
+@Retention(RUNTIME)
+@Target({ FIELD, PARAMETER })
+@Documented
+@Inherited
+@ExtendWith(PrivateDirectoryResolver.class)
+public @interface PrivateDir {
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/junit/PrivateDirectoryResolver.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/junit/PrivateDirectoryResolver.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.junit;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+
+import org.apache.logging.log4j.core.util.ReflectionUtil;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.support.TypeBasedParameterResolver;
+import org.junit.platform.commons.util.AnnotationUtils;
+
+public class PrivateDirectoryResolver extends TypeBasedParameterResolver<Path>
+        implements BeforeAllCallback, BeforeEachCallback {
+
+    private static final String KEY = "privateDir";
+    private static final Path PARENT_PATH = Paths.get("target", KEY);
+    private static final Namespace NAMESPACE = Namespace.create(PrivateDirectoryResolver.class);
+
+    @Override
+    public Path resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return getPrivateDirectory(extensionContext);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        final Class<?> testClass = context.getRequiredTestClass();
+        AnnotationUtils.findAnnotatedFields(testClass, PrivateDir.class,
+                field -> Modifier.isStatic(field.getModifiers()))
+                .forEach(field -> {
+                    final Path privateDir = getPrivateDirectory(context);
+                    ReflectionUtil.setStaticFieldValue(field, privateDir);
+                });
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        final Class<?> testClass = context.getRequiredTestClass();
+        final Object testInstance = context.getRequiredTestInstance();
+        AnnotationUtils.findAnnotatedFields(testClass, PrivateDir.class,
+                field -> !Modifier.isStatic(field.getModifiers()))
+                .forEach(field -> {
+                    final Path privateDir = getPrivateDirectory(context);
+                    ReflectionUtil.setFieldValue(field, testInstance, privateDir);
+                });
+    }
+
+    private Path getPrivateDirectory(ExtensionContext context) {
+        return context.getStore(NAMESPACE)
+                .getOrComputeIfAbsent(KEY, unused -> {
+                    final PathHolder holder = createPrivateDirectory(context.getRequiredTestClass());
+                    TestPropertyResolver.getProperties(context)
+                            .setProperty(KEY, holder.getPath().toString());
+                    return holder;
+                }, PathHolder.class)
+                .getPath();
+    }
+
+    private PathHolder createPrivateDirectory(Class<?> testClass) {
+        try {
+            Files.createDirectories(PARENT_PATH);
+            return new PathHolder(Files.createTempDirectory(PARENT_PATH, testClass.getName()));
+        } catch (IOException e) {
+            throw new ExtensionConfigurationException("Failed to create private directory", e);
+        }
+    }
+
+    private static class PathHolder implements CloseableResource {
+
+        private final Path path;
+
+        public PathHolder(Path path) {
+            this.path = path;
+        }
+
+        public Path getPath() {
+            return path;
+        }
+
+        @Override
+        public void close() throws Throwable {
+            Files.walk(path)
+                    .sorted(Comparator.reverseOrder())
+                    .map(Path::toFile)
+                    .forEach(File::delete);
+        }
+
+    }
+
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/junit/SetTestProperties.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/junit/SetTestProperties.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.junit;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD })
+@Documented
+@Inherited
+public @interface SetTestProperties {
+
+    SetTestProperty[] value();
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/junit/SetTestProperty.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/junit/SetTestProperty.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.junit;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.apache.logging.log4j.test.TestPropertySource;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Registers a Log4j2 system property with the {@link TestPropertySource}. The
+ * property will also be available in configuration files using the
+ * {@code ${test:...} lookup.
+ *
+ */
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD })
+@Inherited
+@Documented
+@ExtendWith(TestPropertyResolver.class)
+@Repeatable(SetTestProperties.class)
+public @interface SetTestProperty {
+
+    String key();
+
+    String value();
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/junit/TestProperties.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/junit/TestProperties.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.junit;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Properties;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * A field or method parameter of type {@link Properties} with {@code @TestProperties} 
+ * will be injected with a per-test copy of Log4j2's system properties.
+ */
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD })
+@Inherited
+@Documented
+@ExtendWith(TestPropertyResolver.class)
+public @interface TestProperties {
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/junit/TestPropertyResolver.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/junit/TestPropertyResolver.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.junit;
+
+import java.lang.reflect.Modifier;
+import java.util.Properties;
+
+import org.apache.logging.log4j.core.util.ReflectionUtil;
+import org.apache.logging.log4j.test.TestPropertySource;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.extension.ExtensionContextException;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.support.TypeBasedParameterResolver;
+import org.junit.platform.commons.util.AnnotationUtils;
+
+public class TestPropertyResolver extends TypeBasedParameterResolver<Properties>
+        implements BeforeAllCallback, BeforeEachCallback {
+
+    private static final Namespace CLASS_NAMESPACE = Namespace.create(TestPropertyResolver.class);
+    private static final Namespace INSTANCE_NAMESPACE = CLASS_NAMESPACE.append("INSTANCE");
+    private static final String KEY = "properties";
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        final SetTestProperty[] setProperties = context.getRequiredTestMethod()
+                .getAnnotationsByType(SetTestProperty.class);
+        if (setProperties.length > 0) {
+            final Properties props = getProperties(context);
+            for (final SetTestProperty setProperty : setProperties) {
+                props.setProperty(setProperty.key(), setProperty.value());
+            }
+        }
+        final Class<?> testClass = context.getRequiredTestClass();
+        Object testInstance = context.getRequiredTestInstance();
+        AnnotationUtils.findAnnotatedFields(testClass, TestProperties.class,
+                field -> !Modifier.isStatic(field.getModifiers()))
+                .forEach(field -> {
+                    final Properties props = getProperties(context);
+                    ReflectionUtil.setFieldValue(field, testInstance, props);
+                });
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        final SetTestProperty[] setProperties = context.getRequiredTestClass()
+                .getAnnotationsByType(SetTestProperty.class);
+        if (setProperties.length > 0) {
+            final Properties props = getProperties(context);
+            for (final SetTestProperty setProperty : setProperties) {
+                props.setProperty(setProperty.key(), setProperty.value());
+            }
+        }
+        final Class<?> testClass = context.getRequiredTestClass();
+        AnnotationUtils.findAnnotatedFields(testClass, TestProperties.class,
+                field -> Modifier.isStatic(field.getModifiers()))
+                .forEach(field -> {
+                    final Properties props = getProperties(context);
+                    ReflectionUtil.setStaticFieldValue(field, props);
+                });
+    }
+
+    static Properties getProperties(ExtensionContext context) {
+        final Namespace namespace = context.getTestInstance().isPresent() ? INSTANCE_NAMESPACE : CLASS_NAMESPACE;
+        return context.getStore(namespace)
+                .getOrComputeIfAbsent(KEY, unused -> {
+                    final Properties parent = TestPropertySource.peek();
+                    final PropertiesHolder holder = new PropertiesHolder(parent);
+                    TestPropertySource.push(holder.getProperties());
+                    return holder;
+                }, PropertiesHolder.class)
+                .getProperties();
+    }
+
+    private static class PropertiesHolder implements CloseableResource {
+
+        private final Properties properties;
+
+        public PropertiesHolder(final Properties defaults) {
+            this.properties = new Properties(defaults);
+        }
+
+        public Properties getProperties() {
+            return properties;
+        }
+
+        @Override
+        public void close() throws Throwable {
+            Properties properties = TestPropertySource.pop();
+            if (!this.properties.equals(properties)) {
+                throw new ExtensionContextException("Test properties corruption.");
+            }
+        }
+
+    }
+
+    @Override
+    public Properties resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return getProperties(extensionContext);
+    }
+}

--- a/log4j-core/src/test/java/org/apache/logging/log4j/test/TestPropertySource.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/test/TestPropertySource.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+
+package org.apache.logging.log4j.test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.lookup.StrLookup;
+import org.apache.logging.log4j.util.PropertySource;
+
+@Plugin(name = "test", category = StrLookup.CATEGORY)
+public class TestPropertySource implements PropertySource, StrLookup {
+
+    private static final ThreadLocal<PropertiesStack> STACK = ThreadLocal.withInitial(PropertiesStack::new);
+    private static final String PREFIX = "log4j2.";
+
+    @Override
+    public int getPriority() {
+        // Highest priority
+        return Integer.MIN_VALUE;
+    }
+
+    private static Properties getProperties(boolean create) {
+        final PropertiesStack stack = STACK.get();
+        Properties props = stack.peek();
+        if (create && props == null) {
+            props = new Properties();
+            stack.push(props);
+        }
+        return props;
+    }
+
+    public static void setProperty(final String key, final String value) {
+        getProperties(true).setProperty(key, value);
+    }
+
+    public static void setProperty(final String key, final boolean value) {
+        setProperty(key, value ? "true" : "false");
+    }
+
+    public static void setProperty(final String key, final int value) {
+        setProperty(key, Integer.toString(value));
+    }
+
+    public static void clearProperty(final String key) {
+        final Properties props = getProperties(false);
+        if (props != null) {
+            props.remove(key);
+        }
+    }
+    public static Properties peek() {
+        return STACK.get().peek();
+    }
+
+    public static void push(Properties props) {
+        STACK.get().push(props);
+    }
+
+    public static Properties pop() {
+        final PropertiesStack stack = STACK.get();
+        final Properties props = stack.pop();
+        if (stack.isEmpty()) {
+            STACK.remove();
+        }
+        return props;
+    }
+
+    @Override
+    public CharSequence getNormalForm(Iterable<? extends CharSequence> tokens) {
+        return PREFIX + Util.joinAsCamelCase(tokens);
+    }
+
+    @Override
+    public String getProperty(String key) {
+        final Properties props = getProperties(false);
+        return props != null ? props.getProperty(key) : null;
+    }
+
+    @Override
+    public boolean containsProperty(String key) {
+        final Properties props = getProperties(false);
+        return props != null ? props.containsKey(key) : false;
+    }
+
+    @Override
+    public String lookup(String key) {
+        return getProperty(key);
+    }
+
+    @Override
+    public String lookup(LogEvent event, String key) {
+        return lookup(key);
+    }
+
+    private static class PropertiesStack {
+
+        private final List<Properties> stack = new ArrayList<>();
+
+        public Properties peek() {
+            if (stack.isEmpty()) {
+                return null;
+            }
+            final int last = stack.size() - 1;
+            return stack.get(last);
+        }
+
+        public Properties pop() {
+            if (stack.isEmpty()) {
+                return null;
+            }
+            final int last = stack.size() - 1;
+            return stack.remove(last);
+        }
+
+        public void push(final Properties props) {
+            stack.add(props);
+        }
+
+        public boolean isEmpty() {
+            return stack.isEmpty();
+        }
+    }
+}

--- a/log4j-core/src/test/resources/META-INF/services/org.apache.logging.log4j.util.PropertySource
+++ b/log4j-core/src/test/resources/META-INF/services/org.apache.logging.log4j.util.PropertySource
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache license, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the license for the specific language governing permissions and
+# limitations under the license.
+
+org.apache.logging.log4j.test.TestPropertySource

--- a/log4j-core/src/test/resources/log4j2-mutableFilter.xml
+++ b/log4j-core/src/test/resources/log4j2-mutableFilter.xml
@@ -17,7 +17,7 @@
 
 -->
 <Configuration name="ConfigTest" status="ERROR">
-  <MutableThreadContextMapFilter  configLocation="${sys:configLocation}" pollInterval="1" onMatch="ACCEPT" onMismatch="NEUTRAL">
+  <MutableThreadContextMapFilter  configLocation="${test:configLocation}" pollInterval="1" onMatch="ACCEPT" onMismatch="NEUTRAL">
   </MutableThreadContextMapFilter>
   <Appenders>
     <Console name="STDOUT">


### PR DESCRIPTION
Unit tests in `release-2.x` are executed sequentially in per-test JVMs. While parallel execution in a single JVM requires a lot of work, this PR makes a step in this direction: the tests based on JUnit5 in `log4j-core` (about 50% of the tests) are executed in per-test JVMs, but in parallel.

This requires only a private/temporary directory for each test to store its logs (@PrivateDir extension), so that tests using the same file names don't clash.

As a preliminary step to phase 2 (running multiple JVMs in parallel and reusing them for multiple tests), this PR also introduces a thread-bound property source/lookup that can be retrieved with the @TestProperties annotation (or @SetTestProperty).