### PR TITLE
Serialize cached location

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/MutableLogEventTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/MutableLogEventTest.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.impl;
 
 import java.io.ByteArrayInputStream;
@@ -33,13 +32,14 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.message.ReusableMessageFactory;
 import org.apache.logging.log4j.message.ReusableSimpleMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.logging.log4j.spi.MutableThreadContextStack;
 import org.apache.logging.log4j.util.FilteredObjectInputStream;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
 import org.apache.logging.log4j.util.StringMap;
-import org.apache.logging.log4j.spi.MutableThreadContextStack;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -359,6 +359,16 @@ public class MutableLogEventTest {
         assertEquals(0, evt2.getNanoTime());
     }
 
+    @Test
+    public void testPreservesLocation() {
+        final StackTraceElement source = new RuntimeException().getStackTrace()[0];
+        final MutableLogEvent mutable = new MutableLogEvent();
+        mutable.setSource(source);
+        mutable.setIncludeLocation(false);
+        final Log4jLogEvent immutable = mutable.toImmutable();
+        assertThat(immutable.getSource()).isEqualTo(source);
+    }
+
     private byte[] serialize(final MutableLogEvent event) throws IOException {
         final ByteArrayOutputStream arr = new ByteArrayOutputStream();
         final ObjectOutputStream out = new ObjectOutputStream(arr);
@@ -373,6 +383,5 @@ public class MutableLogEventTest {
         final Log4jLogEvent result = (Log4jLogEvent) in.readObject();
         return result;
     }
-
 
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jLogEvent.java
@@ -29,22 +29,25 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.ContextDataInjector;
-import org.apache.logging.log4j.core.util.*;
-import org.apache.logging.log4j.core.time.Instant;
-import org.apache.logging.log4j.core.time.MutableInstant;
-import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.async.RingBufferLogEvent;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.time.Instant;
+import org.apache.logging.log4j.core.time.MutableInstant;
+import org.apache.logging.log4j.core.util.Clock;
+import org.apache.logging.log4j.core.util.ClockFactory;
+import org.apache.logging.log4j.core.util.DummyNanoClock;
+import org.apache.logging.log4j.core.util.NanoClock;
 import org.apache.logging.log4j.message.LoggerNameAwareMessage;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ReusableMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.message.TimestampMessage;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.StackLocatorUtil;
 import org.apache.logging.log4j.util.StringMap;
-import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
 
 /**
@@ -945,7 +948,7 @@ public class Log4jLogEvent implements LogEvent {
             this.thrownProxy = event.thrownProxy;
             this.contextData = event.contextData;
             this.contextStack = event.contextStack;
-            this.source = includeLocation ? event.getSource() : null;
+            this.source = includeLocation ? event.getSource() : event.source;
             this.threadId = event.getThreadId();
             this.threadName = event.getThreadName();
             this.threadPriority = event.getThreadPriority();
@@ -970,7 +973,8 @@ public class Log4jLogEvent implements LogEvent {
             this.thrownProxy = event.getThrownProxy();
             this.contextData = memento(event.getContextData());
             this.contextStack = event.getContextStack();
-            this.source = includeLocation ? event.getSource() : null;
+            this.source = includeLocation ? event.getSource()
+                    : event instanceof MutableLogEvent ? ((MutableLogEvent) event).source : null;
             this.threadId = event.getThreadId();
             this.threadName = event.getThreadName();
             this.threadPriority = event.getThreadPriority();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
@@ -26,10 +26,17 @@ import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.async.InternalAsyncUtil;
-import org.apache.logging.log4j.core.util.*;
 import org.apache.logging.log4j.core.time.Instant;
 import org.apache.logging.log4j.core.time.MutableInstant;
-import org.apache.logging.log4j.message.*;
+import org.apache.logging.log4j.core.util.Clock;
+import org.apache.logging.log4j.core.util.Constants;
+import org.apache.logging.log4j.core.util.NanoClock;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ParameterConsumer;
+import org.apache.logging.log4j.message.ParameterVisitable;
+import org.apache.logging.log4j.message.ReusableMessage;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.logging.log4j.message.TimestampMessage;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.StackLocatorUtil;
 import org.apache.logging.log4j.util.StringBuilders;
@@ -62,7 +69,7 @@ public class MutableLogEvent implements LogEvent, ReusableMessage, ParameterVisi
     private StringMap contextData = ContextDataFactory.createContextData();
     private Marker marker;
     private String loggerFqcn;
-    private StackTraceElement source;
+    StackTraceElement source;
     private ThreadContext.ContextStack contextStack;
     transient boolean reserved = false;
 

--- a/src/changelog/.2.x.x/1197_preserve_location.xml
+++ b/src/changelog/.2.x.x/1197_preserve_location.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry type="fixed">
+  <issue id="1197" link="https://github.com/apache/logging-log4j2/pull/1197"/>
+  <author id="pkarwasz"/>
+  <description format="asciidoc">
+    Copy programmatically supplied location even if `includeLocation="false"`.
+  </description>
+</entry>


### PR DESCRIPTION
The current code does not copy the location information if `includeLocation` is false.

The primary goal was to prevent an expensive call to `StackLocatorUtil`, but it also erases location obtained through other means (e.g. `LogBuilder#withLocation`). This PR fixes it.