### PR TITLE
Correctly default to not include location info for AsyncRootLoggers L…

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncRootLoggerDefaultLocationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncRootLoggerDefaultLocationTest.java
@@ -36,12 +36,12 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 @Category(AsyncLoggers.class)
-public class AsyncLoggerDefaultLocationTest {
+public class AsyncRootLoggerDefaultLocationTest {
 
     @BeforeClass
     public static void beforeClass() {
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
-                "AsyncLoggerDefaultLocationTest.xml");
+                "AsyncRootLoggerDefaultLocationTest.xml");
     }
 
     @AfterClass
@@ -55,7 +55,7 @@ public class AsyncLoggerDefaultLocationTest {
         ListAppender app = context.getConfiguration().getAppender("List");
         assertNotNull(app);
         final Logger log = context.getLogger("com.foo.Bar");
-        final String msg = "Async logger msg with no location by default";
+        final String msg = "Async root logger msg with no location by default";
         log.info(msg);
         context.stop();
         assertEquals(1, app.getEvents().size());
@@ -63,5 +63,4 @@ public class AsyncLoggerDefaultLocationTest {
         assertFalse("includeLocation should be false", event.isIncludeLocation());
         assertNull("Location data should not be present", event.getSource());
     }
-
 }

--- a/log4j-core-test/src/test/resources/AsyncRootLoggerDefaultLocationTest.xml
+++ b/log4j-core-test/src/test/resources/AsyncRootLoggerDefaultLocationTest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="OFF">
+  <Appenders>
+    <List name="List"/>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout>
+        <pattern>%d %p %c{1.} [%t] %X{aKey} %m %ex%n</pattern>
+      </PatternLayout>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <AsyncRoot level="info">
+      <AppenderRef ref="List"/>
+      <AppenderRef ref="Console"/>
+    </AsyncRoot>
+  </Loggers>
+</Configuration>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
@@ -319,7 +319,8 @@ public class AsyncLoggerConfig extends LoggerConfig {
                 LevelAndRefs container = LoggerConfig.getLevelAndRefs(getLevel(), getRefs(), getLevelAndRefs(),
                         getConfig());
                 return new AsyncLoggerConfig(LogManager.ROOT_LOGGER_NAME, container.refs, getFilter(), container.level,
-                        isAdditivity(), getProperties(), getConfig(), includeLocation(getIncludeLocation()));
+                        isAdditivity(), getProperties(), getConfig(),
+                        AsyncLoggerConfig.includeLocation(getIncludeLocation()));
             }
         }
 

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -30,6 +30,9 @@
          - "remove" - Removed
     -->
     <release version="2.19.1" date="TBD" description="GA Release 2.19.1">
+      <action issue="LOG4J2-3487" dev="dmessink" type="fix" due-to="Dave Messink">
+        Correct default to not include location for AsyncRootLoggers
+      </action>
       <action issue="LOG4J2-2678" dev="pkarwasz" type="update" due-to="Federico D'Ambrosio">
         Add LogEvent timestamp to ProducerRecord in KafkaAppender.
       </action>


### PR DESCRIPTION
…OG4J2-3487

This addresses a change in the AsyncRootLogger includeLocation default value introduced in 2.17.2. The default value should be false, but ends up being true. A previous fix addressed this for AsyncLoggers, but missed the AsyncRootLogger.