### PR TITLE
[LOG4J2-3615] Fix `log4j-api` OSGI encapsulation problem

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/internal/DefaultLogBuilderTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/internal/DefaultLogBuilderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.internal;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.logging.log4j.LogBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.test.TestLogger;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DefaultLogBuilderTest {
+
+    private final TestLogger logger1 = (TestLogger) LogManager.getLogger(DefaultLogBuilderTest.class);
+    private final TestLogger logger2 = (TestLogger) LogManager.getLogger("second.logger");
+
+    @Test
+    public void testConcurrentUsage() {
+        logger1.getEntries().clear();
+        logger2.getEntries().clear();
+        final List<LogBuilder> logBuilders = Arrays.asList(
+                logger1.atDebug(),
+                logger1.atInfo(),
+                logger2.atDebug(),
+                logger2.atInfo());
+        logBuilders.forEach(logBuilder -> logBuilder.log("Hello LogBuilder!"));
+        assertThat(logger1.getEntries()).hasSize(2)
+                .containsExactly(" DEBUG Hello LogBuilder!", " INFO Hello LogBuilder!");
+        assertThat(logger2.getEntries()).hasSize(2)
+                .containsExactly(" DEBUG Hello LogBuilder!", " INFO Hello LogBuilder!");
+    }
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
@@ -38,7 +38,7 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     private static final String FQCN = DefaultLogBuilder.class.getName();
     private static final Logger LOGGER = StatusLogger.getLogger();
 
-    private final Logger logger;
+    private Logger logger;
     private Level level;
     private Marker marker;
     private Throwable throwable;
@@ -51,13 +51,11 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
         this.logger = logger;
         this.level = level;
         this.threadId = Thread.currentThread().getId();
-        this.inUse = true;
+        this.inUse = level != null;
     }
 
-    public DefaultLogBuilder(Logger logger) {
-        this.logger = logger;
-        this.inUse = false;
-        this.threadId = Thread.currentThread().getId();
+    public DefaultLogBuilder() {
+        this(null, null);
     }
 
     @Override
@@ -70,12 +68,13 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
      * @param level The logging level for this event.
      * @return This LogBuilder instance.
      */
-    public LogBuilder reset(Level level) {
-        this.inUse = true;
+    public LogBuilder reset(Logger logger, Level level) {
+        this.logger = logger;
         this.level = level;
         this.marker = null;
         this.throwable = null;
         this.location = null;
+        this.inUse = true;
         return this;
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -108,7 +108,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     private final MessageFactory2 messageFactory;
     private final FlowMessageFactory flowMessageFactory;
     private static final ThreadLocal<int[]> recursionDepthHolder = new ThreadLocal<>(); // LOG4J2-1518, LOG4J2-2031
-    protected final transient ThreadLocal<DefaultLogBuilder> logBuilder;
+    private final transient ThreadLocal<DefaultLogBuilder> logBuilder;
 
     /**
      * Creates a new logger named after this class (or subclass).

--- a/src/changelog/.2.x.x/LOG4J2-3615_Fix_OSGI_API_leak.xml
+++ b/src/changelog/.2.x.x/LOG4J2-3615_Fix_OSGI_API_leak.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry type="added">
+  <issue id="LOG4J2-3615" link="https://issues.apache.org/jira/browse/LOG4J2-3615"/>
+  <author id="pkarwasz"/>
+  <description format="asciidoc">
+    Removes internal field that leaked into public API.
+  </description>
+</entry>


### PR DESCRIPTION
The protected `AbstractLogger.logBuilder` field leaks the internal `DefaultLogBuilder` class into the public API. This causes a warning in the upgraded `maven-bundle-plugin`.

Since this is a breaking change, I think that a larger consensus is necessary.