### PR TITLE
[LOG4J2-3647] Add global filter support to `LogBuilder`

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.internal;
 
+import java.util.Arrays;
+
 import org.apache.logging.log4j.BridgeAware;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogBuilder;
@@ -23,11 +25,11 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.logging.log4j.spi.ExtendedLogger;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LambdaUtil;
 import org.apache.logging.log4j.util.StackLocatorUtil;
 import org.apache.logging.log4j.util.Supplier;
-
 
 /**
  * Collects data for a log event and then logs it. This class should be considered private.
@@ -38,7 +40,7 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     private static final String FQCN = DefaultLogBuilder.class.getName();
     private static final Logger LOGGER = StatusLogger.getLogger();
 
-    private Logger logger;
+    private ExtendedLogger logger;
     private Level level;
     private Marker marker;
     private Throwable throwable;
@@ -47,7 +49,7 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     private long threadId;
     private String fqcn = FQCN;
 
-    public DefaultLogBuilder(Logger logger, Level level) {
+    public DefaultLogBuilder(ExtendedLogger logger, Level level) {
         this.logger = logger;
         this.level = level;
         this.threadId = Thread.currentThread().getId();
@@ -68,7 +70,7 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
      * @param level The logging level for this event.
      * @return This LogBuilder instance.
      */
-    public LogBuilder reset(Logger logger, Level level) {
+    public LogBuilder reset(ExtendedLogger logger, Level level) {
         this.logger = logger;
         this.level = level;
         this.marker = null;
@@ -108,7 +110,7 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
 
     @Override
     public void log(Message message) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message)) {
             logMessage(message);
         }
     }
@@ -116,99 +118,98 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     @Override
     public Message logAndGet(Supplier<Message> messageSupplier) {
         Message message = null;
-        if (isValid()) {
-            logMessage(message = messageSupplier.get());
+        if (isValid() && isEnabled(message = messageSupplier.get())) {
+            logMessage(message);
         }
         return message;
     }
 
     @Override
     public void log(final CharSequence message) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message)) {
             logMessage(logger.getMessageFactory().newMessage(message));
         }
     }
 
     @Override
     public void log(String message) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message)) {
             logMessage(logger.getMessageFactory().newMessage(message));
         }
     }
 
     @Override
     public void log(String message, Object... params) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message, params)) {
             logMessage(logger.getMessageFactory().newMessage(message, params));
         }
     }
 
     @Override
     public void log(String message, Supplier<?>... params) {
-        if (isValid()) {
-            logMessage(logger.getMessageFactory().newMessage(message, LambdaUtil.getAll(params)));
+        final Object[] objs;
+        if (isValid() && isEnabled(message, objs = LambdaUtil.getAll(params))) {
+            logMessage(logger.getMessageFactory().newMessage(message, objs));
         }
     }
 
     @Override
     public void log(Supplier<Message> messageSupplier) {
-        if (isValid()) {
-            logMessage(messageSupplier.get());
-        }
+        logAndGet(messageSupplier);
     }
 
     @Override
     public void log(Object message) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message)) {
             logMessage(logger.getMessageFactory().newMessage(message));
         }
     }
 
     @Override
     public void log(String message, Object p0) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message, p0)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0));
         }
     }
 
     @Override
     public void log(String message, Object p0, Object p1) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message, p0, p1)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1));
         }
     }
 
     @Override
     public void log(String message, Object p0, Object p1, Object p2) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message, p0, p1, p2)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2));
         }
     }
 
     @Override
     public void log(String message, Object p0, Object p1, Object p2, Object p3) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message, p0, p1, p2, p3)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3));
         }
     }
 
     @Override
     public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message, p0, p1, p2, p3, p4)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4));
         }
     }
 
     @Override
     public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message, p0, p1, p2, p3, p4, p5)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5));
         }
     }
 
     @Override
     public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message, p0, p1, p2, p3, p4, p5, p6)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6));
         }
     }
@@ -216,7 +217,7 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     @Override
     public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
             Object p7) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message, p0, p1, p2, p3, p4, p5, p6, p7)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7));
         }
     }
