### PR TITLE
[LOG4J2-3581] Provide a JCL to Log4j2 API binary weaver

### DIFF
--- a/log4j-migration/pom.xml
+++ b/log4j-migration/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache license, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the license for the specific language governing permissions and
+  ~ limitations under the license.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.logging.log4j</groupId>
+    <artifactId>log4j</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>log4j-migration</artifactId>
+  <name>Apache Log4j Migration Tool</name>
+  <description>The Apache Log4j Migration Tool for logging frameworks</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/log4j-migration/src/main/java/org/apache/logging/log4j/migration/AbstractClassConverter.java
+++ b/log4j-migration/src/main/java/org/apache/logging/log4j/migration/AbstractClassConverter.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.migration;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.security.ProtectionDomain;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+
+public abstract class AbstractClassConverter implements ClassFileTransformer, Converter {
+
+    protected final ConverterProfile profile;
+
+    protected abstract ClassVisitor createRemapper(final ClassVisitor classVisitor);
+
+    protected abstract ClassVisitor createValidator(final ClassVisitor classVisitor);
+
+    public AbstractClassConverter(ConverterProfile profile) {
+        this.profile = profile;
+    }
+
+    @Override
+    public boolean accepts(String filename) {
+        return filename.endsWith(".class");
+    }
+
+    @Override
+    public void convert(String path, InputStream src, OutputStream dest) throws IOException {
+        final ClassReader reader = new ClassReader(src);
+        final ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        final ClassVisitor remapper = createRemapper(writer);
+        final ClassVisitor validator = createValidator(remapper);
+        reader.accept(validator, 0);
+        dest.write(writer.toByteArray());
+    }
+
+    @Override
+    public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer)
+            throws IllegalClassFormatException {
+                ByteArrayInputStream inputStream = new ByteArrayInputStream(classfileBuffer);
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                try {
+                    convertInternal(className, inputStream, outputStream, profile);
+                } catch (IOException e) {
+                    throw new IllegalClassFormatException(e.getLocalizedMessage());
+                }
+                return outputStream.toByteArray();
+            }
+
+    protected void convertInternal(final String className, final InputStream src, final OutputStream dest, final ConverterProfile profile) throws IOException {
+        final ClassReader reader = new ClassReader(src);
+        final ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+        final ClassVisitor remapper = createRemapper(writer);
+        final ClassVisitor validator = createValidator(remapper);
+        reader.accept(validator, 0);
+        dest.write(writer.toByteArray());
+    }
+
+}

--- a/log4j-migration/src/main/java/org/apache/logging/log4j/migration/ConversionException.java
+++ b/log4j-migration/src/main/java/org/apache/logging/log4j/migration/ConversionException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.migration;
+
+/**
+ * Thrown by the converter, when it encounters some logging framework feature that is not supported.
+ */
+public class ConversionException extends RuntimeException {
+
+    private static final long serialVersionUID = -177281028782936849L;
+
+    public ConversionException(String message) {
+        super(message);
+    }
+
+}

--- a/log4j-migration/src/main/java/org/apache/logging/log4j/migration/Converter.java
+++ b/log4j-migration/src/main/java/org/apache/logging/log4j/migration/Converter.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.migration;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public interface Converter {
+
+	/**
+	 * @param filename file to convert
+	 * @return {@code true} if this converter can convert the file
+	 */
+	boolean accepts(String filename);
+
+	/**
+	 * Copies the source to the destination, converting it if necessary, according
+	 * to the requirements of the given profile.
+	 *
+	 * @param path The path to the data being converted
+	 * @param src  The source data to convert
+	 * @param dest The destination to write the converted data
+	 *
+	 * @throws IOException If the conversion fails
+	 */
+	void convert(String path, InputStream src, OutputStream dest) throws IOException;
+}

--- a/log4j-migration/src/main/java/org/apache/logging/log4j/migration/ConverterProfile.java
+++ b/log4j-migration/src/main/java/org/apache/logging/log4j/migration/ConverterProfile.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.migration;
+
+/**
+ * Supported _modi operandi_ of the JCL weaver.
+ */
+public enum ConverterProfile {
+    /**
+     * Converts all calls or fails.
+     */
+    FULL,
+    /**
+     * Drops all unsupported method calls.
+     */
+    DROP_UNSUPPORTED;
+}

