### PR TITLE
This change fixes incorrect behavior of stack elements cache.

### DIFF
--- a/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/StackLocatorTest.java
+++ b/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/StackLocatorTest.java
@@ -16,16 +16,16 @@
  */
 package org.apache.logging.log4j.util.java9;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-
 import java.util.Deque;
 import java.util.Stack;
 
 import org.apache.logging.log4j.util.StackLocator;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class StackLocatorTest {
 
@@ -133,8 +133,15 @@ public class StackLocatorTest {
          */
         final StackTraceElement element = new Foo().foo();
         assertEquals("org.apache.logging.log4j.util.java9.StackLocatorTest$Foo", element.getClassName());
-        // The line number below may need adjustment if this file is changed. 
+        // The line number below may need adjustment if this file is changed.
         assertEquals(100, element.getLineNumber());
+    }
+
+    @Test
+    public void testTopElementInStackTrace() {
+        final StackLocator stackLocator = StackLocator.getInstance();
+        final Deque<Class<?>> classes = stackLocator.getCurrentStackTrace();
+        assertSame(StackLocator.class, classes.getFirst());
     }
 
     @Test

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/StackLocatorTestIT.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/StackLocatorTestIT.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.util;
+
+import java.security.Permission;
+import java.util.Deque;
+
+import org.apache.logging.log4j.test.junit.SecurityManagerTestRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+
+/**
+ * Tests https://github.com/apache/logging-log4j2/pull/1214.
+ * <p>
+ * Using a security manager can mess up other tests so this is best used from
+ * integration tests (classes that end in "IT" instead of "Test" and
+ * "TestCase".)
+ * </p>
+ *
+ * @see StackLocator
+ * @see SecurityManager
+ * @see System#setSecurityManager(SecurityManager)
+ */
+@ResourceLock("java.lang.SecurityManager")
+public class StackLocatorTestIT {
+  @Rule
+  public final SecurityManagerTestRule rule = new SecurityManagerTestRule(new TestSecurityManager());
+
+  /**
+   * Always throws a SecurityException for any reques to create a new SecurityManager
+   */
+  private static class TestSecurityManager extends SecurityManager {
+    @Override
+    public void checkPermission(final Permission permission) {
+      if ("createSecurityManager".equals(permission.getName())) {
+        throw new SecurityException();
+      }
+    }
+  }
+
+  @Test
+  public void testGetCurrentStacktraceSlowPath() {
+    final StackLocator stackLocator = StackLocator.getInstance();
+    final Deque<Class<?>> classes = stackLocator.getCurrentStackTrace();
+    Assertions.assertSame(StackLocator.class, classes.getFirst());
+  }
+}

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/StackLocatorUtilTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/StackLocatorUtilTest.java
@@ -16,21 +16,22 @@
  */
 package org.apache.logging.log4j.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-
 import java.util.Deque;
 import java.util.Stack;
 
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.ParentRunner;
 
 import sun.reflect.Reflection;
 
-/** 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+/**
  * Tests {@link StackLocatorUtilTest}.
  */
 @RunWith(BlockJUnit4ClassRunner.class)
@@ -80,6 +81,15 @@ public class StackLocatorUtilTest {
         }
         reversed.pop(); // ReflectionUtil
         assertSame(StackLocatorUtilTest.class, reversed.pop());
+    }
+
+    @Test
+    public void testTopElementInStackTrace() {
+        final StackLocator stackLocator = StackLocator.getInstance();
+        final Deque<Class<?>> classes = stackLocator.getCurrentStackTrace();
+        //Removing private class in "PrivateSecurityManagerStackTraceUtil"
+        classes.removeFirst();
+        Assertions.assertSame(PrivateSecurityManagerStackTraceUtil.class, classes.getFirst());
     }
 
     @Test

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -54,7 +54,7 @@ public final class StackLocator {
     private static final Method GET_CALLER_CLASS_METHOD;
 
     private static final StackLocator INSTANCE;
-    
+
     /** TODO: Use Object.class. */
     private static final Class<?> DEFAULT_CALLER_CLASS = null;
 
@@ -203,7 +203,7 @@ public final class StackLocator {
         final Deque<Class<?>> classes = new ArrayDeque<>();
         Class<?> clazz;
         for (int i = 1; null != (clazz = getCallerClass(i)); i++) {
-            classes.push(clazz);
+            classes.addLast(clazz);
         }
         return classes;
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/ThrowableProxyHelperTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/ThrowableProxyHelperTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.impl;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Tests ThrowableProxyHelper.
+ */
+public class ThrowableProxyHelperTest {
+
+  /**
+   * We populate dummy stack trace and array of stack trace elements in the right order
+   * It supposed to always trigger fast path so cache won't be populated
+   * This simulates the case when current thread's and throwable stack traces have the same elements
+   */
+  @Test
+  public void testSuccessfulCacheHit() {
+    final Map<String, ThrowableProxyHelper.CacheEntry> map = new HashMap<>();
+    final Deque<Class<?>> stack = new ArrayDeque<>(3);
+    StackTraceElement[] stackTraceElements = new StackTraceElement[3];
+    stackTraceElements[0] = new StackTraceElement(Integer.class.getName(), "toString",
+          "Integer.java", 1);
+    stack.addLast(Integer.class);
+    stackTraceElements[1] = new StackTraceElement(Float.class.getName(), "toString",
+        "Float.java", 1);
+    stack.addLast(Float.class);
+    stackTraceElements[2] = new StackTraceElement(Double.class.getName(), "toString",
+        "Double.java", 1);
+    stack.addLast(Double.class);
+    final Throwable throwable = new IllegalStateException("This is a test");
+    final ThrowableProxy proxy = new ThrowableProxy(throwable);
+    ThrowableProxyHelper.toExtendedStackTrace(proxy, stack, map, null, stackTraceElements);
+    assertTrue(map.isEmpty());
+  }
+
+  /**
+   * We populate dummy stack trace and array of stack trace elements in the wrong order
+   * It will trigger fast path only once so cache will have two items
+   */
+  @Test
+  public void testFailedCacheHit() {
+    final Map<String, ThrowableProxyHelper.CacheEntry> map = new HashMap<>();
+    final Deque<Class<?>> stack = new ArrayDeque<>(3);
+    StackTraceElement[] stackTraceElements = new StackTraceElement[3];
+    stackTraceElements[0] = new StackTraceElement(Integer.class.getName(), "toString",
+        "Integer.java", 1);
+    stack.addFirst(Integer.class);
+    stackTraceElements[1] = new StackTraceElement(Float.class.getName(), "toString",
+        "Float.java", 1);
+    stack.addFirst(Float.class);
+    stackTraceElements[2] = new StackTraceElement(Double.class.getName(), "toString",
+        "Double.java", 1);
+    stack.addFirst(Double.class);
+    final Throwable throwable = new IllegalStateException("This is a test");
+    final ThrowableProxy proxy = new ThrowableProxy(throwable);
+    ThrowableProxyHelper.toExtendedStackTrace(proxy, stack, map, null, stackTraceElements);
+    assertFalse(map.isEmpty());
+    //Integer will match, so fast path won't cache it, only Float and Double will appear in cache after class loading
+    assertTrue(map.containsKey(Double.class.getName()));
+    assertTrue(map.containsKey(Float.class.getName()));
+  }
+
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/ThrowableProxyHelperTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/ThrowableProxyHelperTest.java
@@ -20,10 +20,11 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.junit.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests ThrowableProxyHelper.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxyHelper.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxyHelper.java
@@ -85,7 +85,7 @@ class ThrowableProxyHelper {
             stackLength = stackTrace.length;
         }
         final ExtendedStackTraceElement[] extStackTrace = new ExtendedStackTraceElement[stackLength];
-        Class<?> clazz = stack.isEmpty() ? null : stack.peek();
+        Class<?> clazz = stack.isEmpty() ? null : stack.peekLast();
         ClassLoader lastLoader = null;
         for (int i = stackLength - 1; i >= 0; --i) {
             final StackTraceElement stackTraceElement = stackTrace[i];
@@ -98,8 +98,8 @@ class ThrowableProxyHelper {
                 final CacheEntry entry = toCacheEntry(clazz, true);
                 extClassInfo = entry.element;
                 lastLoader = entry.loader;
-                stack.pop();
-                clazz = stack.isEmpty() ? null : stack.peek();
+                stack.pollLast();
+                clazz = stack.isEmpty() ? null : stack.peekLast();
             } else {
                 final CacheEntry cacheEntry = map.get(className);
                 if (cacheEntry != null) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxyHelper.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThrowableProxyHelper.java
@@ -99,7 +99,7 @@ class ThrowableProxyHelper {
                 extClassInfo = entry.element;
                 lastLoader = entry.loader;
                 stack.pollLast();
-                clazz = stack.isEmpty() ? null : stack.peekLast();
+                clazz = stack.peekLast();
             } else {
                 final CacheEntry cacheEntry = map.get(className);
                 if (cacheEntry != null) {

--- a/src/changelog/.2.x.x/1214_fix_stacktrace_order.xml
+++ b/src/changelog/.2.x.x/1214_fix_stacktrace_order.xml
@@ -17,6 +17,7 @@
 -->
 <entry type="changed">
   <issue id="1214" link="https://github.com/apache/logging-log4j2/pull/1214"/>
-  <author id="vy"/>
-  <description format="asciidoc">Fixing the issue with stacktrace elements order which causes major regression due to cache misses</description>
+  <author id="alex-dubrouski" name="Aliaksei Durbouski"/>
+  <author id="ppkarwasz"/>
+  <description format="asciidoc">Fix order of stacktrace elements, that causes cache misses in `ThrowableProxyHelper`.</description>
 </entry>

--- a/src/changelog/.2.x.x/1214_fix_stacktrace_order.xml
+++ b/src/changelog/.2.x.x/1214_fix_stacktrace_order.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry type="changed">
+  <issue id="1214" link="https://github.com/apache/logging-log4j2/pull/1214"/>
+  <author id="vy"/>
+  <description format="asciidoc">Fixing the issue with stacktrace elements order which causes major regression due to cache misses</description>
+</entry>


### PR DESCRIPTION
Change of data structure from Stack to Deque (LIFO to FIFO) in this commit https://github.com/apache/logging-log4j2/commit/97f3153b73ab071a69c2e61e0130fd0104d45407 broke cache logic. This bug causes a major performance regression. 
![Screen Shot 2023-01-11 at 6 31 58 PM](https://user-images.githubusercontent.com/36453467/212984460-9c8a63c9-db7d-40c7-b17a-e5ec96a170ed.png)
![Screen Shot 2023-01-11 at 6 32 55 PM](https://user-images.githubusercontent.com/36453467/212984479-1f308cfe-1d20-44ad-bf20-9aa5a75a9bc7.png)

I created a small local project to reproduce the issue. I can attach it if needed.

P.S. I signed ICLA and got a confirmation, but haven't got any response to my request to create a JIRA account, so can't create a bug.