### PR TITLE
[LOG4J2-3565] Fix RollingRandomAccessFileAppender with DirectWriteRol…

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
@@ -139,10 +139,7 @@ public class RollingRandomAccessFileManager extends RollingFileManager {
     protected synchronized void writeToDestination(final byte[] bytes, final int offset, final int length) {
         try {
             if (randomAccessFile == null) {
-                final String fileName = getFileName();
-                final File file = new File(fileName);
-                FileUtils.makeParentDirs(file);
-                createFileAfterRollover(fileName);
+                createFileAfterRollover();
             }
             randomAccessFile.write(bytes, offset, length);
             size += length;
@@ -154,7 +151,10 @@ public class RollingRandomAccessFileManager extends RollingFileManager {
 
     @Override
     protected void createFileAfterRollover() throws IOException {
-        createFileAfterRollover(getFileName());
+        final String fileName = getFileName();
+        final File file = new File(fileName);
+        FileUtils.makeParentDirs(file);
+        createFileAfterRollover(fileName);
     }
 
     private void createFileAfterRollover(final String fileName) throws IOException {

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAppenderDirectWriteAndSwitchDirectorTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAppenderDirectWriteAndSwitchDirectorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.appender.rolling;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.junit.LoggerContextRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.File;
+import java.time.LocalTime;
+
+import static org.apache.logging.log4j.hamcrest.Descriptors.that;
+import static org.apache.logging.log4j.hamcrest.FileMatchers.hasName;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ */
+public class RollingRandomAppenderDirectWriteAndSwitchDirectorTest {
+
+    private static final String CONFIG = "log4j-rolling-random-direct-switch-director.xml";
+
+    private static final String DIR = "target/rolling-random-direct-switch-director";
+
+    public static LoggerContextRule loggerContextRule = LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
+
+    @Rule
+    public RuleChain chain = loggerContextRule.withCleanFoldersRule(DIR);
+
+    private Logger logger;
+
+    @Before
+    public void setUp() throws Exception {
+        this.logger = loggerContextRule.getLogger(RollingRandomAppenderDirectWriteAndSwitchDirectorTest.class.getName());
+    }
+
+    @Test
+    public void testAppender() throws Exception {
+        LocalTime start = LocalTime.now();
+        LocalTime end;
+        do {
+            end = LocalTime.now();
+            logger.info("test log");
+            Thread.sleep(100);
+        } while (start.getSecond() == end.getSecond());
+
+        File nextLogFile = new File(String.format("%s/%d/%d.log", DIR, end.getSecond(), end.getSecond()));
+        assertTrue("nextLogFile not created", nextLogFile.exists());
+    }
+}

--- a/log4j-core/src/test/resources/log4j-rolling-random-direct-switch-director.xml
+++ b/log4j-core/src/test/resources/log4j-rolling-random-direct-switch-director.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration status="WARN" name="XMLConfigTest">
+    <Properties>
+        <Property name="LOG_HEADER">start log4j-rolling-random-direct-switch-director test</Property>
+        <Property name="LOG_PATTERN">%d %p %C{1.} [%t] %m%n</Property>
+        <Property name="baseDir">target/rolling-random-direct-switch-director</Property>
+    </Properties>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT" follow="true">
+            <PatternLayout header= "${LOG_HEADER}">
+                <Pattern>${LOG_PATTERN}</Pattern>
+            </PatternLayout>
+        </Console>
+        <RollingRandomAccessFile name="RollingFile"  filePattern="${baseDir}/%d{s}/%d{s}.log">
+            <PatternLayout header= "${LOG_HEADER}">
+                <Pattern>${LOG_PATTERN}</Pattern>
+            </PatternLayout>
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+            </Policies>
+        </RollingRandomAccessFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.apache.logging.log4j.core.appender.rolling" level="debug" additivity="false">
+            <AppenderRef ref="RollingFile"/>
+        </Logger>>
+        <Root level="error">
+            <AppenderRef ref="STDOUT" />
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
fix [LOG4J2-3565](https://issues.apache.org/jira/browse/LOG4J2-3565)
When you want split the log into different directories by period (day, hour, minute, etc.), and use
RollingRandomAccessFileAppender with a DirectWrite rollover, the config should be:

``` xml
<RollingRandomAccessFile name="RollingFile"  filePattern="${baseDir}/%d{s}/%d{s}.log">
    <PatternLayout header= "${LOG_HEADER}">
        <Pattern>${LOG_PATTERN}</Pattern>
    </PatternLayout>
    <Policies>
        <TimeBasedTriggeringPolicy/>
    </Policies>
</RollingRandomAccessFile>
```
At that time when the first log of each directory try to create， console shows;

``` shell
2022-07-31 03:17:44,009 main ERROR RollingRandomAccessFileManager target/rolling-random-direct-switch-director/%d{s}/%d{s}.log Failed to create file after rollover: java.io.FileNotFoundException: target/rolling-random-direct-switch-director/44/44.log (No such file or directory) java.io.FileNotFoundException: target/rolling-random-direct-switch-director/44/44.log (No such file or directory)
```
Apparently the directory has not been created when the file is creating