--- a/log4j-migration/src/main/java/org/apache/logging/log4j/migration/Log4j2Types.java
+++ b/log4j-migration/src/main/java/org/apache/logging/log4j/migration/Log4j2Types.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.migration;
+
+public class Log4j2Types {
+
+    public static final String LOGMANAGER = "org/apache/logging/log4j/LogManager";
+    public static final String LOGGERCONTEXT = "org/apache/logging/log4j/spi/LoggerContext";
+    public static final String LOGGER = "org/apache/logging/log4j/Logger";
+
+    // LogManager methods
+    public static final String GET_CONTEXT_NAME = "getContext";
+    public static final String GET_CONTEXT_BOOLEAN_DESC = "(Z)Lorg/apache/logging/log4j/spi/LoggerContext;";
+    public static final String GET_LOGGER_NAME = "getLogger";
+    public static final String LOGMANAGER_GET_LOGGER_STRING_DESC = "(Ljava/lang/String;)Lorg/apache/logging/log4j/Logger;";
+    public static final String LOGMANAGER_GET_LOGGER_CLASS_DESC = "(Ljava/lang/Class;)Lorg/apache/logging/log4j/Logger;";
+
+    // LoggerContext methods
+    public static final String LOGGERCONTEXT_GET_LOGGER_STRING_DESC = "(Ljava/lang/String;)Lorg/apache/logging/log4j/spi/ExtendedLogger;";
+    public static final String LOGGERCONTEXT_GET_LOGGER_CLASS_DESC = "(Ljava/lang/Class;)Lorg/apache/logging/log4j/spi/ExtendedLogger;";
+
+    private Log4j2Types() {
+        // prevent instantiation
+    }
+}

--- a/log4j-migration/src/main/java/org/apache/logging/log4j/migration/jcl/JclClassConverter.java
+++ b/log4j-migration/src/main/java/org/apache/logging/log4j/migration/jcl/JclClassConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.migration.jcl;
+
+import org.apache.logging.log4j.migration.AbstractClassConverter;
+import org.apache.logging.log4j.migration.ConverterProfile;
+import org.objectweb.asm.ClassVisitor;
+
+public class JclClassConverter extends AbstractClassConverter {
+
+    public JclClassConverter(final ConverterProfile profile) {
+        super(profile);
+    }
+
+    @Override
+    protected ClassVisitor createValidator(final ClassVisitor classVisitor) {
+        return new JclClassValidator(classVisitor, profile);
+    }
+
+    @Override
+    protected ClassVisitor createRemapper(final ClassVisitor classVisitor) {
+        return new JclClassRemapper(classVisitor, new JclRemapper());
+    }
+}

