### PR TITLE
[LOG4J2-3645] Minimal changes to allow flow tracing with LogBuilder

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/LoggerSupplierTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/LoggerSupplierTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.logging.log4j;
 
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+
 import org.apache.logging.log4j.message.FormattedMessage;
 import org.apache.logging.log4j.message.JsonMessage;
 import org.apache.logging.log4j.message.LocalizedMessage;
@@ -34,10 +38,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
-
-import java.util.List;
-import java.util.Locale;
-import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -173,14 +173,14 @@ public class LoggerSupplierTest {
         String entry = results.get(0);
         assertThat(entry).startsWith("ENTER[ FLOW ] TRACE Enter").contains("RUNNABLE", "Title of ...", getClass().getName());
     }
-    
+
     @BeforeEach
     public void setup() {
         results.clear();
         defaultLocale = Locale.getDefault(Locale.Category.FORMAT);
         Locale.setDefault(Locale.Category.FORMAT, java.util.Locale.US);
     }
-    
+
     @AfterEach
     public void tearDown() {
         Locale.setDefault(Locale.Category.FORMAT, defaultLocale);

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/LoggerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/LoggerTest.java
@@ -16,15 +16,6 @@
  */
 package org.apache.logging.log4j;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.endsWith;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -50,6 +41,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junitpioneer.jupiter.ReadsSystemProperty;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ResourceLock(value = Resources.MARKER_MANAGER, mode = ResourceAccessMode.READ)
 @ReadsSystemProperty
@@ -87,8 +87,8 @@ public class LoggerTest {
         logger.traceEntry();
         logger.traceExit();
         assertEquals(2, results.size());
-        assertThat("Incorrect Entry", results.get(0), equalTo("ENTER[ FLOW ] TRACE Enter"));
-        assertThat("incorrect Exit", results.get(1), equalTo("EXIT[ FLOW ] TRACE Exit"));
+        assertThat(results.get(0)).isEqualTo("ENTER[ FLOW ] TRACE Enter");
+        assertThat(results.get(1)).isEqualTo("EXIT[ FLOW ] TRACE Exit");
 
     }
 
@@ -99,73 +99,63 @@ public class LoggerTest {
         logger.traceEntry(new JsonMessage(props));
         final Response response = new Response(-1, "Generic error");
         logger.traceExit(new JsonMessage(response),  response);
-        assertEquals(2, results.size());
-        assertThat("Incorrect Entry", results.get(0), startsWith("ENTER[ FLOW ] TRACE Enter"));
-        assertThat("Missing entry data", results.get(0), containsString("\"foo\":\"bar\""));
-        assertThat("incorrect Exit", results.get(1), startsWith("EXIT[ FLOW ] TRACE Exit"));
-        assertThat("Missing exit data", results.get(1), containsString("\"message\":\"Generic error\""));
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0)).startsWith("ENTER[ FLOW ] TRACE Enter").contains("\"foo\":\"bar\"");
+        assertThat(results.get(1)).startsWith("EXIT[ FLOW ] TRACE Exit").contains("\"message\":\"Generic error\"");
     }
 
     @Test
     public void flowTracingString_ObjectArray1() {
         logger.traceEntry("doFoo(a={}, b={})", 1, 2);
         logger.traceExit("doFoo(a=1, b=2): {}", 3);
-        assertEquals(2, results.size());
-        assertThat("Incorrect Entry", results.get(0), startsWith("ENTER[ FLOW ] TRACE Enter"));
-        assertThat("Missing entry data", results.get(0), containsString("doFoo(a=1, b=2)"));
-        assertThat("Incorrect Exit", results.get(1), startsWith("EXIT[ FLOW ] TRACE Exit"));
-        assertThat("Missing exit data", results.get(1), containsString("doFoo(a=1, b=2): 3"));
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0)).startsWith("ENTER[ FLOW ] TRACE Enter").contains("doFoo(a=1, b=2)");
+        assertThat(results.get(1)).startsWith("EXIT[ FLOW ] TRACE Exit").contains("doFoo(a=1, b=2): 3");
     }
 
     @Test
     public void flowTracingExitValueOnly() {
         logger.traceEntry("doFoo(a={}, b={})", 1, 2);
         logger.traceExit(3);
-        assertEquals(2, results.size());
-        assertThat("Incorrect Entry", results.get(0), startsWith("ENTER[ FLOW ] TRACE Enter"));
-        assertThat("Missing entry data", results.get(0), containsString("doFoo(a=1, b=2)"));
-        assertThat("Incorrect Exit", results.get(1), startsWith("EXIT[ FLOW ] TRACE Exit"));
-        assertThat("Missing exit data", results.get(1), containsString("3"));
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0)).startsWith("ENTER[ FLOW ] TRACE Enter").contains("doFoo(a=1, b=2)");
+        assertThat(results.get(1)).startsWith("EXIT[ FLOW ] TRACE Exit").contains("3");
     }
 
     @Test
     public void flowTracingString_ObjectArray2() {
         final EntryMessage msg = logger.traceEntry("doFoo(a={}, b={})", 1, 2);
         logger.traceExit(msg, 3);
-        assertEquals(2, results.size());
-        assertThat("Incorrect Entry", results.get(0), startsWith("ENTER[ FLOW ] TRACE Enter"));
-        assertThat("Missing entry data", results.get(0), containsString("doFoo(a=1, b=2)"));
-        assertThat("Incorrect Exit", results.get(1), startsWith("EXIT[ FLOW ] TRACE Exit"));
-        assertThat("Missing exit data", results.get(1), containsString("doFoo(a=1, b=2): 3"));
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0)).startsWith("ENTER[ FLOW ] TRACE Enter").contains("doFoo(a=1, b=2)");
+        assertThat(results.get(1)).startsWith("EXIT[ FLOW ] TRACE Exit").contains("doFoo(a=1, b=2): 3");
     }
 
     @Test
     public void flowTracingVoidReturn() {
         final EntryMessage msg = logger.traceEntry("doFoo(a={}, b={})", 1, 2);
         logger.traceExit(msg);
-        assertEquals(2, results.size());
-        assertThat("Incorrect Entry", results.get(0), startsWith("ENTER[ FLOW ] TRACE Enter"));
-        assertThat("Missing entry data", results.get(0), containsString("doFoo(a=1, b=2)"));
-        assertThat("Incorrect Exit", results.get(1), startsWith("EXIT[ FLOW ] TRACE Exit"));
-        assertThat("Missing exit data", results.get(1), endsWith("doFoo(a=1, b=2)"));
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0)).startsWith("ENTER[ FLOW ] TRACE Enter").contains("doFoo(a=1, b=2)");
+        assertThat(results.get(1)).startsWith("EXIT[ FLOW ] TRACE Exit").endsWith("doFoo(a=1, b=2)");
     }
 
     @Test
     public void flowTracingNoExitArgs() {
         logger.traceEntry();
         logger.traceExit();
-        assertEquals(2, results.size());
-        assertThat("Incorrect Entry", results.get(0), startsWith("ENTER[ FLOW ] TRACE Enter"));
-        assertThat("Incorrect Exit", results.get(1), startsWith("EXIT[ FLOW ] TRACE Exit"));
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0)).startsWith("ENTER[ FLOW ] TRACE Enter");
+        assertThat(results.get(1)).startsWith("EXIT[ FLOW ] TRACE Exit");
     }
 
     @Test
     public void flowTracingNoArgs() {
         final EntryMessage message = logger.traceEntry();
         logger.traceExit(message);
-        assertEquals(2, results.size());
-        assertThat("Incorrect Entry", results.get(0), startsWith("ENTER[ FLOW ] TRACE Enter"));
-        assertThat("Incorrect Exit", results.get(1), startsWith("EXIT[ FLOW ] TRACE Exit"));
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0)).startsWith("ENTER[ FLOW ] TRACE Enter");
+        assertThat(results.get(1)).startsWith("EXIT[ FLOW ] TRACE Exit");
     }
 
     @Test
