### PR TITLE
[LOG4J2-3360] Pin codeql-action/init to a full length commit SHA

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@935969c6f771d9f0a35efa2ae9cf7c10d9886ca3    # 2.8.5
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.


### PR DESCRIPTION
As part of LOG4J2-3360 GitHub Action versions were replaced by commit checksums, except for github/codeql-action/init. This was probably an oversight.