### PR TITLE
Add minimal style check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8   # 3.1.0
+        with:
+          fetch-depth: 32
 
       # JDK 11 is needed for the build.
       # Search `maven-toolchains-plugin` usages for details.
@@ -113,6 +115,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8   # 3.1.0
+        with:
+          fetch-depth: 32
 
       # JDK 11 is needed for the build.
       # Search `maven-toolchains-plugin` usages for details.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8   # 3.1.0
+        with:
+          fetch-depth: 32
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/log4j-kafka-test.yml
+++ b/.github/workflows/log4j-kafka-test.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8   # 3.1.0
+        with:
+          fetch-depth: 32
 
       - name: Setup JDK 8
         uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc   # 3.6.0

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8   # 3.1.0
         with:
           persist-credentials: false
+          fetch-depth: 32
 
       - name: "Run analysis"
         uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d    # 2.0.6

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/TestProperties.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/TestProperties.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.test;
 
 /**

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/ExtensionContextAnchor.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/ExtensionContextAnchor.java
@@ -14,10 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.test.junit;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -25,6 +22,8 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ExtensionContextAnchor
         implements BeforeAllCallback, BeforeEachCallback, AfterAllCallback, AfterEachCallback {

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/InitializesThreadContext.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/InitializesThreadContext.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.test.junit;
 
 import java.lang.annotation.Documented;

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/Resources.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/Resources.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.test.junit;
 
 import org.junit.jupiter.api.parallel.ResourceLock;

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/SetTestProperty.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/SetTestProperty.java
@@ -14,12 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.test.junit;
-
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Inherited;
@@ -30,6 +25,10 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junitpioneer.jupiter.ReadsEnvironmentVariable;
 import org.junitpioneer.jupiter.ReadsSystemProperty;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Registers a Log4j2 system property with the {@link TestPropertySource}. The

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/TestPropertySource.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/TestPropertySource.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.test.junit;
 
 import org.apache.logging.log4j.test.TestProperties;

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/ThreadContextMapExtension.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/ThreadContextMapExtension.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.test.junit;
 
 import java.util.Map;

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/UsingThreadContextMap.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/UsingThreadContextMap.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.test.junit;
 
 import java.lang.annotation.Documented;

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/LambdaLoggerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/LambdaLoggerTest.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j;
 
 import java.util.ArrayList;

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/LogManagerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/LogManagerTest.java
@@ -35,20 +35,20 @@ public class LogManagerTest {
     class Inner {
         final Logger LOGGER = LogManager.getLogger();
     }
-    
+
     @SuppressWarnings("InnerClassMayBeStatic")
     class InnerByClass {
         final Logger LOGGER = LogManager.getLogger(InnerByClass.class);
     }
-    
+
     static class StaticInner {
         final static Logger LOGGER = LogManager.getLogger();
     }
-    
+
     static class StaticInnerByClass {
         final static Logger LOGGER = LogManager.getLogger(StaticInnerByClass.class);
     }
-    
+
     @Test
     public void testGetLogger() {
         Logger logger = LogManager.getLogger();
@@ -80,9 +80,9 @@ public class LogManagerTest {
     @Test
     public void testGetLoggerForAnonymousInnerClass1() throws IOException {
         final Closeable closeable = new Closeable() {
-            
+
             final Logger LOGGER = LogManager.getLogger();
-            
+
             @Override
             public void close() throws IOException {
                 assertEquals("org.apache.logging.log4j.LogManagerTest$1", LOGGER.getName());
@@ -94,9 +94,9 @@ public class LogManagerTest {
     @Test
     public void testGetLoggerForAnonymousInnerClass2() throws IOException {
         final Closeable closeable = new Closeable() {
-            
+
             final Logger LOGGER = LogManager.getLogger(getClass());
-            
+
             @Override
             public void close() throws IOException {
                 assertEquals("org.apache.logging.log4j.LogManagerTest$2", LOGGER.getName());

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/LoggerSupplierTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/LoggerSupplierTest.java
@@ -172,14 +172,14 @@ public class LoggerSupplierTest {
         String entry = results.get(0);
         assertThat(entry).startsWith("ENTER[ FLOW ] TRACE Enter").contains("RUNNABLE", "Title of ...", getClass().getName());
     }
-    
+
     @BeforeEach
     public void setup() {
         results.clear();
         defaultLocale = Locale.getDefault(Locale.Category.FORMAT);
         Locale.setDefault(Locale.Category.FORMAT, java.util.Locale.US);
     }
-    
+
     @AfterEach
     public void tearDown() {
         Locale.setDefault(Locale.Category.FORMAT, defaultLocale);

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/MarkerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/MarkerTest.java
@@ -60,7 +60,7 @@ public class MarkerTest {
         existing.setParents(parent);
         assertTrue(existing.hasParents());
     }
-    
+
     @Test
     public void testMarker() {
         // root (level 1)

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/spi/DefaultThreadContextMapTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/spi/DefaultThreadContextMapTest.java
@@ -134,7 +134,7 @@ public class DefaultThreadContextMapTest {
         assertEquals("value2", map.get("key2"));
         return map;
     }
-    
+
     @Test
     public void testGetCopyReturnsMutableMap() {
         final DefaultThreadContextMap map = new DefaultThreadContextMap(true);
@@ -227,7 +227,7 @@ public class DefaultThreadContextMapTest {
         final ThreadLocal<Map<String, String>> threadLocal = DefaultThreadContextMap.createThreadLocalMap(true);
         assertFalse(threadLocal instanceof InheritableThreadLocal<?>);
     }
-    
+
     @Test
     @SetSystemProperty(key = DefaultThreadContextMap.INHERITABLE_MAP, value = "true")
     @InitializesThreadContext

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/spi/DefaultThreadContextStackTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/spi/DefaultThreadContextStackTest.java
@@ -16,6 +16,14 @@
  */
 package org.apache.logging.log4j.spi;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.apache.logging.log4j.ThreadContext.ContextStack;