@@ -182,11 +172,9 @@ public class LoggerTest {
             }
         });
         logger.traceExit(msg, 3);
-        assertEquals(2, results.size());
-        assertThat("Incorrect Entry", results.get(0), startsWith("ENTER[ FLOW ] TRACE Enter"));
-        assertThat("Missing entry data", results.get(0), containsString("doFoo(a=1, b=2)"));
-        assertThat("Incorrect Exit", results.get(1), startsWith("EXIT[ FLOW ] TRACE Exit"));
-        assertThat("Missing exit data", results.get(1), containsString("doFoo(a=1, b=2): 3"));
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0)).startsWith("ENTER[ FLOW ] TRACE Enter").contains("doFoo(a=1, b=2)");
+        assertThat(results.get(1)).startsWith("EXIT[ FLOW ] TRACE Exit").contains("doFoo(a=1, b=2): 3");
     }
 
     @Test
@@ -203,11 +191,18 @@ public class LoggerTest {
             }
         });
         logger.traceExit(msg, 3);
-        assertEquals(2, results.size());
-        assertThat("Incorrect Entry", results.get(0), startsWith("ENTER[ FLOW ] TRACE Enter"));
-        assertThat("Missing entry data", results.get(0), containsString("doFoo(a=1, b=2)"));
-        assertThat("Incorrect Exit", results.get(1), startsWith("EXIT[ FLOW ] TRACE Exit"));
-        assertThat("Missing exit data", results.get(1), containsString("doFoo(a=1, b=2): 3"));
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0)).startsWith("ENTER[ FLOW ] TRACE Enter").contains("doFoo(a=1, b=2)");
+        assertThat(results.get(1)).startsWith("EXIT[ FLOW ] TRACE Exit").contains("doFoo(a=1, b=2): 3");
+    }
+
+    @Test
+    public void flowTracingNoFormat() {
+        logger.traceEntry(null, 1, "2", new ObjectMessage(3));
+        logger.traceExit((String) null, 4);
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0)).isEqualTo("ENTER[ FLOW ] TRACE Enter params(1, 2, 3)");
+        assertThat(results.get(1)).isEqualTo("EXIT[ FLOW ] TRACE Exit with(4)");
     }
 
     @Test

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
@@ -113,6 +113,17 @@ public interface LogBuilder {
     }
 
     /**
+     * Causes all the data collected to be logged along with the message.
+     *
+     * @param messageSupplier The supplier of the message to log.
+     * @return the message logger or {@literal null} if no logging occurred.
+     * @since 2.20
+     */
+    default Message logAndGet(final Supplier<Message> messageSupplier) {
+        return null;
+    }
+
+    /**
      * Causes all the data collected to be logged along with the message. Interface default method does nothing.
      * @param message The message to log.
      */

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -17,6 +17,7 @@
 package org.apache.logging.log4j;
 
 import org.apache.logging.log4j.message.EntryMessage;