@@ -224,7 +225,7 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     @Override
     public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
             Object p7, Object p8) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message, p0, p1, p2, p3, p4, p5, p6, p7, p8)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8));
         }
     }
@@ -232,14 +233,14 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     @Override
     public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
             Object p7, Object p8, Object p9) {
-        if (isValid()) {
+        if (isValid() && isEnabled(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9));
         }
     }
 
     @Override
     public void log() {
-        if (isValid()) {
+        if (isValid() && isEnabled(EMPTY_MESSAGE)) {
             logMessage(EMPTY_MESSAGE);
         }
     }
@@ -264,5 +265,88 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
             return false;
         }
         return true;
+    }
+
+    protected boolean isEnabled(Message message) {
+        return logger.isEnabled(level, marker, message, throwable);
+    }
+
+    protected boolean isEnabled(CharSequence message) {
+        return logger.isEnabled(level, marker, message, throwable);
+    }
+
+    protected boolean isEnabled(String message) {
+        return logger.isEnabled(level, marker, message, throwable);
+    }
+
+    protected boolean isEnabled(String message, Object... params) {
+        final Object[] newParams;
+        if (throwable != null) {
+            newParams = Arrays.copyOf(params, params.length + 1);
+            newParams[params.length] = throwable;
+        } else {
+            newParams = params;
+        }
+        return logger.isEnabled(level, marker, message, newParams);
+    }
+
+    protected boolean isEnabled(Object message) {
+        return logger.isEnabled(level, marker, message, throwable);
+    }
+
+    protected boolean isEnabled(String message, Object p0) {
+        return throwable != null ? logger.isEnabled(level, marker, message, p0, throwable)
+                : logger.isEnabled(level, marker, message, p0);
+    }
+
+    protected boolean isEnabled(String message, Object p0, Object p1) {
+        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, throwable)
+                : logger.isEnabled(level, marker, message, p0, p1);
+    }
+
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2) {
+        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, throwable)
+                : logger.isEnabled(level, marker, message, p0, p1, p2);
+    }
+
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3) {
+        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, throwable)
+                : logger.isEnabled(level, marker, message, p0, p1, p2, p3);
+    }
+
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, throwable)
+                : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4);
+    }
+
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, throwable)
+                : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+            Object p6) {
+        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, throwable)
+                : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+            Object p6, Object p7) {
+        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, throwable)
+                : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+            Object p6, Object p7, Object p8) {
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, throwable)
+                : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+            Object p6, Object p7, Object p8, Object p9) {
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, throwable)
+                : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -2881,14 +2881,20 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     @Override
     public LogBuilder atLevel(Level level) {
         if (isEnabled(level)) {
-            return getLogBuilder(level).reset(this, level);
+            return getLogBuilder(level);
         }
         return LogBuilder.NOOP;
     }
 
