### PR TITLE
Delegate plugin versions to ASF parent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 mvnw.cmd eol=crlf

--- a/log4j-1.2-api/pom.xml
+++ b/log4j-1.2-api/pom.xml
@@ -191,7 +191,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-api-test/pom.xml
+++ b/log4j-api-test/pom.xml
@@ -146,7 +146,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/log4j-api/pom.xml
+++ b/log4j-api/pom.xml
@@ -129,7 +129,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -211,7 +210,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-appserver/pom.xml
+++ b/log4j-appserver/pom.xml
@@ -109,7 +109,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-bom/pom.xml
+++ b/log4j-bom/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.logging</groupId>
     <artifactId>logging-parent</artifactId>
-    <version>5</version>
+    <version>7</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <name>Apache Log4j BOM</name>
@@ -28,16 +28,6 @@
   <artifactId>log4j-bom</artifactId>
   <version>2.19.1-SNAPSHOT</version>
   <packaging>pom</packaging>
-
-  <!-- `log4j-bom` doesn't inherit from the room POM, but `org.apache.logging:logging-parent`.
-       Hence Maven repositories need to be explicitly provided for SNAPSHOT artifact deployments. -->
-  <distributionManagement>
-    <snapshotRepository>
-      <id>asf-snapshots</id>
-      <name>ASF snapshot repository</name>
-      <url>https://repository.apache.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
 
   <dependencyManagement>
     <dependencies>
@@ -222,7 +212,6 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
-        <version>0.13</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/log4j-cassandra/pom.xml
+++ b/log4j-cassandra/pom.xml
@@ -150,7 +150,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-core-its/pom.xml
+++ b/log4j-core-its/pom.xml
@@ -203,7 +203,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/log4j-core-java9/pom.xml
+++ b/log4j-core-java9/pom.xml
@@ -114,7 +114,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -122,7 +121,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>${site.plugin.version}</version>
         <configuration>
           <skip>true</skip>
           <skipDeploy>true</skipDeploy>

--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -331,7 +331,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <failOnError>false</failOnError>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;

--- a/log4j-couchdb/pom.xml
+++ b/log4j-couchdb/pom.xml
@@ -126,7 +126,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-distribution/pom.xml
+++ b/log4j-distribution/pom.xml
@@ -594,7 +594,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>post-integration-test</phase>
@@ -667,7 +666,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -690,7 +688,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>${site.plugin.version}</version>
         <configuration>
           <skip>true</skip>
           <skipDeploy>true</skipDeploy>

--- a/log4j-docker/pom.xml
+++ b/log4j-docker/pom.xml
@@ -146,7 +146,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-flume-ng/pom.xml
+++ b/log4j-flume-ng/pom.xml
@@ -192,7 +192,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-iostreams/pom.xml
+++ b/log4j-iostreams/pom.xml
@@ -138,7 +138,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-jakarta-smtp/pom.xml
+++ b/log4j-jakarta-smtp/pom.xml
@@ -33,6 +33,7 @@
     <docLabel>Log4j SMTP Appender Documentation</docLabel>
     <projectDir>/log4j-jakarta-smtp</projectDir>
     <maven.doap.skip>true</maven.doap.skip>
+    <module.name>org.apache.logging.log4j.smtp</module.name>
   </properties>
 
   <dependencies>
@@ -143,7 +144,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-jakarta-web/pom.xml
+++ b/log4j-jakarta-web/pom.xml
@@ -133,7 +133,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-jcl/pom.xml
+++ b/log4j-jcl/pom.xml
@@ -132,7 +132,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-jdbc-dbcp2/pom.xml
+++ b/log4j-jdbc-dbcp2/pom.xml
@@ -112,7 +112,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-jmx-gui/pom.xml
+++ b/log4j-jmx-gui/pom.xml
@@ -119,7 +119,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-jpa/pom.xml
+++ b/log4j-jpa/pom.xml
@@ -132,7 +132,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-jpl/pom.xml
+++ b/log4j-jpl/pom.xml
@@ -193,7 +193,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,
@@ -245,8 +244,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <!-- Use Maven Surefire 2.21 which brings module support -->
-            <version>${surefire.plugin.version}</version>
             <!-- Disable forked VM as 2.21 yields https://issues.apache.org/jira/browse/SUREFIRE-720 -->
             <configuration combine.self="override"/>
             <executions>