--- a/log4j-migration/src/main/java/org/apache/logging/log4j/migration/jcl/JclClassRemapper.java
+++ b/log4j-migration/src/main/java/org/apache/logging/log4j/migration/jcl/JclClassRemapper.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.migration.jcl;
+
+import org.apache.logging.log4j.migration.Log4j2Types;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.ClassRemapper;
+import org.objectweb.asm.commons.MethodRemapper;
+import org.objectweb.asm.commons.Remapper;
+
+public class JclClassRemapper extends ClassRemapper {
+
+    public JclClassRemapper(ClassVisitor classVisitor, Remapper remapper) {
+        super(Opcodes.ASM9, classVisitor, remapper);
+    }
+
+    @Override
+    protected MethodVisitor createMethodRemapper(MethodVisitor methodVisitor) {
+        return new JclMethodRemapper(methodVisitor, remapper);
+    }
+
+    private static class JclMethodRemapper extends MethodRemapper {
+
+        public JclMethodRemapper(MethodVisitor methodVisitor, Remapper remapper) {
+            super(Opcodes.ASM9, methodVisitor, remapper);
+        }
+
+        @Override
+        public void visitMethodInsn(int opcodeAndSource, String owner, String name, String descriptor,
+                boolean isInterface) {
+            if (JclTypes.LOGFACTORY.equals(owner)) {
+                switch (name) {
+                    // Call LogManager.getContext(false) (method descriptor changes)
+                    case JclTypes.GET_FACTORY_NAME:
+                        mv.visitInsn(Opcodes.ICONST_0);
+                        mv.visitMethodInsn(opcodeAndSource, Log4j2Types.LOGMANAGER, Log4j2Types.GET_CONTEXT_NAME,
+                                Log4j2Types.GET_CONTEXT_BOOLEAN_DESC, isInterface);
+                        break;
+                    case JclTypes.GET_LOG_NAME:
+                        final String logManagerDescriptor = JclTypes.GET_LOG_STRING_DESC.equals(descriptor)
+                                ? Log4j2Types.LOGMANAGER_GET_LOGGER_STRING_DESC
+                                : Log4j2Types.LOGMANAGER_GET_LOGGER_CLASS_DESC;
+                        mv.visitMethodInsn(opcodeAndSource, Log4j2Types.LOGMANAGER, Log4j2Types.GET_LOGGER_NAME,
+                                logManagerDescriptor, isInterface);
+                        break;
+                    case JclTypes.GET_INSTANCE_NAME:
+                        final String loggerContextDescriptor = JclTypes.GET_INSTANCE_STRING_DESC.equals(descriptor)
+                                ? Log4j2Types.LOGGERCONTEXT_GET_LOGGER_STRING_DESC
+                                : Log4j2Types.LOGGERCONTEXT_GET_LOGGER_CLASS_DESC;
+                        mv.visitMethodInsn(Opcodes.INVOKEINTERFACE, Log4j2Types.LOGGERCONTEXT, Log4j2Types.GET_LOGGER_NAME,
+                                loggerContextDescriptor, true);
+                        break;
+                    default:
+                        // Ignore the call
+                        final int argSize = Type.getArgumentsAndReturnSizes(descriptor) >> 2;
+                        for (int i = 0; i < argSize; i++) {
+                            mv.visitInsn(Opcodes.POP);
+                        }
+                }
+            } else {
+                super.visitMethodInsn(opcodeAndSource, owner, name, descriptor, isInterface);
+            }
+            ;
+        }
+
+    }
+}

--- a/log4j-migration/src/main/java/org/apache/logging/log4j/migration/jcl/JclClassValidator.java
+++ b/log4j-migration/src/main/java/org/apache/logging/log4j/migration/jcl/JclClassValidator.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.migration.jcl;
+
+import org.apache.logging.log4j.migration.ConversionException;
+import org.apache.logging.log4j.migration.ConverterProfile;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+/**
+ * Checks the original code for features that this weaver does not support.
+ *
+ */
+public class JclClassValidator extends ClassVisitor {
+
+    private final ConverterProfile profile;
+
+    public JclClassValidator(ClassVisitor classVisitor, ConverterProfile profile) {
+        super(Opcodes.ASM9, classVisitor);
+        this.profile = profile;
+    }
+
+    @Override
+    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        if (JclTypes.LOGFACTORY.equals(superName)) {
+            throw new ConversionException("Classes extending 'LogFactory' are not supported.");
+        }
+        for (final String iface : interfaces) {
+            if (JclTypes.LOG.equals(iface)) {
+                throw new ConversionException("Classes implementing 'Log' are not supported.");
+            }
+        }
+        super.visit(version, access, name, signature, superName, interfaces);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
+            String[] exceptions) {
+        return new JclMethodValidator(super.visitMethod(access, name, descriptor, signature, exceptions));
+    }
+
+    private class JclMethodValidator extends MethodVisitor {
+
+        protected JclMethodValidator(MethodVisitor methodVisitor) {
+            super(Opcodes.ASM9, methodVisitor);
+        }
+
+        @Override
+        public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+            if (JclTypes.LOGFACTORY.equals(owner)) {
+                switch (name) {
+                    case JclTypes.GET_FACTORY_NAME:
+                    case JclTypes.GET_LOG_NAME:
+                    case JclTypes.GET_INSTANCE_NAME:
+                        break;
+                    default:
+                        if (profile == ConverterProfile.FULL) {
+                            throw new ConversionException(
+                                    "Usage of the 'LogFactory#" + name + "' method is not supported.");
+                        }
+                }
+            }
+            super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+        }
+
+    }
+}