-    private DefaultLogBuilder getLogBuilder(Level level) {
+    /**
+     * Returns a log builder that logs at the specified level.
+     *
+     * @since 2.20.0
+     */
+    protected LogBuilder getLogBuilder(Level level) {
         DefaultLogBuilder builder = logBuilder.get();
-        return Constants.ENABLE_THREADLOCALS && !builder.isInUse() ? builder : new DefaultLogBuilder(this, level);
+        return Constants.ENABLE_THREADLOCALS && !builder.isInUse() ? builder.reset(this, level)
+                : new DefaultLogBuilder(this, level);
     }
 
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/test/LogBuilderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/test/LogBuilderTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.test;
+
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogBuilder;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@LoggerContextSource("org/apache/logging/log4j/core/test/LogBuilderTest.xml")
+public class LogBuilderTest {
+
+    private static final Marker MARKER = MarkerManager.getMarker("TestMarker");
+    private static final CharSequence CHAR_SEQUENCE = "CharSequence";
+    private static final String STRING = "String";
+    private static final Message MESSAGE = new SimpleMessage();
+    private static final Throwable THROWABLE = new RuntimeException();
+    private static final Object[] P = {
+            "p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9"
+    };
+    private static final Object OBJECT = "Object";
+
+    private Logger logger;
+    private ListAppender appender;
+
+    @BeforeEach
+    public void setupAppender(LoggerContext context, @Named("LIST") ListAppender appender) {
+        this.logger = context.getLogger(getClass());
+        this.appender = appender;
+    }
+
+    static Stream<Consumer<LogBuilder>> testMarkerFilter() {
+        return Stream.of(logBuilder -> logBuilder.log(),
+                logBuilder -> logBuilder.log(CHAR_SEQUENCE),
+                logBuilder -> logBuilder.log(MESSAGE),
+                logBuilder -> logBuilder.log(OBJECT),
+                logBuilder -> logBuilder.log(STRING),
+                logBuilder -> logBuilder.log(STRING, P[0]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3], P[4]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3], P[4], P[5]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3], P[4], P[5], P[6]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3], P[4], P[5], P[6], P[7]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3], P[4], P[5], P[6], P[7], P[8]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3], P[4], P[5], P[6], P[7], P[8], P[9]),
+                logBuilder -> logBuilder.log(STRING, P), logBuilder -> logBuilder.log(STRING, () -> OBJECT),
+                logBuilder -> logBuilder.log(() -> MESSAGE));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testMarkerFilter(Consumer<LogBuilder> consumer) {
+        appender.clear();
+        consumer.accept(logger.atTrace().withMarker(MARKER));
+        consumer.accept(logger.atTrace().withThrowable(THROWABLE).withMarker(MARKER));
+        assertThat(appender.getEvents()).hasSize(2);
+    }
+}

--- a/log4j-core-test/src/test/resources/org/apache/logging/log4j/core/test/LogBuilderTest.xml
+++ b/log4j-core-test/src/test/resources/org/apache/logging/log4j/core/test/LogBuilderTest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration name="LogBuilderTest" status="error">
+  <MarkerFilter marker="TestMarker" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+  <Appenders>
+    <List name="LIST"/>
+  </Appenders>
+  <Loggers>
+    <Root level="INFO">
+      <AppenderRef ref="LIST"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogBuilder;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LocationAwareReliabilityStrategy;
@@ -364,6 +365,16 @@ public class Logger extends AbstractLogger implements Supplier<LoggerConfig> {
         privateConfig.config.setLoggerAdditive(this, additive);
     }
 
