### PR TITLE
fix(sec): upgrade org.slf4j:slf4j-ext to 1.7.26

### DIFF
--- a/log4j-slf4j-impl/pom.xml
+++ b/log4j-slf4j-impl/pom.xml
@@ -32,7 +32,7 @@
     <projectDir>/slf4j-impl</projectDir>
     <!-- Do not upgrade the SLF4J version. 1.7.26 broke backward compatibility. Users can update the version if
       they do not require support for SLF4J's EventData -->
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j.version>1.8.0-beta2</slf4j.version>
     <module.name>org.apache.logging.log4j.slf4j</module.name>
     <maven.doap.skip>true</maven.doap.skip>
   </properties>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.slf4j:slf4j-ext 1.7.25
- [CVE-2018-8088](https://www.oscs1024.com/hd/CVE-2018-8088)


### What did I do？
Upgrade org.slf4j:slf4j-ext from 1.7.25 to 1.7.26 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS