### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka-clients to 2.7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,7 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the license for the specific language governing permissions and
   ~ limitations under the license.
-  -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.logging.log4j</groupId>
   <artifactId>log4j</artifactId>
@@ -347,7 +346,7 @@
     <junit.version>4.13.2</junit.version>
     <junit-jupiter.version>5.9.0</junit-jupiter.version>
     <junit-pioneer.version>1.6.2</junit-pioneer.version>
-    <kafka.version>1.1.1</kafka.version>
+    <kafka.version>2.7.2</kafka.version>
     <kubernetes-client.version>5.12.2</kubernetes-client.version>
     <lightcouch.version>0.2.0</lightcouch.version>
     <liquibase.version>3.5.5</liquibase.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka-clients 1.1.1
- [CVE-2021-38153](https://www.oscs1024.com/hd/CVE-2021-38153)


### What did I do？
Upgrade org.apache.kafka:kafka-clients from 1.1.1 to 2.7.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS