### PR TITLE
[LOG4J2-3598] Lazily evaluate the level in `Log4jEventBuilder`

### DIFF
--- a/log4j-slf4j2-impl/pom.xml
+++ b/log4j-slf4j2-impl/pom.xml
@@ -31,7 +31,7 @@
     <docLabel>SLF4J Documentation</docLabel>
     <projectDir>/slf4j2-impl</projectDir>
     <!-- Override parent's default -->
-    <slf4j.version>2.0.0</slf4j.version>
+    <slf4j.version>2.0.6</slf4j.version>
     <module.name>org.apache.logging.log4j.slf4j</module.name>
     <maven.doap.skip>true</maven.doap.skip>
   </properties>

--- a/log4j-slf4j2-impl/src/main/java/org/apache/logging/slf4j/Log4jLogger.java
+++ b/log4j-slf4j2-impl/src/main/java/org/apache/logging/slf4j/Log4jLogger.java
@@ -413,56 +413,11 @@ public class Log4jLogger implements LocationAwareLogger, Serializable {
     @Override
     public LoggingEventBuilder makeLoggingEventBuilder(org.slf4j.event.Level level) {
         final Level log4jLevel = getLevel(level.toInt());
-        if (logger.isEnabled(log4jLevel)) {
-            return new Log4jEventBuilder(markerFactory, logger.atLevel(log4jLevel));
-        }
-        return NOPLoggingEventBuilder.singleton();
-    }
-
-    @Override
-    public LoggingEventBuilder atTrace() {
-        if (logger.isTraceEnabled()) {
-            return new Log4jEventBuilder(markerFactory, logger.atTrace());
-        }
-        return NOPLoggingEventBuilder.singleton();
-    }
-
-    @Override
-    public LoggingEventBuilder atDebug() {
-        if (logger.isDebugEnabled()) {
-            return new Log4jEventBuilder(markerFactory, logger.atDebug());
-        }
-        return NOPLoggingEventBuilder.singleton();
-    }
-
-    @Override
-    public LoggingEventBuilder atInfo() {
-        if (logger.isInfoEnabled()) {
-            return new Log4jEventBuilder(markerFactory, logger.atInfo());
-        }
-        return NOPLoggingEventBuilder.singleton();
-    }
-
-    @Override
-    public LoggingEventBuilder atWarn() {
-        if (logger.isWarnEnabled()) {
-            return new Log4jEventBuilder(markerFactory, logger.atWarn());
-        }
-        return NOPLoggingEventBuilder.singleton();
-    }
-
-    @Override
-    public LoggingEventBuilder atError() {
-        if (logger.isErrorEnabled()) {
-            return new Log4jEventBuilder(markerFactory, logger.atError());
-        }
-        return NOPLoggingEventBuilder.singleton();
+        return new Log4jEventBuilder(markerFactory, logger, log4jLevel);
     }
 
     @Override
     public boolean isEnabledForLevel(org.slf4j.event.Level level) {
         return logger.isEnabled(getLevel(level.toInt()));
     }
-
-    
 }

--- a/src/changelog/.2.x.x/LOG4J2-3598_Lazily_evaluate_SLF4J_LogEventBuilder_level.xml
+++ b/src/changelog/.2.x.x/LOG4J2-3598_Lazily_evaluate_SLF4J_LogEventBuilder_level.xml
@@ -1,0 +1,7 @@
+<entry type="fixed">
+  <issue id="LOG4J2-3598" link="https://issues.apache.org/jira/browse/LOG4J2-3598"/>
+  <author id="pkarwasz"/>
+  <description format="asciidoc">
+    Lazily evaluate the level of a SLF4J `LogEventBuilder`.
+  </description>
+</entry>


### PR DESCRIPTION
To ensure maximum compatibility with Logback and the changes in SLF4J 2.0.1 (cf. [SLF4J-560](https://jira.qos.ch/browse/SLF4J-560)) we create the `LogBuilder` lazily only when `log()` is called.