### PR TITLE
LOG4J2-3560: Logger$PrivateConfig.filter(Level, Marker, String) varargs does not allocate

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/Filter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/Filter.java
@@ -20,6 +20,7 @@ package org.apache.logging.log4j.core;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.EnglishEnums;
 
 /**
@@ -305,24 +306,10 @@ public interface Filter extends LifeCycle {
      * @param level The event logging Level.
      * @param marker The Marker for the event or null.
      * @param msg The Message
-     * @param t A Throwable or null.
      * @return the Result.
      */
-    default Result filter(Logger logger, Level level, Marker marker, String msg, Throwable t) {
-        return filter(logger, level, marker, (CharSequence) msg, t);
-    }
-
-    /**
-     * Filter an event.
-     * @param logger The Logger.
-     * @param level The event logging Level.
-     * @param marker The Marker for the event or null.
-     * @param msg The Message
-     * @param t A Throwable or null.
-     * @return the Result.
-     */
-    default Result filter(Logger logger, Level level, Marker marker, CharSequence msg, Throwable t) {
-        return filter(logger, level, marker, (Object) msg, t);
+    default Result filter(Logger logger, Level level, Marker marker, String msg) {
+        return filter(logger, level, marker, msg, Constants.EMPTY_OBJECT_ARRAY);
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/Filter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/Filter.java
@@ -301,6 +301,32 @@ public interface Filter extends LifeCycle {
 
     /**
      * Filter an event.
+     * @param logger The Logger.
+     * @param level The event logging Level.
+     * @param marker The Marker for the event or null.
+     * @param msg The Message
+     * @param t A Throwable or null.
+     * @return the Result.
+     */
+    default Result filter(Logger logger, Level level, Marker marker, String msg, Throwable t) {
+        return filter(logger, level, marker, (CharSequence) msg, t);
+    }
+
+    /**
+     * Filter an event.
+     * @param logger The Logger.
+     * @param level The event logging Level.
+     * @param marker The Marker for the event or null.
+     * @param msg The Message
+     * @param t A Throwable or null.
+     * @return the Result.
+     */
+    default Result filter(Logger logger, Level level, Marker marker, CharSequence msg, Throwable t) {
+        return filter(logger, level, marker, (Object) msg, t);
+    }
+
+    /**
+     * Filter an event.
      * @param event The Event to filter on.
      * @return the Result.
      */

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
@@ -53,9 +53,6 @@ public class Logger extends AbstractLogger implements Supplier<LoggerConfig> {
 
     private static final long serialVersionUID = 1L;
 
-    // Used to avoid allocations for empty varargs
-    private static final Object[] EMPTY_VARARGS = new Object[] {};
-
     /**
      * Config should be consistent across threads.
      */
@@ -436,7 +433,7 @@ public class Logger extends AbstractLogger implements Supplier<LoggerConfig> {
         boolean filter(final Level level, final Marker marker, final String msg) {
             final Filter filter = config.getFilter();
             if (filter != null) {
-                final Filter.Result r = filter.filter(logger, level, marker, msg, EMPTY_VARARGS);
+                final Filter.Result r = filter.filter(logger, level, marker, msg, (Throwable) null);
                 if (r != Filter.Result.NEUTRAL) {
                     return r == Filter.Result.ACCEPT;
                 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
@@ -54,7 +54,7 @@ public class Logger extends AbstractLogger implements Supplier<LoggerConfig> {
     private static final long serialVersionUID = 1L;
 
     // Used to avoid allocations for empty varargs
-    private static final Object[] EMPTY_VARARGS = new Object[0];
+    private static final Object[] EMPTY_VARARGS = new Object[] {};
 
     /**
      * Config should be consistent across threads.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
@@ -53,6 +53,9 @@ public class Logger extends AbstractLogger implements Supplier<LoggerConfig> {
 
     private static final long serialVersionUID = 1L;
 
+    // Used to avoid allocations for empty varargs
+    private static final Object[] EMPTY_VARARGS = new Object[0];
+
     /**
      * Config should be consistent across threads.
      */
@@ -433,7 +436,7 @@ public class Logger extends AbstractLogger implements Supplier<LoggerConfig> {
         boolean filter(final Level level, final Marker marker, final String msg) {
             final Filter filter = config.getFilter();
             if (filter != null) {
-                final Filter.Result r = filter.filter(logger, level, marker, msg);
+                final Filter.Result r = filter.filter(logger, level, marker, msg, EMPTY_VARARGS);
                 if (r != Filter.Result.NEUTRAL) {
                     return r == Filter.Result.ACCEPT;
                 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
@@ -172,7 +172,7 @@ public class Logger extends AbstractLogger implements Supplier<LoggerConfig> {
 
     @Override
     public boolean isEnabled(final Level level, final Marker marker, final String message) {
-        return privateConfig.filter(level, marker, message);
+        return privateConfig.filter(level, marker, message, (Throwable) null);
     }
 
     @Override
@@ -428,10 +428,6 @@ public class Logger extends AbstractLogger implements Supplier<LoggerConfig> {
         // LOG4J2-151: changed visibility to public
         public void logEvent(final LogEvent event) {
             loggerConfig.log(event);
-        }
-
-        boolean filter(final Level level, final Marker marker, final String msg) {
-            return filter(level, marker, msg, (Throwable) null);
         }
 
         boolean filter(final Level level, final Marker marker, final String msg, final Throwable t) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
@@ -431,14 +431,7 @@ public class Logger extends AbstractLogger implements Supplier<LoggerConfig> {
         }
 
         boolean filter(final Level level, final Marker marker, final String msg) {
-            final Filter filter = config.getFilter();
-            if (filter != null) {
-                final Filter.Result r = filter.filter(logger, level, marker, msg, (Throwable) null);
-                if (r != Filter.Result.NEUTRAL) {
-                    return r == Filter.Result.ACCEPT;
-                }
-            }
-            return level != null && intLevel >= level.intLevel();
+            return filter(level, marker, msg, (Throwable) null);
         }
 
         boolean filter(final Level level, final Marker marker, final String msg, final Throwable t) {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/GcFreeLoggingTestUtil.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/GcFreeLoggingTestUtil.java
@@ -18,6 +18,7 @@ package org.apache.logging.log4j.core;
 
 import com.google.monitoring.runtime.instrumentation.AllocationRecorder;
 import com.google.monitoring.runtime.instrumentation.Sampler;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
@@ -57,6 +58,7 @@ public enum GcFreeLoggingTestUtil {;
         final Marker testGrandParent = MarkerManager.getMarker("testGrandParent");
         final Marker testParent = MarkerManager.getMarker("testParent").setParents(testGrandParent);
         final Marker test = MarkerManager.getMarker("test").setParents(testParent); // initial creation, value is cached
+        final StringMapMessage mapMessage = new StringMapMessage().with("eventId", "Login");
 
         // initialize LoggerContext etc.
         // This is not steady-state logging and will allocate objects.
@@ -69,6 +71,7 @@ public enum GcFreeLoggingTestUtil {;
         logger.error("Sample error message");
         logger.error("Test parameterized message {}", "param");
         logger.error(new StringMapMessage().with("eventId", "Login")); // initialize GelfLayout's messageStringBuilder
+        singleLoggingIteration(logger, myCharSeq, mapMessage);
         for (int i = 0; i < 256; i++) {
             logger.debug("ensure all ringbuffer slots have been used once"); // allocate MutableLogEvent.messageText
         }
@@ -100,7 +103,6 @@ public enum GcFreeLoggingTestUtil {;
             new RuntimeException().printStackTrace();
         };
         Thread.sleep(500);
-        final StringMapMessage mapMessage = new StringMapMessage().with("eventId", "Login");
         AllocationRecorder.addSampler(sampler);
 
         // now do some steady-state logging
@@ -110,13 +112,7 @@ public enum GcFreeLoggingTestUtil {;
 
         final int ITERATIONS = 5;
         for (int i = 0; i < ITERATIONS; i++) {
-            logger.error(myCharSeq);
-            logger.error(MarkerManager.getMarker("test"), myCharSeq);
-            logger.error("Test message");
-            logger.error("Test parameterized message {}", "param");
-            logger.error("Test parameterized message {}{}", "param", "param2");
-            logger.error("Test parameterized message {}{}{}", "param", "param2", "abc");
-            logger.error(mapMessage); // LOG4J2-1683
+            singleLoggingIteration(logger, myCharSeq, mapMessage);
             ThreadContext.remove("aKey");
             ThreadContext.put("aKey", "value1");
         }
@@ -124,6 +120,89 @@ public enum GcFreeLoggingTestUtil {;
         samplingEnabled.set(false); // reliably ignore all allocations from now on
         AllocationRecorder.removeSampler(sampler);
         Thread.sleep(100);
+    }
+
+    private static void singleLoggingIteration(
+            final org.apache.logging.log4j.Logger logger,
+            final MyCharSeq myCharSeq,
+            final StringMapMessage mapMessage) {
+        logger.isEnabled(Level.TRACE);
+        logger.isEnabled(Level.TRACE, MarkerManager.getMarker("test"));
+        logger.isTraceEnabled();
+        logger.isTraceEnabled(MarkerManager.getMarker("test"));
+        logger.trace(myCharSeq);
+        logger.trace(MarkerManager.getMarker("test"), myCharSeq);
+        logger.trace("Test message");
+        logger.trace("Test parameterized message {}", "param");
+        logger.trace("Test parameterized message {}{}", "param", "param2");
+        logger.trace("Test parameterized message {}{}{}", "param", "param2", "abc");
+        logger.trace(MarkerManager.getMarker("test"), "Test parameterized message {}{}{}", "param", "param2", "abc");
+        logger.trace(mapMessage); // LOG4J2-1683
+
+        logger.isEnabled(Level.DEBUG);
+        logger.isEnabled(Level.DEBUG, MarkerManager.getMarker("test"));
+        logger.isDebugEnabled();
+        logger.isDebugEnabled(MarkerManager.getMarker("test"));
+        logger.debug(myCharSeq);
+        logger.debug(MarkerManager.getMarker("test"), myCharSeq);
+        logger.debug("Test message");
+        logger.debug("Test parameterized message {}", "param");
+        logger.debug("Test parameterized message {}{}", "param", "param2");
+        logger.debug("Test parameterized message {}{}{}", "param", "param2", "abc");
+        logger.debug(MarkerManager.getMarker("test"), "Test parameterized message {}{}{}", "param", "param2", "abc");
+        logger.debug(mapMessage); // LOG4J2-1683
+
+        logger.isEnabled(Level.INFO);
+        logger.isEnabled(Level.INFO, MarkerManager.getMarker("test"));
+        logger.isInfoEnabled();
+        logger.isInfoEnabled(MarkerManager.getMarker("test"));
+        logger.info(myCharSeq);
+        logger.info(MarkerManager.getMarker("test"), myCharSeq);
+        logger.info("Test message");
+        logger.info("Test parameterized message {}", "param");
+        logger.info("Test parameterized message {}{}", "param", "param2");
+        logger.info("Test parameterized message {}{}{}", "param", "param2", "abc");
+        logger.info(MarkerManager.getMarker("test"), "Test parameterized message {}{}{}", "param", "param2", "abc");
+        logger.info(mapMessage); // LOG4J2-1683
+
+        logger.isEnabled(Level.WARN);
+        logger.isEnabled(Level.WARN, MarkerManager.getMarker("test"));
+        logger.isWarnEnabled();
+        logger.isWarnEnabled(MarkerManager.getMarker("test"));
+        logger.warn(myCharSeq);
+        logger.warn(MarkerManager.getMarker("test"), myCharSeq);
+        logger.warn("Test message");
+        logger.warn("Test parameterized message {}", "param");
+        logger.warn("Test parameterized message {}{}", "param", "param2");
+        logger.warn("Test parameterized message {}{}{}", "param", "param2", "abc");
+        logger.warn(MarkerManager.getMarker("test"), "Test parameterized message {}{}{}", "param", "param2", "abc");
+        logger.warn(mapMessage); // LOG4J2-1683
+
+        logger.isEnabled(Level.ERROR);
+        logger.isEnabled(Level.ERROR, MarkerManager.getMarker("test"));
+        logger.isErrorEnabled();
+        logger.isErrorEnabled(MarkerManager.getMarker("test"));
+        logger.error(myCharSeq);
+        logger.error(MarkerManager.getMarker("test"), myCharSeq);
+        logger.error("Test message");
+        logger.error("Test parameterized message {}", "param");
+        logger.error("Test parameterized message {}{}", "param", "param2");
+        logger.error("Test parameterized message {}{}{}", "param", "param2", "abc");
+        logger.error(MarkerManager.getMarker("test"), "Test parameterized message {}{}{}", "param", "param2", "abc");
+        logger.error(mapMessage); // LOG4J2-1683
+
+        logger.isEnabled(Level.FATAL);
+        logger.isEnabled(Level.FATAL, MarkerManager.getMarker("test"));
+        logger.isFatalEnabled();
+        logger.isFatalEnabled(MarkerManager.getMarker("test"));
+        logger.fatal(myCharSeq);
+        logger.fatal(MarkerManager.getMarker("test"), myCharSeq);
+        logger.fatal("Test message");
+        logger.fatal("Test parameterized message {}", "param");
+        logger.fatal("Test parameterized message {}{}", "param", "param2");
+        logger.fatal("Test parameterized message {}{}{}", "param", "param2", "abc");
+        logger.fatal(MarkerManager.getMarker("test"), "Test parameterized message {}{}{}", "param", "param2", "abc");
+        logger.fatal(mapMessage); // LOG4J2-1683
     }
 
     public static void runTest(final Class<?> cls) throws Exception {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/LoggerTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/LoggerTest.java
@@ -24,7 +24,6 @@ import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.filter.AbstractFilter;
 import org.apache.logging.log4j.junit.LoggerContextSource;
 import org.apache.logging.log4j.junit.Named;
 import org.apache.logging.log4j.junit.ReconfigurationPolicy;
@@ -49,7 +48,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.jupiter.api.Assertions.*;
@@ -122,7 +120,7 @@ public class LoggerTest {
         final List<LogEvent> events = app.getEvents();
         assertEventCount(events, 3);
         assertEquals(
-                "org.apache.logging.log4j.core.LoggerTest.builder(LoggerTest.java:118)", events.get(0).getSource().toString(),
+                "org.apache.logging.log4j.core.LoggerTest.builder(LoggerTest.java:116)", events.get(0).getSource().toString(),
                 "Incorrect location");
         assertEquals(Level.DEBUG, events.get(0).getLevel(), "Incorrect Level");
         MatcherAssert.assertThat("Incorrect message", events.get(1).getMessage().getFormattedMessage(), equalTo("Hello John"));
@@ -536,29 +534,6 @@ public class LoggerTest {
         logger.throwing(new IllegalArgumentException("Test Exception"));
         final List<LogEvent> events = app.getEvents();
         assertEventCount(events, 1);
-    }
-
-    @Test
-    public void isEnabledDoesNotAllocateWithFilter(final LoggerContext context) {
-        final AtomicInteger filterCount = new AtomicInteger();
-        context.addFilter(new AbstractFilter() {
-            @Override
-            public Result filter(Logger logger, Level level, Marker marker, String message) {
-                filterCount.getAndIncrement();
-                return super.filter(logger, level, marker, message);
-            }
-        });
-        final Logger testLogger = context.getLogger("org.apache.logging.log4j.core.LoggerTest");
-
-        assertEquals(0, filterCount.get());
-        testLogger.isDebugEnabled();
-        assertEquals(1, filterCount.get());
-        testLogger.debug("debug enabled");
-        assertEquals(1, filterCount.get()); // only enabled checks hit our filter
-        testLogger.isInfoEnabled();
-        assertEquals(2, filterCount.get());
-        testLogger.info("debug disabled");
-        assertEquals(2, filterCount.get()); // only enabled checks hit our filter
     }
 }
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/LoggerTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/LoggerTest.java
@@ -543,9 +543,9 @@ public class LoggerTest {
         final AtomicInteger filterCount = new AtomicInteger();
         context.addFilter(new AbstractFilter() {
             @Override
-            public Result filter(Logger logger, Level level, Marker marker, Object msg, Throwable t) {
+            public Result filter(Logger logger, Level level, Marker marker, String message) {
                 filterCount.getAndIncrement();
-                return super.filter(logger, level, marker, msg, t);
+                return super.filter(logger, level, marker, message);
             }
         });
         final Logger testLogger = context.getLogger("org.apache.logging.log4j.core.LoggerTest");
@@ -554,11 +554,11 @@ public class LoggerTest {
         testLogger.isDebugEnabled();
         assertEquals(1, filterCount.get());
         testLogger.debug("debug enabled");
-        assertEquals(2, filterCount.get());
+        assertEquals(1, filterCount.get()); // only enabled checks hit our filter
         testLogger.isInfoEnabled();
-        assertEquals(3, filterCount.get());
+        assertEquals(2, filterCount.get());
         testLogger.info("debug disabled");
-        assertEquals(4, filterCount.get());
+        assertEquals(2, filterCount.get()); // only enabled checks hit our filter
     }
 }
 

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -33,6 +33,9 @@
       <action issue="LOG4J2-3550" dev="rgoers" type="fix" due-to="DongjianPeng">
         SystemPropertyAribiter was assigning the value as the name.
       </action>
+      <action issue="LOG4J2-3560" dev="schlosna" type="fix">
+        Logger$PrivateConfig.filter(Level, Marker, String) was allocating empty varargs array.
+      </action>
     </release>
     <release version="2.18.0" date="2022-06-28" description="GA Release 2.18.0">
       <action issue="LOG4J2-3339" dev="rgoers" type="fix">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -33,7 +33,7 @@
       <action issue="LOG4J2-3550" dev="rgoers" type="fix" due-to="DongjianPeng">
         SystemPropertyAribiter was assigning the value as the name.
       </action>
-      <action issue="LOG4J2-3560" dev="schlosna" type="fix">
+      <action issue="LOG4J2-3560" dev="ckozak" type="fix" due-to="David Schlosnagle">
         Logger$PrivateConfig.filter(Level, Marker, String) was allocating empty varargs array.
       </action>
     </release>


### PR DESCRIPTION
Fixes [LOG4J2-3560](https://issues.apache.org/jira/browse/LOG4J2-3560)

While reviewing some JFR profiles, I notice significant allocations of `Object[]` due to use of some `isEnabled` conditions that ends up using empty varargs invoking `org.apache.logging.log4j.core.Filter#filter(Logger, Level, Marker, String, Object...)`, for example the following call trace:

```
at org.apache.logging.log4j.core.Logger$PrivateConfig.filter(Level, Marker, String)
at org.apache.logging.log4j.core.Logger.isEnabled(Level, Marker, String)
```

We can avoid allocation on this hot path when invoking `Filter#filter(Logger, Level, Marker, String, Object...)` by reusing an empty object array for the varargs.