### PR TITLE
LOG4J2-3537 Fixes problem with wrong ANSI escape code for bright colors

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/AnsiEscape.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/AnsiEscape.java
@@ -59,8 +59,17 @@ public enum AnsiEscape {
 
     /**
      * Bright general attribute.
+     *
+     * @deprecated This attribute sets font-weight as "bold" and doesn't set color brightness. Use BOLD if you
+     * need to change font-weight and BRIGHT_* to use a bright color.
+     *
      */
     BRIGHT("1"),
+
+    /**
+     * Bold general attribute.
+     */
+    BOLD("1"),
 
     /**
      * Dim general attribute.
@@ -215,7 +224,127 @@ public enum AnsiEscape {
     /**
      * White background color.
      */
-    BG_WHITE("47");
+    BG_WHITE("47"),
+
+    /**
+     * Bright black foreground color.
+     */
+    BRIGHT_BLACK("90"),
+
+    /**
+     * Bright black foreground color.
+     */
+    FG_BRIGHT_BLACK("90"),
+
+    /**
+     * Bright red foreground color.
+     */
+    BRIGHT_RED("91"),
+
+    /**
+     * Bright red foreground color.
+     */
+    FG_BRIGHT_RED("91"),
+
+    /**
+     * Bright green foreground color.
+     */
+    BRIGHT_GREEN("92"),
+
+    /**
+     * Bright green foreground color.
+     */
+    FG_BRIGHT_GREEN("92"),
+
+    /**
+     * Bright yellow foreground color.
+     */
+    BRIGHT_YELLOW("93"),
+
+    /**
+     * Bright yellow foreground color.
+     */
+    FG_BRIGHT_YELLOW("93"),
+
+    /**
+     * Bright blue foreground color.
+     */
+    BRIGHT_BLUE("94"),
+
+    /**
+     * Bright blue foreground color.
+     */
+    FG_BRIGHT_BLUE("94"),
+
+    /**
+     * Bright magenta foreground color.
+     */
+    BRIGHT_MAGENTA("95"),
+
+    /**
+     * Bright magenta foreground color.
+     */
+    FG_BRIGHT_MAGENTA("95"),
+
+    /**
+     * Bright cyan foreground color.
+     */
+    BRIGHT_CYAN("96"),
+
+    /**
+     * Bright cyan foreground color.
+     */
+    FG_BRIGHT_CYAN("96"),
+
+    /**
+     * Bright white foreground color.
+     */
+    BRIGHT_WHITE("97"),
+
+    /**
+     * Bright white foreground color.
+     */
+    FG_BRIGHT_WHITE("97"),
+
+    /**
+     * Bright black background color.
+     */
+    BG_BRIGHT_BLACK("100"),
+
+    /**
+     * Bright red background color.
+     */
+    BG_BRIGHT_RED("101"),
+
+    /**
+     * Bright green background color.
+     */
+    BG_BRIGHT_GREEN("102"),
+
+    /**
+     * Bright yellow background color.
+     */
+    BG_BRIGHT_YELLOW("103"),
+
+    /**
+     * Bright blue background color.
+     */
+    BG_BRIGHT_BLUE("104"),
+
+    /**
+     * Bright magenta background color.
+     */
+    BG_BRIGHT_MAGENTA("105"),
+
+    /**
+     * Bright cyan background color.
+     */
+    BG_BRIGHT_CYAN("106"),
+
+    /**
+     * Bright white background color.
+     */
+    BG_BRIGHT_WHITE("107");
 
     private static final String DEFAULT_STYLE = CSI.getCode() + SUFFIX.getCode();
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/HighlightConverterTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/pattern/HighlightConverterTest.java
@@ -77,6 +77,36 @@ public class HighlightConverterTest {
     }
 
     @Test
+    public void testLevelNamesBrightShort() {
+        final String colorName = "bright_red";
+        final String[] options = {"%-5level: %msg", PatternParser.NO_CONSOLE_NO_ANSI + "=false, "
+                + PatternParser.DISABLE_ANSI + "=false, " + "INFO=" + colorName};
+        final HighlightConverter converter = HighlightConverter.newInstance(null, options);
+        assertNotNull(converter);
+
+        final LogEvent event = Log4jLogEvent.newBuilder().setLevel(Level.INFO).setLoggerName("a.b.c").setMessage(
+                new SimpleMessage("")).build();
+        final StringBuilder buffer = new StringBuilder();
+        converter.format(event, buffer);
+        assertEquals("\u001B[91mINFO : \u001B[m", buffer.toString());
+    }
+
+    @Test
+    public void testLevelNamesBrightFull() {
+        final String colorName = "fg_bright_red bg_bright_blue bold";
+        final String[] options = {"%-5level: %msg", PatternParser.NO_CONSOLE_NO_ANSI + "=false, "
+                + PatternParser.DISABLE_ANSI + "=false, " + "INFO=" + colorName};
+        final HighlightConverter converter = HighlightConverter.newInstance(null, options);
+        assertNotNull(converter);
+
+        final LogEvent event = Log4jLogEvent.newBuilder().setLevel(Level.INFO).setLoggerName("a.b.c").setMessage(
+                new SimpleMessage("")).build();
+        final StringBuilder buffer = new StringBuilder();
+        converter.format(event, buffer);
+        assertEquals("\u001B[91;104;1mINFO : \u001B[m", buffer.toString());
+    }
+
+    @Test
     public void testLevelNamesUnknown() {
         final String colorName = "blue";
         final String[] options = { "%level", PatternParser.NO_CONSOLE_NO_ANSI + "=false, " + PatternParser.DISABLE_ANSI
@@ -96,7 +126,7 @@ public class HighlightConverterTest {
                 toFormattedCharSeq(converter, Level.forName("CUSTOM1", 412)).toString().getBytes());
         assertArrayEquals(new byte[] { 'C', 'U', 'S', 'T', 'O', 'M', '2' },
                 toFormattedCharSeq(converter, Level.forName("CUSTOM2", 512)).toString().getBytes());
-    }    
+    }
 
     @Test
     public void testLevelNamesNone() {

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -160,6 +160,9 @@
       <action issue="LOG4J2-3531" dev="pkarwasz" type="fix" due-to="Simo Nikula, Piotr P. Karwasz">
         Fix parsing error, when XInclude is disabled.
       </action>
+      <action issue="LOG4J2-3537" dev="pavel_k" type="fix" due-to="Pavel_K">
+        Fixes problem with wrong ANSI escape code for bright colors
+      </action>      
     </release>
     <release version="2.17.2" date="2022-02-23" description="GA Release 2.17.2">
       <!-- FIXES -->

--- a/src/site/xdoc/manual/layouts.xml.vm
+++ b/src/site/xdoc/manual/layouts.xml.vm
@@ -1338,7 +1338,7 @@ WARN  [main]: Message 2</pre>
                  <pre>%highlight{%d [%t] %-5level: %msg%n%throwable}{FATAL=white, ERROR=red, WARN=bright_blue, INFO=black, DEBUG=bright_green, TRACE=blue}</pre>
  #end
                 </p>
-                <p>At the same time it is possible to use 24 bit colors. For example:
+                <p>At the same time it is possible to use true colors (24 bit) colors. For example:
  #if ($isPDF)
                  <pre>%highlight{%d [%t] %-5level: %msg%n%throwable}
    {FATAL=white, ERROR=red, WARN=bg_#5792e6 fg_#eef26b bold, INFO=black,

--- a/src/site/xdoc/manual/layouts.xml.vm
+++ b/src/site/xdoc/manual/layouts.xml.vm
@@ -1338,7 +1338,7 @@ WARN  [main]: Message 2</pre>
                  <pre>%highlight{%d [%t] %-5level: %msg%n%throwable}{FATAL=white, ERROR=red, WARN=bright_blue, INFO=black, DEBUG=bright_green, TRACE=blue}</pre>
  #end
                 </p>
-                <p>At the same time it is possible to use true colors (24 bit) colors. For example:
+                <p>At the same time it is possible to use true colors (24 bit). For example:
  #if ($isPDF)
                  <pre>%highlight{%d [%t] %-5level: %msg%n%throwable}
    {FATAL=white, ERROR=red, WARN=bg_#5792e6 fg_#eef26b bold, INFO=black,

--- a/src/site/xdoc/manual/layouts.xml.vm
+++ b/src/site/xdoc/manual/layouts.xml.vm
@@ -1332,10 +1332,19 @@ WARN  [main]: Message 2</pre>
                 <p>You can override the default colors in the optional {style} option. For example:
  #if ($isPDF)
                  <pre>%highlight{%d [%t] %-5level: %msg%n%throwable}
-   {FATAL=white, ERROR=red, WARN=blue, INFO=black,
-    DEBUG=green, TRACE=blue}</pre>
+   {FATAL=white, ERROR=red, WARN=bright_blue, INFO=black,
+    DEBUG=bright_green, TRACE=blue}</pre>
  #else
-                 <pre>%highlight{%d [%t] %-5level: %msg%n%throwable}{FATAL=white, ERROR=red, WARN=blue, INFO=black, DEBUG=green, TRACE=blue}</pre>
+                 <pre>%highlight{%d [%t] %-5level: %msg%n%throwable}{FATAL=white, ERROR=red, WARN=bright_blue, INFO=black, DEBUG=bright_green, TRACE=blue}</pre>
+ #end
+                </p>
+                <p>At the same time it is possible to use 24 bit colors. For example:
+ #if ($isPDF)
+                 <pre>%highlight{%d [%t] %-5level: %msg%n%throwable}
+   {FATAL=white, ERROR=red, WARN=bg_#5792e6 fg_#eef26b bold, INFO=black,
+    DEBUG=#3fe0a8, TRACE=blue}</pre>
+ #else
+                 <pre>%highlight{%d [%t] %-5level: %msg%n%throwable}{FATAL=white, ERROR=red, WARN=bg_#5792e6 fg_#eef26b bold, INFO=black, DEBUG=#3fe0a8, TRACE=blue}</pre>
  #end
                 </p>
                 <p>You can highlight only the a portion of the log event:

--- a/src/site/xdoc/manual/layouts.xml.vm
+++ b/src/site/xdoc/manual/layouts.xml.vm
@@ -1338,15 +1338,6 @@ WARN  [main]: Message 2</pre>
                  <pre>%highlight{%d [%t] %-5level: %msg%n%throwable}{FATAL=white, ERROR=red, WARN=bright_blue, INFO=black, DEBUG=bright_green, TRACE=blue}</pre>
  #end
                 </p>
-                <p>At the same time it is possible to use true colors (24 bit). For example:
- #if ($isPDF)
-                 <pre>%highlight{%d [%t] %-5level: %msg%n%throwable}
-   {FATAL=white, ERROR=red, WARN=bg_#5792e6 fg_#eef26b bold, INFO=black,
-    DEBUG=#3fe0a8, TRACE=blue}</pre>
- #else
-                 <pre>%highlight{%d [%t] %-5level: %msg%n%throwable}{FATAL=white, ERROR=red, WARN=bg_#5792e6 fg_#eef26b bold, INFO=black, DEBUG=#3fe0a8, TRACE=blue}</pre>
- #end
-                </p>
                 <p>You can highlight only the a portion of the log event:
                  <pre>%d [%t] %highlight{%-5level: %msg%n%throwable}</pre>
                 </p>


### PR DESCRIPTION
Here it is. Please, check.