+    @Override
+    public LogBuilder atLevel(Level level) {
+        // A global filter might accept messages less specific than level.
+        // Therefore we return always a functional builder.
+        if (privateConfig.hasFilter()) {
+            return getLogBuilder(level);
+        }
+        return super.atLevel(level);
+    }
+
     /**
      * Associates this Logger with a new Configuration. This method is not
      * exposed through the public API.
@@ -429,6 +440,10 @@ public class Logger extends AbstractLogger implements Supplier<LoggerConfig> {
         // LOG4J2-151: changed visibility to public
         public void logEvent(final LogEvent event) {
             loggerConfig.log(event);
+        }
+
+        boolean hasFilter() {
+            return config.getFilter() != null;
         }
 
         boolean filter(final Level level, final Marker marker, final String msg) {

--- a/log4j-osgi/src/test/java/org/apache/logging/log4j/osgi/tests/JULProviderTest.java
+++ b/log4j-osgi/src/test/java/org/apache/logging/log4j/osgi/tests/JULProviderTest.java
@@ -14,18 +14,10 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.osgi.tests;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.ops4j.pax.exam.CoreOptions.junitBundles;
-import static org.ops4j.pax.exam.CoreOptions.linkBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
 
 import java.util.Optional;
 import java.util.stream.Stream;
-
 import javax.inject.Inject;
 
 import org.apache.logging.log4j.LogManager;
@@ -40,6 +32,12 @@ import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.linkBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
@@ -60,7 +58,7 @@ public class JULProviderTest {
                 junitBundles());
     }
 
-    @Test
+    @Test(timeout = 10_000L)
     public void testJulFactoryResolves() {
         final Optional<Bundle> julBundle = Stream.of(context.getBundles())
                 .filter(b -> "org.apache.logging.log4j.to-jul".equals(b.getSymbolicName()))

--- a/log4j-osgi/src/test/java/org/apache/logging/log4j/osgi/tests/SLF4JProviderTest.java
+++ b/log4j-osgi/src/test/java/org/apache/logging/log4j/osgi/tests/SLF4JProviderTest.java
@@ -14,18 +14,10 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.osgi.tests;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.ops4j.pax.exam.CoreOptions.junitBundles;
-import static org.ops4j.pax.exam.CoreOptions.linkBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
 
 import java.util.Optional;
 import java.util.stream.Stream;
-
 import javax.inject.Inject;
 
 import org.apache.logging.log4j.LogManager;
@@ -40,6 +32,12 @@ import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.linkBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
@@ -59,7 +57,7 @@ public class SLF4JProviderTest {
                 junitBundles());
     }
 
-    @Test
+    @Test(timeout = 10_000L)
     public void testSlf4jFactoryResolves() {
         final Optional<Bundle> slf4jBundle = Stream.of(context.getBundles())
                 .filter(b -> "org.apache.logging.log4j.to-slf4j".equals(b.getSymbolicName()))

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/LogBuilderMarkerFilterBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/LogBuilderMarkerFilterBenchmark.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.perf.jmh;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.LogBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+
+/**
+ * <p>
+ * Compares {@link Logger} and {@link LogBuilder} in the presence or absence of
+ * a global filter. In the absence of a global filter ({@code -Dnofilter}) the
+ * {@link Logger} can return a no-op {@link LogBuilder} if the level is
+ * disabled. No such an optimization is possible in the presence of a global
+ * filter.
+ * </p>
+ * <p>
+ * HOW TO RUN THIS TEST
+ * </p>
+ * <ul>
+ * <li>single thread:
+ *
+ * <pre>
+ * java -jar target/benchmarks.jar ".*LogBuilderMarkerFilterBenchmark.*" -p useFilter=true,false
+ * </pre>
+ *
+ * </li>
+ * <li>multiple threads (for example, 4 threads):
+ *
+ * <pre>
+ * java -jar target/benchmarks.jar ".*LogBuilderMarkerFilterBenchmark.*" -p useFilter=true,false -t 4
+ * </pre>
+ *
+ * </li>
+ * </ul>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class LogBuilderMarkerFilterBenchmark {
+
+    @Param("target/logbuilder.benchmark.log")
+    private String fileName;
+
+    @Param("true")
+    private boolean useFilter;
+
+    private static final String MESSAGE = "This is a test!";
+    private Marker marker;
+    private Logger logger;
+
+    @Setup
+    public void setUp() {
+        System.setProperty("logbuilder.benchmark.output", fileName);
+        if (useFilter) {
+            System.setProperty("log4j2.configurationFile", "log4j2-markerFilter-perf2.xml");
+        } else {
+            System.setProperty("log4j2.configurationFile", "log4j2-noFilter-perf.xml");
+        }
+        logger = LogManager.getLogger(getClass());
+        marker = MarkerManager.getMarker("TestMarker");
+    }
+
+    @TearDown
+    public void tearDown() throws IOException {
+        System.clearProperty("log4j2.configurationFile");
+        LogManager.shutdown();
+        Path filePath = Paths.get(fileName);
+        if (Files.isRegularFile(filePath)) {
+            Files.deleteIfExists(filePath);
+        }
+    }
+
+    @Benchmark
+    public void loggerTraceMarker() {
+        logger.trace(marker, MESSAGE);
+    }
+
+    @Benchmark
+    public void loggerInfoNoMarker() {
+        logger.info(MESSAGE);
+    }
+
+    @Benchmark
+    public void loggerTraceNoMarker() {
+        logger.trace(MESSAGE);
+    }
+
+    @Benchmark
+    public void logBuilderTraceMarker() {
+        logger.atTrace().withMarker(marker).log(MESSAGE);
+    }
+
+    @Benchmark
+    public void logBuilderInfoNoMarker() {
+        logger.atInfo().log(MESSAGE);
+    }
+
+    @Benchmark
+    public void logBuilderTraceNoMarker() {
+        logger.atTrace().log(MESSAGE);
+    }
+}

--- a/log4j-perf/src/main/resources/log4j2-markerFilter-perf2.xml
+++ b/log4j-perf/src/main/resources/log4j2-markerFilter-perf2.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration name="LogBuilderMarkerFilterBenchmark" status="error">
+  <MarkerFilter marker="TestMarker" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+  <Appenders>
+    <File name="FILE" fileName="${sys:logbuilder.benchmark.output}">
+      <PatternLayout pattern="%m%n"/>
+    </File>
+  </Appenders>
+  <Loggers>
+    <Root level="INFO">
+      <AppenderRef ref="FILE"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/log4j-perf/src/main/resources/log4j2-noFilter-perf.xml
+++ b/log4j-perf/src/main/resources/log4j2-noFilter-perf.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+<Configuration name="LogBuilderMarkerFilterBenchmark" status="error">
+  <Appenders>
+    <File name="FILE" fileName="${sys:logbuilder.benchmark.output}">
+      <PatternLayout pattern="%m%n"/>
+    </File>
+  </Appenders>
+  <Loggers>
+    <Root level="INFO">
+      <AppenderRef ref="FILE"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/log4j-to-slf4j/pom.xml
+++ b/log4j-to-slf4j/pom.xml
@@ -47,6 +47,11 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <scope>test</scope>
@@ -54,6 +59,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogBuilder.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogBuilder.java
@@ -17,112 +17,233 @@
 package org.apache.logging.slf4j;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.internal.DefaultLogBuilder;
+import org.apache.logging.log4j.LogBuilder;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.spi.ExtendedLogger;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.LambdaUtil;
+import org.apache.logging.log4j.util.StackLocatorUtil;
+import org.apache.logging.log4j.util.Supplier;
 
-public class SLF4JLogBuilder extends DefaultLogBuilder {
+public class SLF4JLogBuilder implements LogBuilder {
 
-    public SLF4JLogBuilder(ExtendedLogger logger, Level level) {
-        super(logger, level);
+    private static Message EMPTY_MESSAGE = new SimpleMessage("");
+    private static final String FQCN = SLF4JLogBuilder.class.getName();
+    private static final Logger LOGGER = StatusLogger.getLogger();
+
+    private ExtendedLogger logger;
+    private Level level;
+    private Marker marker;
+    private Throwable throwable;
+    private volatile boolean inUse;
+    private final long threadId;
+
+    public SLF4JLogBuilder(SLF4JLogger logger, Level level) {
+        this.logger = logger;
+        this.level = level;
+        this.threadId = Thread.currentThread().getId();
+        this.inUse = level != null;
     }
 
     public SLF4JLogBuilder() {
-        super();
+        this(null, null);
     }
 
-    @Override
-    protected boolean isEnabled(Message message) {
-        // SLF4J will check again later
+    public LogBuilder reset(SLF4JLogger logger, Level level) {
+        this.logger = logger;
+        this.level = level;
+        this.marker = null;
+        this.throwable = null;
+        this.inUse = true;
+        return this;
+    }
+
+    public boolean isInUse() {
+        return this.inUse;
+    }
+
+    private boolean isValid() {
+        if (!inUse) {
+            LOGGER.warn("Attempt to reuse LogBuilder was ignored. {}", StackLocatorUtil.getCallerClass(2));
+            return false;
+        }
+        if (this.threadId != Thread.currentThread().getId()) {
+            LOGGER.warn("LogBuilder can only be used on the owning thread. {}", StackLocatorUtil.getCallerClass(2));
+            return false;
+        }
         return true;
     }
 
-    @Override
-    protected boolean isEnabled(CharSequence message) {
-        // SLF4J will check again later
-        return true;
+    private void logMessage(Message message) {
+        try {
+            logger.logMessage(FQCN, level, marker, message, throwable);
+        } finally {
+            inUse = false;
+        }
     }
 
     @Override
-    protected boolean isEnabled(String message) {
-        // SLF4J will check again later
-        return true;
+    public LogBuilder withMarker(Marker marker) {
+        this.marker = marker;
+        return this;
     }
 
     @Override
-    protected boolean isEnabled(String message, Object... params) {
-        // SLF4J will check again later
-        return true;
+    public LogBuilder withThrowable(Throwable throwable) {
+        this.throwable = throwable;
+        return this;
     }
 
     @Override
-    protected boolean isEnabled(Object message) {
-        // SLF4J will check again later
-        return true;
+    public LogBuilder withLocation() {
+        LOGGER.info("Call to withLocation() ignored since SLF4J does not support setting location information.");
+        return this;
     }
 
     @Override
-    protected boolean isEnabled(String message, Object p0) {
-        // SLF4J will check again later
-        return true;
+    public LogBuilder withLocation(StackTraceElement location) {
+        return withLocation();
     }
 
     @Override
-    protected boolean isEnabled(String message, Object p0, Object p1) {
-        // SLF4J will check again later
-        return true;
+    public void log(CharSequence message) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message));
+        }
     }
 
     @Override
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2) {
-        // SLF4J will check again later
-        return true;
+    public void log(String message) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message));
+        }
     }
 
     @Override
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3) {
-        // SLF4J will check again later
-        return true;
+    public void log(String message, Object... params) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, params));
+        }
     }
 
     @Override
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
-        // SLF4J will check again later
-        return true;
+    public void log(String message, Supplier<?>... params) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, LambdaUtil.getAll(params)));
+        }
     }
 
     @Override
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
-        // SLF4J will check again later
-        return true;
+    public void log(Message message) {
+        if (isValid()) {
+            logMessage(message);
+        }
     }
 
     @Override
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6) {
-        // SLF4J will check again later
-        return true;
+    public void log(Supplier<Message> messageSupplier) {
+        if (isValid()) {
+            logMessage(messageSupplier.get());
+        }
     }
 
     @Override
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6, Object p7) {
-        // SLF4J will check again later
-        return true;
+    public Message logAndGet(Supplier<Message> messageSupplier) {
+        Message message = null;
+        if (isValid()) {
+            logMessage(message = messageSupplier.get());
+        }
+        return message;
     }
 
     @Override
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6, Object p7, Object p8) {
-        // SLF4J will check again later
-        return true;
+    public void log(Object message) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message));
+        }
     }
 
     @Override
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6, Object p7, Object p8, Object p9) {
-        // SLF4J will check again later
-        return true;
+    public void log(String message, Object p0) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+            Object p7) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+            Object p7, Object p8) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8));
+        }
+    }
+
+    @Override
+    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+            Object p7, Object p8, Object p9) {
+        if (isValid()) {
+            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9));
+        }
+    }
+
+    @Override
+    public void log() {
+        if (isValid()) {
+            logMessage(EMPTY_MESSAGE);
+        }
     }
 
 }

--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogBuilder.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogBuilder.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.slf4j;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.internal.DefaultLogBuilder;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.spi.ExtendedLogger;
+
+public class SLF4JLogBuilder extends DefaultLogBuilder {
+
+    public SLF4JLogBuilder(ExtendedLogger logger, Level level) {
+        super(logger, level);
+    }
+
+    public SLF4JLogBuilder() {
+        super();
+    }
+
+    @Override
+    protected boolean isEnabled(Message message) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(CharSequence message) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(String message) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(String message, Object... params) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(Object message) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(String message, Object p0) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(String message, Object p0, Object p1) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+            Object p6) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+            Object p6, Object p7) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+            Object p6, Object p7, Object p8) {
+        // SLF4J will check again later
+        return true;
+    }
+
+    @Override
+    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+            Object p6, Object p7, Object p8, Object p9) {
+        // SLF4J will check again later
+        return true;
+    }
+
+}

--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogger.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogger.java
@@ -268,6 +268,11 @@ public class SLF4JLogger extends AbstractLogger {
     }
 
     @Override
+    public LogBuilder always() {
+        return atLevel(Level.OFF);
+    }
+
+    @Override
     public LogBuilder atTrace() {
         return atLevel(Level.TRACE);
     }

--- a/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/LogBuilderTest.java
+++ b/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/LogBuilderTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.slf4j;
+
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.CloseableThreadContext;
+import org.apache.logging.log4j.CloseableThreadContext.Instance;
+import org.apache.logging.log4j.LogBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.testUtil.StringListAppender;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LogBuilderTest {
+
+    private static final String CONFIG = "target/test-classes/logback-turbofilter.xml";
+    private static final CharSequence CHAR_SEQUENCE = "CharSequence";
+    private static final String STRING = "String";
+    private static final Message MESSAGE = new SimpleMessage();
+    private static final Object[] P = { "p0", "p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8", "p9" };
+    private static final Object OBJECT = "Object";
+
+    private static LoggerContext context;
+    private static Logger logger;
+    private static StringListAppender<ILoggingEvent> list;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        context = (LoggerContext) LoggerFactory.getILoggerFactory();
+        final JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(context);
+        configurator.doConfigure(CONFIG);
+
+        final org.slf4j.Logger slf4jLogger = context.getLogger(LogBuilderTest.class);
+        logger = LogManager.getLogger(LogBuilderTest.class);
+        assertThat(slf4jLogger).isSameAs(((SLF4JLogger) logger).getLogger());
+        final ch.qos.logback.classic.Logger rootLogger = context.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+        rootLogger.detachAppender("console");
+        list = TestUtil.getListAppender(rootLogger, "LIST");
+        assertThat(list).isNotNull().extracting("strList").isNotNull();
+        list.strList.clear();
+    }
+
+    static Stream<Consumer<LogBuilder>> logBuilderMethods() {
+        return Stream.of(logBuilder -> logBuilder.log(), logBuilder -> logBuilder.log(CHAR_SEQUENCE),
+                logBuilder -> logBuilder.log(MESSAGE), logBuilder -> logBuilder.log(OBJECT),
+                logBuilder -> logBuilder.log(STRING), logBuilder -> logBuilder.log(STRING, P[0]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3], P[4]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3], P[4], P[5]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3], P[4], P[5], P[6]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3], P[4], P[5], P[6], P[7]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3], P[4], P[5], P[6], P[7], P[8]),
+                logBuilder -> logBuilder.log(STRING, P[0], P[1], P[2], P[3], P[4], P[5], P[6], P[7], P[8], P[9]),
+                logBuilder -> logBuilder.log(STRING, P), logBuilder -> logBuilder.log(STRING, () -> OBJECT),
+                logBuilder -> logBuilder.log(() -> MESSAGE));
+    }
+
+    @ParameterizedTest
+    @MethodSource("logBuilderMethods")
+    void testTurboFilter(Consumer<LogBuilder> consumer) {
+        consumer.accept(logger.atTrace());
+        try (Instance c = CloseableThreadContext.put("callerId", "Log4j2")) {
+            consumer.accept(logger.atTrace());
+            assertThat(list.strList).hasSize(1);
+        }
+        list.strList.clear();
+    }
+
+    @ParameterizedTest
+    @MethodSource("logBuilderMethods")
+    void testLevelThreshold(Consumer<LogBuilder> consumer) {
+        consumer.accept(logger.atInfo());
+        assertThat(list.strList).hasSize(1);
+        list.strList.clear();
+    }
+}

--- a/log4j-to-slf4j/src/test/resources/logback-turbofilter.xml
+++ b/log4j-to-slf4j/src/test/resources/logback-turbofilter.xml
@@ -17,13 +17,23 @@
   -->
 <configuration>
 
+  <turboFilter class="ch.qos.logback.classic.turbo.DynamicThresholdFilter">
+    <OnHigherOrEqual>ACCEPT</OnHigherOrEqual>
+    <Key>callerId</Key>
+    <DefaultThreshold>INFO</DefaultThreshold>
+    <MDCValueLevelPair>
+      <value>Log4j2</value>
+      <level>TRACE</level>
+    </MDCValueLevelPair>
+  </turboFilter>
+
   <appender name="LIST" class="ch.qos.logback.core.testUtil.StringListAppender">
     <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>%X{TestYear}%msg</Pattern>
+      <Pattern>%msg</Pattern>
     </layout>
   </appender>
 
-  <root level="trace">
+  <root level="INFO">
     <appender-ref ref="LIST" />
   </root>
 </configuration>

--- a/src/changelog/.2.x.x/LOG4J2-3647_Add_support_for_global_filters_to_LogBuilder.xml
+++ b/src/changelog/.2.x.x/LOG4J2-3647_Add_support_for_global_filters_to_LogBuilder.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry type="fixed">
+  <issue id="LOG4J2-3647" link="https://issues.apache.org/jira/browse/LOG4J2-3647"/>
+  <author id="ppkarwasz"/>
+  <description format="asciidoc">Fixed `LogBuilder` filtering in the presence of global filters.</description>
+</entry>


### PR DESCRIPTION
The way the `LogBuilder` works right now makes the following calls equivalent:

```lang-xml
logger.atTrace().withMarker(marker).log("Hello");
if (logger.isTraceEnabled()) {
    logger.trace(marker, "Hello");
}
```

If the user configures a global filter and sets a level more specific than `TRACE`, the code will not log anything, regardless of the result of the filter.

This patch:

 * introduces an appropriate `isEnabled(...)` check to `LogBuilder`, so that messages are filtered even if the `at*` methods were to return a real builder,
 * overrides the `at*` methods in Log4j2 Core: if no global filter is present the builder works the same way as before. However if a global filter is present, the `at*` methods always return **real** builder instances instead of no-ops,
 * overrides the logger in `log4j-to-slf4j`: if the backend is Logback (which also supports global filters), no filtering is performed by the Log4j2 API. Filtering is delegated to SLF4J.

# Benchmark results

Running the `LogBuilderMarkerFilterBenchmark` on a single thread of a 3.2 GHz Intel i7 gives the following results:

| Benchmark | Global Filter | Mode | Cnt | Score | Error | Units |
| - | - | - | - | - | - | - |
| logBuilderInfoNoMarker  | false  | thrpt | 25 |    401955,662 |    4452,326 | ops/s |
| loggerInfoNoMarker      | false  | thrpt | 25 |    401901,138 |    4962,817 | ops/s |
| logBuilderInfoNoMarker  |  true  | thrpt | 25 |    397392,140 |    5714,547 | ops/s |
| loggerInfoNoMarker      |  true  | thrpt | 25 |    401216,060 |    5157,227 | ops/s |
| logBuilderTraceNoMarker | false  | thrpt | 25 | 481090144,928 | 1047566,448 | ops/s |
| loggerTraceNoMarker     | false  | thrpt | 25 | 696911075,263 | 3323230,926 | ops/s |
| logBuilderTraceNoMarker |  true  | thrpt | 25 | 230876086,487 | 3658691,602 | ops/s |
| loggerTraceNoMarker     |  true  | thrpt | 25 | 545905032,453 | 3454089,549 | ops/s |
| logBuilderTraceMarker   | false  | thrpt | 25 | 479616595,520 | 2696417,835 | ops/s |
| loggerTraceMarker       | false  | thrpt | 25 | 604741975,172 | 4017689,657 | ops/s |
| logBuilderTraceMarker   |  true  | thrpt | 25 |    401843,967 |    2733,869 | ops/s |
| loggerTraceMarker       |  true  | thrpt | 25 |    401009,737 |    3303,312 | ops/s |

The logger was configured with a threshold of `INFO` and the global marker filter accepts all marked messages.

These figures suggest that:

 * when the logger is enabled, there is not statistical difference between `LogBuilder` and `Logger` or the presence/absence of a global filter,
 * when the logger is disabled, there is a 20% penalty for using a `LogBuilder` if no-op log builders are returned and a 50% penalty if a real log builder is returned. Anyway each operation takes no more than 15 CPU cycles, which I find acceptable.