### PR TITLE
Check urlConnection for being instance of JarURLConnection instead of relying on protocol name

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
@@ -62,8 +62,6 @@ public class ConfigurationSource {
      * ConfigurationSource to use with {@link org.apache.logging.log4j.core.config.composite.CompositeConfiguration}.
      */
     public static final ConfigurationSource COMPOSITE_SOURCE = new ConfigurationSource(Constants.EMPTY_BYTE_ARRAY, null, 0);
-    private static final String HTTPS = "https";
-    private static final String JAR = "jar";
 
     private final InputStream stream;
     private volatile byte[] data;
@@ -367,7 +365,7 @@ public class ConfigurationSource {
             try {
                 if (file != null) {
                     return new ConfigurationSource(urlConnection.getInputStream(), FileUtils.fileFromUri(url.toURI()));
-                } else if (JAR.equals(url.getProtocol())) {
+                } else if (urlConnection instanceof JarURLConnection) {
                     // Work around https://bugs.openjdk.java.net/browse/JDK-6956385.
                     long lastModified = new File(((JarURLConnection)urlConnection).getJarFile().getName())
                             .lastModified();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.config;
 
 import java.io.ByteArrayInputStream;
@@ -34,19 +33,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 
-import javax.net.ssl.HttpsURLConnection;
-
 import org.apache.logging.log4j.core.net.UrlConnectionFactory;
-import org.apache.logging.log4j.core.net.ssl.LaxHostnameVerifier;
-import org.apache.logging.log4j.core.net.ssl.SslConfiguration;
-import org.apache.logging.log4j.core.net.ssl.SslConfigurationFactory;
-import org.apache.logging.log4j.core.util.AuthorizationProvider;
 import org.apache.logging.log4j.core.util.FileUtils;
 import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.core.util.Source;
 import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.LoaderUtil;
-import org.apache.logging.log4j.util.PropertiesUtil;
 
 /**
  * Represents the source for the logging configuration.
@@ -209,15 +201,15 @@ public class ConfigurationSource {
     private boolean isFile() {
         return source == null ? false : source.getFile() != null;
     }
-    
+
     private boolean isURL() {
         return source == null ? false : source.getURI() != null;
     }
-    
+
     private boolean isLocation() {
         return source == null ? false : source.getLocation() != null;
     }
-    
+
     /**
      * Returns the configuration source URL, or {@code null} if this configuration source is based on a file or has
      * neither a file nor an URL.


### PR DESCRIPTION
This PR resolves Log4j initialization problem in Intellij IDEA plugins which use Log4j2 for logging

```
Caused by: java.lang.ClassCastException: class com.intellij.util.lang.ZipResourceFile$MyUrlConnection cannot be cast to class java.net.JarURLConnection (com.intellij.util.lang.ZipResourceFile$MyUrlConnection is in unnamed module of loader 'app'; java.net.JarURLConnection is in module java.base of loader 'bootstrap')
	at org.apache.logging.log4j.core.config.ConfigurationSource.getConfigurationSource(ConfigurationSource.java:372)
```