+import org.apache.logging.log4j.message.FlowMessageFactory;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.util.MessageSupplier;
@@ -1685,6 +1686,14 @@ public interface Logger {
      * @return the message factory, as an instance of {@link MessageFactory}
      */
     <MF extends MessageFactory> MF getMessageFactory();
+
+    /**
+     * Gets the flow message factory used to convert messages into flow messages.
+     *
+     * @return the flow message factory, as an instance of {@link FlowMessageFactory}.
+     * @since 2.20
+     */
+    FlowMessageFactory getFlowMessageFactory();
 
     /**
      * Gets the logger name.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
@@ -112,6 +112,15 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     }
 
     @Override
+    public Message logAndGet(Supplier<Message> messageSupplier) {
+        Message message = null;
+        if (isValid()) {
+            logMessage(message = messageSupplier.get());
+        }
+        return message;
+    }
+
+    @Override
     public void log(final CharSequence message) {
         if (isValid()) {
             logMessage(logger.getMessageFactory().newMessage(message));

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
@@ -18,6 +18,11 @@ package org.apache.logging.log4j.message;
 
 import java.io.Serializable;
 
+import org.apache.logging.log4j.spi.LoggingSystem;
+import org.apache.logging.log4j.util.StringBuilderFormattable;
+import org.apache.logging.log4j.util.StringBuilders;
+import org.apache.logging.log4j.util.Strings;
+
 /**
  * Default factory for flow messages.
  *
@@ -31,6 +36,7 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
 
     private final String entryText;
     private final String exitText;
+    private final MessageFactory messageFactory;
 
     /**
      * Constructs a message factory with {@code "Enter"} and {@code "Exit"} as the default flow strings.
@@ -48,9 +54,10 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
         super();
         this.entryText = entryText;
         this.exitText = exitText;
+        this.messageFactory = LoggingSystem.getMessageFactory();
     }
 
-    private static class AbstractFlowMessage implements FlowMessage {
+    private static class AbstractFlowMessage implements FlowMessage, StringBuilderFormattable {
 
         private static final long serialVersionUID = 1L;
         private final Message message;
@@ -72,7 +79,7 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
         @Override
         public String getFormat() {
             if (message != null) {
-                return text + ": " + message.getFormat();
+                return text + " " + message.getFormat();
             }
             return text;
         }
@@ -102,6 +109,15 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
         public String getText() {
             return text;
         }
+
+        @Override
+        public void formatTo(StringBuilder buffer) {
+            buffer.append(text);
+            if (message != null) {
+                buffer.append(" ");
+                StringBuilders.appendValue(buffer, message);
+            }
+        }
     }
 
     private static final class SimpleEntryMessage extends AbstractFlowMessage implements EntryMessage {
@@ -122,15 +138,17 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
         private final boolean isVoid;
 
         SimpleExitMessage(final String exitText, final EntryMessage message) {
-            super(exitText, message.getMessage());
+            this(exitText, message.getMessage());
+        }
+
+        SimpleExitMessage(final String exitText, final Message message) {
+            super(exitText, message);
             this.result = null;
             isVoid = true;
         }
 
         SimpleExitMessage(final String exitText, final Object result, final EntryMessage message) {
-            super(exitText, message.getMessage());
-            this.result = result;
-            isVoid = false;
+            this(exitText, result, message.getMessage());
         }
 
         SimpleExitMessage(final String exitText, final Object result, final Message message) {
@@ -165,6 +183,28 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
         return exitText;
     }
 
+    @Override
+    public EntryMessage newEntryMessage(String format, Object... params) {
+        final boolean hasFormat = Strings.isNotEmpty(format);
+        final Message message;
+        if (params == null || params.length == 0) {
+            message = hasFormat ? messageFactory.newMessage(format) : null;
+        } else if (hasFormat) {
+            message = messageFactory.newMessage(format, params);
+        } else {
+            final StringBuilder sb = new StringBuilder("params(");
+            for (int i = 0; i < params.length; i++) {
+                if (i > 0) {
+                    sb.append(", ");
+                }
+                sb.append("{}");
+            }
+            sb.append(")");
+            message = messageFactory.newMessage(sb.toString(), params);
+        }
+        return newEntryMessage(message);
+    }
+
     /*
      * (non-Javadoc)
      *
@@ -176,10 +216,27 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
     }
 
     private Message makeImmutable(final Message message) {
-        if (!(message instanceof ReusableMessage)) {
-            return message;
+        if (message instanceof ReusableMessage) {
+            return ((ReusableMessage) message).memento();
         }
-        return new SimpleMessage(message.getFormattedMessage());
+        return message;
+    }
+
+    @Override
+    public ExitMessage newExitMessage(String format, Object result) {
+        final boolean hasFormat = Strings.isNotEmpty(format);
+        final Message message;
+        if (result == null) {
+            message = hasFormat ? messageFactory.newMessage(format) : null;
+        } else {
+            message = messageFactory.newMessage(hasFormat ? format : "with({})", result);
+        }
+        return newExitMessage(message);
+    }
+
+    @Override
+    public ExitMessage newExitMessage(Message message) {
+        return new SimpleExitMessage(exitText, message);
     }
 
     /*

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/FlowMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/FlowMessageFactory.java
@@ -21,7 +21,17 @@ package org.apache.logging.log4j.message;
  * @since 2.6
  */
 public interface FlowMessageFactory {
-    
+
+    /**
+     * Creates a new entry message based on a format string with parameters.
+     *
+     * @param message format string
+     * @param params  parameters
+     * @return the new entry message
+     * @since 2.20
+     */
+    EntryMessage newEntryMessage(String message, Object... params);
+
     /**
      * Creates a new entry message based on an existing message.
      *
@@ -29,6 +39,25 @@ public interface FlowMessageFactory {
      * @return the new entry message
      */
     EntryMessage newEntryMessage(Message message);
+
+    /**
+     * Creates a new exit message based on a return value and a forma string.
+     *
+     * @param format a format string
+     * @param result the return value
+     * @return the new exit message
+     * @since 2.20
+     */
+    ExitMessage newExitMessage(String format, Object result);
+
+    /**
+     * Creates a new exit message based on no return value and an existing message.
+     *
+     * @param message the original entry message
+     * @return the new exit message
+     * @since 2.20
+     */
+    ExitMessage newExitMessage(Message message);
 
     /**
      * Creates a new exit message based on a return value and an existing message.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -31,9 +31,7 @@ import org.apache.logging.log4j.message.EntryMessage;
 import org.apache.logging.log4j.message.FlowMessageFactory;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MessageFactory;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.message.ReusableMessageFactory;
-import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.message.StringFormattedMessage;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Constants;
@@ -41,7 +39,6 @@ import org.apache.logging.log4j.util.LambdaUtil;
 import org.apache.logging.log4j.util.MessageSupplier;
 import org.apache.logging.log4j.util.PerformanceSensitive;
 import org.apache.logging.log4j.util.StackLocatorUtil;
-import org.apache.logging.log4j.util.Strings;
 import org.apache.logging.log4j.util.Supplier;
 
 /**
@@ -456,7 +453,8 @@ public abstract class AbstractLogger implements ExtendedLogger, Serializable {
     protected EntryMessage enter(final String fqcn, final String format, final Supplier<?>... paramSuppliers) {
         EntryMessage entryMsg = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg = entryMsg(format, paramSuppliers), null);
+            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER,
+                    entryMsg = flowMessageFactory.newEntryMessage(format, LambdaUtil.getAll(paramSuppliers)), null);
         }
         return entryMsg;
     }
@@ -472,7 +470,7 @@ public abstract class AbstractLogger implements ExtendedLogger, Serializable {
     protected EntryMessage enter(final String fqcn, final String format, final Object... params) {
         EntryMessage entryMsg = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg = entryMsg(format, params), null);
+            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg = flowMessageFactory.newEntryMessage(format, params), null);
         }
         return entryMsg;
     }
@@ -511,27 +509,7 @@ public abstract class AbstractLogger implements ExtendedLogger, Serializable {
     }
 
     protected EntryMessage entryMsg(final String format, final Object... params) {
-        final int count = params == null ? 0 : params.length;
-        if (count == 0) {
-            if (Strings.isEmpty(format)) {
-                return flowMessageFactory.newEntryMessage(null);
-            }
-            return flowMessageFactory.newEntryMessage(new SimpleMessage(format));
-        }
-        if (format != null) {
-            return flowMessageFactory.newEntryMessage(new ParameterizedMessage(format, params));
-        }
-        final StringBuilder sb = new StringBuilder();
-        sb.append("params(");
-        for (int i = 0; i < count; i++) {
-            if (i > 0) {
-                sb.append(", ");
-            }
-            final Object parm = params[i];
-            sb.append(parm instanceof Message ? ((Message) parm).getFormattedMessage() : String.valueOf(parm));
-        }
-        sb.append(')');
-        return flowMessageFactory.newEntryMessage(new SimpleMessage(sb));
+        return flowMessageFactory.newEntryMessage(format, params);
     }
 
     protected EntryMessage entryMsg(final String format, final MessageSupplier... paramSuppliers) {
@@ -539,21 +517,12 @@ public abstract class AbstractLogger implements ExtendedLogger, Serializable {
         final Object[] params = new Object[count];
         for (int i = 0; i < count; i++) {
             params[i] = paramSuppliers[i].get();
-            params[i] = params[i] != null ? ((Message) params[i]).getFormattedMessage() : null;
         }
         return entryMsg(format, params);
     }
 
     protected EntryMessage entryMsg(final String format, final Supplier<?>... paramSuppliers) {
-        final int count = paramSuppliers == null ? 0 : paramSuppliers.length;
-        final Object[] params = new Object[count];
-        for (int i = 0; i < count; i++) {
-            params[i] = paramSuppliers[i].get();
-            if (params[i] instanceof Message) {
-                params[i] = ((Message) params[i]).getFormattedMessage();
-            }
-        }
-        return entryMsg(format, params);
+        return entryMsg(format, LambdaUtil.getAll(paramSuppliers));
     }
 
     @Override
@@ -823,7 +792,7 @@ public abstract class AbstractLogger implements ExtendedLogger, Serializable {
      */
     protected <R> R exit(final String fqcn, final R result) {
         if (isEnabled(Level.TRACE, EXIT_MARKER, (CharSequence) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, EXIT_MARKER, exitMsg(null, result), null);
+            logMessageSafely(fqcn, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(null, result), null);
         }
         return result;
     }
@@ -839,23 +808,13 @@ public abstract class AbstractLogger implements ExtendedLogger, Serializable {
      */
     protected <R> R exit(final String fqcn, final String format, final R result) {
         if (isEnabled(Level.TRACE, EXIT_MARKER, (CharSequence) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, EXIT_MARKER, exitMsg(format, result), null);
+            logMessageSafely(fqcn, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(format, result), null);
         }
         return result;
     }
 
     protected Message exitMsg(final String format, final Object result) {
-        if (result == null) {
-            if (format == null) {
-                return messageFactory.newMessage("Exit");
-            }
-            return messageFactory.newMessage("Exit: " + format);
-        }
-        if (format == null) {
-            return messageFactory.newMessage("Exit with(" + result + ')');
-        }
-        return messageFactory.newMessage("Exit: " + format, result);
-
+        return flowMessageFactory.newExitMessage(format, result);
     }
 
     @Override
@@ -1118,6 +1077,11 @@ public abstract class AbstractLogger implements ExtendedLogger, Serializable {
     @Override
     public <MF extends MessageFactory> MF getMessageFactory() {
         return (MF) messageFactory;
+    }
+
+    @Override
+    public FlowMessageFactory getFlowMessageFactory() {
+        return flowMessageFactory;
     }
 
     @Override

--- a/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/AbstractLoggerTest.java
+++ b/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/AbstractLoggerTest.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.jul.test;
 
 import java.util.List;


### PR DESCRIPTION
This PR adds a minimal amount of methods to greatly simplify flow tracing with `LogBuilder`. E.g.:

```
logger.traceEntry("a={}, b={}", 1, 42);
```

can be now rewrittent as:

```
logger.atTrace()
        .withMarker(AbstractLogger.ENTRY_MARKER)
        .logAndGet(() -> {
            LoggingSystem.getFlowMessageFactory()
                    .newEntryMessage("a={}, b={}", 1, 42);
        });
```

The latter can be easily perfomed by a bytecode manipulation tool (cf. #1147).

It also refactors the factory methods that create `EntryMessage/ExitMessage`s to be low-garbage.