+import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -24,14 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
-
-import org.apache.logging.log4j.ThreadContext.ContextStack;
-import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
-import org.junit.jupiter.api.Test;
 
 @UsingAnyThreadContext
 public class DefaultThreadContextStackTest {

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusConsoleListenerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusConsoleListenerTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.status;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogBuilder;
 import org.apache.logging.log4j.message.Message;
@@ -25,9 +28,6 @@ import org.apache.logging.log4j.simple.SimpleLogger;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 
 public class StatusConsoleListenerTest {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/ThreadContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/ThreadContext.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j;
 
 import java.io.Serializable;
@@ -27,13 +26,13 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 
 import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.logging.log4j.spi.CleanableThreadContextMap;
 import org.apache.logging.log4j.spi.DefaultThreadContextMap;
 import org.apache.logging.log4j.spi.DefaultThreadContextStack;
 import org.apache.logging.log4j.spi.NoOpThreadContextMap;
 import org.apache.logging.log4j.spi.ReadOnlyThreadContextMap;
 import org.apache.logging.log4j.spi.ThreadContextMap;
 import org.apache.logging.log4j.spi.ThreadContextMap2;
-import org.apache.logging.log4j.spi.CleanableThreadContextMap;
 import org.apache.logging.log4j.spi.ThreadContextMapFactory;
 import org.apache.logging.log4j.spi.ThreadContextStack;
 import org.apache.logging.log4j.util.PropertiesUtil;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -2860,7 +2860,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     public LogBuilder atDebug() {
         return atLevel(Level.DEBUG);
     }
-    
+
     /**
      * Construct an informational log event.
      * @return a LogBuilder.
@@ -2870,7 +2870,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     public LogBuilder atInfo() {
         return atLevel(Level.INFO);
     }
-    
+
     /**
      * Construct a warning log event.
      * @return a LogBuilder.
@@ -2880,7 +2880,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     public LogBuilder atWarn() {
         return atLevel(Level.WARN);
     }
-    
+
     /**
      * Construct an error log event.
      * @return a LogBuilder.
@@ -2890,7 +2890,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     public LogBuilder atError() {
         return atLevel(Level.ERROR);
     }
-    
+
     /**
      * Construct a fatal log event.
      * @return a LogBuilder.
@@ -2900,7 +2900,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     public LogBuilder atFatal() {
         return atLevel(Level.FATAL);
     }
-    
+
     /**
      * Construct a log event that will always be logged.
      * @return a LogBuilder.
@@ -2914,7 +2914,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         }
         return builder.reset(Level.OFF);
     }
-    
+
     /**
      * Construct a log event.
      * @return a LogBuilder.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/SimpleLoggerFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/SimpleLoggerFactory.java
@@ -16,12 +16,12 @@
  */
 package org.apache.logging.log4j.status;
 
+import java.io.PrintStream;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.simple.SimpleLogger;
 import org.apache.logging.log4j.util.Strings;
-
-import java.io.PrintStream;
 
 /**
  * {@link org.apache.logging.log4j.simple.SimpleLogger} factory to be used by {@link StatusLogger} and {@link StatusConsoleListener}.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
@@ -16,13 +16,13 @@
  */
 package org.apache.logging.log4j.status;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedNoReferenceMessageFactory;
-
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Objects;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedNoReferenceMessageFactory;
 
 /**
  * {@link StatusListener} that writes to the console.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -16,17 +16,6 @@
  */
 package org.apache.logging.log4j.status;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.Marker;
-import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.message.MessageFactory;
-import org.apache.logging.log4j.message.ParameterizedNoReferenceMessageFactory;
-import org.apache.logging.log4j.simple.SimpleLogger;
-import org.apache.logging.log4j.simple.SimpleLoggerContext;
-import org.apache.logging.log4j.spi.AbstractLogger;
-import org.apache.logging.log4j.util.Constants;
-import org.apache.logging.log4j.util.PropertiesUtil;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,6 +28,17 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.MessageFactory;
+import org.apache.logging.log4j.message.ParameterizedNoReferenceMessageFactory;
+import org.apache.logging.log4j.simple.SimpleLogger;
+import org.apache.logging.log4j.simple.SimpleLoggerContext;
+import org.apache.logging.log4j.spi.AbstractLogger;
+import org.apache.logging.log4j.util.Constants;
+import org.apache.logging.log4j.util.PropertiesUtil;
 
 /**
  * Records events that occur in the logging system. By default, only error messages are logged to {@link System#err}.
@@ -130,7 +130,7 @@ public final class StatusLogger extends AbstractLogger {
      * <li>LOG4J2-3340 StatusLogger's log Level cannot be changed as advertised.</li>
      * </ol>
      * </p>
-     * 
+     *
      * @param name The logger name.
      * @param messageFactory The message factory.
      */

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 
 /**
  * <em>Consider this class private.</em>
- * 
+ *
  * @see <a href="http://commons.apache.org/proper/commons-lang/">Apache Commons Lang</a>
  */
 public final class Strings {
@@ -34,12 +34,12 @@ public final class Strings {
      */
     public static final String EMPTY = "";
     private static final String COMMA_DELIMITED_RE = "\\s*,\\s*";
-    
+
     /**
      * The empty array.
      */
     public static final String[] EMPTY_ARRAY = {};
-    
+
     /**
      * OS-dependent line separator, defaults to {@code "\n"} if the system property {@code ""line.separator"} cannot be
      * read.
@@ -49,14 +49,14 @@ public final class Strings {
 
     /**
      * Returns a double quoted string.
-     * 
+     *
      * @param str a String
      * @return {@code "str"}
      */
     public static String dquote(final String str) {
         return Chars.DQUOTE + str + Chars.DQUOTE;
     }
-    
+
     /**
      * Checks if a String is blank. A blank string is one that is either
      * {@code null}, empty, or all characters are {@link Character#isWhitespace(char)}.
@@ -223,7 +223,7 @@ public final class Strings {
      * <p>
      * Copied from Apache Commons Lang org.apache.commons.lang3.StringUtils.
      * </p>
-     * 
+     *
      * @param str  the String to get the leftmost characters from, may be null
      * @param len  the length of the required String
      * @return the leftmost characters, {@code null} if null String input
@@ -243,14 +243,14 @@ public final class Strings {
 
     /**
      * Returns a quoted string.
-     * 
+     *
      * @param str a String
      * @return {@code 'str'}
      */
     public static String quote(final String str) {
         return Chars.QUOTE + str + Chars.QUOTE;
     }
-    
+
     /**
      * <p>
      * Removes control characters (char &lt;= 32) from both ends of this String returning {@code null} if the String is

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/SystemPropertiesPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/SystemPropertiesPropertySource.java
@@ -29,79 +29,79 @@ import java.util.Properties;
  */
 public class SystemPropertiesPropertySource implements PropertySource {
 
-	private static final int DEFAULT_PRIORITY = 0;
-	private static final String PREFIX = "log4j2.";
+    private static final int DEFAULT_PRIORITY = 0;
+    private static final String PREFIX = "log4j2.";
 
-	/**
-	 * Used by bootstrap code to get system properties without loading PropertiesUtil.
-	 */
-	public static String getSystemProperty(final String key, final String defaultValue) {
-		try {
-			return System.getProperty(key, defaultValue);
-		} catch (SecurityException e) {
-			// Silently ignore the exception
-			return defaultValue;
-		}
-	}
+    /**
+     * Used by bootstrap code to get system properties without loading PropertiesUtil.
+     */
+    public static String getSystemProperty(final String key, final String defaultValue) {
+        try {
+            return System.getProperty(key, defaultValue);
+        } catch (SecurityException e) {
+            // Silently ignore the exception
+            return defaultValue;
+        }
+    }
 
-	@Override
-	public int getPriority() {
-		return DEFAULT_PRIORITY;
-	}
+    @Override
+    public int getPriority() {
+        return DEFAULT_PRIORITY;
+    }
 
-	@Override
-	public void forEach(final BiConsumer<String, String> action) {
-		Properties properties;
-		try {
-			properties = System.getProperties();
-		} catch (final SecurityException e) {
-			// (1) There is no status logger.
-			// (2) LowLevelLogUtil also consults system properties ("line.separator") to
-			// open a BufferedWriter, so this may fail as well. Just having a hard reference
-			// in this code to LowLevelLogUtil would cause a problem.
-			// (3) We could log to System.err (nah) or just be quiet as we do now.
-			return;
-		}
-		// Lock properties only long enough to get a thread-safe SAFE snapshot of its
-		// current keys, an array.
-		final Object[] keySet;
-		synchronized (properties) {
-			keySet = properties.keySet().toArray();
-		}
-		// Then traverse for an unknown amount of time.
-		// Some keys may now be absent, in which case, the value is null.
-		for (final Object key : keySet) {
-			final String keyStr = Objects.toString(key, null);
-			action.accept(keyStr, properties.getProperty(keyStr));
-		}
-	}
+    @Override
+    public void forEach(final BiConsumer<String, String> action) {
+        Properties properties;
+        try {
+            properties = System.getProperties();
+        } catch (final SecurityException e) {
+            // (1) There is no status logger.
+            // (2) LowLevelLogUtil also consults system properties ("line.separator") to
+            // open a BufferedWriter, so this may fail as well. Just having a hard reference
+            // in this code to LowLevelLogUtil would cause a problem.
+            // (3) We could log to System.err (nah) or just be quiet as we do now.
+            return;
+        }
+        // Lock properties only long enough to get a thread-safe SAFE snapshot of its
+        // current keys, an array.
+        final Object[] keySet;
+        synchronized (properties) {
+            keySet = properties.keySet().toArray();
+        }
+        // Then traverse for an unknown amount of time.
+        // Some keys may now be absent, in which case, the value is null.
+        for (final Object key : keySet) {
+            final String keyStr = Objects.toString(key, null);
+            action.accept(keyStr, properties.getProperty(keyStr));
+        }
+    }
 
-	@Override
-	public CharSequence getNormalForm(final Iterable<? extends CharSequence> tokens) {
-		return PREFIX + Util.joinAsCamelCase(tokens);
-	}
+    @Override
+    public CharSequence getNormalForm(final Iterable<? extends CharSequence> tokens) {
+        return PREFIX + Util.joinAsCamelCase(tokens);
+    }
 
-	@Override
-	public Collection<String> getPropertyNames() {
-		try {
-			return System.getProperties().stringPropertyNames();
-		} catch (final SecurityException e) {
-			return PropertySource.super.getPropertyNames();
-		}
-	}
+    @Override
+    public Collection<String> getPropertyNames() {
+        try {
+            return System.getProperties().stringPropertyNames();
+        } catch (final SecurityException e) {
+            return PropertySource.super.getPropertyNames();
+        }
+    }
 
-	@Override
-	public String getProperty(String key) {
-		try {
-			return System.getProperty(key);
-		} catch (final SecurityException e) {
-			return PropertySource.super.getProperty(key);
-		}
-	}
+    @Override
+    public String getProperty(String key) {
+        try {
+            return System.getProperty(key);
+        } catch (final SecurityException e) {
+            return PropertySource.super.getProperty(key);
+        }
+    }
 
-	@Override
-	public boolean containsProperty(String key) {
-		return getProperty(key) != null;
-	}
+    @Override
+    public boolean containsProperty(String key) {
+        return getProperty(key) != null;
+    }
 
 }

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/Compiler.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/Compiler.java
@@ -14,21 +14,20 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.test;
 
-import javax.tools.Diagnostic;
-import javax.tools.DiagnosticCollector;
-import javax.tools.JavaCompiler;
-import javax.tools.JavaFileObject;
-import javax.tools.StandardJavaFileManager;
-import javax.tools.ToolProvider;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/ConfigurationResolver.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/ConfigurationResolver.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.test.junit;
 
 import org.apache.logging.log4j.core.LoggerContext;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/LoggerContextResolver.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/LoggerContextResolver.java
@@ -14,16 +14,15 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.test.junit;
 
 import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.logging.log4j.test.junit.TypeBasedParameterResolver;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.LoggerContextAccessor;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.test.junit.TypeBasedParameterResolver;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppenderCloseTimeoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppenderCloseTimeoutTest.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.appender.mom.kafka;
 
 import java.time.Duration;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/AnnotationProcessorCompilerErrorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/AnnotationProcessorCompilerErrorTest.java
@@ -14,17 +14,16 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.config.plugins.processor;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.apache.logging.log4j.core.test.Compiler;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junitpioneer.jupiter.Issue;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 @Issue("LOG4J2-3609")
 // only enabled for explicit testing of what may be a javac bug

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/util/PluginManagerPackagesTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/util/PluginManagerPackagesTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.logging.log4j.core.config.plugins.util;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -27,10 +31,6 @@ import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/HtmlLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/HtmlLayoutTest.java
@@ -47,8 +47,8 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat;
+import static org.junit.jupiter.api.Assertions.*;
 
 @UsingAnyThreadContext
 public class HtmlLayoutTest {
@@ -266,7 +266,7 @@ public class HtmlLayoutTest {
 
         // LOG4J2-3019 HtmlLayoutTest.testLayoutWithDatePatternFixedFormat test fails on windows
         // https://issues.apache.org/jira/browse/LOG4J2-3019
-        // java.time.format.DateTimeFormatterBuilder.toFormatter() defaults to using 
+        // java.time.format.DateTimeFormatterBuilder.toFormatter() defaults to using
         // Locale.getDefault(Locale.Category.FORMAT)
         final Locale formatLocale = Locale.getDefault(Locale.Category.FORMAT);
         final Locale locale = Locale.getDefault().equals(formatLocale) ? formatLocale : Locale.getDefault();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppender.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.appender.mom.kafka;
 
 import java.io.Serializable;
@@ -175,7 +174,7 @@ public final class KafkaAppender extends AbstractAppender {
         return new Builder<B>().asBuilder();
     }
 
-	private final Integer retryCount;
+    private final Integer retryCount;
 
     private final KafkaManager manager;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/Configurator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/Configurator.java
@@ -16,6 +16,11 @@
  */
 package org.apache.logging.log4j.core.config;
 
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -26,11 +31,6 @@ import org.apache.logging.log4j.spi.LoggerContextFactory;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.StackLocatorUtil;
 import org.apache.logging.log4j.util.Strings;
-
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Initializes and configure the Logging system. This class provides several ways to construct a LoggerContext using

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/util/InstantFormatterTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/util/InstantFormatterTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.layout.template.json.util;
 
+import java.util.Locale;
+import java.util.TimeZone;
+
 import org.apache.logging.log4j.core.time.MutableInstant;
 import org.apache.logging.log4j.core.util.datetime.FastDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
@@ -23,9 +26,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-
-import java.util.Locale;
-import java.util.TimeZone;
 
 class InstantFormatterTest {
 

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/InstantFormatter.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/InstantFormatter.java
@@ -16,19 +16,19 @@
  */
 package org.apache.logging.log4j.layout.template.json.util;
 
-import org.apache.logging.log4j.core.time.Instant;
-import org.apache.logging.log4j.core.time.MutableInstant;
-import org.apache.logging.log4j.core.util.datetime.FastDateFormat;
-import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
-import org.apache.logging.log4j.status.StatusLogger;
-import org.apache.logging.log4j.util.Strings;
-
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.TimeZone;
+
+import org.apache.logging.log4j.core.time.Instant;
+import org.apache.logging.log4j.core.time.MutableInstant;
+import org.apache.logging.log4j.core.util.datetime.FastDateFormat;
+import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Strings;
 
 /**
  * A composite {@link Instant} formatter trying to employ either

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/JdbcAppenderBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/JdbcAppenderBenchmark.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.perf.jmh;
 
 import java.sql.Connection;

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/JpaAppenderBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/JpaAppenderBenchmark.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.perf.jmh;
 
 import java.sql.Connection;

--- a/log4j-samples/pom.xml
+++ b/log4j-samples/pom.xml
@@ -28,6 +28,7 @@
   <name>Apache Log4j Samples</name>
   <url>http://maven.apache.org</url>
   <properties>
+    <log4jParentDir>${basedir}/..</log4jParentDir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <revapi.skip>true</revapi.skip>
 

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,7 @@
     <maven-taglib-plugin.version>2.4</maven-taglib-plugin.version>
     <maven-toolchains-plugin.version>3.1.0</maven-toolchains-plugin.version>
     <spotbugs-maven-plugin.version>4.7.2.1</spotbugs-maven-plugin.version>
+    <spotless-maven-plugin.version>2.27.2</spotless-maven-plugin.version>
     <!-- surefire.plugin.version 2.18 yields http://jira.codehaus.org/browse/SUREFIRE-1121, which is fixed in 2.18.1 -->
     <!-- surefire.plugin.version 2.19 yields https://issues.apache.org/jira/browse/SUREFIRE-1193. -->
     <!-- all versions after 2.13 yield https://issues.apache.org/jira/browse/SUREFIRE-720 -->
@@ -1292,6 +1293,33 @@
             <threshold>Normal</threshold>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${spotless-maven-plugin.version}</version>
+          <configuration>
+            <!-- Check only files modified since 2022-10-01 -->
+            <ratchetFrom>3164c0dac25df0205498c683f9d5ae5ad34015bd</ratchetFrom>
+            <java>
+              <licenseHeader>
+                <file>${log4jParentDir}/checkstyle-header.txt</file>
+              </licenseHeader>
+
+              <!-- Whitespace -->
+              <trimTrailingWhitespace/>
+              <endWithNewline/>
+              <indent>
+                <spaces>true</spaces>
+                <spacesPerTab>4</spacesPerTab>
+              </indent>
+
+              <!-- Imports -->
+              <importOrder>
+                <order>java,org,com,\#</order>
+              </importOrder>
+            </java>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -1528,6 +1556,18 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-spotless</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1298,8 +1298,8 @@
           <artifactId>spotless-maven-plugin</artifactId>
           <version>${spotless-maven-plugin.version}</version>
           <configuration>
-            <!-- Check only files modified since 2022-10-01 -->
-            <ratchetFrom>3164c0dac25df0205498c683f9d5ae5ad34015bd</ratchetFrom>
+            <!-- Check last 32 commits -->
+            <ratchetFrom>HEAD~31</ratchetFrom>
             <java>
               <licenseHeader>
                 <file>${log4jParentDir}/checkstyle-header.txt</file>


### PR DESCRIPTION
This PR adds a check for formatting problems in files from the last 32 commits. These include:
* differences in the license,
* trailing whitespace,
* incorrect file endings,
* indentation with tabs,
* incorrect ordering of imports.

Problems can be corrected by running `mvn spotless:apply`.