--- a/log4j-jul/pom.xml
+++ b/log4j-jul/pom.xml
@@ -101,14 +101,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.plugin.version}</version>
         <dependencies>
           <!-- Manual override of the Surefire provider -->
           <!-- The `surefire-platform` provider initializes JUL before calling our tests -->
           <dependency>
             <groupId>org.apache.maven.surefire</groupId>
             <artifactId>surefire-junit47</artifactId>
-            <version>${surefire.plugin.version}</version>
+            <version>${surefire.version}</version>
           </dependency>
         </dependencies>
         <configuration>
@@ -187,7 +186,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-kubernetes/pom.xml
+++ b/log4j-kubernetes/pom.xml
@@ -143,7 +143,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-layout-template-json/pom.xml
+++ b/log4j-layout-template-json/pom.xml
@@ -325,7 +325,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-liquibase/pom.xml
+++ b/log4j-liquibase/pom.xml
@@ -200,7 +200,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-mongodb3/pom.xml
+++ b/log4j-mongodb3/pom.xml
@@ -140,7 +140,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-mongodb4/pom.xml
+++ b/log4j-mongodb4/pom.xml
@@ -140,7 +140,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-osgi/pom.xml
+++ b/log4j-osgi/pom.xml
@@ -245,7 +245,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-perf/pom.xml
+++ b/log4j-perf/pom.xml
@@ -41,6 +41,7 @@
     <uberjar.name>benchmarks</uberjar.name>
     <revapi.skip>true</revapi.skip>
     <maven.doap.skip>true</maven.doap.skip>
+    <module.name>org.apache.logging.log4j.perf</module.name>
   </properties>
 
   <dependencies>
@@ -171,7 +172,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${compiler.plugin.version}</version>
         <configuration>
           <compilerVersion>9</compilerVersion>
           <source>9</source>
@@ -181,7 +181,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/log4j-samples/log4j-samples-configuration/pom.xml
+++ b/log4j-samples/log4j-samples-configuration/pom.xml
@@ -29,6 +29,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <log4jParentDir>${basedir}/../..</log4jParentDir>
+    <module.name>org.apache.logging.log4j.samples.configuration</module.name>
   </properties>
   <dependencies>
     <dependency>
@@ -54,7 +55,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/log4j-samples/log4j-samples-flume-common/pom.xml
+++ b/log4j-samples/log4j-samples-flume-common/pom.xml
@@ -29,6 +29,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <log4jParentDir>${basedir}/../..</log4jParentDir>
+    <module.name>org.apache.logging.log4j.samples.flume.common</module.name>
   </properties>
   <dependencies>
     <dependency>
@@ -75,7 +76,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/log4j-samples/log4j-samples-flume-embedded/pom.xml
+++ b/log4j-samples/log4j-samples-flume-embedded/pom.xml
@@ -28,8 +28,8 @@
   <url>http://maven.apache.org</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <deploy.plugin.version>2.8.2</deploy.plugin.version>
     <log4jParentDir>${basedir}/../..</log4jParentDir>
+    <module.name>org.apache.logging.log4j.samples.flume.embedded</module.name>
   </properties>
   <dependencies>
     <dependency>
@@ -109,7 +109,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -117,7 +116,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <version>2.5.2</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/log4j-samples/log4j-samples-flume-remote/pom.xml
+++ b/log4j-samples/log4j-samples-flume-remote/pom.xml
@@ -28,8 +28,8 @@
   <url>http://maven.apache.org</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <deploy.plugin.version>2.8.2</deploy.plugin.version>
     <log4jParentDir>${basedir}/../..</log4jParentDir>
+    <module.name>org.apache.logging.log4j.samples.flume.remote</module.name>
   </properties>
   <dependencies>
     <dependency>
@@ -97,7 +97,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -105,7 +104,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-install-plugin</artifactId>
-        <version>2.5.2</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/log4j-samples/log4j-samples-loggerProperties/pom.xml
+++ b/log4j-samples/log4j-samples-loggerProperties/pom.xml
@@ -29,6 +29,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <log4jParentDir>${basedir}/../..</log4jParentDir>
+    <module.name>org.apache.logging.log4j.samples.logger_properties</module.name>
   </properties>
   <dependencies>
     <dependency>
@@ -54,7 +55,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/log4j-samples/pom.xml
+++ b/log4j-samples/pom.xml
@@ -89,7 +89,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -112,7 +111,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>${site.plugin.version}</version>
         <configuration>
           <skip>true</skip>
           <skipDeploy>true</skipDeploy>

--- a/log4j-slf4j-impl/pom.xml
+++ b/log4j-slf4j-impl/pom.xml
@@ -246,7 +246,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-slf4j2-impl/pom.xml
+++ b/log4j-slf4j2-impl/pom.xml
@@ -210,7 +210,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-spring-boot/pom.xml
+++ b/log4j-spring-boot/pom.xml
@@ -246,7 +246,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-client/pom.xml
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-client/pom.xml
@@ -201,7 +201,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/log4j-spring-cloud-config-sample-application/pom.xml
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/log4j-spring-cloud-config-sample-application/pom.xml
@@ -178,7 +178,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -216,7 +215,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>${site.plugin.version}</version>
         <configuration>
           <skip>true</skip>
           <skipDeploy>true</skipDeploy>

--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/log4j-spring-cloud-config-sample-server/pom.xml
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/log4j-spring-cloud-config-sample-server/pom.xml
@@ -41,7 +41,6 @@
     <log4jParentDir>${basedir}/../../..</log4jParentDir>
     <java.version>1.8</java.version>
     <spring-cloud.version>Hoxton.SR9</spring-cloud.version>
-    <deploy.plugin.version>2.8.2</deploy.plugin.version>
 
     <!-- paths -->
     <sonar.dependencyCheck.reportPath>${project.build.directory}/dependency-check-report.xml
@@ -54,10 +53,8 @@
     <maven.google.code.findbugs.findbugs.version>3.0.1</maven.google.code.findbugs.findbugs.version>
     <maven.jacoco.version>0.8.8</maven.jacoco.version>
     <maven.pmd.version>3.9.0</maven.pmd.version>
-    <site.plugin.version>3.11.0</site.plugin.version>
     <!-- maven plugin config -->
     <pmd.failurePriority>2</pmd.failurePriority>
-    <deploy.plugin.version>2.8.2</deploy.plugin.version>
     <rat.plugin.version>0.13</rat.plugin.version>
     <maven.doap.skip>true</maven.doap.skip>
   </properties>