--- a/log4j-migration/src/main/java/org/apache/logging/log4j/migration/jcl/JclRemapper.java
+++ b/log4j-migration/src/main/java/org/apache/logging/log4j/migration/jcl/JclRemapper.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.migration.jcl;
+
+import org.apache.logging.log4j.migration.Log4j2Types;
+import org.objectweb.asm.commons.Remapper;
+
+public class JclRemapper extends Remapper {
+
+    @Override
+    public String map(String internalName) {
+        switch (internalName) {
+            case JclTypes.LOG:
+                return Log4j2Types.LOGGER;
+            case JclTypes.LOGFACTORY:
+                // the exception LogFactory.getFactory() is dealt with in JclMethodRemapper
+                return Log4j2Types.LOGGERCONTEXT;
+        }
+        return super.map(internalName);
+    }
+
+}

--- a/log4j-migration/src/main/java/org/apache/logging/log4j/migration/jcl/JclTypes.java
+++ b/log4j-migration/src/main/java/org/apache/logging/log4j/migration/jcl/JclTypes.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.migration.jcl;
+
+public class JclTypes {
+
+    public static final String LOG = "org/apache/commons/logging/Log";
+    public static final String LOGFACTORY = "org/apache/commons/logging/LogFactory";
+    public static final String LOGFACTORY_DESC = "Lorg/apache/commons/logging/LogFactory;";
+
+    // Supported LogFactory methods
+    public static final String GET_FACTORY_NAME = "getFactory";
+    public static final String GET_FACTORY_DESC = "()Lorg/apache/commons/logging/LogFactory;";
+    public static final String GET_LOG_NAME = "getLog";
+    public static final String GET_LOG_STRING_DESC = "(Ljava/lang/String;)Lorg/apache/commons/logging/Log;";
+    public static final String GET_LOG_CLASS_DESC = "(Ljava/lang/Class;)Lorg/apache/commons/logging/Log;";
+    public static final String GET_INSTANCE_NAME = "getInstance";
+    public static final String GET_INSTANCE_STRING_DESC = "(Ljava/lang/String;)Lorg/apache/commons/logging/Log;";
+    public static final String GET_INSTANCE_CLASS_DESC = "(Ljava/lang/Class;)Lorg/apache/commons/logging/Log;";
+
+    private JclTypes() {
+        // prevents instantiation
+    }
+}

--- a/log4j-migration/src/test/java/org/apache/logging/log4j/migration/jcl/JclConverterExample.java
+++ b/log4j-migration/src/test/java/org/apache/logging/log4j/migration/jcl/JclConverterExample.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.migration.jcl;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * This class written for JCL should send its logs to Log4j2 after weaving.
+ *
+ */
+public class JclConverterExample {
+
+    private static final LogFactory factory = LogFactory.getFactory();
+    private static final Log logFromString = LogFactory.getLog("test");
+    private static final Log logFromClass = LogFactory.getLog(JclConverterExample.class);
+
+    public void testLog(Throwable t) {
+        final Throwable t1 = t;
+        logFromString.fatal("This is fatal.");
+        logFromString.fatal("This is fatal.", t1);
+        logFromString.error("This is an error.");
+        logFromString.error("This is an error.", t1);
+        logFromString.warn("This is a warning.");
+        logFromString.warn("This is a warning.", t1);
+        logFromString.info("This is informational.");
+        logFromString.info("This is informational.", t1);
+        logFromString.debug("This is a debug message.");
+        logFromString.debug("This is a debug message.", t1);
+        logFromString.trace("This is a trace message.");
+        logFromString.trace("This is a trace message.", t1);
+    }
+
+    public LogFactory getLogFactory() {
+        return factory;
+    }
+
+    public Log getLogFromString() {
+        return logFromString;
+    }
+
+    public Log getLogFromClass() {
+        return logFromClass;
+    }
+
+    public Log getLogFromFactoryAndString() {
+        return factory.getInstance("test");
+    }
+
+    public Log getLogFromFactoryAndClass() {
+        return factory.getInstance(JclConverterExample.class);
+    }
+}

