### PR TITLE
[LOG4J2-3601] log4j-slf4j2-impl: depend on log4j-core scope=runtime

### DIFF
--- a/log4j-slf4j2-impl/pom.xml
+++ b/log4j-slf4j2-impl/pom.xml
@@ -50,12 +50,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api-test</artifactId>
-      <scope>test</scope>
+      <artifactId>log4j-core</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
+      <artifactId>log4j-api-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/changelog/.2.x.x/LOG4J2-3601_Add_Log4j2_Core_as_runtime_dep_for_SLF4J-to-LOG4J2-API.xml
+++ b/src/changelog/.2.x.x/LOG4J2-3601_Add_Log4j2_Core_as_runtime_dep_for_SLF4J-to-LOG4J2-API.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.0.xsd"
+       type="changed">
+  <issue id="LOG4J2-3601" link="https://issues.apache.org/jira/browse/LOG4J2-3601"/>
+  <author id="afs" name="Andy Seaborne"/>
+  <author id="pkarwasz"/>
+  <description format="asciidoc">
+    Add Log4j2 Core as default runtime dependency of the SLF4J2-to-Log4j2 API bridge.
+  </description>
+</entry>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/LOG4J2-3601

This makes the dependency structure the same between log4j-slf4j-impl and log4j-slf4j2-impl. 

Then user applications only need a dependency on log4j-slf4j2-impl and it is then the same pattern as for log4j-slf4j-impl.