### PR TITLE
(doc) Improve documentation for logging methods with Object param

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
@@ -17,12 +17,13 @@
 package org.apache.logging.log4j;
 
 import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.util.Supplier;
 
 
 /**
  * Interface for constructing log events before logging them. Instances of LogBuilders should only be created
- * by calling one of the Logger methods that return a LogBuilder.
+ * by calling one of the {@link Logger} methods that return a LogBuilder, such as {@link Logger#atInfo()}.
  */
 public interface LogBuilder {
 
@@ -40,7 +41,7 @@ public interface LogBuilder {
     /**
      * Includes a Throwable in the log event. Interface default method does nothing.
      * @param throwable The Throwable to log.
-     * @return the LogBuilder.
+     * @return The LogBuilder.
      */
     default LogBuilder withThrowable(final Throwable throwable) {
         return this;
@@ -114,6 +115,11 @@ public interface LogBuilder {
 
     /**
      * Causes all the data collected to be logged along with the message. Interface default method does nothing.
+     *
+     * <p>The message argument should not be a {@link Throwable}. The default {@link MessageFactory} might
+     * only log the {@code toString()} value of the throwable but ignore its stack trace. Prefer
+     * {@link #withThrowable(Throwable)} to set the throwable.
+     *
      * @param message The message to log.
      */
     default void log(final Object message) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -285,6 +285,10 @@ public interface Logger {
     /**
      * Logs a message object with the {@link Level#DEBUG DEBUG} level.
      *
+     * <p>The message argument should not be a {@link Throwable}. The default {@link MessageFactory} might
+     * only log the {@code toString()} value of the throwable but ignore its stack trace. Prefer
+     * one of the logging methods with explicit {@code Throwable} parameter.
+     *
      * @param message the message object to log.
      */
     void debug(Object message);
@@ -811,6 +815,10 @@ public interface Logger {
     /**
      * Logs a message object with the {@link Level#ERROR ERROR} level.
      *
+     * <p>The message argument should not be a {@link Throwable}. The default {@link MessageFactory} might
+     * only log the {@code toString()} value of the throwable but ignore its stack trace. Prefer
+     * one of the logging methods with explicit {@code Throwable} parameter.
+     *
      * @param message the message object to log.
      */
     void error(Object message);
@@ -1336,6 +1344,10 @@ public interface Logger {
 
     /**
      * Logs a message object with the {@link Level#FATAL FATAL} level.
+     *
+     * <p>The message argument should not be a {@link Throwable}. The default {@link MessageFactory} might
+     * only log the {@code toString()} value of the throwable but ignore its stack trace. Prefer
+     * one of the logging methods with explicit {@code Throwable} parameter.
      *
      * @param message the message object to log.
      */
@@ -1884,6 +1896,10 @@ public interface Logger {
 
     /**
      * Logs a message object with the {@link Level#INFO INFO} level.
+     *
+     * <p>The message argument should not be a {@link Throwable}. The default {@link MessageFactory} might
+     * only log the {@code toString()} value of the throwable but ignore its stack trace. Prefer
+     * one of the logging methods with explicit {@code Throwable} parameter.
      *
      * @param message the message object to log.
      */
@@ -3148,6 +3164,10 @@ public interface Logger {
     /**
      * Logs a message object with the {@link Level#TRACE TRACE} level.
      *
+     * <p>The message argument should not be a {@link Throwable}. The default {@link MessageFactory} might
+     * only log the {@code toString()} value of the throwable but ignore its stack trace. Prefer
+     * one of the logging methods with explicit {@code Throwable} parameter.
+     *
      * @param message the message object to log.
      */
     void trace(Object message);
@@ -3862,6 +3882,10 @@ public interface Logger {
 
     /**
      * Logs a message object with the {@link Level#WARN WARN} level.
+     *
+     * <p>The message argument should not be a {@link Throwable}. The default {@link MessageFactory} might
+     * only log the {@code toString()} value of the throwable but ignore its stack trace. Prefer
+     * one of the logging methods with explicit {@code Throwable} parameter.
      *
      * @param message the message object to log.
      */


### PR DESCRIPTION
Logging methods which only have an `Object` parameter do not log the exception strack trace when the argument is a `Throwable`. As mentioned [here](https://issues.apache.org/jira/browse/LOG4J2-86?focusedCommentId=17199071&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17199071) this is quite error-prone and I would be much happier if that behavior was changed. But at the very least the documentation should highlight this (even though I am afraid not many users read the documentation in detail).

Please let me know if this PR should be retargeted against the `release-2.x` branch.