### PR TITLE
fix(sec): upgrade org.liquibase:liquibase-core to 4.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@
     <kafka.version>1.1.1</kafka.version>
     <kubernetes-client.version>5.12.2</kubernetes-client.version>
     <lightcouch.version>0.2.0</lightcouch.version>
-    <liquibase.version>3.5.5</liquibase.version>
+    <liquibase.version>4.8.0</liquibase.version>
     <log4j.version>1.2.17</log4j.version>
     <log4j2-cachefile-transformer.version>2.15.0</log4j2-cachefile-transformer.version>
     <log4j2-ecs-layout.version>1.5.0</log4j2-ecs-layout.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.liquibase:liquibase-core 3.5.5
- [CVE-2022-0839](https://www.oscs1024.com/hd/CVE-2022-0839)


### What did I do？
Upgrade org.liquibase:liquibase-core from 3.5.5 to 4.8.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS