### PR TITLE
[LOG4J2-3583] Implements stack-valued MDC

### DIFF
--- a/log4j-slf4j20-impl/pom.xml
+++ b/log4j-slf4j20-impl/pom.xml
@@ -91,6 +91,14 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/log4j-slf4j20-impl/src/test/java/org/apache/logging/slf4j/Log4jMDCAdapterTest.java
+++ b/log4j-slf4j20-impl/src/test/java/org/apache/logging/slf4j/Log4jMDCAdapterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.slf4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class Log4jMDCAdapterTest {
+
+    private static final Log4jMDCAdapter MDC_ADAPTER = new Log4jMDCAdapter();
+    private static final String KEY = "Log4j2";
+
+    private static Deque<String> createDeque(int size) {
+        final Deque<String> result = new ArrayDeque<>(size);
+        IntStream.range(0, size).mapToObj(Integer::toString).forEach(result::addLast);
+        return result;
+    }
+
+    private static Deque<String> popDeque(String key) {
+        final Deque<String> result = new ArrayDeque<>();
+        String value;
+        while ((value = MDC_ADAPTER.popByKey(key)) != null) {
+            result.addLast(value);
+        }
+        return result;
+    }
+
+    static Stream<String> keys() {
+        return Stream.of(KEY, "", null);
+    }
+
+    @ParameterizedTest
+    @MethodSource("keys")
+    public void testPushPopByKey(final String key) {
+        MDC_ADAPTER.clearDequeByKey(key);
+        final Deque<String> expectedValues = createDeque(100);
+        expectedValues.descendingIterator().forEachRemaining(v -> MDC_ADAPTER.pushByKey(key, v));
+        assertThat(MDC_ADAPTER.getCopyOfDequeByKey(key)).containsExactlyElementsOf(expectedValues);
+        assertThat(popDeque(key)).containsExactlyElementsOf(expectedValues);
+    }
+
+}

--- a/log4j-slf4j20-impl/src/test/java/org/apache/logging/slf4j/LoggerTest.java
+++ b/log4j-slf4j20-impl/src/test/java/org/apache/logging/slf4j/LoggerTest.java
@@ -118,6 +118,22 @@ public class LoggerTest {
         verify("List", "o.a.l.s.LoggerTest Debug message MDC{}" + Strings.LINE_SEPARATOR);
     }
 
+    @Test
+    public void mdcStack() {
+        MDC.pushByKey("TestYear", "2010");
+        logger.debug("Debug message");
+        verify("List", "o.a.l.s.LoggerTest Debug message MDC{TestYear=2010}" + Strings.LINE_SEPARATOR);
+        MDC.pushByKey("TestYear", "2011");
+        logger.debug("Debug message");
+        verify("List", "o.a.l.s.LoggerTest Debug message MDC{TestYear=2011}" + Strings.LINE_SEPARATOR);
+        MDC.popByKey("TestYear");
+        logger.debug("Debug message");
+        verify("List", "o.a.l.s.LoggerTest Debug message MDC{TestYear=2010}" + Strings.LINE_SEPARATOR);
+        MDC.clear();
+        logger.debug("Debug message");
+        verify("List", "o.a.l.s.LoggerTest Debug message MDC{}" + Strings.LINE_SEPARATOR);
+    }
+
     /**
      * @see <a href="https://issues.apache.org/jira/browse/LOG4J2-793">LOG4J2-793</a>
      */

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -60,6 +60,9 @@
       <action issue="LOG4J2-3559" dev="pkarwasz" type="fix" due-to="Gary Gregory">
         Fix resolution of properties not starting with `log4j2.`.
       </action>
+      <action issue="LOG4J2-3583" dev="pkarwasz" type="add" due-to="Pierrick Terrettaz">
+        Add support for SLF4J2 stack-valued MDC.
+      </action>
     </release>
     <release version="2.18.0" date="2022-06-28" description="GA Release 2.18.0">
       <action issue="LOG4J2-3339" dev="rgoers" type="fix">


### PR DESCRIPTION
This PR implements SLF4J-531 by storing the result of `pushByKey(key, value)` in the usual thread context map and restoring the previous value, when a `popByKey(key)` call occurs.

The same behavior can be obtained in the Log4j2 API using `CloseableThreadContext.put(key, value)` as "push" and closing the returned value as "pop", so I believe we do not need to add anything to the API.