### PR TITLE
[LOG4J2-3559] Correct normalization problem.

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/EnvironmentPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/EnvironmentPropertySource.java
@@ -64,13 +64,15 @@ public class EnvironmentPropertySource implements PropertySource {
 	@Override
 	public CharSequence getNormalForm(final Iterable<? extends CharSequence> tokens) {
 		final StringBuilder sb = new StringBuilder("LOG4J");
+		boolean empty = true;
 		for (final CharSequence token : tokens) {
+			empty = false;
 			sb.append('_');
 			for (int i = 0; i < token.length(); i++) {
 				sb.append(Character.toUpperCase(token.charAt(i)));
 			}
 		}
-		return sb.toString();
+		return empty ? null : sb.toString();
 	}
 
 	@Override

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
@@ -58,7 +58,8 @@ public class PropertiesPropertySource implements PropertySource {
 
     @Override
     public CharSequence getNormalForm(final Iterable<? extends CharSequence> tokens) {
-        return PREFIX + Util.joinAsCamelCase(tokens);
+        final CharSequence camelCase = Util.joinAsCamelCase(tokens);
+        return camelCase.length() > 0 ? PREFIX + camelCase : null;
     }
 
     @Override

--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/EnvironmentPropertySourceTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/EnvironmentPropertySourceTest.java
@@ -35,6 +35,7 @@ public class EnvironmentPropertySourceTest {
             {"LOG4J_FOO_BAR_PROPERTY", Arrays.asList("foo", "bar", "property")},
             {"LOG4J_EXACT", Collections.singletonList("EXACT")},
             {"LOG4J_TEST_PROPERTY_NAME", PropertySource.Util.tokenize("Log4jTestPropertyName")},
+            {null, Collections.emptyList()}
         };
     }
 

--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/PropertiesPropertySourceTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/PropertiesPropertySourceTest.java
@@ -36,6 +36,7 @@ public class PropertiesPropertySourceTest {
             {"log4j2.fooBarProperty", Arrays.asList("foo", "bar", "property")},
             {"log4j2.EXACT", Collections.singletonList("EXACT")},
             {"log4j2.testPropertyName", PropertySource.Util.tokenize("Log4jTestPropertyName")},
+            {null, Collections.emptyList()}
         };
     }
 

--- a/log4j-api/src/test/java/org/apache/logging/log4j/util/PropertiesUtilTest.java
+++ b/log4j-api/src/test/java/org/apache/logging/log4j/util/PropertiesUtilTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
+import org.junitpioneer.jupiter.ReadsSystemProperty;
+import org.junitpioneer.jupiter.SetSystemProperty;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -147,5 +149,21 @@ public class PropertiesUtilTest {
         for (final String[] pair : data) {
             assertEquals(pair[0], util.getStringProperty(pair[1]));
         }
+    }
+
+    /**
+     * LOG4J2-3559: the fix for LOG4J2-3413 returns the value of 'log4j2.' for each
+     * property not starting with 'log4j'.
+     */
+    @Test
+    @ReadsSystemProperty
+    public void testLog4jProperty() {
+        final Properties props = new Properties();
+        final String incorrect = "log4j2.";
+        final String correct = "not.starting.with.log4j";
+        props.setProperty(incorrect, incorrect);
+        props.setProperty(correct, correct);
+        final PropertiesUtil util = new PropertiesUtil(props);
+        assertEquals(correct, util.getStringProperty(correct));
     }
 }

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -54,6 +54,9 @@
       <action issue="LOG4J2-3565" dev="dafengsu7" type="fix">
         Fix RollingRandomAccessFileAppender with DirectWriteRolloverStrategy can't create the first log file of different directory.
       </action>
+      <action issue="LOG4J2-3559" dev="pkarwasz" type="fix" due-to="Gary Gregory">
+        Fix resolution of properties not starting with `log4j2.`.
+      </action>
     </release>
     <release version="2.18.0" date="2022-06-28" description="GA Release 2.18.0">
       <action issue="LOG4J2-3339" dev="rgoers" type="fix">


### PR DESCRIPTION
Properties not starting with 'log4j' are normalized to 'LOG4J' for environment variables and 'log4j2.' for system properties. This PR
normalizes them to `null`.

@garydgregory, can you check if it solves your problem?