### PR TITLE
fix: Restore previous behavior ignoring exceptions when translating a…

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/PatternLayoutStyleAnsiTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/PatternLayoutStyleAnsiTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.layout;
+
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.ConfigurationFactory;
+import org.apache.logging.log4j.core.test.BasicConfigurationFactory;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.test.junit.StatusLoggerLevel;
+import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@StatusLoggerLevel("WARN")
+@UsingAnyThreadContext
+public class PatternLayoutStyleAnsiTest {
+
+    static ConfigurationFactory cf = new BasicConfigurationFactory();
+
+    public static void cleanupClass() {
+        ConfigurationFactory.removeConfigurationFactory(cf);
+    }
+
+    @BeforeAll
+    public static void setupClass() {
+        ConfigurationFactory.setConfigurationFactory(cf);
+        final LoggerContext ctx = LoggerContext.getContext();
+        ctx.reconfigure();
+    }
+
+    LoggerContext ctx = LoggerContext.getContext();
+
+    @Test
+    public void testStylePatternDisableAnsiDoesNotThrowException() {
+        StatusLogger statusLogger = StatusLogger.getLogger();
+        statusLogger.clear();
+
+        assertDoesNotThrow( () ->
+        PatternLayout.newBuilder().withPattern("%style{Hello, world!}{disableAnsi=false}")
+                .withConfiguration(ctx.getConfiguration()).build()
+        );
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/AnsiEscape.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/AnsiEscape.java
@@ -487,7 +487,8 @@ public enum AnsiEscape {
                     sb.append(escape.getCode());
                 }
             } catch (final Exception ex) {
-                StatusLogger.getLogger().warn("The style attribute {} is incorrect.", name, ex);
+                // Ignore the error.
+                // We rely on this behavior to pass through ANSI style for the style conversion pattern.
             }
         }
         sb.append(AnsiEscape.SUFFIX.getCode());


### PR DESCRIPTION
… conversion parameter to an AnsiEscape enum