@@ -143,7 +140,6 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
-        <version>${rat.plugin.version}</version>
         <configuration>
           <excludes>
             <exclude>**/*.yaml</exclude>
@@ -189,7 +185,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -220,7 +215,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>${site.plugin.version}</version>
         <configuration>
           <skip>true</skip>
           <skipDeploy>true</skipDeploy>

--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/pom.xml
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/pom.xml
@@ -72,7 +72,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>${deploy.plugin.version}</version>
         <configuration>
           <skip>true</skip>
         </configuration>
@@ -95,7 +94,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>${site.plugin.version}</version>
         <configuration>
           <skip>true</skip>
           <skipDeploy>true</skipDeploy>

--- a/log4j-taglib/pom.xml
+++ b/log4j-taglib/pom.xml
@@ -143,7 +143,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-to-jul/pom.xml
+++ b/log4j-to-jul/pom.xml
@@ -129,7 +129,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-to-slf4j/pom.xml
+++ b/log4j-to-slf4j/pom.xml
@@ -142,7 +142,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/log4j-web/pom.xml
+++ b/log4j-web/pom.xml
@@ -137,7 +137,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>${javadoc.plugin.version}</version>
         <configuration>
           <bottom>&lt;p align="center"&gt;Copyright &amp;#169; {inceptionYear}-{currentYear} {organizationName}. All Rights Reserved.&lt;br /&gt;
             Apache Logging, Apache Log4j, Log4j, Apache, the Apache feather logo, the Apache Logging project logo,

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.logging</groupId>
     <artifactId>logging-parent</artifactId>
-    <version>5</version>
+    <version>7</version>
     <relativePath/>
   </parent>
   <description>Apache Log4j 2</description>
@@ -252,29 +252,22 @@
     <!-- POM for jackson-dataformat-xml 2.13.1 depends on woodstox-core 6.2.7 -->
     <woodstox.version>6.3.1</woodstox.version>
     <groovy.version>3.0.10</groovy.version>
-    <compiler.plugin.version>3.10.1</compiler.plugin.version>
     <pmd.plugin.version>3.16.0</pmd.plugin.version>
     <changes.plugin.version>2.12.1</changes.plugin.version>
-    <javadoc.plugin.version>3.3.2</javadoc.plugin.version>
     <!-- surefire.plugin.version 2.18 yields http://jira.codehaus.org/browse/SUREFIRE-1121, which is fixed in 2.18.1 -->
     <!-- surefire.plugin.version 2.19 yields https://issues.apache.org/jira/browse/SUREFIRE-1193. -->
     <!-- all versions after 2.13 yield https://issues.apache.org/jira/browse/SUREFIRE-720 -->
-    <surefire.plugin.version>3.0.0-M6</surefire.plugin.version>
-    <failsafe.plugin.version>3.0.0-M6</failsafe.plugin.version>
+    <!-- property specified in `apache.org:apache` -->
+    <surefire.version>3.0.0-M6</surefire.version>
     <checkstyle.plugin.version>3.1.2</checkstyle.plugin.version>
     <!-- checkstyle 10.0 requires Java 11 -->
     <checkstyle.tool.version>8.45.1</checkstyle.tool.version>
-    <deploy.plugin.version>2.8.2</deploy.plugin.version>
-    <rat.plugin.version>0.13</rat.plugin.version>
     <!-- Do not update the pdf plugin version without verifying the new version works by running mvn site -->
     <pdf.plugin.version>1.2</pdf.plugin.version>
     <cobertura.plugin.version>2.7</cobertura.plugin.version>
     <jacoco.plugin.version>0.8.8</jacoco.plugin.version>
-    <release.plugin.version>2.5.3</release.plugin.version>
-    <scm.plugin.version>1.12.2</scm.plugin.version>
     <jxr.plugin.version>3.2.0</jxr.plugin.version>
     <revapi.skip>false</revapi.skip>
-    <site.plugin.version>3.11.0</site.plugin.version>
     <!-- Maven site depends on Velocity and the escaping rules are different in newer versions. -->
     <!-- See https://maven.apache.org/plugins/maven-site-plugin/migrate.html -->
     <velocity.plugin.version>1.5</velocity.plugin.version>
@@ -319,20 +312,7 @@
     <netty-all.version>4.1.80.Final</netty-all.version>
     <wiremock.version>2.34.0</wiremock.version>
   </properties>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>apache</id>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
-    </pluginRepository>
-<!--     <pluginRepository> -->
-<!--       <id>apache.snapshots</id> -->
-<!--       <name>Apache snapshots repository</name> -->
-<!--       <url>http://repository.apache.org/content/groups/snapshots</url> -->
-<!--       <snapshots> -->
-<!--         <enabled>true</enabled> -->
-<!--       </snapshots> -->
-<!--     </pluginRepository>     -->
-  </pluginRepositories>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -378,14 +358,14 @@
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core-test</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core-java9</artifactId>
         <version>${project.version}</version>
         <type>zip</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core-test</artifactId>
+        <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
@@ -1130,7 +1110,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${compiler.plugin.version}</version>
           <configuration>
             <source>${maven.compiler.source}</source>
             <target>${maven.compiler.target}</target>
@@ -1150,12 +1129,11 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${failsafe.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.1.0</version>
+          <!-- version inherited from ASF parent POM -->
           <executions>
             <execution>
               <id>default-jar</id>
@@ -1229,11 +1207,6 @@
           </executions>
         </plugin>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>${surefire.plugin.version}</version>
-        </plugin>
-        <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
           <version>4.7.0.0</version>
@@ -1258,7 +1231,6 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
-        <version>${rat.plugin.version}</version>
         <configuration>
           <consoleOutput>true</consoleOutput>
           <excludes>
@@ -1337,7 +1309,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
-        <version>3.2.0</version>
       </plugin>
       <!-- DOAP (RDF) metadata generation -->
       <plugin>
@@ -1380,7 +1351,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <version>${failsafe.plugin.version}</version>
         <executions>
           <execution>
             <goals>
@@ -1472,7 +1442,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>${site.plugin.version}</version>
+        <!-- version inherited from ASF parent POM -->
         <dependencies>
           <dependency>
             <groupId>org.asciidoctor</groupId>
@@ -1506,7 +1476,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire.plugin.version}</version>
         <configuration>
           <systemPropertyVariables>
             <java.awt.headless>true</java.awt.headless>
@@ -1523,7 +1492,7 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
-        <version>${rat.plugin.version}</version>
+        <!-- version inherited from ASF parent POM -->
         <configuration>
           <consoleOutput>true</consoleOutput>
           <excludes>
@@ -1585,7 +1554,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.9</version>
+        <!-- version inherited from ASF parent POM -->
         <reportSets>
           <reportSet>
             <reports>
@@ -1594,10 +1563,10 @@
               <report>dependency-info</report>
               <report>dependency-convergence</report>
               <report>dependency-management</report>
-              <report>project-team</report>
-              <report>mailing-list</report>
-              <report>issue-tracking</report>
-              <report>license</report>
+              <report>team</report>
+              <report>mailing-lists</report>
+              <report>issue-management</report>
+              <report>licenses</report>
               <report>scm</report>
               <report>summary</report>
             </reports>
@@ -1616,7 +1585,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>${surefire.plugin.version}</version>
+        <!-- version specified in ASF parent POM through `surefire.version` -->
         <reportSets>
           <reportSet>
             <id>integration-tests</id>
@@ -1635,11 +1604,8 @@
       <id>www.example.com</id>
       <url>scp://www.example.com/www/docs/project/</url>
     </site>
-    <snapshotRepository>
-      <id>asf-snapshots</id>
-      <name>ASF snapshot repository</name>
-      <url>https://repository.apache.org/content/repositories/snapshots</url>
-    </snapshotRepository>
+    <!-- `repository` from ASF parent POM (id: apache.releases.https) -->
+    <!-- `snapshotRepository` from ASF parent POM (id: apache.snapshots.https) -->
   </distributionManagement>
   <modules>
     <!-- Unpublished modules first: -->
@@ -1777,7 +1743,7 @@
           <plugin>
             <groupId>org.apache.rat</groupId>
             <artifactId>apache-rat-plugin</artifactId>
-            <version>${rat.plugin.version}</version>
+            <!-- version inherited from ASF parent POM -->
             <configuration>
               <consoleOutput>true</consoleOutput>
               <excludes>


### PR DESCRIPTION
This PR removes all explicitly versioned plugins that are also defined in the Apache ASF parent POM (`org.apache:apache`).

This has the following effect on plugin versions:

 * `maven-assembly-plugin` bumped to 3.4.1
 * `maven-jar-plugin` bumped to 3.2.2
 * `maven-javadoc-plugin` bumped to 3.4.0
 * `maven-project-info-reports-plugin` bumped to 3.3.0
 * `maven-release-plugin` bumped to 3.0.0-M6
 * `maven-scm-plugin` bumped to 1.13.0
 * `maven-site-plugin` bumped to 3.12.0