### PR TITLE
[LOG4J2-3642] Consider Osgi versions older than 1.5 as not available.

### DIFF
--- a/log4j-api-test/pom.xml
+++ b/log4j-api-test/pom.xml
@@ -99,16 +99,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.felix</groupId>
-      <artifactId>org.apache.felix.framework</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.tycho</groupId>
-      <artifactId>org.eclipse.osgi</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>uk.org.webcompere</groupId>
       <artifactId>system-stubs-jupiter</artifactId>
       <scope>test</scope>

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/ServiceLoaderUtilTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/ServiceLoaderUtilTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.util;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
@@ -66,4 +67,11 @@ public class ServiceLoaderUtilTest {
                 ServiceConfigurationError.class, ServiceConfigurationError.class, ClassFormatError.class);
     }
 
+    @Test
+    public void testOsgiUnavailable() {
+        // OSGI classes are present...
+        assertDoesNotThrow(() -> Class.forName("org.osgi.framework.FrameworkUtil"));
+        // ...but we don't run in an OSGI container
+        assertThat(OsgiServiceLocator.isAvailable()).as("Running in OSGI container").isFalse();
+    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/OsgiServiceLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/OsgiServiceLocator.java
@@ -30,12 +30,17 @@ public class OsgiServiceLocator {
 
     private static boolean checkOsgiAvailable() {
         try {
-            Class.forName("org.osgi.framework.Bundle");
-            return true;
-        } catch (final ClassNotFoundException | LinkageError e) {
+            /*
+             * OSGI classes of any version can still be present even if Log4j2 does not run in
+             * an OSGI container, hence we check if this class is in a bundle.
+             */
+            final Class< ? > clazz = Class.forName("org.osgi.framework.FrameworkUtil");
+            return clazz.getMethod("getBundle", Class.class)
+                    .invoke(null, OsgiServiceLocator.class) != null;
+        } catch (final ClassNotFoundException | NoSuchMethodException | LinkageError e) {
             return false;
         } catch (final Throwable e) {
-            LowLevelLogUtil.logException("Unknown error checking for existence of class: org.osgi.framework.Bundle", e);
+            LowLevelLogUtil.logException("Unknown error checking OSGI environment.", e);
             return false;
         }
     }

--- a/log4j-osgi/src/test/java/org/apache/logging/log4j/osgi/tests/AbstractLoadBundleTest.java
+++ b/log4j-osgi/src/test/java/org/apache/logging/log4j/osgi/tests/AbstractLoadBundleTest.java
@@ -258,6 +258,9 @@ public abstract class AbstractLoadBundleTest {
         final Bundle core = getCoreBundle();
         final Bundle apiTests = getApiTestsBundle();
 
+        final Class<?> osgiServiceLocator = api.loadClass("org.apache.logging.log4j.util.OsgiServiceLocator");
+        assertTrue("OsgiServiceLocator is active", (boolean) osgiServiceLocator.getMethod("isAvailable").invoke(null));
+
         api.start();
         core.start();
         assertEquals("api-tests is not in RESOLVED state", Bundle.RESOLVED, apiTests.getState());

--- a/src/changelog/.2.x.x/LOG4J2-3642_disable_OSGI_locator_if_not_OSGI.xml
+++ b/src/changelog/.2.x.x/LOG4J2-3642_disable_OSGI_locator_if_not_OSGI.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.0.xsd"
+       type="fixed">
+  <issue id="LOG4J2-3642" link="https://issues.apache.org/jira/browse/LOG4J2-3642"/>
+  <author id="adwsingh" name="Adwait Kumar Singh"/>
+  <author id="pkarwasz"/>
+  <description format="asciidoc">Disable `OsgiServiceLocator` if not running in OSGI container.</description>
+</entry>


### PR DESCRIPTION
We use the method [FrameworkUtil.getBundle](https://github.com/apache/logging-log4j2/blob/release-2.x/log4j-core/src/main/java/org/apache/logging/log4j/core/osgi/BundleContextSelector.java#L59) from OSGi, but this method was added [only in OSGi 1.5](https://github.com/osgi/osgi/blob/main/org.osgi.framework/src/org/osgi/framework/FrameworkUtil.java#L224), this causes NoSuchMethodError if older version of OSGi is used.

I would suggest to consider OSGi being unavailable for OSGi version < 1.5 or when that method is not available.