--- a/log4j-migration/src/test/java/org/apache/logging/log4j/migration/jcl/JclConverterTest.java
+++ b/log4j-migration/src/test/java/org/apache/logging/log4j/migration/jcl/JclConverterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.migration.jcl;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.apache.logging.log4j.migration.AbstractClassConverter;
+import org.apache.logging.log4j.migration.ConverterProfile;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@LoggerContextSource("log4j2-test.xml")
+public class JclConverterTest {
+
+    private static Class<?> convertedClass;
+    private static Object testObject;
+
+    @BeforeAll
+    public static void setup() throws ReflectiveOperationException, IOException {
+        final AbstractClassConverter converter = new JclClassConverter(ConverterProfile.FULL);
+        final ByteArrayOutputStream os = new ByteArrayOutputStream();
+        converter.convert(null, JclConverterTest.class.getResourceAsStream("JclConverterExample.class"), os);
+        convertedClass = MethodHandles.lookup().defineClass(os.toByteArray());
+        testObject = convertedClass.getConstructor().newInstance();
+    }
+
+    @Test
+    public void testLog(final @Named("List") ListAppender app) throws Exception {
+        final Throwable t = new RuntimeException();
+        convertedClass.getDeclaredMethod("testLog", Throwable.class).invoke(testObject, t);
+        final List<LogEvent> events = app.getEvents();
+        assertThat(events).extracting(LogEvent::getLevel).containsExactly(Level.FATAL, Level.FATAL, Level.ERROR,
+                Level.ERROR, Level.WARN, Level.WARN, Level.INFO, Level.INFO, Level.DEBUG, Level.DEBUG, Level.TRACE,
+                Level.TRACE);
+        assertThat(events).extracting(LogEvent::getThrown).filteredOn(Objects::nonNull).allMatch(t::equals);
+    }
+
+    static Stream<Arguments> testInstances() {
+        return Stream.of(Arguments.of("getLogFactory", org.apache.logging.log4j.spi.LoggerContext.class),
+                Arguments.of("getLogFromString", Logger.class), Arguments.of("getLogFromClass", Logger.class),
+                Arguments.of("getLogFromFactoryAndString", Logger.class),
+                Arguments.of("getLogFromFactoryAndClass", Logger.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void testInstances(final String methodName, final Class<?> clazz) throws Exception {
+        assertThat(convertedClass.getMethod(methodName).invoke(testObject)).isInstanceOf(clazz);
+    }
+}

--- a/log4j-migration/src/test/resources/log4j2-test.xml
+++ b/log4j-migration/src/test/resources/log4j2-test.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache license, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the license for the specific language governing permissions and
+  ~ limitations under the license.
+  -->
+<Configuration status="off">
+  <Appenders>
+    <List name="List" />
+  </Appenders>
+  <Loggers>
+    <Root level="trace">
+      <AppenderRef ref="List" />
+    </Root>
+  </Loggers>
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,7 @@
     <!-- Properties in the format `<artifactId>.version` -->
     <!-- Spring Boot uses the same convention. -->
     <asciidoctor-maven-plugin.version>1.5.6</asciidoctor-maven-plugin.version>
+    <asm.version>9.4</asm.version>
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
     <!-- checkstyle 10.0 requires Java 11 -->
     <checkstyle.version>9.3</checkstyle.version>
@@ -383,6 +384,13 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
         <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm-bom</artifactId>
+        <version>${asm.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -1865,6 +1873,7 @@
     <module>log4j-layout-template-json</module>
     <module>log4j-layout-template-json-test</module>
     <module>log4j-liquibase</module>
+    <module>log4j-migration</module>
     <module>log4j-mongodb3</module>
     <module>log4j-mongodb4</module>
     <module>log4j-osgi</module>


### PR DESCRIPTION
Similarly to what the [Tomcat Migration Tools for Jakarta EE](https://github.com/apache/tomcat-jakartaee-migration) does, this PR provides a binary classfile weaver that replaces JCL loggers and methods with Log4j2 API.

The supported JCL methods include the whole `Log` interface  and those `LogFactory` methods that produce (directly or indirectly) loggers, cf. `JclConverterExample/JclConverterTest` for the current limits of the weaver.

This PR most notably **lacks**:

- a command line interface,
- a converter to refactor source code,
- more converters to transform entire JARs or WARs (though we can borrow these from Tomcat).
