### PR TITLE
Pre-2.20.0 dependency version dump

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/LevelMixInJsonTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/LevelMixInJsonTest.java
@@ -14,15 +14,10 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.experimental.categories.Category;
-
-@Category(Layouts.Json.class)
 public class LevelMixInJsonTest extends LevelMixInTest {
 
     @Override

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/LevelMixInTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/LevelMixInTest.java
@@ -20,21 +20,20 @@ import java.io.IOException;
 import java.util.Objects;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import org.junit.experimental.categories.Category;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@link LevelMixIn}.
  */
-@Category(Layouts.Json.class)
 public abstract class LevelMixInTest {
 
     static class Fixture {
@@ -70,31 +69,31 @@ public abstract class LevelMixInTest {
 
     private ObjectWriter writer;
 
-    @Before
+    protected abstract ObjectMapper newObjectMapper();
+
+    @BeforeEach
     public void setUp() {
         log4jObjectMapper = newObjectMapper();
         writer = log4jObjectMapper.writer();
         reader = log4jObjectMapper.readerFor(Level.class);
     }
 
-    protected abstract ObjectMapper newObjectMapper();
-
     @Test
     public void testContainer() throws IOException {
         final Fixture expected = new Fixture();
         final String str = writer.writeValueAsString(expected);
-        Assert.assertTrue(str.contains("DEBUG"));
+        assertTrue(str.contains("DEBUG"));
         final ObjectReader fixtureReader = log4jObjectMapper.readerFor(Fixture.class);
         final Fixture actual = fixtureReader.readValue(str);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void testNameOnly() throws IOException {
         final Level expected = Level.getLevel("DEBUG");
         final String str = writer.writeValueAsString(expected);
-        Assert.assertTrue(str.contains("DEBUG"));
+        assertTrue(str.contains("DEBUG"));
         final Level actual = reader.readValue(str);
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/LevelMixInXmlTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/LevelMixInXmlTest.java
@@ -14,22 +14,28 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.jackson;
 
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.Ignore;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.experimental.categories.Category;
 
-@Ignore("Fails for #testNameOnly()")
-@Category(Layouts.Xml.class)
 public class LevelMixInXmlTest extends LevelMixInTest {
 
     @Override
     protected ObjectMapper newObjectMapper() {
         return new Log4jXmlObjectMapper();
+    }
+
+    @Test
+    @Disabled("String-like objects like Level do not work as root elements.")
+    @Override
+    public void testNameOnly() throws IOException {
+        // Disabled: see https://github.com/FasterXML/jackson-dataformat-xml
+        super.testNameOnly();
     }
 
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/LevelMixInYamlTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jackson/LevelMixInYamlTest.java
@@ -14,15 +14,10 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.logging.log4j.core.test.categories.Layouts;
-import org.junit.experimental.categories.Category;
-
-@Category(Layouts.Yaml.class)
 public class LevelMixInYamlTest extends LevelMixInTest {
 
     @Override

--- a/log4j-samples/pom.xml
+++ b/log4j-samples/pom.xml
@@ -34,7 +34,7 @@
 
     <maven-jetty-plugin.version>6.1.26</maven-jetty-plugin.version>
 
-    <spring-ws.version>3.1.3</spring-ws.version>
+    <spring-ws.version>4.0.0</spring-ws.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/pom.xml
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-samples/pom.xml
@@ -31,7 +31,7 @@
     <revapi.skip>true</revapi.skip>
     <log4jParentDir>${basedir}/../..</log4jParentDir>
 
-    <spring-ws.version>3.1.3</spring-ws.version>
+    <spring-ws.version>4.0.0</spring-ws.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
     <cassandra.version>3.11.13</cassandra.version>
     <cassandra-driver.version>3.11.3</cassandra-driver.version>
     <commons-codec.version>1.15</commons-codec.version>
-    <commons-compress.version>1.21</commons-compress.version>
+    <commons-compress.version>1.22</commons-compress.version>
     <commons-csv.version>1.9.0</commons-csv.version>
     <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
     <commons-io.version>2.11.0</commons-io.version>

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
     <commons-pool2.version>2.11.1</commons-pool2.version>
     <conversant.disruptor.version>1.2.15</conversant.disruptor.version> <!-- Version 1.2.16 requires Java 9 -->
     <disruptor.version>3.4.4</disruptor.version>
-    <elasticsearch.version>7.17.6</elasticsearch.version>
+    <elasticsearch.version>7.17.8</elasticsearch.version>
     <embedded-ldap.version>0.9.0</embedded-ldap.version>
     <embedded-mongo.version>3.5.1</embedded-mongo.version>
     <felix.version>7.0.5</felix.version>

--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
     <plexus-utils.version>3.5.0</plexus-utils.version>
     <slf4j.version>1.7.36</slf4j.version>
     <spring.version>5.3.24</spring.version>
-    <spring-boot.version>2.7.5</spring-boot.version>
+    <spring-boot.version>2.7.7</spring-boot.version>
     <system-stubs.version>2.0.1</system-stubs.version>
     <tomcat-juli.version>10.0.23</tomcat-juli.version>
     <velocity.version>1.7</velocity.version>

--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
     <system-stubs.version>2.0.1</system-stubs.version>
     <tomcat-juli.version>10.0.23</tomcat-juli.version>
     <velocity.version>1.7</velocity.version>
-    <wiremock.version>2.34.0</wiremock.version>
+    <wiremock.version>2.35.0</wiremock.version>
     <woodstox.version>6.4.0</woodstox.version>
     <xmlunit.version>2.9.0</xmlunit.version>
     <xz.version>1.9</xz.version>

--- a/pom.xml
+++ b/pom.xml
@@ -394,7 +394,7 @@
     <tomcat-juli.version>10.0.23</tomcat-juli.version>
     <velocity.version>1.7</velocity.version>
     <wiremock.version>2.34.0</wiremock.version>
-    <woodstox.version>6.3.1</woodstox.version>
+    <woodstox.version>6.4.0</woodstox.version>
     <xmlunit.version>2.9.0</xmlunit.version>
     <xz.version>1.9</xz.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
     <embedded-mongo.version>3.5.1</embedded-mongo.version>
     <felix.version>7.0.5</felix.version>
     <flume.version>1.11.0</flume.version>
-    <groovy.version>3.0.13</groovy.version>
+    <groovy.version>3.0.14</groovy.version>
     <guava.version>31.1-jre</guava.version>
     <h2.version>2.1.214</h2.version>
     <hadoop.version>1.2.1</hadoop.version>

--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,7 @@
     <jconsole.version>1.7.0</jconsole.version>
     <jctools.version>3.3.0</jctools.version>
     <je.version>18.3.12</je.version>
-    <jeromq.version>0.5.2</jeromq.version>
+    <jeromq.version>0.5.3</jeromq.version>
     <jetty.version>9.4.49.v20220914</jetty.version>
     <jmdns.version>3.5.8</jmdns.version>
     <jmh.version>1.36</jmh.version>

--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
     <assertj.version>3.23.1</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
     <bsh.version>2.0b6</bsh.version>
-    <cassandra.version>3.11.13</cassandra.version>
+    <cassandra.version>3.11.14</cassandra.version>
     <cassandra-driver.version>3.11.3</cassandra-driver.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-compress.version>1.22</commons-compress.version>

--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
     <jeromq.version>0.5.2</jeromq.version>
     <jetty.version>9.4.49.v20220914</jetty.version>
     <jmdns.version>3.5.8</jmdns.version>
-    <jmh.version>1.35</jmh.version>
+    <jmh.version>1.36</jmh.version>
     <jna.version>5.12.1</jna.version>
     <json-unit.version>2.36.0</json-unit.version>
     <junit.version>4.13.2</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
     <!-- Dependency versions -->
     <!-- We can use the property names from Spring Boot: -->
     <!--  https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.7.4/spring-boot-dependencies-2.7.4.pom -->
-    <activemq.version>5.17.2</activemq.version>
+    <activemq.version>5.17.3</activemq.version>
     <assertj.version>3.23.1</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
     <bsh.version>2.0b6</bsh.version>

--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@
     <jctools.version>3.3.0</jctools.version>
     <je.version>18.3.12</je.version>
     <jeromq.version>0.5.3</jeromq.version>
-    <jetty.version>9.4.49.v20220914</jetty.version>
+    <jetty.version>9.4.50.v20221201</jetty.version>
     <jmdns.version>3.5.8</jmdns.version>
     <jmh.version>1.36</jmh.version>
     <jna.version>5.12.1</jna.version>

--- a/pom.xml
+++ b/pom.xml
@@ -386,7 +386,7 @@
     <!-- The OSGi API version MUST always be the MINIMUM version Log4j supports -->
     <osgi.api.version>6.0.0</osgi.api.version>
     <pax-exam.version>4.13.5</pax-exam.version>
-    <plexus-utils.version>3.4.2</plexus-utils.version>
+    <plexus-utils.version>3.5.0</plexus-utils.version>
     <slf4j.version>1.7.36</slf4j.version>
     <spring.version>5.3.23</spring.version>
     <spring-boot.version>2.7.5</spring-boot.version>

--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
     <hsqldb.version>2.5.2</hsqldb.version>
     <icu4j.version>72.1</icu4j.version>
     <jackson1.version>1.9.13</jackson1.version>
-    <jackson-bom.version>2.13.4.20221013</jackson-bom.version>
+    <jackson-bom.version>2.14.1</jackson-bom.version>
     <!-- Implementation of `jakarta.activation-api` -->
     <jakarta-activation.version>2.0.1</jakarta-activation.version>
     <jakarta-mail.version>2.0.1</jakarta-mail.version>

--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,7 @@
     <embedded-ldap.version>0.9.0</embedded-ldap.version>
     <embedded-mongo.version>3.5.1</embedded-mongo.version>
     <felix.version>7.0.5</felix.version>
-    <flume.version>1.10.1</flume.version>
+    <flume.version>1.11.0</flume.version>
     <groovy.version>3.0.13</groovy.version>
     <guava.version>31.1-jre</guava.version>
     <h2.version>2.1.214</h2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,7 @@
     <maven.version>3.8.6</maven.version>
     <mockito.version>4.11.0</mockito.version>
     <mongodb.version>4.5.0</mongodb.version>
-    <netty.version>4.1.84.Final</netty.version>
+    <netty.version>4.1.86.Final</netty.version>
     <org.eclipse.osgi.version>3.13.0.v20180226-1711</org.eclipse.osgi.version>
     <org.eclipse.persistence.version>2.7.11</org.eclipse.persistence.version>
     <oro.version>2.0.8</oro.version>

--- a/pom.xml
+++ b/pom.xml
@@ -377,7 +377,7 @@
     <log4j2-ecs-layout.version>1.5.0</log4j2-ecs-layout.version>
     <logback.version>1.2.11</logback.version>
     <maven.version>3.8.6</maven.version>
-    <mockito.version>4.8.1</mockito.version>
+    <mockito.version>4.11.0</mockito.version>
     <mongodb.version>4.5.0</mongodb.version>
     <netty.version>4.1.84.Final</netty.version>
     <org.eclipse.osgi.version>3.13.0.v20180226-1711</org.eclipse.osgi.version>

--- a/pom.xml
+++ b/pom.xml
@@ -388,7 +388,7 @@
     <pax-exam.version>4.13.5</pax-exam.version>
     <plexus-utils.version>3.5.0</plexus-utils.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <spring.version>5.3.23</spring.version>
+    <spring.version>5.3.24</spring.version>
     <spring-boot.version>2.7.5</spring-boot.version>
     <system-stubs.version>2.0.1</system-stubs.version>
     <tomcat-juli.version>10.0.23</tomcat-juli.version>


### PR DESCRIPTION
This PR contains most upgrade suggestions from Dependabot since the latest `2.19.0` release.

Only `LevelMixInXmlTest` gave some problems with the newest Jackson version, but I came to the conclusion that it didn't apply: XML documents must have a root element, so  simple text-only values such as `Level` are serialized as complex values. The deserializer can not always decide whether the document is a "JSON string" or "JSON object" and results vary between Jackson version.