### PR TITLE
[LOG4J2-708] Improve `Log4jServletFilter` async behavior

### DIFF
--- a/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/Log4jServletFilter.java
+++ b/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/Log4jServletFilter.java
@@ -71,6 +71,8 @@ public class Log4jServletFilter implements Filter {
                 chain.doFilter(request, response);
             } finally {
                 this.initializer.clearLoggerContext();
+                // Execute once per thread
+                request.removeAttribute(ALREADY_FILTERED_ATTRIBUTE);
             }
         }
     }

--- a/log4j-jakarta-web/src/test/java/org/apache/logging/log4j/web/Log4jServletFilterTest.java
+++ b/log4j-jakarta-web/src/test/java/org/apache/logging/log4j/web/Log4jServletFilterTest.java
@@ -93,6 +93,7 @@ public class Log4jServletFilterTest {
         then(chain).should().doFilter(same(request), same(response));
         then(chain).shouldHaveNoMoreInteractions();
         then(initializer).should().clearLoggerContext();
+        then(request).should().removeAttribute(Log4jServletFilter.ALREADY_FILTERED_ATTRIBUTE);
     }
 
     @Test

--- a/log4j-web/src/main/java/org/apache/logging/log4j/web/Log4jServletFilter.java
+++ b/log4j-web/src/main/java/org/apache/logging/log4j/web/Log4jServletFilter.java
@@ -71,6 +71,8 @@ public class Log4jServletFilter implements Filter {
                 chain.doFilter(request, response);
             } finally {
                 this.initializer.clearLoggerContext();
+                // Execute once per thread
+                request.removeAttribute(ALREADY_FILTERED_ATTRIBUTE);
             }
         }
     }

--- a/log4j-web/src/test/java/org/apache/logging/log4j/web/Log4jServletFilterTest.java
+++ b/log4j-web/src/test/java/org/apache/logging/log4j/web/Log4jServletFilterTest.java
@@ -93,6 +93,7 @@ public class Log4jServletFilterTest {
         then(chain).should().doFilter(same(request), same(response));
         then(chain).shouldHaveNoMoreInteractions();
         then(initializer).should().clearLoggerContext();
+        then(request).should().removeAttribute(Log4jServletFilter.ALREADY_FILTERED_ATTRIBUTE);
     }
 
     @Test


### PR DESCRIPTION
The `Log4jServletFilter` filter should run on all the threads a request is run. The current version ignores all async dispatches.