### PR TITLE
Reparent Spring Cloud samples

### DIFF
--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/log4j-spring-cloud-config-sample-application/pom.xml
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/log4j-spring-cloud-config-sample-application/pom.xml
@@ -24,7 +24,7 @@
     <version>2.19.1-SNAPSHOT</version>
   </parent>
 
-  <artifactId>sample-app</artifactId>
+  <artifactId>log4j-spring-cloud-config-sample-application</artifactId>
   <packaging>jar</packaging>
 
   <name>Apache Log4j Spring Cloud Config Sample Application</name>
@@ -33,41 +33,34 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <log4jParentDir>${basedir}/../../..</log4jParentDir>
-    <!--<manifestfile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestfile>-->
+    <module.name>org.apache.logging.log4j.spring.cloud.config.sample.application</module.name>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <classifier>tests</classifier>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-docker</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <!-- Required for Flume -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-flume-ng</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-jcl</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-kubernetes</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-spring-cloud-config-client</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <!-- Required for Async Loggers -->
     <dependency>
@@ -148,8 +141,11 @@
   </dependencies>
 
   <build>
-    <finalName>sampleapp</finalName>
     <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/log4j-spring-cloud-config-sample-server/pom.xml
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/log4j-spring-cloud-config-sample-server/pom.xml
@@ -18,29 +18,24 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.apache.logging.log4j.samples</groupId>
+    <artifactId>log4j-spring-cloud-config-samples</artifactId>
+    <version>2.19.1-SNAPSHOT</version>
+  </parent>
   <groupId>org.apache.logging.log4j.samples</groupId>
   <artifactId>log4j-spring-cloud-config-sample-server</artifactId>
   <packaging>jar</packaging>
-  <version>2.19.1-SNAPSHOT</version>
 
   <name>Apache Log4j Sample Configuration Service</name>
   <description>Sample Cloud Config Server</description>
 
-  <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.6.RELEASE</version>
-    <relativePath/> <!-- lookup parent from repository -->
-  </parent>
-
   <properties>
-    <!-- Overrides version from `spring-boot-dependencies` ancestor -->
-    <log4j2.version>${project.version}</log4j2.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <log4jParentDir>${basedir}/../../..</log4jParentDir>
     <java.version>1.8</java.version>
-    <spring-cloud.version>Hoxton.SR9</spring-cloud.version>
+    <module.name>org.apache.logging.log4j.spring.cloud.config.sample.server</module.name>
 
     <!-- paths -->
     <sonar.dependencyCheck.reportPath>${project.build.directory}/dependency-check-report.xml
@@ -58,18 +53,6 @@
     <rat.plugin.version>0.13</rat.plugin.version>
     <maven.doap.skip>true</maven.doap.skip>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.cloud</groupId>
-        <artifactId>spring-cloud-dependencies</artifactId>
-        <version>${spring-cloud.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -97,7 +80,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- log dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-log4j2</artifactId>
@@ -127,6 +109,11 @@
       <artifactId>spring-cloud-starter-config</artifactId>
     </dependency>
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
@@ -136,25 +123,6 @@
 
   <build>
     <plugins>
-      <!-- RAT report -->
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>**/*.yaml</exclude>
-            <exclude>**/readme.txt</exclude>
-          </excludes>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
@@ -183,6 +151,10 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <configuration>
@@ -190,8 +162,8 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.2.0</version>
         <executions>
           <execution>
             <id>copy-resources</id>
@@ -237,21 +209,6 @@
   </distributionManagement>
 
   <repositories>
-    <repository>
-      <id>apache</id>
-      <url>https://repository.apache.org/content/repositories/releases/</url>
-      <snapshots> 
-        <enabled>false</enabled>
-      </snapshots> 
-    </repository>
-    <repository>
-      <id>apache.snapshots</id>
-      <name>Apache snapshots repository</name> 
-      <url>https://repository.apache.org/content/groups/snapshots</url> 
-      <snapshots> 
-        <enabled>true</enabled>
-      </snapshots> 
-    </repository>
     <repository>
       <id>spring-snapshots</id>
       <name>Spring Snapshots</name>

--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/log4j-spring-cloud-config-sample-server/src/main/resources/log4j2.xml
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/log4j-spring-cloud-config-sample-server/src/main/resources/log4j2.xml
@@ -15,14 +15,14 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<Configuration status="ERROR" name="ConfigService">
+<Configuration status="WARN" name="ConfigService">
   <Appenders>
     <Console name="STDOUT">
       <PatternLayout pattern="%d %-5level [%t][%logger]%notEmpty{[%markerSimpleName]} %msg%n%xThrowable" />
     </Console>
   </Appenders>
   <Loggers>
-    <Root level="ERROR">
+    <Root level="INFO">
       <AppenderRef ref="STDOUT" />
     </Root>
   </Loggers>

--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/pom.xml
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/pom.xml
@@ -34,32 +34,9 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>servlet-api</artifactId>
-        <version>2.5</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-beans</artifactId>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-core</artifactId>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-webmvc</artifactId>
-      </dependency>
-      <dependency>
         <groupId>org.springframework.ws</groupId>
         <artifactId>spring-ws-core</artifactId>
         <version>3.1.3</version>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -68,6 +45,22 @@
     <module>log4j-spring-cloud-config-sample-application</module>
   </modules>
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <version>${spring-boot.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>repackage</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/log4j-spring-cloud-config/pom.xml
+++ b/log4j-spring-cloud-config/pom.xml
@@ -28,15 +28,23 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <revapi.skip>true</revapi.skip>
-    <spring-cloud-version>2020.0.4</spring-cloud-version>
+    <spring-cloud.version>2021.0.4</spring-cloud.version>
     <log4jParentDir>${basedir}/..</log4jParentDir>
     <maven.doap.skip>true</maven.doap.skip>
   </properties>
   <dependencyManagement>
     <dependencies>
+      <!-- First BOM declaring a version wins, so it must be ours. -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
+        <artifactId>spring-boot-dependencies</artifactId>
         <version>${spring-boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
@@ -44,7 +52,7 @@
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
-        <version>${spring-cloud-version}</version>
+        <version>${spring-cloud.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
By changing the `log4j-spring-cloud-config-sample-server` parent from `spring-boot-starter-parent` to `log4j-spring-cloud-config-samples`, we can reuse the plugin configuration (and versions) of the ASF parent POM.