### PR TITLE
LOG4J2-1631 Honor timezone in file name pattern

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/PatternProcessorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/PatternProcessorTest.java
@@ -16,9 +16,11 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -34,8 +36,10 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class PatternProcessorTest {
 
-    private String format(final long time) {
-        return new SimpleDateFormat("yyyy/MM/dd HH:mm:ss.SSS").format(new Date(time));
+    private static Instant parseLocalDateTime(String text) {
+        return LocalDateTime.parse(text)
+                .atZone(ZoneId.systemDefault())
+                .toInstant();
     }
 
     @Test
@@ -56,30 +60,22 @@ public class PatternProcessorTest {
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeHourlyReturnsFirstMinuteOfNextHour() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd-HH}.log.gz");
-        final Calendar initial = Calendar.getInstance();
-        initial.set(2014, Calendar.MARCH, 4, 10, 31, 59); // Tue, March 4, 2014, 10:31
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = parseLocalDateTime("2014-03-04T10:31:59");
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // expect Wed, March 4, 2014, 11:00
-        final Calendar expected = Calendar.getInstance();
-        expected.set(2014, Calendar.MARCH, 4, 11, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = parseLocalDateTime("2014-03-04T11:00:00");
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeHourlyReturnsFirstMinuteOfNextHour2() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd-HH}.log.gz");
-        final Calendar initial = Calendar.getInstance();
-        initial.set(2014, Calendar.MARCH, 4, 23, 31, 59); // Tue, March 4, 2014, 23:31
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = parseLocalDateTime("2014-03-04T23:31:59");
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // expect Wed, March 5, 2014, 00:00
-        final Calendar expected = Calendar.getInstance();
-        expected.set(2014, Calendar.MARCH, 5, 0, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = parseLocalDateTime("2014-03-05T00:00:00");
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
@@ -89,15 +85,11 @@ public class PatternProcessorTest {
         // during winter GMT-6
         // during summer GMT-5
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd-HH}{America/Chicago}.log.gz");
-        final Calendar initial = Calendar.getInstance(TimeZone.getTimeZone("GMT-6"));
-        initial.set(2014, Calendar.MARCH, 9, 1, 31, 59); // Tue, March 9, 2014, 01:31
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = OffsetDateTime.parse("2014-03-09T01:31:59-06:00").toInstant();
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // expect Wed, March 9, 2014, 02:00
-        final Calendar expected = Calendar.getInstance(TimeZone.getTimeZone("GMT-6"));
-        expected.set(2014, Calendar.MARCH, 9, 2, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = OffsetDateTime.parse("2014-03-09T02:00:00-06:00").toInstant();
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
@@ -107,140 +99,103 @@ public class PatternProcessorTest {
         // during summer GMT-5
         // during winter GMT-6
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd-HH}{America/Chicago}.log.gz");
-        final Calendar initial = Calendar.getInstance(TimeZone.getTimeZone("GMT-5"));
-        initial.set(2014, Calendar.NOVEMBER, 2, 1, 31, 59); // Sun, November 2, 2014, 01:31
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = OffsetDateTime.parse("2014-11-02T01:31:59-05:00").toInstant();
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // expect Sun, November 2, 2014, 03:00 (i.e. 1h 29min since initial)
-        final Calendar expected = Calendar.getInstance(TimeZone.getTimeZone("GMT-5"));
-        expected.set(2014, Calendar.NOVEMBER, 2, 3, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        // expect 1h 29min since initial
+        Instant expected = OffsetDateTime.parse("2014-11-02T03:00:00-05:00").toInstant();
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeHourlyReturnsFirstMinuteOfNextYear() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd-HH}.log.gz");
-        final Calendar initial = Calendar.getInstance();
-        initial.set(2015, Calendar.DECEMBER, 31, 23, 31, 59);
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = parseLocalDateTime("2015-12-31T23:31:59");
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        final Calendar expected = Calendar.getInstance();
-        expected.set(2016, Calendar.JANUARY, 1, 0, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = parseLocalDateTime("2016-01-01T00:00:00");
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeMillisecondlyReturnsNextMillisec() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd-HH-mm-ss.SSS}.log.gz");
-        final Calendar initial = Calendar.getInstance();
-        initial.set(2014, Calendar.MARCH, 4, 10, 31, 53); // Tue, March 4, 2014, 10:31:53.123
-        initial.set(Calendar.MILLISECOND, 123);
-        assertEquals("2014/03/04 10:31:53.123", format(initial.getTimeInMillis()));
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = parseLocalDateTime("2014-03-04T10:31:53.123");
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // expect Tue, March 4, 2014, 10:31:53.124
-        final Calendar expected = Calendar.getInstance();
-        expected.set(2014, Calendar.MARCH, 4, 10, 31, 53);
-        expected.set(Calendar.MILLISECOND, 124);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = parseLocalDateTime("2014-03-04T10:31:53.124");
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeMinutelyReturnsFirstSecondOfNextMinute() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd-HH-mm}.log.gz");
-        final Calendar initial = Calendar.getInstance();
-        initial.set(2014, Calendar.MARCH, 4, 10, 31, 59); // Tue, March 4, 2014, 10:31
-        initial.set(Calendar.MILLISECOND, 0);
-        assertEquals("2014/03/04 10:31:59.000", format(initial.getTimeInMillis()));
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = parseLocalDateTime("2014-03-04T10:31:59");
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // expect Tue, March 4, 2014, 10:32
-        final Calendar expected = Calendar.getInstance();
-        expected.set(2014, Calendar.MARCH, 4, 10, 32, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = parseLocalDateTime("2014-03-04T10:32:00");
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeMonthlyReturnsFirstDayOfNextMonth() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM}.log.gz");
-        final Calendar initial = Calendar.getInstance();
-        initial.set(2014, Calendar.OCTOBER, 15, 10, 31, 59); // Oct 15th
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = parseLocalDateTime("2014-10-15T10:31:59");
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // We expect 1st day of next month
-        final Calendar expected = Calendar.getInstance();
-        expected.set(2014, Calendar.NOVEMBER, 1, 0, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = parseLocalDateTime("2014-11-01T00:00:00");
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeMonthlyReturnsFirstDayOfNextMonth2() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM}.log.gz");
-        final Calendar initial = Calendar.getInstance();
-        initial.set(2014, Calendar.JANUARY, 31, 10, 31, 59); // 2014 Jan 31st
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = parseLocalDateTime("2014-01-31T10:31:59");
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
         // Expect 1st of next month: 2014 Feb 1st
-        final Calendar expected = Calendar.getInstance();
-        expected.set(2014, Calendar.FEBRUARY, 1, 0, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = parseLocalDateTime("2014-02-01T00:00:00");
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeMonthlyReturnsFirstDayOfNextMonth3() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM}.log.gz");
-        final Calendar initial = Calendar.getInstance();
-        initial.set(2014, Calendar.DECEMBER, 31, 10, 31, 59); // 2014 Dec 31st
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = parseLocalDateTime("2014-12-31T10:31:59");
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
         // Expect 1st of next month: 2015 Jan 1st
-        final Calendar expected = Calendar.getInstance();
-        expected.set(2015, Calendar.JANUARY, 1, 0, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = parseLocalDateTime("2015-01-01T00:00:00");
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeMonthlyReturnsFirstDayOfNextYear() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM}.log.gz");
-        final Calendar initial = Calendar.getInstance();
-        initial.set(2015, Calendar.DECEMBER, 28, 0, 0, 0);
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = parseLocalDateTime("2015-12-28T00:00:00");
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
         // We expect 1st day of next month
-        final Calendar expected = Calendar.getInstance();
-        expected.set(2016, Calendar.JANUARY, 1, 0, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = parseLocalDateTime("2016-01-01T00:00:00");
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeSecondlyReturnsFirstMillisecOfNextSecond() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd-HH-mm-ss}.log.gz");
-        final Calendar initial = Calendar.getInstance();
-        initial.set(2014, Calendar.MARCH, 4, 10, 31, 53); // Tue, March 4, 2014, 10:31:53
-        initial.set(Calendar.MILLISECOND, 123);
-        assertEquals("2014/03/04 10:31:53.123", format(initial.getTimeInMillis()));
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = parseLocalDateTime("2014-03-04T10:31:53.123");
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // expect Tue, March 4, 2014, 10:31:54
-        final Calendar expected = Calendar.getInstance();
-        expected.set(2014, Calendar.MARCH, 4, 10, 31, 54);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = parseLocalDateTime("2014-03-04T10:31:54");
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
@@ -251,15 +206,11 @@ public class PatternProcessorTest {
 
         try {
             final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-W}.log.gz");
-            final Calendar initial = Calendar.getInstance();
-            initial.set(2014, Calendar.MARCH, 4, 10, 31, 59); // Tue, March 4, 2014
-            final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+            Instant initial = parseLocalDateTime("2014-03-04T10:31:59");
+            final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-            // expect Monday, March 10, 2014
-            final Calendar expected = Calendar.getInstance();
-            expected.set(2014, Calendar.MARCH, 10, 0, 0, 0);
-            expected.set(Calendar.MILLISECOND, 0);
-            assertEquals(format(expected.getTimeInMillis()), format(actual));
+            Instant expected = parseLocalDateTime("2014-03-10T00:00:00");
+            assertEquals(expected, Instant.ofEpochMilli(actual));
         } finally {
             Locale.setDefault(old);
         }
@@ -273,15 +224,11 @@ public class PatternProcessorTest {
 
         try {
             final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-W}.log.gz");
-            final Calendar initial = Calendar.getInstance();
-            initial.set(2014, Calendar.MARCH, 4, 10, 31, 59); // Tue, March 4, 2014
-            final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+            Instant initial = parseLocalDateTime("2014-03-04T10:31:59");
+            final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-            // expect Sunday, March 9, 2014
-            final Calendar expected = Calendar.getInstance();
-            expected.set(2014, Calendar.MARCH, 9, 0, 0, 0);
-            expected.set(Calendar.MILLISECOND, 0);
-            assertEquals(format(expected.getTimeInMillis()), format(actual));
+            Instant expected = parseLocalDateTime("2014-03-09T00:00:00");
+            assertEquals(expected, Instant.ofEpochMilli(actual));
         } finally {
             Locale.setDefault(old);
         }
@@ -297,15 +244,11 @@ public class PatternProcessorTest {
         Locale.setDefault(Locale.US); // force 1st day of the week to be Sunday
         try {
             final PatternProcessor pp = new PatternProcessor("logs/market_data_msg.log-%d{yyyy-MM-'W'W}");
-            final Calendar initial = Calendar.getInstance();
-            initial.set(2015, Calendar.DECEMBER, 28, 0, 0, 0); // Monday, December 28, 2015
-            final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+            Instant initial = parseLocalDateTime("2015-12-28T00:00:00");
+            final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-            // expect Sunday January 3, 2016
-            final Calendar expected = Calendar.getInstance();
-            expected.set(2016, Calendar.JANUARY, 3, 0, 0, 0);
-            expected.set(Calendar.MILLISECOND, 0);
-            assertEquals(format(expected.getTimeInMillis()), format(actual));
+            Instant expected = parseLocalDateTime("2016-01-03T00:00:00");
+            assertEquals(expected, Instant.ofEpochMilli(actual));
         } finally {
             Locale.setDefault(old);
         }
@@ -315,30 +258,22 @@ public class PatternProcessorTest {
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeDailyReturnsFirstHourOfNextDay() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd}.log.gz");
-        final Calendar initial = Calendar.getInstance();
-        initial.set(2014, Calendar.MARCH, 4, 2, 31, 59); // Tue, March 4, 2014, 02:31
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = parseLocalDateTime("2014-03-04T02:31:59");
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // expect Wed, March 5, 2014, 00:00
-        final Calendar expected = Calendar.getInstance();
-        expected.set(2014, Calendar.MARCH, 5, 0, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = parseLocalDateTime("2014-03-05T00:00:00");
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeDailyReturnsFirstHourOfNextDayHonoringTimeZoneOption1() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd}{GMT-6}.log.gz");
-        final Calendar initial = Calendar.getInstance(TimeZone.getTimeZone("GMT-6"));
-        initial.set(2014, Calendar.MARCH, 4, 2, 31, 59); // Tue, March 4, 2014, 02:31
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = OffsetDateTime.parse("2014-03-04T02:31:59-06:00").toInstant();
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // expect Wed, March 5, 2014, 00:00
-        final Calendar expected = Calendar.getInstance(TimeZone.getTimeZone("GMT-6"));
-        expected.set(2014, Calendar.MARCH, 5, 0, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = OffsetDateTime.parse("2014-03-05T00:00:00-06:00").toInstant();
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
@@ -349,15 +284,11 @@ public class PatternProcessorTest {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+10")); // default is ignored if pattern contains timezone
         try {
             final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd}{GMT-6}.log.gz");
-            final Calendar initial = Calendar.getInstance(TimeZone.getTimeZone("GMT-6"));
-            initial.set(2014, Calendar.MARCH, 4, 2, 31, 59); // Tue, March 4, 2014, 02:31
-            final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+            Instant initial = OffsetDateTime.parse("2014-03-04T02:31:59-06:00").toInstant();
+            final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-            // expect Wed, March 5, 2014, 00:00
-            final Calendar expected = Calendar.getInstance(TimeZone.getTimeZone("GMT-6"));
-            expected.set(2014, Calendar.MARCH, 5, 0, 0, 0);
-            expected.set(Calendar.MILLISECOND, 0);
-            assertEquals(format(expected.getTimeInMillis()), format(actual));
+            Instant expected = OffsetDateTime.parse("2014-03-05T00:00:00-06:00").toInstant();
+            assertEquals(expected, Instant.ofEpochMilli(actual));
         } finally {
             TimeZone.setDefault(old);
         }
@@ -371,15 +302,11 @@ public class PatternProcessorTest {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT-10")); // default is ignored if pattern contains timezone
         try {
             final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd}{GMT-6}.log.gz");
-            final Calendar initial = Calendar.getInstance(TimeZone.getTimeZone("GMT-6"));
-            initial.set(2014, Calendar.MARCH, 4, 2, 31, 59); // Tue, March 4, 2014, 02:31
-            final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+            Instant initial = OffsetDateTime.parse("2014-03-04T02:31:59-06:00").toInstant();
+            final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-            // expect Wed, March 5, 2014, 00:00
-            final Calendar expected = Calendar.getInstance(TimeZone.getTimeZone("GMT-6"));
-            expected.set(2014, Calendar.MARCH, 5, 0, 0, 0);
-            expected.set(Calendar.MILLISECOND, 0);
-            assertEquals(format(expected.getTimeInMillis()), format(actual));
+            Instant expected = OffsetDateTime.parse("2014-03-05T00:00:00-06:00").toInstant();
+            assertEquals(expected, Instant.ofEpochMilli(actual));
         } finally {
             TimeZone.setDefault(old);
         }
@@ -389,30 +316,22 @@ public class PatternProcessorTest {
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeDailyReturnsFirstHourOfNextDayDstJan() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd}{America/Chicago}.log.gz");
-        final Calendar initial = Calendar.getInstance(TimeZone.getTimeZone("GMT-6"));
-        initial.set(2014, Calendar.JANUARY, 4, 0, 31, 59); // Sat, January 4, 2014, 00:31
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = OffsetDateTime.parse("2014-01-04T00:31:59-06:00").toInstant();
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // expect Sun, January 5, 2014, 00:00
-        final Calendar expected = Calendar.getInstance(TimeZone.getTimeZone("GMT-6"));
-        expected.set(2014, Calendar.JANUARY, 5, 0, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = OffsetDateTime.parse("2014-01-05T00:00:00-06:00").toInstant();
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
     @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
     public void testGetNextTimeDailyReturnsFirstHourOfNextDayDstJun() {
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd}{America/Chicago}.log.gz");
-        final Calendar initial = Calendar.getInstance(TimeZone.getTimeZone("GMT-5"));
-        initial.set(2014, Calendar.JUNE, 4, 0, 31, 59); // Wed, March 4, 2014, 00:31
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = OffsetDateTime.parse("2014-06-04T00:31:59-05:00").toInstant();
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // expect Thu, March 5, 2014, 00:00
-        final Calendar expected = Calendar.getInstance(TimeZone.getTimeZone("GMT-5"));
-        expected.set(2014, Calendar.JUNE, 5, 0, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = OffsetDateTime.parse("2014-06-05T00:00:00-05:00").toInstant();
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
@@ -422,15 +341,11 @@ public class PatternProcessorTest {
         // during winter GMT-6
         // during summer GMT-5
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd}{America/Chicago}.log.gz");
-        final Calendar initial = Calendar.getInstance(TimeZone.getTimeZone("GMT-6"));
-        initial.set(2014, Calendar.MARCH, 9, 0, 31, 59); // Sun, March 9, 2014, 00:31
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = OffsetDateTime.parse("2014-03-09T00:31:59-06:00").toInstant();
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // expect Mon, March 10, 2014, 00:00
-        final Calendar expected = Calendar.getInstance(TimeZone.getTimeZone("GMT-5")); // offset changed
-        expected.set(2014, Calendar.MARCH, 10, 0, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = OffsetDateTime.parse("2014-03-10T00:00:00-05:00").toInstant();
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
@@ -440,15 +355,11 @@ public class PatternProcessorTest {
         // during summer GMT-5
         // during winter GMT-6
         final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd}{America/Chicago}.log.gz");
-        final Calendar initial = Calendar.getInstance(TimeZone.getTimeZone("GMT-5"));
-        initial.set(2014, Calendar.NOVEMBER, 2, 0, 31, 59); // Sun, November 2, 2014, 00:31
-        final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+        Instant initial = OffsetDateTime.parse("2014-11-02T00:31:59-05:00").toInstant();
+        final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-        // expect Mon, November 3, 2014, 00:00
-        final Calendar expected = Calendar.getInstance(TimeZone.getTimeZone("GMT-6")); // offset changed
-        expected.set(2014, Calendar.NOVEMBER, 3, 0, 0, 0);
-        expected.set(Calendar.MILLISECOND, 0);
-        assertEquals(format(expected.getTimeInMillis()), format(actual));
+        Instant expected = OffsetDateTime.parse("2014-11-03T00:00:00-06:00").toInstant();
+        assertEquals(expected, Instant.ofEpochMilli(actual));
     }
 
     @Test
@@ -459,15 +370,11 @@ public class PatternProcessorTest {
         TimeZone.setDefault(TimeZone.getTimeZone("GMT-10")); // default is ignored even if timezone option invalid
         try {
             final PatternProcessor pp = new PatternProcessor("logs/app-%d{yyyy-MM-dd}{NOTVALID}.log.gz");
-            final Calendar initial = Calendar.getInstance(TimeZone.getTimeZone("GMT+0"));
-            initial.set(2014, Calendar.MARCH, 4, 2, 31, 59); // Tue, March 4, 2014, 02:31
-            final long actual = pp.getNextTime(initial.getTimeInMillis(), 1, false);
+            Instant initial = Instant.parse("2014-03-04T02:31:59Z");
+            final long actual = pp.getNextTime(initial.toEpochMilli(), 1, false);
 
-            // expect Wed, March 5, 2014, 00:00
-            final Calendar expected = Calendar.getInstance(TimeZone.getTimeZone("GMT+0"));
-            expected.set(2014, Calendar.MARCH, 5, 0, 0, 0);
-            expected.set(Calendar.MILLISECOND, 0);
-            assertEquals(format(expected.getTimeInMillis()), format(actual));
+            Instant expected = Instant.parse("2014-03-05T00:00:00Z");
+            assertEquals(expected, Instant.ofEpochMilli(actual));
         } finally {
             TimeZone.setDefault(old);
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/PatternProcessor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/PatternProcessor.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
@@ -61,6 +62,7 @@ public class PatternProcessor {
     private boolean isTimeBased = false;
 
     private RolloverFrequency frequency = null;
+    private TimeZone timeZone;
 
     private final String pattern;
 
@@ -92,9 +94,11 @@ public class PatternProcessor {
             if (converter instanceof DatePatternConverter) {
                 final DatePatternConverter dateConverter = (DatePatternConverter) converter;
                 frequency = calculateFrequency(dateConverter.getPattern());
+                timeZone = dateConverter.getTimeZone();
             }
         }
     }
+
 
     /**
      * Copy constructor with another pattern as source.
@@ -160,9 +164,9 @@ public class PatternProcessor {
         if (frequency == null) {
             throw new IllegalStateException("Pattern does not contain a date");
         }
-        final Calendar currentCal = Calendar.getInstance();
+        final Calendar currentCal = Calendar.getInstance(timeZone);
         currentCal.setTimeInMillis(currentMillis);
-        final Calendar cal = Calendar.getInstance();
+        final Calendar cal = Calendar.getInstance(timeZone);
         currentCal.setMinimalDaysInFirstWeek(7);
         cal.setMinimalDaysInFirstWeek(7);
         cal.set(currentCal.get(Calendar.YEAR), 0, 1, 0, 0, 0);
@@ -232,10 +236,10 @@ public class PatternProcessor {
     }
 
     public void updateTime() {
-    	if (nextFileTime != 0 || !isTimeBased) {
-			prevFileTime = nextFileTime;
+        if (nextFileTime != 0 || !isTimeBased) {
+            prevFileTime = nextFileTime;
             currentFileTime = 0;
-		}
+        }
     }
 
     private long debugGetNextTime(final long nextTime) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/DatePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/DatePatternConverter.java
@@ -25,9 +25,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
-import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.time.Instant;
 import org.apache.logging.log4j.core.time.MutableInstant;
+import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.datetime.FastDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat;
@@ -51,6 +51,10 @@ public final class DatePatternConverter extends LogEventPatternConverter impleme
 
         public String toPattern() {
             return null;
+        }
+
+        public TimeZone getTimeZone() {
+            return TimeZone.getDefault();
         }
     }
 
@@ -82,6 +86,11 @@ public final class DatePatternConverter extends LogEventPatternConverter impleme
         @Override
         public String toPattern() {
             return fastDateFormat.getPattern();
+        }
+
+        @Override
+        public TimeZone getTimeZone() {
+            return fastDateFormat.getTimeZone();
         }
     }
 
@@ -116,6 +125,11 @@ public final class DatePatternConverter extends LogEventPatternConverter impleme
         @Override
         public String toPattern() {
             return fixedDateFormat.getFormat();
+        }
+
+        @Override
+        public TimeZone getTimeZone() {
+            return fixedDateFormat.getTimeZone();
         }
     }
 
@@ -353,4 +367,12 @@ public final class DatePatternConverter extends LogEventPatternConverter impleme
         return formatter.toPattern();
     }
 
+    /**
+     * Gets the timezone used by this date format.
+     *
+     * @return the timezone used by this date format.
+     */
+    public TimeZone getTimeZone() {
+        return formatter.getTimeZone();
+    }
 }


### PR DESCRIPTION
Given pattern "app-%d{yyyy-MM-dd}{timezone}.log.gz" treat second pair of curly braces as timezone option.

If timezone option is not set, then use default timezone as before.
If timezone option is set, but it's parsing fails, then use GMT+0.
(same DatePatternConverter behavior as in other places)