### PR TITLE
Use setters for builder classes

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/CustomConfigurationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/CustomConfigurationTest.java
@@ -81,8 +81,12 @@ public class CustomConfigurationTest {
         final AppenderRef ref = AppenderRef.createAppenderRef("File", null, null);
         final AppenderRef[] refs = new AppenderRef[] {ref};
 
-        final LoggerConfig loggerConfig = LoggerConfig.createLogger(false, Level.INFO, "org.apache.logging.log4j",
-            "true", refs, null, config, null );
+        final LoggerConfig loggerConfig = LoggerConfig.newBuilder()
+                .setLevel(Level.INFO)
+                .setLoggerName("org.apache.logging.log4j")
+                .setIncludeLocation("true")
+                .setConfig(config)
+                .build();
         loggerConfig.addAppender(appender, null, null);
         config.addLogger("org.apache.logging.log4j", loggerConfig);
         ctx.updateLoggers();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/JiraLog4j2_2134Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/JiraLog4j2_2134Test.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.config;
 
 import org.apache.logging.log4j.Level;
@@ -25,8 +24,8 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
@@ -34,107 +33,116 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 @LoggerContextSource("log4j2-2134.yml")
 public class JiraLog4j2_2134Test {
 
-	@Test
-	public void testRefresh() {
-		Logger log = LogManager.getLogger(this.getClass());
-		final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-		final Configuration config = ctx.getConfiguration();
-		PatternLayout layout = PatternLayout.newBuilder()
-		// @formatter:off
-				.setPattern(PatternLayout.SIMPLE_CONVERSION_PATTERN)
-				.setConfiguration(config)
-				.build();
-		// @formatter:on
-		Appender appender = FileAppender.newBuilder().setFileName("target/test.log").setLayout(layout)
-				.setConfiguration(config).setBufferSize(4000).setName("File").build();
-		// appender.start();
-		config.addAppender(appender);
-		AppenderRef ref = AppenderRef.createAppenderRef("File", null, null);
-		AppenderRef[] refs = new AppenderRef[] { ref };
-		LoggerConfig loggerConfig = LoggerConfig.createLogger(false, Level.INFO, "testlog4j2refresh", "true", refs,
-				null, config, null);
-		loggerConfig.addAppender(appender, null, null);
-		config.addLogger("testlog4j2refresh", loggerConfig);
-		ctx.stop();
-		ctx.start(config);
-
-		assertDoesNotThrow(() -> log.error("Info message"));
-	}
-
-	@Test
-	public void testRefreshMinimalCodeStart() {
-		Logger log = LogManager.getLogger(this.getClass());
-		final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-		final Configuration config = ctx.getConfiguration();
-		ctx.start(config);
-
-		assertDoesNotThrow(() -> log.error("Info message"));
-	}
-
-	@Test
-	public void testRefreshMinimalCodeStopStart() {
-		Logger log = LogManager.getLogger(this.getClass());
-		final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-		ctx.stop();
-		ctx.start();
-
-		assertDoesNotThrow(() -> log.error("Info message"));
-	}
-
-	@Test
-	public void testRefreshMinimalCodeStopStartConfig() {
-		Logger log = LogManager.getLogger(this.getClass());
-		final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-		final Configuration config = ctx.getConfiguration();
-		ctx.stop();
-		ctx.start(config);
-
-		assertDoesNotThrow(() -> log.error("Info message"));
-	}
-
-	@SuppressWarnings("deprecation")
-	@Test
-	public void testRefreshDeprecatedApis() {
-		Logger log = LogManager.getLogger(this.getClass());
-		final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
-		final Configuration config = ctx.getConfiguration();
-		PatternLayout layout = PatternLayout.newBuilder()
-		        .setPattern(PatternLayout.SIMPLE_CONVERSION_PATTERN)
-		        .setPatternSelector(null)
-		        .setConfiguration(config)
-		        .setRegexReplacement(null)
-		        .setCharset(null)
-		        .setAlwaysWriteExceptions(false)
-		        .setNoConsoleNoAnsi(false)
-		        .setHeader(null)
-		        .setFooter(null)
-		        .build();
-		// @formatter:off
-		Appender appender = FileAppender.newBuilder()
-		        .setFileName("target/test.log")
-		        .setAppend(false)
-		        .setLocking(false)
-		        .setName("File")
-		        .setImmediateFlush(true)
-		        .setIgnoreExceptions(false)
-		        .setBufferedIo(false)
-		        .setBufferSize(4000)
-		        .setLayout(layout)
-		        .setAdvertise(false)
-		        .setConfiguration(config)
-		        .build();
+    @Test
+    public void testRefresh() {
+        Logger log = LogManager.getLogger(this.getClass());
+        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        final Configuration config = ctx.getConfiguration();
+        PatternLayout layout = PatternLayout.newBuilder()
+        // @formatter:off
+                .setPattern(PatternLayout.SIMPLE_CONVERSION_PATTERN)
+                .setConfiguration(config)
+                .build();
         // @formatter:on
-		appender.start();
-		config.addAppender(appender);
-		AppenderRef ref = AppenderRef.createAppenderRef("File", null, null);
-		AppenderRef[] refs = new AppenderRef[] { ref };
-		LoggerConfig loggerConfig = LoggerConfig.createLogger(false, Level.INFO, "testlog4j2refresh", "true", refs,
-				null, config, null);
-		loggerConfig.addAppender(appender, null, null);
-		config.addLogger("testlog4j2refresh", loggerConfig);
-		ctx.stop();
-		ctx.start(config);
+        Appender appender = FileAppender.newBuilder().setFileName("target/test.log").setLayout(layout)
+                .setConfiguration(config).setBufferSize(4000).setName("File").build();
+        // appender.start();
+        config.addAppender(appender);
+        AppenderRef ref = AppenderRef.createAppenderRef("File", null, null);
+        AppenderRef[] refs = new AppenderRef[] { ref };
+        LoggerConfig loggerConfig = LoggerConfig.newBuilder()
+                .setLevel(Level.INFO)
+                .setLoggerName("testlog4j2refresh")
+                .setIncludeLocation("true")
+                .setRefs(refs)
+                .setConfig(config)
+                .build();
+        loggerConfig.addAppender(appender, null, null);
+        config.addLogger("testlog4j2refresh", loggerConfig);
+        ctx.stop();
+        ctx.start(config);
 
-		assertDoesNotThrow(() -> log.error("Info message"));
-	}
+        assertDoesNotThrow(() -> log.error("Info message"));
+    }
+
+    @Test
+    public void testRefreshMinimalCodeStart() {
+        Logger log = LogManager.getLogger(this.getClass());
+        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        final Configuration config = ctx.getConfiguration();
+        ctx.start(config);
+
+        assertDoesNotThrow(() -> log.error("Info message"));
+    }
+
+    @Test
+    public void testRefreshMinimalCodeStopStart() {
+        Logger log = LogManager.getLogger(this.getClass());
+        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        ctx.stop();
+        ctx.start();
+
+        assertDoesNotThrow(() -> log.error("Info message"));
+    }
+
+    @Test
+    public void testRefreshMinimalCodeStopStartConfig() {
+        Logger log = LogManager.getLogger(this.getClass());
+        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        final Configuration config = ctx.getConfiguration();
+        ctx.stop();
+        ctx.start(config);
+
+        assertDoesNotThrow(() -> log.error("Info message"));
+    }
+
+    @Test
+    public void testRefreshDeprecatedApis() {
+        Logger log = LogManager.getLogger(this.getClass());
+        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        final Configuration config = ctx.getConfiguration();
+        PatternLayout layout = PatternLayout.newBuilder()
+                .setPattern(PatternLayout.SIMPLE_CONVERSION_PATTERN)
+                .setPatternSelector(null)
+                .setConfiguration(config)
+                .setRegexReplacement(null)
+                .setCharset(null)
+                .setAlwaysWriteExceptions(false)
+                .setNoConsoleNoAnsi(false)
+                .setHeader(null)
+                .setFooter(null)
+                .build();
+        // @formatter:off
+        Appender appender = FileAppender.newBuilder()
+                .setFileName("target/test.log")
+                .setAppend(false)
+                .setLocking(false)
+                .setName("File")
+                .setImmediateFlush(true)
+                .setIgnoreExceptions(false)
+                .setBufferedIo(false)
+                .setBufferSize(4000)
+                .setLayout(layout)
+                .setAdvertise(false)
+                .setConfiguration(config)
+                .build();
+        // @formatter:on
+        appender.start();
+        config.addAppender(appender);
+        AppenderRef ref = AppenderRef.createAppenderRef("File", null, null);
+        AppenderRef[] refs = new AppenderRef[] { ref };
+        LoggerConfig loggerConfig = LoggerConfig.newBuilder()
+                .setLevel(Level.INFO)
+                .setLoggerName("testlog4j2refresh")
+                .setIncludeLocation("true")
+                .setRefs(refs)
+                .setConfig(config)
+                .build();
+        loggerConfig.addAppender(appender, null, null);
+        config.addLogger("testlog4j2refresh", loggerConfig);
+        ctx.stop();
+        ctx.start(config);
+
+        assertDoesNotThrow(() -> log.error("Info message"));
+    }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/LoggerConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/LoggerConfigTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
 package org.apache.logging.log4j.core.config;/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
@@ -15,13 +31,13 @@ package org.apache.logging.log4j.core.config;/*
  * limitations under the license.
  */
 
+import java.util.HashSet;
+import java.util.List;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent.Builder;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.junit.jupiter.api.Test;
-
-import java.util.HashSet;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -31,11 +47,16 @@ import static org.junit.jupiter.api.Assertions.*;
 public class LoggerConfigTest {
 
     private static LoggerConfig createForProperties(final Property[] properties) {
-        return LoggerConfig.createLogger(true, Level.INFO, "name", "false", new AppenderRef[0], properties,
-                new NullConfiguration(), null);
+        return LoggerConfig.newBuilder()
+                .setAdditivity(true)
+                .setLevel(Level.INFO)
+                .setLoggerName("name")
+                .setIncludeLocation("false")
+                .setProperties(properties)
+                .setConfig(new NullConfiguration())
+                .build();
     }
 
-    @SuppressWarnings({"deprecation"})
     @Test
     public void testPropertiesWithoutSubstitution() {
         assertNull(createForProperties(null).getPropertyList(), "null propertiesList");
@@ -47,7 +68,7 @@ public class LoggerConfigTest {
         final LoggerConfig loggerConfig = createForProperties(all);
         final List<Property> list = loggerConfig.getPropertyList();
         assertEquals(new HashSet<>(list),
-        		     new HashSet<>(loggerConfig.getPropertyList()), "map and list contents equal");
+                     new HashSet<>(loggerConfig.getPropertyList()), "map and list contents equal");
 
         final Object[] actualList = new Object[1];
         loggerConfig.setLogEventFactory((loggerName, marker, fqcn, level, data, properties, t) -> {
@@ -67,7 +88,7 @@ public class LoggerConfigTest {
         final LoggerConfig loggerConfig = createForProperties(all);
         final List<Property> list = loggerConfig.getPropertyList();
         assertEquals(new HashSet<>(list),
-        		     new HashSet<>(loggerConfig.getPropertyList()), "map and list contents equal");
+                     new HashSet<>(loggerConfig.getPropertyList()), "map and list contents equal");
 
         final Object[] actualListHolder = new Object[1];
         loggerConfig.setLogEventFactory((loggerName, marker, fqcn, level, data, properties, t) -> {
@@ -78,7 +99,7 @@ public class LoggerConfigTest {
         assertNotSame(list, actualListHolder[0], "propertiesList with substitutions");
 
         @SuppressWarnings("unchecked")
-		final List<Property> actualList = (List<Property>) actualListHolder[0];
+        final List<Property> actualList = (List<Property>) actualListHolder[0];
 
         for (int i = 0; i < list.size(); i++) {
             assertEquals(list.get(i).getName(), actualList.get(i).getName(), "name[" + i + "]");
@@ -91,15 +112,15 @@ public class LoggerConfigTest {
     public void testLevel() {
         Configuration configuration = new DefaultConfiguration();
         LoggerConfig config1 = LoggerConfig.newBuilder()
-                .withLoggerName("org.apache.logging.log4j.test")
-                .withLevel(Level.ERROR)
-                .withAdditivity(false)
-                .withConfig(configuration)
+                .setLoggerName("org.apache.logging.log4j.test")
+                .setLevel(Level.ERROR)
+                .setAdditivity(false)
+                .setConfig(configuration)
                 .build();
         LoggerConfig config2 = LoggerConfig.newBuilder()
-                .withLoggerName("org.apache.logging.log4j")
-                .withAdditivity(false)
-                .withConfig(configuration)
+                .setLoggerName("org.apache.logging.log4j")
+                .setAdditivity(false)
+                .setConfig(configuration)
                 .build();
         config1.setParent(config2);
         assertEquals(config1.getLevel(), Level.ERROR, "Unexpected Level");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/filter/ThreadContextMapFilterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/filter/ThreadContextMapFilterTest.java
@@ -32,7 +32,10 @@ public class ThreadContextMapFilterTest {
         ThreadContext.put("organization", "Apache");
         final KeyValuePair[] pairs = new KeyValuePair[] { new KeyValuePair("userid", "JohnDoe"),
                                                     new KeyValuePair("organization", "Apache")};
-        ThreadContextMapFilter filter = ThreadContextMapFilter.createFilter(pairs, "and", null, null);
+        ThreadContextMapFilter filter = ThreadContextMapFilter.newBuilder()
+                .setPairs(pairs)
+                .setOperator("and")
+                .get();
         assertNotNull(filter);
         filter.start();
         assertTrue(filter.isStarted());
@@ -44,7 +47,10 @@ public class ThreadContextMapFilterTest {
         ThreadContext.put("organization", "ASF");
         assertSame(Filter.Result.DENY, filter.filter(null, Level.DEBUG, null, (Object) null, (Throwable) null));
         ThreadContext.clearMap();
-        filter = ThreadContextMapFilter.createFilter(pairs, "or", null, null);
+        filter = ThreadContextMapFilter.newBuilder()
+                .setPairs(pairs)
+                .setOperator("or")
+                .get();
         assertNotNull(filter);
         filter.start();
         assertTrue(filter.isStarted());
@@ -56,7 +62,7 @@ public class ThreadContextMapFilterTest {
         ThreadContext.remove("organization");
         assertSame(Filter.Result.DENY, filter.filter(null, Level.DEBUG, null, (Object) null, (Throwable) null));
         final KeyValuePair[] single = new KeyValuePair[] {new KeyValuePair("userid", "testuser")};
-        filter = ThreadContextMapFilter.createFilter(single, null, null, null);
+        filter = ThreadContextMapFilter.newBuilder().setPairs(single).get();
         assertNotNull(filter);
         filter.start();
         assertTrue(filter.isStarted());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/PatternSelectorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/PatternSelectorTest.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PatternSelectorTest {
 
@@ -74,7 +74,13 @@ public class PatternSelectorTest {
     public void testLevelPatternSelector() throws Exception {
         final PatternMatch[] patterns = new PatternMatch[1];
         patterns[0] = new PatternMatch("TRACE", "%d %-5p [%t]: ====== %C{1}.%M:%L %m ======%n");
-        final PatternSelector selector = LevelPatternSelector.createSelector(patterns, "%d %-5p [%t]: %m%n", true, true, ctx.getConfiguration());
+        final PatternSelector selector = LevelPatternSelector.newBuilder()
+                .setProperties(patterns)
+                .setDefaultPattern("%d %-5p [%t]: %m%n")
+                .setAlwaysWriteExceptions(true)
+                .setNoConsoleNoAnsi(true)
+                .setConfiguration(ctx.getConfiguration())
+                .build();
         final PatternLayout layout = PatternLayout.newBuilder().setPatternSelector(selector)
                 .setConfiguration(ctx.getConfiguration()).build();
         final LogEvent event1 = Log4jLogEvent.newBuilder() //

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AbstractManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AbstractManager.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationException;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Cast;
 
 /**
  * Abstract base class used to register managers.
@@ -107,8 +108,7 @@ public abstract class AbstractManager implements AutoCloseable {
                                                               final T data) {
         LOCK.lock();
         try {
-            @SuppressWarnings("unchecked")
-            M manager = (M) MAP.get(name);
+            M manager = Cast.cast(MAP.get(name));
             if (manager == null) {
                 manager = factory.createManager(name, data);
                 if (manager == null) {
@@ -161,8 +161,8 @@ public abstract class AbstractManager implements AutoCloseable {
      * @see <a href="https://issues.apache.org/jira/browse/LOG4J2-1908">LOG4J2-1908</a>
      */
     protected static <M extends AbstractManager> M narrow(final Class<M> narrowClass, final AbstractManager manager) {
-        if (narrowClass.isAssignableFrom(manager.getClass())) {
-            return (M) manager;
+        if (narrowClass.isInstance(manager)) {
+            return narrowClass.cast(manager);
         }
         throw new ConfigurationException(
                 "Configuration has multiple incompatible Appenders pointing to the same resource '" +

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AbstractWriterAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AbstractWriterAppender.java
@@ -18,8 +18,7 @@ package org.apache.logging.log4j.core.appender;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
@@ -44,8 +43,7 @@ public abstract class AbstractWriterAppender<M extends WriterManager> extends Ab
      */
     protected final boolean immediateFlush;
     private final M manager;
-    private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
-    private final Lock readLock = readWriteLock.readLock();
+    private final Lock lock = new ReentrantLock();
 
     /**
      * Instantiates.
@@ -76,7 +74,7 @@ public abstract class AbstractWriterAppender<M extends WriterManager> extends Ab
      */
     @Override
     public void append(final LogEvent event) {
-        readLock.lock();
+        lock.lock();
         try {
             final String str = getStringLayout().toSerializable(event);
             if (str.length() > 0) {
@@ -89,7 +87,7 @@ public abstract class AbstractWriterAppender<M extends WriterManager> extends Ab
             error("Unable to write " + manager.getName() + " for appender " + getName(), event, ex);
             throw ex;
         } finally {
-            readLock.unlock();
+            lock.unlock();
         }
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
@@ -39,7 +39,6 @@ import org.apache.logging.log4j.core.config.AppenderRef;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationException;
 import org.apache.logging.log4j.core.config.Property;
-import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
 import org.apache.logging.log4j.core.filter.AbstractFilterable;
 import org.apache.logging.log4j.plugins.Configurable;
@@ -47,6 +46,7 @@ import org.apache.logging.log4j.plugins.Plugin;
 import org.apache.logging.log4j.plugins.PluginAliases;
 import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.plugins.PluginElement;
+import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.plugins.validation.constraints.Required;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.util.InternalApi;
@@ -234,13 +234,13 @@ public final class AsyncAppender extends AbstractAppender {
         }
     }
 
-    @PluginBuilderFactory
+    @PluginFactory
     public static Builder newBuilder() {
         return new Builder();
     }
 
-    public static class Builder<B extends Builder<B>> extends AbstractFilterable.Builder<B>
-            implements org.apache.logging.log4j.core.util.Builder<AsyncAppender> {
+    public static class Builder extends AbstractFilterable.Builder<Builder>
+            implements org.apache.logging.log4j.plugins.util.Builder<AsyncAppender> {
 
         @PluginElement("AppenderRef")
         @Required(message = "No appender references provided to AsyncAppender")
@@ -274,6 +274,46 @@ public final class AsyncAppender extends AbstractAppender {
 
         @PluginElement(BlockingQueueFactory.ELEMENT_TYPE)
         private BlockingQueueFactory<LogEvent> blockingQueueFactory = new ArrayBlockingQueueFactory<>();
+
+        public AppenderRef[] getAppenderRefs() {
+            return appenderRefs;
+        }
+
+        public String getErrorRef() {
+            return errorRef;
+        }
+
+        public boolean isBlocking() {
+            return blocking;
+        }
+
+        public long getShutdownTimeout() {
+            return shutdownTimeout;
+        }
+
+        public int getBufferSize() {
+            return bufferSize;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public boolean isIncludeLocation() {
+            return includeLocation;
+        }
+
+        public Configuration getConfiguration() {
+            return configuration;
+        }
+
+        public boolean isIgnoreExceptions() {
+            return ignoreExceptions;
+        }
+
+        public BlockingQueueFactory<LogEvent> getBlockingQueueFactory() {
+            return blockingQueueFactory;
+        }
 
         public Builder setAppenderRefs(final AppenderRef[] appenderRefs) {
             this.appenderRefs = appenderRefs;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
@@ -109,15 +109,14 @@ public final class ConsoleAppender extends AbstractOutputStreamAppender<OutputSt
     }
 
     @PluginFactory
-    public static <B extends Builder<B>> B newBuilder() {
-        return new Builder<B>().asBuilder();
+    public static Builder newBuilder() {
+        return new Builder();
     }
 
     /**
      * Builds ConsoleAppender instances.
-     * @param <B> The type to build
      */
-    public static class Builder<B extends Builder<B>> extends AbstractOutputStreamAppender.Builder<B>
+    public static class Builder extends AbstractOutputStreamAppender.Builder<Builder>
             implements org.apache.logging.log4j.plugins.util.Builder<ConsoleAppender> {
 
         @PluginBuilderAttribute
@@ -130,19 +129,31 @@ public final class ConsoleAppender extends AbstractOutputStreamAppender<OutputSt
         @PluginBuilderAttribute
         private boolean direct;
 
-        public B setTarget(final Target aTarget) {
+        public Target getTarget() {
+            return target;
+        }
+
+        public boolean isFollow() {
+            return follow;
+        }
+
+        public boolean isDirect() {
+            return direct;
+        }
+
+        public Builder setTarget(final Target aTarget) {
             this.target = aTarget;
-            return asBuilder();
+            return this;
         }
 
-        public B setFollow(final boolean shouldFollow) {
+        public Builder setFollow(final boolean shouldFollow) {
             this.follow = shouldFollow;
-            return asBuilder();
+            return this;
         }
 
-        public B setDirect(final boolean shouldDirect) {
+        public Builder setDirect(final boolean shouldDirect) {
             this.direct = shouldDirect;
-            return asBuilder();
+            return this;
         }
 
         @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FailoverAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FailoverAppender.java
@@ -16,6 +16,11 @@
  */
 package org.apache.logging.log4j.core.appender;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.logging.log4j.LoggingException;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Filter;
@@ -31,11 +36,6 @@ import org.apache.logging.log4j.plugins.PluginAttribute;
 import org.apache.logging.log4j.plugins.PluginElement;
 import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.plugins.validation.constraints.Required;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * The FailoverAppender will capture exceptions in an Appender and then route the event
@@ -176,8 +176,8 @@ public final class FailoverAppender extends AbstractAppender {
      * @param retryIntervalSeconds The retry interval in seconds.
      * @param config The current Configuration (passed by the Configuration when the appender is created).
      * @param filter A Filter (optional).
-     * @param ignore If {@code "true"} (default) exceptions encountered when appending events are logged; otherwise
-     *               they are propagated to the caller.
+     * @param ignoreExceptions If {@code "true"} (default) exceptions encountered when appending events are logged;
+     *                        otherwise they are propagated to the caller.
      * @return The FailoverAppender that was created.
      */
     @PluginFactory

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FileAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FileAppender.java
@@ -42,11 +42,8 @@ public final class FileAppender extends AbstractOutputStreamAppender<FileManager
 
     /**
      * Builds FileAppender instances.
-     *
-     * @param <B>
-     *            The type to build
      */
-    public static class Builder<B extends Builder<B>> extends AbstractOutputStreamAppender.Builder<B>
+    public static class Builder extends AbstractOutputStreamAppender.Builder<Builder>
             implements org.apache.logging.log4j.plugins.util.Builder<FileAppender> {
 
         @PluginBuilderAttribute
@@ -136,56 +133,56 @@ public final class FileAppender extends AbstractOutputStreamAppender<FileManager
             return fileGroup;
         }
 
-        public B setAdvertise(final boolean advertise) {
+        public Builder setAdvertise(final boolean advertise) {
             this.advertise = advertise;
-            return asBuilder();
+            return this;
         }
 
-        public B setAdvertiseUri(final String advertiseUri) {
+        public Builder setAdvertiseUri(final String advertiseUri) {
             this.advertiseUri = advertiseUri;
-            return asBuilder();
+            return this;
         }
 
-        public B setAppend(final boolean append) {
+        public Builder setAppend(final boolean append) {
             this.append = append;
-            return asBuilder();
+            return this;
         }
 
-        public B setFileName(final String fileName) {
+        public Builder setFileName(final String fileName) {
             this.fileName = fileName;
-            return asBuilder();
+            return this;
         }
 
-        public B setCreateOnDemand(final boolean createOnDemand) {
+        public Builder setCreateOnDemand(final boolean createOnDemand) {
             this.createOnDemand = createOnDemand;
-            return asBuilder();
+            return this;
         }
 
-        public B setLocking(final boolean locking) {
+        public Builder setLocking(final boolean locking) {
             this.locking = locking;
-            return asBuilder();
+            return this;
         }
 
-        public B setFilePermissions(final String filePermissions) {
+        public Builder setFilePermissions(final String filePermissions) {
             this.filePermissions = filePermissions;
-            return asBuilder();
+            return this;
         }
 
-        public B setFileOwner(final String fileOwner) {
+        public Builder setFileOwner(final String fileOwner) {
             this.fileOwner = fileOwner;
-            return asBuilder();
+            return this;
         }
 
-        public B setFileGroup(final String fileGroup) {
+        public Builder setFileGroup(final String fileGroup) {
             this.fileGroup = fileGroup;
-            return asBuilder();
+            return this;
         }
 
     }
 
     @PluginFactory
-    public static <B extends Builder<B>> B newBuilder() {
-        return new Builder<B>().asBuilder();
+    public static Builder newBuilder() {
+        return new Builder();
     }
 
     private final String fileName;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/HttpAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/HttpAppender.java
@@ -43,9 +43,8 @@ public final class HttpAppender extends AbstractAppender {
 
     /**
      * Builds HttpAppender instances.
-     * @param <B> The type to build
      */
-    public static class Builder<B extends Builder<B>> extends AbstractAppender.Builder<B>
+    public static class Builder extends AbstractAppender.Builder<Builder>
             implements org.apache.logging.log4j.plugins.util.Builder<HttpAppender> {
 
         @PluginBuilderAttribute
@@ -105,39 +104,39 @@ public final class HttpAppender extends AbstractAppender {
             return verifyHostname;
         }
 
-        public B setUrl(final URL url) {
+        public Builder setUrl(final URL url) {
             this.url = url;
-            return asBuilder();
+            return this;
         }
 
-        public B setMethod(final String method) {
+        public Builder setMethod(final String method) {
             this.method = method;
-            return asBuilder();
+            return this;
         }
 
-        public B setConnectTimeoutMillis(final int connectTimeoutMillis) {
+        public Builder setConnectTimeoutMillis(final int connectTimeoutMillis) {
             this.connectTimeoutMillis = connectTimeoutMillis;
-            return asBuilder();
+            return this;
         }
 
-        public B setReadTimeoutMillis(final int readTimeoutMillis) {
+        public Builder setReadTimeoutMillis(final int readTimeoutMillis) {
             this.readTimeoutMillis = readTimeoutMillis;
-            return asBuilder();
+            return this;
         }
 
-        public B setHeaders(final Property[] headers) {
+        public Builder setHeaders(final Property[] headers) {
             this.headers = headers;
-            return asBuilder();
+            return this;
         }
 
-        public B setSslConfiguration(final SslConfiguration sslConfiguration) {
+        public Builder setSslConfiguration(final SslConfiguration sslConfiguration) {
             this.sslConfiguration = sslConfiguration;
-            return asBuilder();
+            return this;
         }
 
-        public B setVerifyHostname(final boolean verifyHostname) {
+        public Builder setVerifyHostname(final boolean verifyHostname) {
             this.verifyHostname = verifyHostname;
-            return asBuilder();
+            return this;
         }
     }
 
@@ -145,8 +144,8 @@ public final class HttpAppender extends AbstractAppender {
      * @return a builder for a HttpAppender.
      */
     @PluginFactory
-    public static <B extends Builder<B>> B newBuilder() {
-        return new Builder<B>().asBuilder();
+    public static Builder newBuilder() {
+        return new Builder();
     }
 
     private final HttpManager manager;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/MemoryMappedFileAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/MemoryMappedFileAppender.java
@@ -46,7 +46,7 @@ public final class MemoryMappedFileAppender extends AbstractOutputStreamAppender
      * @param <B>
      *            The type to build
      */
-    public static class Builder<B extends Builder<B>> extends AbstractOutputStreamAppender.Builder<B>
+    public static class Builder extends AbstractOutputStreamAppender.Builder<Builder>
             implements org.apache.logging.log4j.plugins.util.Builder<MemoryMappedFileAppender> {
 
         @PluginBuilderAttribute("fileName")
@@ -89,29 +89,49 @@ public final class MemoryMappedFileAppender extends AbstractOutputStreamAppender
                     advertise ? getConfiguration().getAdvertiser() : null, getPropertyArray());
         }
 
-        public B setFileName(final String fileName) {
+        public String getFileName() {
+            return fileName;
+        }
+
+        public boolean isAppend() {
+            return append;
+        }
+
+        public int getRegionLength() {
+            return regionLength;
+        }
+
+        public boolean isAdvertise() {
+            return advertise;
+        }
+
+        public String getAdvertiseURI() {
+            return advertiseURI;
+        }
+
+        public Builder setFileName(final String fileName) {
             this.fileName = fileName;
-            return asBuilder();
+            return this;
         }
 
-        public B setAppend(final boolean append) {
+        public Builder setAppend(final boolean append) {
             this.append = append;
-            return asBuilder();
+            return this;
         }
 
-        public B setRegionLength(final int regionLength) {
+        public Builder setRegionLength(final int regionLength) {
             this.regionLength = regionLength;
-            return asBuilder();
+            return this;
         }
 
-        public B setAdvertise(final boolean advertise) {
+        public Builder setAdvertise(final boolean advertise) {
             this.advertise = advertise;
-            return asBuilder();
+            return this;
         }
 
-        public B setAdvertiseURI(final String advertiseURI) {
+        public Builder setAdvertiseURI(final String advertiseURI) {
             this.advertiseURI = advertiseURI;
-            return asBuilder();
+            return this;
         }
 
     }
@@ -169,8 +189,8 @@ public final class MemoryMappedFileAppender extends AbstractOutputStreamAppender
     }
 
     @PluginFactory
-    public static <B extends Builder<B>> B newBuilder() {
-        return new Builder<B>().asBuilder();
+    public static Builder newBuilder() {
+        return new Builder();
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RandomAccessFileAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RandomAccessFileAppender.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.net.Advertiser;
 import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Plugin;
-import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.plugins.PluginAttribute;
 import org.apache.logging.log4j.plugins.PluginFactory;
 
 /**
@@ -38,23 +38,13 @@ public final class RandomAccessFileAppender extends AbstractOutputStreamAppender
 
     /**
      * Builds RandomAccessFileAppender instances.
-     *
-     * @param <B>
-     *            The type to build
      */
-    public static class Builder<B extends Builder<B>> extends AbstractOutputStreamAppender.Builder<B>
+    public static class Builder extends AbstractOutputStreamAppender.Builder<Builder>
             implements org.apache.logging.log4j.plugins.util.Builder<RandomAccessFileAppender> {
 
-        @PluginBuilderAttribute("fileName")
         private String fileName;
-
-        @PluginBuilderAttribute("append")
         private boolean append = true;
-
-        @PluginBuilderAttribute("advertise")
         private boolean advertise;
-
-        @PluginBuilderAttribute("advertiseURI")
         private String advertiseURI;
 
         public Builder() {
@@ -85,24 +75,40 @@ public final class RandomAccessFileAppender extends AbstractOutputStreamAppender
                     immediateFlush, advertise ? getConfiguration().getAdvertiser() : null);
         }
 
-        public B setFileName(final String fileName) {
+        public String getFileName() {
+            return fileName;
+        }
+
+        public boolean isAppend() {
+            return append;
+        }
+
+        public boolean isAdvertise() {
+            return advertise;
+        }
+
+        public String getAdvertiseURI() {
+            return advertiseURI;
+        }
+
+        public Builder setFileName(@PluginAttribute final String fileName) {
             this.fileName = fileName;
-            return asBuilder();
+            return this;
         }
 
-        public B setAppend(final boolean append) {
+        public Builder setAppend(@PluginAttribute(defaultBoolean = true) final boolean append) {
             this.append = append;
-            return asBuilder();
+            return this;
         }
 
-        public B setAdvertise(final boolean advertise) {
+        public Builder setAdvertise(@PluginAttribute final boolean advertise) {
             this.advertise = advertise;
-            return asBuilder();
+            return this;
         }
 
-        public B setAdvertiseURI(final String advertiseURI) {
+        public Builder setAdvertiseURI(@PluginAttribute String advertiseURI) {
             this.advertiseURI = advertiseURI;
-            return asBuilder();
+            return this;
         }
 
     }
@@ -161,8 +167,8 @@ public final class RandomAccessFileAppender extends AbstractOutputStreamAppender
      * @return a builder for a RandomAccessFileAppender.
      */
     @PluginFactory
-    public static <B extends Builder<B>> B newBuilder() {
-        return new Builder<B>().asBuilder();
+    public static Builder newBuilder() {
+        return new Builder();
     }
 
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RollingFileAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RollingFileAppender.java
@@ -51,11 +51,9 @@ public final class RollingFileAppender extends AbstractOutputStreamAppender<Roll
     /**
      * Builds FileAppender instances.
      *
-     * @param <B>
-     *            The type to build
      * @since 2.7
      */
-    public static class Builder<B extends Builder<B>> extends AbstractOutputStreamAppender.Builder<B>
+    public static class Builder extends AbstractOutputStreamAppender.Builder<Builder>
             implements org.apache.logging.log4j.plugins.util.Builder<RollingFileAppender> {
 
         @PluginBuilderAttribute
@@ -188,34 +186,34 @@ public final class RollingFileAppender extends AbstractOutputStreamAppender<Roll
             return fileGroup;
         }
 
-        public B setAdvertise(final boolean advertise) {
+        public Builder setAdvertise(final boolean advertise) {
             this.advertise = advertise;
-            return asBuilder();
+            return this;
         }
 
-        public B setAdvertiseUri(final String advertiseUri) {
+        public Builder setAdvertiseUri(final String advertiseUri) {
             this.advertiseUri = advertiseUri;
-            return asBuilder();
+            return this;
         }
 
-        public B setAppend(final boolean append) {
+        public Builder setAppend(final boolean append) {
             this.append = append;
-            return asBuilder();
+            return this;
         }
 
-        public B setFileName(final String fileName) {
+        public Builder setFileName(final String fileName) {
             this.fileName = fileName;
-            return asBuilder();
+            return this;
         }
 
-        public B setCreateOnDemand(final boolean createOnDemand) {
+        public Builder setCreateOnDemand(final boolean createOnDemand) {
             this.createOnDemand = createOnDemand;
-            return asBuilder();
+            return this;
         }
 
-        public B setLocking(final boolean locking) {
+        public Builder setLocking(final boolean locking) {
             this.locking = locking;
-            return asBuilder();
+            return this;
         }
 
         public String getFilePattern() {
@@ -230,34 +228,34 @@ public final class RollingFileAppender extends AbstractOutputStreamAppender<Roll
             return strategy;
         }
 
-        public B setFilePattern(final String filePattern) {
+        public Builder setFilePattern(final String filePattern) {
             this.filePattern = filePattern;
-            return asBuilder();
+            return this;
         }
 
-        public B setPolicy(final TriggeringPolicy policy) {
+        public Builder setPolicy(final TriggeringPolicy policy) {
             this.policy = policy;
-            return asBuilder();
+            return this;
         }
 
-        public B setStrategy(final RolloverStrategy strategy) {
+        public Builder setStrategy(final RolloverStrategy strategy) {
             this.strategy = strategy;
-            return asBuilder();
+            return this;
         }
 
-        public B setFilePermissions(final String filePermissions) {
+        public Builder setFilePermissions(final String filePermissions) {
             this.filePermissions = filePermissions;
-            return asBuilder();
+            return this;
         }
 
-        public B setFileOwner(final String fileOwner) {
+        public Builder setFileOwner(final String fileOwner) {
             this.fileOwner = fileOwner;
-            return asBuilder();
+            return this;
         }
 
-        public B setFileGroup(final String fileGroup) {
+        public Builder setFileGroup(final String fileGroup) {
             this.fileGroup = fileGroup;
-            return asBuilder();
+            return this;
         }
 
     }
@@ -336,7 +334,7 @@ public final class RollingFileAppender extends AbstractOutputStreamAppender<Roll
      * @since 2.7
      */
     @PluginFactory
-    public static <B extends Builder<B>> B newBuilder() {
-        return new Builder<B>().asBuilder();
+    public static Builder newBuilder() {
+        return new Builder();
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RollingRandomAccessFileAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/RollingRandomAccessFileAppender.java
@@ -46,7 +46,7 @@ import org.apache.logging.log4j.plugins.PluginFactory;
 @Plugin("RollingRandomAccessFile")
 public final class RollingRandomAccessFileAppender extends AbstractOutputStreamAppender<RollingRandomAccessFileManager> {
 
-    public static class Builder<B extends Builder<B>> extends AbstractOutputStreamAppender.Builder<B>
+    public static class Builder extends AbstractOutputStreamAppender.Builder<Builder>
             implements org.apache.logging.log4j.plugins.util.Builder<RollingRandomAccessFileAppender> {
 
         public Builder() {
@@ -139,54 +139,54 @@ public final class RollingRandomAccessFileAppender extends AbstractOutputStreamA
                     isIgnoreExceptions(), immediateFlush, bufferSize, advertise ? getConfiguration().getAdvertiser() : null);
         }
 
-        public B setFileName(final String fileName) {
+        public Builder setFileName(final String fileName) {
             this.fileName = fileName;
-            return asBuilder();
+            return this;
         }
 
-        public B setFilePattern(final String filePattern) {
+        public Builder setFilePattern(final String filePattern) {
             this.filePattern = filePattern;
-            return asBuilder();
+            return this;
         }
 
-        public B setAppend(final boolean append) {
+        public Builder setAppend(final boolean append) {
             this.append = append;
-            return asBuilder();
+            return this;
         }
 
-        public B setPolicy(final TriggeringPolicy policy) {
+        public Builder setPolicy(final TriggeringPolicy policy) {
             this.policy = policy;
-            return asBuilder();
+            return this;
         }
 
-        public B setStrategy(final RolloverStrategy strategy) {
+        public Builder setStrategy(final RolloverStrategy strategy) {
             this.strategy = strategy;
-            return asBuilder();
+            return this;
         }
 
-        public B setAdvertise(final boolean advertise) {
+        public Builder setAdvertise(final boolean advertise) {
             this.advertise = advertise;
-            return asBuilder();
+            return this;
         }
 
-        public B setAdvertiseURI(final String advertiseURI) {
+        public Builder setAdvertiseURI(final String advertiseURI) {
             this.advertiseURI = advertiseURI;
-            return asBuilder();
+            return this;
         }
 
-        public B setFilePermissions(final String filePermissions) {
+        public Builder setFilePermissions(final String filePermissions) {
             this.filePermissions = filePermissions;
-            return asBuilder();
+            return this;
         }
 
-        public B setFileOwner(final String fileOwner) {
+        public Builder setFileOwner(final String fileOwner) {
             this.fileOwner = fileOwner;
-            return asBuilder();
+            return this;
         }
 
-        public B setFileGroup(final String fileGroup) {
+        public Builder setFileGroup(final String fileGroup) {
             this.fileGroup = fileGroup;
-            return asBuilder();
+            return this;
         }
 
     }
@@ -266,8 +266,8 @@ public final class RollingRandomAccessFileAppender extends AbstractOutputStreamA
     }
 
     @PluginFactory
-    public static <B extends Builder<B>> B newBuilder() {
-        return new Builder<B>().asBuilder();
+    public static Builder newBuilder() {
+        return new Builder();
     }
 
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/WriterAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/WriterAppender.java
@@ -16,29 +16,23 @@
  */
 package org.apache.logging.log4j.core.appender;
 
-import org.apache.logging.log4j.core.Appender;
+import java.io.Writer;
+
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.StringLayout;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.util.CloseShieldWriter;
-import org.apache.logging.log4j.plugins.Configurable;
-import org.apache.logging.log4j.plugins.Plugin;
-import org.apache.logging.log4j.plugins.PluginFactory;
-
-import java.io.Writer;
 
 /**
  * Appends log events to a {@link Writer}.
  */
-@Configurable(elementType = Appender.ELEMENT_TYPE, printObject = true)
-@Plugin("Writer")
 public final class WriterAppender extends AbstractWriterAppender<WriterManager> {
 
     /**
      * Builds WriterAppender instances.
      */
-    public static class Builder<B extends Builder<B>> extends AbstractAppender.Builder<B>
+    public static class Builder extends AbstractAppender.Builder<Builder>
             implements org.apache.logging.log4j.plugins.util.Builder<WriterAppender> {
 
         private boolean follow = false;
@@ -53,14 +47,22 @@ public final class WriterAppender extends AbstractWriterAppender<WriterManager> 
                     isIgnoreExceptions(), getPropertyArray());
         }
 
-        public B setFollow(final boolean shouldFollow) {
-            this.follow = shouldFollow;
-            return asBuilder();
+        public boolean isFollow() {
+            return follow;
         }
 
-        public B setTarget(final Writer aTarget) {
+        public Writer getTarget() {
+            return target;
+        }
+
+        public Builder setFollow(final boolean shouldFollow) {
+            this.follow = shouldFollow;
+            return this;
+        }
+
+        public Builder setTarget(final Writer aTarget) {
             this.target = aTarget;
-            return asBuilder();
+            return this;
         }
     }
     /**
@@ -127,7 +129,6 @@ public final class WriterAppender extends AbstractWriterAppender<WriterManager> 
      *            the caller. Use true as the default.
      * @return The ConsoleAppender.
      */
-    @PluginFactory
     public static WriterAppender createAppender(StringLayout layout, final Filter filter, final Writer target,
             final String name, final boolean follow, final boolean ignore) {
         if (name == null) {
@@ -147,9 +148,8 @@ public final class WriterAppender extends AbstractWriterAppender<WriterManager> 
         return WriterManager.getManager(managerName, new FactoryData(writer, managerName, layout), factory);
     }
 
-    @PluginFactory
-    public static <B extends Builder<B>> B newBuilder() {
-        return new Builder<B>().asBuilder();
+    public static Builder newBuilder() {
+        return new Builder();
     }
 
     private WriterAppender(final String name, final StringLayout layout, final Filter filter,

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/ColumnMapping.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/ColumnMapping.java
@@ -106,6 +106,42 @@ public class ColumnMapping {
             return new ColumnMapping(name, source, layout, literal, parameter, type, () -> injector.getTypeConverter(type));
         }
 
+        public Configuration getConfiguration() {
+            return configuration;
+        }
+
+        public StringLayout getLayout() {
+            return layout;
+        }
+
+        public String getLiteral() {
+            return literal;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getParameter() {
+            return parameter;
+        }
+
+        public String getPattern() {
+            return pattern;
+        }
+
+        public String getSource() {
+            return source;
+        }
+
+        public Class<?> getType() {
+            return type;
+        }
+
+        public Injector getInjector() {
+            return injector;
+        }
+
         public Builder setConfiguration(final Configuration configuration) {
             this.configuration = configuration;
             return this;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/nosql/NoSqlAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/nosql/NoSqlAppender.java
@@ -74,9 +74,6 @@ public final class NoSqlAppender extends AbstractDatabaseAppender<NoSqlDatabaseM
 
             final NoSqlDatabaseManager<?> manager = NoSqlDatabaseManager.getNoSqlDatabaseManager(managerName,
                     bufferSize, provider);
-            if (manager == null) {
-                return null;
-            }
 
             return new NoSqlAppender(name, getFilter(), getLayout(), isIgnoreExceptions(), getPropertyArray(), manager);
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/nosql/NoSqlDatabaseManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/nosql/NoSqlDatabaseManager.java
@@ -215,7 +215,7 @@ public final class NoSqlDatabaseManager<W> extends AbstractDatabaseManager {
     private static final class FactoryData extends AbstractDatabaseManager.AbstractFactoryData {
         private final NoSqlProvider<?> provider;
 
-        protected FactoryData(final int bufferSize, final NoSqlProvider<?> provider) {
+        private FactoryData(final int bufferSize, final NoSqlProvider<?> provider) {
             super(bufferSize, null);
             this.provider = provider;
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/MapRewritePolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/MapRewritePolicy.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender.rewrite;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
@@ -29,9 +32,6 @@ import org.apache.logging.log4j.plugins.PluginElement;
 import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.status.StatusLogger;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * This policy modifies events by replacing or possibly adding keys and values to the MapMessage.
  */
@@ -39,10 +39,7 @@ import java.util.Map;
 @Plugin
 public final class MapRewritePolicy implements RewritePolicy {
 
-    /**
-     * Allow subclasses access to the status logger without creating another instance.
-     */
-    protected static final Logger LOGGER = StatusLogger.getLogger();
+    private static final Logger LOGGER = StatusLogger.getLogger();
 
     private final Map<String, Object> map;
 
@@ -62,7 +59,7 @@ public final class MapRewritePolicy implements RewritePolicy {
     @Override
     public LogEvent rewrite(final LogEvent source) {
         final Message msg = source.getMessage();
-        if (msg == null || !(msg instanceof MapMessage)) {
+        if (!(msg instanceof MapMessage)) {
             return source;
         }
 
@@ -130,7 +127,7 @@ public final class MapRewritePolicy implements RewritePolicy {
     public static MapRewritePolicy createPolicy(
             @PluginAttribute final String mode,
             @PluginElement("KeyValuePair") final KeyValuePair[] pairs) {
-        Mode op = mode == null ? op = Mode.Add : Mode.valueOf(mode);
+        Mode op = mode == null ? Mode.Add : Mode.valueOf(mode);
         if (pairs == null || pairs.length == 0) {
             LOGGER.error("keys and values must be specified for the MapRewritePolicy");
             return null;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/PropertiesRewritePolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/PropertiesRewritePolicy.java
@@ -16,6 +16,11 @@
  */
 package org.apache.logging.log4j.core.appender.rewrite;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
@@ -30,11 +35,6 @@ import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.StringMap;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /**
  * This policy modifies events by replacing or possibly adding keys and values to the MapMessage.
  */
@@ -42,10 +42,7 @@ import java.util.Map;
 @Plugin
 public final class PropertiesRewritePolicy implements RewritePolicy {
 
-    /**
-     * Allows subclasses access to the status logger without creating another instance.
-     */
-    protected static final Logger LOGGER = StatusLogger.getLogger();
+    private static final Logger LOGGER = StatusLogger.getLogger();
 
     private final Map<Property, Boolean> properties;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/RewriteAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/RewriteAppender.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.core.appender.rewrite;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
@@ -31,9 +34,6 @@ import org.apache.logging.log4j.plugins.PluginAttribute;
 import org.apache.logging.log4j.plugins.PluginElement;
 import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.plugins.validation.constraints.Required;
-
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * This Appender allows the logging event to be manipulated before it is processed by other Appenders.
@@ -89,8 +89,8 @@ public final class RewriteAppender extends AbstractAppender {
     /**
      * Creates a RewriteAppender.
      * @param name The name of the Appender.
-     * @param ignore If {@code "true"} (default) exceptions encountered when appending events are logged; otherwise
-     *               they are propagated to the caller.
+     * @param ignoreExceptions If {@code "true"} (default) exceptions encountered when appending events are logged;
+     *                         otherwise they are propagated to the caller.
      * @param appenderRefs An array of Appender names to call.
      * @param config The Configuration.
      * @param rewritePolicy The policy to use to modify the event.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
@@ -99,25 +99,6 @@ public class RollingRandomAccessFileManager extends RollingFileManager {
                 filePermissions, fileOwner, fileGroup, configuration), FACTORY));
     }
 
-    /**
-     * No longer used, the {@link org.apache.logging.log4j.core.LogEvent#isEndOfBatch()} attribute is used instead.
-     * @return {@link Boolean#FALSE}.
-     * @deprecated end-of-batch on the event is used instead.
-     */
-    @Deprecated
-    public Boolean isEndOfBatch() {
-        return Boolean.FALSE;
-    }
-
-    /**
-     * No longer used, the {@link org.apache.logging.log4j.core.LogEvent#isEndOfBatch()} attribute is used instead.
-     * This method is a no-op.
-     * @deprecated end-of-batch on the event is used instead.
-     */
-    @Deprecated
-    public void setEndOfBatch(@SuppressWarnings("unused") final boolean endOfBatch) {
-    }
-
     // override to make visible for unit tests
     @Override
     protected synchronized void write(final byte[] bytes, final int offset, final int length,

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/DeleteAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/DeleteAction.java
@@ -14,8 +14,14 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.appender.rolling.action;
+
+import java.io.IOException;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
 
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
@@ -26,13 +32,6 @@ import org.apache.logging.log4j.plugins.Plugin;
 import org.apache.logging.log4j.plugins.PluginAttribute;
 import org.apache.logging.log4j.plugins.PluginElement;
 import org.apache.logging.log4j.plugins.PluginFactory;
-
-import java.io.IOException;
-import java.nio.file.FileVisitor;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Objects;
 
 /**
  * Rollover or scheduled action for deleting old log files that are accepted by the specified PathFilters.
@@ -190,8 +189,8 @@ public class DeleteAction extends AbstractPathAction {
      *            href="http://logging.apache.org/log4j/2.x/manual/configuration.html#StatusMessages">status logger</a>
      *            at INFO level. Users can use this to do a dry run to test if their configuration works as expected.
      *            Default is false.
-     * @param PathSorter a plugin implementing the {@link PathSorter} interface
-     * @param PathConditions an array of path conditions (if more than one, they all need to accept a path before it is
+     * @param sorterParameter a plugin implementing the {@link PathSorter} interface
+     * @param pathConditions an array of path conditions (if more than one, they all need to accept a path before it is
      *            deleted).
      * @param config The Configuration.
      * @return A DeleteAction.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModified.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModified.java
@@ -16,6 +16,14 @@
  */
 package org.apache.logging.log4j.core.appender.rolling.action;
 
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.time.Clock;
 import org.apache.logging.log4j.core.time.ClockFactory;
@@ -26,14 +34,6 @@ import org.apache.logging.log4j.plugins.PluginAttribute;
 import org.apache.logging.log4j.plugins.PluginElement;
 import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.status.StatusLogger;
-
-import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.function.Supplier;
 
 /**
  * PathCondition that accepts paths that are older than the specified duration.
@@ -96,18 +96,6 @@ public final class IfLastModified implements PathCondition {
     public String toString() {
         final String nested = nestedConditions.length == 0 ? "" : " AND " + Arrays.toString(nestedConditions);
         return "IfLastModified(age=" + age + nested + ")";
-    }
-
-    /**
-     * Create an IfLastModified condition.
-     *
-     * @param age The path age that is accepted by this condition. Must be a valid Duration.
-     * @param nestedConditions nested conditions to evaluate if this condition accepts a path
-     * @return An IfLastModified condition.
-     */
-    @Deprecated(since = "3.0.0", forRemoval = true)
-    public static IfLastModified createAgeCondition(final Duration age, final PathCondition... nestedConditions) {
-        return newBuilder().setAge(age).setNestedConditions(nestedConditions).get();
     }
 
     @PluginFactory

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -39,7 +39,6 @@ import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.impl.LogEventFactory;
 import org.apache.logging.log4j.core.impl.ReusableLogEventFactory;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
-import org.apache.logging.log4j.core.util.Booleans;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Inject;
@@ -49,6 +48,7 @@ import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.plugins.PluginElement;
 import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.plugins.validation.constraints.Required;
+import org.apache.logging.log4j.util.Cast;
 import org.apache.logging.log4j.util.PerformanceSensitive;
 import org.apache.logging.log4j.util.StackLocatorUtil;
 import org.apache.logging.log4j.util.Strings;
@@ -88,7 +88,7 @@ public class LoggerConfig extends AbstractFilterable {
      *            The type to build
      */
     public static class Builder<B extends Builder<B>>
-            implements org.apache.logging.log4j.core.util.Builder<LoggerConfig> {
+            implements org.apache.logging.log4j.plugins.util.Builder<LoggerConfig> {
 
         @PluginBuilderAttribute
         private Boolean additivity;
@@ -106,7 +106,7 @@ public class LoggerConfig extends AbstractFilterable {
             return additivity == null || additivity;
         }
 
-        public B withAdditivity(boolean additivity) {
+        public B setAdditivity(boolean additivity) {
             this.additivity = additivity;
             return asBuilder();
         }
@@ -115,7 +115,7 @@ public class LoggerConfig extends AbstractFilterable {
             return level;
         }
 
-        public B withLevel(@PluginAttribute Level level) {
+        public B setLevel(@PluginAttribute Level level) {
             this.level = level;
             return asBuilder();
         }
@@ -124,7 +124,7 @@ public class LoggerConfig extends AbstractFilterable {
             return levelAndRefs;
         }
 
-        public B withLevelAndRefs(@PluginAttribute String levelAndRefs) {
+        public B setLevelAndRefs(@PluginAttribute String levelAndRefs) {
             this.levelAndRefs = levelAndRefs;
             return asBuilder();
         }
@@ -133,7 +133,7 @@ public class LoggerConfig extends AbstractFilterable {
             return loggerName;
         }
 
-        public B withLoggerName(
+        public B setLoggerName(
                 @Required(message = "Loggers cannot be configured without a name") @PluginAttribute String name) {
             this.loggerName = name;
             return asBuilder();
@@ -143,7 +143,7 @@ public class LoggerConfig extends AbstractFilterable {
             return includeLocation;
         }
 
-        public B withIncludeLocation(@PluginAttribute String includeLocation) {
+        public B setIncludeLocation(@PluginAttribute String includeLocation) {
             this.includeLocation = includeLocation;
             return asBuilder();
         }
@@ -152,7 +152,7 @@ public class LoggerConfig extends AbstractFilterable {
             return refs;
         }
 
-        public B withRefs(@PluginElement AppenderRef[] refs) {
+        public B setRefs(@PluginElement AppenderRef[] refs) {
             this.refs = refs;
             return asBuilder();
         }
@@ -161,7 +161,7 @@ public class LoggerConfig extends AbstractFilterable {
             return properties;
         }
 
-        public B withProperties(@PluginElement Property[] properties) {
+        public B setProperties(@PluginElement Property[] properties) {
             this.properties = properties;
             return asBuilder();
         }
@@ -170,7 +170,7 @@ public class LoggerConfig extends AbstractFilterable {
             return config;
         }
 
-        public B withConfig(@PluginConfiguration Configuration config) {
+        public B setConfig(@PluginConfiguration Configuration config) {
             this.config = config;
             return asBuilder();
         }
@@ -179,7 +179,7 @@ public class LoggerConfig extends AbstractFilterable {
             return filter;
         }
 
-        public B withFilter(@PluginElement Filter filter) {
+        public B setFilter(@PluginElement Filter filter) {
             this.filter = filter;
             return asBuilder();
         }
@@ -203,9 +203,8 @@ public class LoggerConfig extends AbstractFilterable {
                     useLocation, logEventFactory);
         }
 
-        @SuppressWarnings("unchecked")
         public B asBuilder() {
-            return (B) this;
+            return Cast.cast(this);
         }
     }
 
@@ -636,29 +635,6 @@ public class LoggerConfig extends AbstractFilterable {
         return Strings.isEmpty(name) ? ROOT : name;
     }
 
-    /**
-     * Factory method to create a LoggerConfig.
-     *
-     * @param additivity true if additive, false otherwise.
-     * @param level The Level to be associated with the Logger.
-     * @param loggerName The name of the Logger.
-     * @param includeLocation whether location should be passed downstream
-     * @param refs An array of Appender names.
-     * @param properties Properties to pass to the Logger.
-     * @param config The Configuration.
-     * @param filter A Filter.
-     * @return A new LoggerConfig.
-     * @since 2.6
-     */
-    @Deprecated
-    public static LoggerConfig createLogger(
-            final boolean additivity, final Level level, final String loggerName, final String includeLocation,
-            final AppenderRef[] refs, final Property[] properties, final Configuration config, final Filter filter) {
-        final String name = loggerName.equals(ROOT) ? Strings.EMPTY : loggerName;
-        return new LoggerConfig(name, Arrays.asList(refs), filter, level, additivity, properties, config,
-            includeLocation(includeLocation, config), config.getComponent(LogEventFactory.KEY));
-    }
-
     // Note: for asynchronous loggers, includeLocation default is FALSE,
     // for synchronous loggers, includeLocation default is TRUE.
     protected static boolean includeLocation(final String includeLocationConfigValue, final Configuration configuration) {
@@ -699,7 +675,7 @@ public class LoggerConfig extends AbstractFilterable {
          *            The type to build
          */
         public static class Builder<B extends Builder<B>>
-                implements org.apache.logging.log4j.core.util.Builder<LoggerConfig> {
+                implements org.apache.logging.log4j.plugins.util.Builder<LoggerConfig> {
 
             private boolean additivity;
             private Level level;
@@ -715,7 +691,7 @@ public class LoggerConfig extends AbstractFilterable {
                 return additivity;
             }
 
-            public B withAdditivity(@PluginAttribute boolean additivity) {
+            public B setAdditivity(@PluginAttribute boolean additivity) {
                 this.additivity = additivity;
                 return asBuilder();
             }
@@ -724,7 +700,7 @@ public class LoggerConfig extends AbstractFilterable {
                 return level;
             }
 
-            public B withLevel(@PluginAttribute Level level) {
+            public B setLevel(@PluginAttribute Level level) {
                 this.level = level;
                 return asBuilder();
             }
@@ -733,7 +709,7 @@ public class LoggerConfig extends AbstractFilterable {
                 return levelAndRefs;
             }
 
-            public B withLevelAndRefs(@PluginAttribute String levelAndRefs) {
+            public B setLevelAndRefs(@PluginAttribute String levelAndRefs) {
                 this.levelAndRefs = levelAndRefs;
                 return asBuilder();
             }
@@ -742,7 +718,7 @@ public class LoggerConfig extends AbstractFilterable {
                 return includeLocation;
             }
 
-            public B withIncludeLocation(@PluginAttribute String includeLocation) {
+            public B setIncludeLocation(@PluginAttribute String includeLocation) {
                 this.includeLocation = includeLocation;
                 return asBuilder();
             }
@@ -751,7 +727,7 @@ public class LoggerConfig extends AbstractFilterable {
                 return refs;
             }
 
-            public B withRefs(@PluginElement AppenderRef[] refs) {
+            public B setRefs(@PluginElement AppenderRef[] refs) {
                 this.refs = refs;
                 return asBuilder();
             }
@@ -760,7 +736,7 @@ public class LoggerConfig extends AbstractFilterable {
                 return properties;
             }
 
-            public B withProperties(@PluginElement Property[] properties) {
+            public B setProperties(@PluginElement Property[] properties) {
                 this.properties = properties;
                 return asBuilder();
             }
@@ -769,7 +745,7 @@ public class LoggerConfig extends AbstractFilterable {
                 return config;
             }
 
-            public B withConfig(@PluginConfiguration Configuration config) {
+            public B setConfig(@PluginConfiguration Configuration config) {
                 this.config = config;
                 return asBuilder();
             }
@@ -778,7 +754,7 @@ public class LoggerConfig extends AbstractFilterable {
                 return filter;
             }
 
-            public B withFilter(@PluginElement Filter filter) {
+            public B setFilter(@PluginElement Filter filter) {
                 this.filter = filter;
                 return asBuilder();
             }
@@ -788,7 +764,7 @@ public class LoggerConfig extends AbstractFilterable {
             }
 
             @Inject
-            public B withLogEventFactory(final LogEventFactory logEventFactory) {
+            public B setLogEventFactory(final LogEventFactory logEventFactory) {
                 this.logEventFactory = logEventFactory;
                 return asBuilder();
             }
@@ -800,25 +776,11 @@ public class LoggerConfig extends AbstractFilterable {
                         additivity, properties, config, includeLocation(includeLocation, config), logEventFactory);
             }
 
-            @SuppressWarnings("unchecked")
             public B asBuilder() {
-                return (B) this;
+                return Cast.cast(this);
             }
         }
 
-
-        @Deprecated
-        public static LoggerConfig createLogger(
-                final String additivity, final Level level, final String includeLocation, final AppenderRef[] refs,
-                final Property[] properties, final Configuration config, final Filter filter) {
-            final List<AppenderRef> appenderRefs = Arrays.asList(refs);
-            final Level actualLevel = level == null ? Level.ERROR : level;
-            final boolean additive = Booleans.parseBoolean(additivity, true);
-
-            return new LoggerConfig(LogManager.ROOT_LOGGER_NAME, appenderRefs, filter, actualLevel, additive,
-                    properties, config, includeLocation(includeLocation, config),
-                    config.getComponent(LogEventFactory.KEY));
-        }
     }
 
     protected static LevelAndRefs getLevelAndRefs(Level level, AppenderRef[] refs, String levelAndRefs,

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/ClassArbiter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/ClassArbiter.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.core.config.arbiters;
 
-import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
-import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Plugin;
+import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.util.LoaderUtil;
 
 /**
@@ -40,18 +40,19 @@ public class ClassArbiter implements Arbiter {
         return LoaderUtil.isClassAvailable(className);
     }
 
-    @PluginBuilderFactory
+    @PluginFactory
     public static ClassArbiter.Builder newBuilder() {
         return new ClassArbiter.Builder();
     }
 
-    public static class Builder implements org.apache.logging.log4j.core.util.Builder<ClassArbiter> {
+    public static class Builder implements org.apache.logging.log4j.plugins.util.Builder<ClassArbiter> {
 
-        public static final String ATTR_CLASS_NAME = "className";
-
-        @PluginBuilderAttribute(ATTR_CLASS_NAME)
+        @PluginBuilderAttribute
         private String className;
 
+        public String getClassName() {
+            return className;
+        }
 
         /**
          * Sets the Class name.
@@ -67,6 +68,7 @@ public class ClassArbiter implements Arbiter {
             return this;
         }
 
+        @Override
         public ClassArbiter build() {
             return new ClassArbiter(className);
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/DefaultArbiter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/DefaultArbiter.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.core.config.arbiters;
 
-import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Plugin;
+import org.apache.logging.log4j.plugins.PluginFactory;
 
 /**
  * Default Condition for a Select Condition.
@@ -35,12 +35,12 @@ public class DefaultArbiter implements Arbiter {
         return true;
     }
 
-    @PluginBuilderFactory
+    @PluginFactory
     public static Builder newBuilder() {
         return new Builder();
     }
 
-    public static class Builder implements org.apache.logging.log4j.core.util.Builder<DefaultArbiter> {
+    public static class Builder implements org.apache.logging.log4j.plugins.util.Builder<DefaultArbiter> {
 
         public Builder asBuilder() {
             return this;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/SelectArbiter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/SelectArbiter.java
@@ -16,12 +16,12 @@
  */
 package org.apache.logging.log4j.core.config.arbiters;
 
-import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
-import org.apache.logging.log4j.plugins.Configurable;
-import org.apache.logging.log4j.plugins.Plugin;
-
 import java.util.List;
 import java.util.Optional;
+
+import org.apache.logging.log4j.plugins.Configurable;
+import org.apache.logging.log4j.plugins.Plugin;
+import org.apache.logging.log4j.plugins.PluginFactory;
 
 /**
  * Class Description goes here.
@@ -46,17 +46,18 @@ public class SelectArbiter {
         return opt.orElse(null);
     }
 
-    @PluginBuilderFactory
+    @PluginFactory
     public static Builder newBuilder() {
         return new Builder();
     }
 
-    public static class Builder implements org.apache.logging.log4j.core.util.Builder<SelectArbiter> {
+    public static class Builder implements org.apache.logging.log4j.plugins.util.Builder<SelectArbiter> {
 
         public Builder asBuilder() {
             return this;
         }
 
+        @Override
         public SelectArbiter build() {
             return new SelectArbiter();
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/SystemPropertyArbiter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/SystemPropertyArbiter.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.core.config.arbiters;
 
-import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
-import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Plugin;
+import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.plugins.PluginFactory;
 
 /**
  * Condition that determines if the specified property is set.
@@ -47,21 +47,27 @@ public class SystemPropertyArbiter implements Arbiter {
         return value != null && (propertyValue == null || value.equals(propertyValue));
     }
 
-    @PluginBuilderFactory
+    @PluginFactory
     public static Builder newBuilder() {
         return new Builder();
     }
 
-    public static class Builder implements org.apache.logging.log4j.core.util.Builder<SystemPropertyArbiter> {
+    public static class Builder implements org.apache.logging.log4j.plugins.util.Builder<SystemPropertyArbiter> {
 
-        public static final String ATTR_PROPERTY_NAME = "propertyName";
-        public static final String ATTR_PROPERTY_VALUE = "propertyValue";
-
-        @PluginBuilderAttribute(ATTR_PROPERTY_NAME)
+        @PluginBuilderAttribute
         private String propertyName;
 
-        @PluginBuilderAttribute(ATTR_PROPERTY_VALUE)
+        @PluginBuilderAttribute
         private String propertyValue;
+
+        public String getPropertyName() {
+            return propertyName;
+        }
+
+        public String getPropertyValue() {
+            return propertyValue;
+        }
+
         /**
          * Sets the Property Name.
          * @param propertyName the property name.
@@ -86,6 +92,7 @@ public class SystemPropertyArbiter implements Arbiter {
             return this;
         }
 
+        @Override
         public SystemPropertyArbiter build() {
             return new SystemPropertyArbiter(propertyName, propertyValue);
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/AbstractFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/AbstractFilter.java
@@ -22,8 +22,9 @@ import org.apache.logging.log4j.core.AbstractLifeCycle;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.util.Cast;
 
 /**
  * Users should extend this class to implement filters. Filters can be either context wide or attached to
@@ -77,9 +78,8 @@ public abstract class AbstractFilter extends AbstractLifeCycle implements Filter
             return asBuilder();
         }
 
-        @SuppressWarnings("unchecked")
         public B asBuilder() {
-            return (B) this;
+            return Cast.cast(this);
         }
 
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/AbstractFilterable.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/AbstractFilterable.java
@@ -21,10 +21,10 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.core.AbstractLifeCycle;
 import org.apache.logging.log4j.core.Filter;
-import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.plugins.PluginElement;
+import org.apache.logging.log4j.util.Cast;
 
 /**
  * Enhances a Class by allowing it to contain Filters.
@@ -44,9 +44,8 @@ public abstract class AbstractFilterable extends AbstractLifeCycle implements Fi
         @PluginElement("Properties")
         private Property[] propertyArray;
 
-        @SuppressWarnings("unchecked")
         public B asBuilder() {
-            return (B) this;
+            return Cast.cast(this);
         }
 
         public Filter getFilter() {
@@ -190,7 +189,7 @@ public abstract class AbstractFilterable extends AbstractLifeCycle implements Fi
         }
         boolean stopped = true;
         if (filter != null) {
-            stopped = ((LifeCycle) filter).stop(timeout, timeUnit);
+            stopped = filter.stop(timeout, timeUnit);
         }
         if (changeLifeCycleState) {
             this.setStopped();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/BurstFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/BurstFilter.java
@@ -14,8 +14,13 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.filter;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.DelayQueue;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
@@ -27,12 +32,6 @@ import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Plugin;
 import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.plugins.PluginFactory;
-
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.DelayQueue;
-import java.util.concurrent.Delayed;
-import java.util.concurrent.TimeUnit;
 
 /**
  * The <code>BurstFilter</code> is a logging filter that regulates logging traffic.
@@ -297,6 +296,18 @@ public final class BurstFilter extends AbstractFilter {
 
         @PluginBuilderAttribute
         private long maxBurst;
+
+        public Level getLevel() {
+            return level;
+        }
+
+        public float getRate() {
+            return rate;
+        }
+
+        public long getMaxBurst() {
+            return maxBurst;
+        }
 
         /**
          * Sets the logging level to use.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/DenyAllFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/DenyAllFilter.java
@@ -145,7 +145,8 @@ public final class DenyAllFilter extends AbstractFilter {
         return new DenyAllFilter.Builder();
     }
 
-    public static class Builder extends AbstractFilterBuilder<DenyAllFilter.Builder> implements org.apache.logging.log4j.core.util.Builder<DenyAllFilter> {
+    public static class Builder extends AbstractFilterBuilder<DenyAllFilter.Builder>
+            implements org.apache.logging.log4j.plugins.util.Builder<DenyAllFilter> {
 
         @Override
         public DenyAllFilter build() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/DynamicThresholdFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/DynamicThresholdFilter.java
@@ -53,30 +53,6 @@ import org.apache.logging.log4j.util.StringMap;
 @PerformanceSensitive("allocation")
 public final class DynamicThresholdFilter extends AbstractFilter {
 
-    /**
-     * Creates a DynamicThresholdFilter.
-     * @param key The name of the key to compare.
-     * @param pairs An array of value and Level pairs.
-     * @param defaultThreshold The default Level.
-     * @param onMatch The action to perform if a match occurs.
-     * @param onMismatch The action to perform if no match occurs.
-     * @return The DynamicThresholdFilter.
-     * @deprecated use {@link Builder}
-     */
-    @Deprecated(since = "3.0.0", forRemoval = true)
-    public static DynamicThresholdFilter createFilter(
-            final String key, final KeyValuePair[] pairs, final Level defaultThreshold, final Result onMatch,
-            final Result onMismatch) {
-        return newBuilder()
-                .setKey(key)
-                .setPairs(pairs)
-                .setDefaultThreshold(defaultThreshold)
-                .setOnMatch(onMatch)
-                .setOnMismatch(onMismatch)
-                .setContextDataInjector(ContextDataInjectorFactory.createInjector())
-                .get();
-    }
-
     @PluginFactory
     public static Builder newBuilder() {
         return new Builder();
@@ -87,6 +63,28 @@ public final class DynamicThresholdFilter extends AbstractFilter {
         private KeyValuePair[] pairs;
         private Level defaultThreshold;
         private ContextDataInjector contextDataInjector;
+
+        public String getKey() {
+            return key;
+        }
+
+        public KeyValuePair[] getPairs() {
+            return pairs;
+        }
+
+        public Level getDefaultThreshold() {
+            if (defaultThreshold == null) {
+                defaultThreshold = Level.ERROR;
+            }
+            return defaultThreshold;
+        }
+
+        public ContextDataInjector getContextDataInjector() {
+            if (contextDataInjector == null) {
+                contextDataInjector = ContextDataInjectorFactory.createInjector();
+            }
+            return contextDataInjector;
+        }
 
         public Builder setKey(@PluginAttribute final String key) {
             this.key = key;
@@ -111,15 +109,9 @@ public final class DynamicThresholdFilter extends AbstractFilter {
 
         @Override
         public DynamicThresholdFilter get() {
-            if (contextDataInjector == null) {
-                contextDataInjector = ContextDataInjectorFactory.createInjector();
-            }
-            if (defaultThreshold == null) {
-                defaultThreshold = Level.ERROR;
-            }
             final Map<String, Level> map =
                     Stream.of(pairs).collect(Collectors.toMap(KeyValuePair::getKey, pair -> Level.toLevel(pair.getValue())));
-            return new DynamicThresholdFilter(key, map, defaultThreshold, getOnMatch(), getOnMismatch(), contextDataInjector);
+            return new DynamicThresholdFilter(key, map, getDefaultThreshold(), getOnMatch(), getOnMismatch(), getContextDataInjector());
         }
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/LevelMatchFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/LevelMatchFilter.java
@@ -151,9 +151,14 @@ public final class LevelMatchFilter extends AbstractFilter {
         return new LevelMatchFilter.Builder();
     }
 
-    public static class Builder extends AbstractFilterBuilder<LevelMatchFilter.Builder> implements org.apache.logging.log4j.core.util.Builder<LevelMatchFilter> {
+    public static class Builder extends AbstractFilterBuilder<LevelMatchFilter.Builder>
+            implements org.apache.logging.log4j.plugins.util.Builder<LevelMatchFilter> {
         @PluginBuilderAttribute
         private Level level = Level.ERROR;
+
+        public Level getLevel() {
+            return level;
+        }
 
         /**
          * Sets the logging level to use.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/MutableThreadContextMapFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/MutableThreadContextMapFilter.java
@@ -200,7 +200,7 @@ public class MutableThreadContextMapFilter extends AbstractFilter {
     }
 
     public static class Builder extends AbstractFilterBuilder<Builder>
-            implements org.apache.logging.log4j.core.util.Builder<MutableThreadContextMapFilter> {
+            implements org.apache.logging.log4j.plugins.util.Builder<MutableThreadContextMapFilter> {
         @PluginAttribute
         private String configLocation;
 
@@ -209,6 +209,18 @@ public class MutableThreadContextMapFilter extends AbstractFilter {
 
         @PluginConfiguration
         private Configuration configuration;
+
+        public String getConfigLocation() {
+            return configLocation;
+        }
+
+        public long getPollInterval() {
+            return pollInterval;
+        }
+
+        public Configuration getConfiguration() {
+            return configuration;
+        }
 
         /**
          * Sets the Configuration.
@@ -255,8 +267,12 @@ public class MutableThreadContextMapFilter extends AbstractFilter {
                 ConfigResult result = getConfig(source, authorizationProvider);
                 if (result.status == Status.SUCCESS) {
                     if (result.pairs.length > 0) {
-                        filter = ThreadContextMapFilter.createFilter(result.pairs, "or",
-                                getOnMatch(), getOnMismatch());
+                        filter = ThreadContextMapFilter.newBuilder()
+                                .setPairs(result.pairs)
+                                .setOperator("or")
+                                .setOnMatch(getOnMatch())
+                                .setOnMismatch(getOnMismatch())
+                                .get();
                     } else {
                         filter = new NoOpFilter();
                     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/NoMarkerFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/NoMarkerFilter.java
@@ -141,7 +141,8 @@ public final class NoMarkerFilter extends AbstractFilter {
         return new Builder();
     }
 
-    public static class Builder extends AbstractFilterBuilder<Builder> implements org.apache.logging.log4j.core.util.Builder<NoMarkerFilter> {
+    public static class Builder extends AbstractFilterBuilder<Builder>
+            implements org.apache.logging.log4j.plugins.util.Builder<NoMarkerFilter> {
 
         @Override
         public NoMarkerFilter build() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/StringMatchFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/StringMatchFilter.java
@@ -153,16 +153,21 @@ public final class StringMatchFilter extends AbstractFilter {
         return new StringMatchFilter.Builder();
     }
 
-    public static class Builder extends AbstractFilterBuilder<StringMatchFilter.Builder> implements org.apache.logging.log4j.core.util.Builder<StringMatchFilter> {
+    public static class Builder extends AbstractFilterBuilder<StringMatchFilter.Builder>
+            implements org.apache.logging.log4j.plugins.util.Builder<StringMatchFilter> {
         @PluginBuilderAttribute
         private String text = "";
 
+        public String getMatchString() {
+            return text;
+        }
+
         /**
          * Sets the logging level to use.
-         * @param level the logging level to use.
+         * @param text the logging level to use.
          * @return this
          */
-        public StringMatchFilter.Builder setMatchString(final String text) {
+        public Builder setMatchString(final String text) {
             this.text = text;
             return this;
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/StructuredDataFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/StructuredDataFilter.java
@@ -72,13 +72,13 @@ public final class StructuredDataFilter extends MapFilter {
         return super.filter(event);
     }
 
-    protected Result filter(final StructuredDataMessage message) {
+    private Result filter(final StructuredDataMessage message) {
         boolean match = false;
         final IndexedReadOnlyStringMap map = getStringMap();
         for (int i = 0; i < map.size(); i++) {
             final StringBuilder toMatch = getValue(message, map.getKeyAt(i));
             if (toMatch != null) {
-                match = listContainsValue((List<String>) map.getValueAt(i), toMatch);
+                match = listContainsValue(map.getValueAt(i), toMatch);
             } else {
                 match = false;
             }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/ThreadContextMapFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/ThreadContextMapFilter.java
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.impl.ContextDataFactory;
-import org.apache.logging.log4j.core.impl.ContextDataInjectorFactory;
 import org.apache.logging.log4j.core.util.KeyValuePair;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.plugins.Configurable;
@@ -212,6 +211,18 @@ public class ThreadContextMapFilter extends MapFilter {
         private String operator;
         private ContextDataInjector contextDataInjector;
 
+        public KeyValuePair[] getPairs() {
+            return pairs;
+        }
+
+        public String getOperator() {
+            return operator;
+        }
+
+        public ContextDataInjector getContextDataInjector() {
+            return contextDataInjector;
+        }
+
         public Builder setPairs(@Required @PluginElement final KeyValuePair[] pairs) {
             this.pairs = pairs;
             return this;
@@ -269,15 +280,4 @@ public class ThreadContextMapFilter extends MapFilter {
         return new Builder();
     }
 
-    @Deprecated(since = "3.0.0", forRemoval = true)
-    public static ThreadContextMapFilter createFilter(
-            final KeyValuePair[] pairs, final String operator, final Result onMatch, final Result onMismatch) {
-        return newBuilder()
-                .setPairs(pairs)
-                .setOperator(operator)
-                .setOnMatch(onMatch)
-                .setOnMismatch(onMismatch)
-                .setContextDataInjector(ContextDataInjectorFactory.createInjector())
-                .get();
-    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/TimeFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/TimeFilter.java
@@ -243,33 +243,6 @@ public final class TimeFilter extends AbstractFilter {
         return sb.toString();
     }
 
-    /**
-     * Creates a TimeFilter.
-     * @param start The start time.
-     * @param end The end time.
-     * @param tz timezone.
-     * @param match Action to perform if the time matches.
-     * @param mismatch Action to perform if the action does not match.
-     * @return A TimeFilter.
-     */
-    @Deprecated(since = "3.0.0", forRemoval = true)
-    public static TimeFilter createFilter(
-            final String start, final String end, final String tz, final Result match, final Result mismatch) {
-        final Builder builder = newBuilder()
-                .setStart(start)
-                .setEnd(end);
-        if (tz != null) {
-            builder.setTimezone(ZoneId.of(tz));
-        }
-        if (match != null) {
-            builder.setOnMatch(match);
-        }
-        if (mismatch != null) {
-            builder.setOnMismatch(mismatch);
-        }
-        return builder.get();
-    }
-
     private static LocalTime parseTimestamp(final String timestamp, final LocalTime defaultValue) {
         if (timestamp == null) {
             return defaultValue;
@@ -294,6 +267,22 @@ public final class TimeFilter extends AbstractFilter {
         @PluginAttribute
         private ZoneId timezone = ZoneId.systemDefault();
         private Clock clock;
+
+        public String getStart() {
+            return start;
+        }
+
+        public String getEnd() {
+            return end;
+        }
+
+        public ZoneId getTimezone() {
+            return timezone;
+        }
+
+        public Clock getClock() {
+            return clock;
+        }
 
         public Builder setStart(@PluginAttribute final String start) {
             this.start = start;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/HtmlLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/HtmlLayout.java
@@ -16,18 +16,6 @@
  */
 package org.apache.logging.log4j.core.layout;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.Layout;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.pattern.DatePatternConverter;
-import org.apache.logging.log4j.core.util.Transform;
-import org.apache.logging.log4j.plugins.Configurable;
-import org.apache.logging.log4j.plugins.Plugin;
-import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
-import org.apache.logging.log4j.plugins.PluginFactory;
-import org.apache.logging.log4j.util.Strings;
-
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.LineNumberReader;
@@ -39,6 +27,18 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Date;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.pattern.DatePatternConverter;
+import org.apache.logging.log4j.core.util.Transform;
+import org.apache.logging.log4j.plugins.Configurable;
+import org.apache.logging.log4j.plugins.Plugin;
+import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.plugins.PluginFactory;
+import org.apache.logging.log4j.util.Strings;
 
 /**
  * Outputs events as rows in an HTML table on an HTML page.
@@ -380,6 +380,38 @@ public final class HtmlLayout extends AbstractStringLayout {
         private String timezone = null; // null means default timezone
 
         private Builder() {
+        }
+
+        public boolean isLocationInfo() {
+            return locationInfo;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public Charset getCharset() {
+            return charset;
+        }
+
+        public FontSize getFontSize() {
+            return fontSize;
+        }
+
+        public String getFontName() {
+            return fontName;
+        }
+
+        public String getDatePattern() {
+            return datePattern;
+        }
+
+        public String getTimezone() {
+            return timezone;
         }
 
         public Builder setLocationInfo(final boolean locationInfo) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/LevelPatternSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/LevelPatternSelector.java
@@ -16,23 +16,23 @@
  */
 package org.apache.logging.log4j.core.layout;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
-import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
-import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.pattern.PatternFormatter;
 import org.apache.logging.log4j.core.pattern.PatternParser;
 import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Plugin;
+import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.plugins.PluginElement;
+import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.status.StatusLogger;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Selects the pattern to use based on the Level in the LogEvent.
@@ -44,7 +44,7 @@ public class LevelPatternSelector implements PatternSelector{
     /**
      * Custom MarkerPatternSelector builder. Use the {@link LevelPatternSelector#newBuilder() builder factory method} to create this.
      */
-    public static class Builder implements org.apache.logging.log4j.core.util.Builder<LevelPatternSelector> {
+    public static class Builder implements org.apache.logging.log4j.plugins.util.Builder<LevelPatternSelector> {
 
         @PluginElement("PatternMatch")
         private PatternMatch[] properties;
@@ -75,6 +75,30 @@ public class LevelPatternSelector implements PatternSelector{
             }
             return new LevelPatternSelector(properties, defaultPattern, alwaysWriteExceptions, disableAnsi,
                     noConsoleNoAnsi, configuration);
+        }
+
+        public PatternMatch[] getProperties() {
+            return properties;
+        }
+
+        public String getDefaultPattern() {
+            return defaultPattern;
+        }
+
+        public boolean isAlwaysWriteExceptions() {
+            return alwaysWriteExceptions;
+        }
+
+        public boolean isDisableAnsi() {
+            return disableAnsi;
+        }
+
+        public boolean isNoConsoleNoAnsi() {
+            return noConsoleNoAnsi;
+        }
+
+        public Configuration getConfiguration() {
+            return configuration;
         }
 
         public Builder setProperties(final PatternMatch[] properties) {
@@ -120,16 +144,6 @@ public class LevelPatternSelector implements PatternSelector{
     private static final Logger LOGGER = StatusLogger.getLogger();
 
     private final boolean requiresLocation;
-
-    /**
-     * @deprecated Use {@link #newBuilder()} instead. This will be private in a future version.
-     */
-    @Deprecated
-    public LevelPatternSelector(final PatternMatch[] properties, final String defaultPattern,
-                                 final boolean alwaysWriteExceptions, final boolean noConsoleNoAnsi,
-                                 final Configuration config) {
-        this(properties, defaultPattern, alwaysWriteExceptions, false, noConsoleNoAnsi, config);
-    }
 
     private LevelPatternSelector(final PatternMatch[] properties, final String defaultPattern,
                                  final boolean alwaysWriteExceptions, final boolean disableAnsi,
@@ -189,35 +203,9 @@ public class LevelPatternSelector implements PatternSelector{
      *
      * @return a ScriptPatternSelector builder.
      */
-    @PluginBuilderFactory
+    @PluginFactory
     public static Builder newBuilder() {
         return new Builder();
-    }
-
-    /**
-     * Deprecated, use {@link #newBuilder()} instead.
-     * @param properties
-     * @param defaultPattern
-     * @param alwaysWriteExceptions
-     * @param noConsoleNoAnsi
-     * @param configuration
-     * @return a new MarkerPatternSelector.
-     * @deprecated Use {@link #newBuilder()} instead.
-     */
-    @Deprecated
-    public static LevelPatternSelector createSelector(
-            final PatternMatch[] properties,
-            final String defaultPattern,
-            final boolean alwaysWriteExceptions,
-            final boolean noConsoleNoAnsi,
-            final Configuration configuration) {
-        final Builder builder = newBuilder();
-        builder.setProperties(properties);
-        builder.setDefaultPattern(defaultPattern);
-        builder.setAlwaysWriteExceptions(alwaysWriteExceptions);
-        builder.setNoConsoleNoAnsi(noConsoleNoAnsi);
-        builder.setConfiguration(configuration);
-        return builder.build();
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/MarkerPatternSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/MarkerPatternSelector.java
@@ -16,6 +16,10 @@
  */
 package org.apache.logging.log4j.core.layout;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.LogEvent;
@@ -29,10 +33,6 @@ import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.plugins.PluginElement;
 import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.status.StatusLogger;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Selects the pattern to use based on the Marker in the LogEvent.
@@ -75,6 +75,30 @@ public class MarkerPatternSelector implements PatternSelector {
             }
             return new MarkerPatternSelector(properties, defaultPattern, alwaysWriteExceptions, disableAnsi,
                     noConsoleNoAnsi, configuration);
+        }
+
+        public PatternMatch[] getProperties() {
+            return properties;
+        }
+
+        public String getDefaultPattern() {
+            return defaultPattern;
+        }
+
+        public boolean isAlwaysWriteExceptions() {
+            return alwaysWriteExceptions;
+        }
+
+        public boolean isDisableAnsi() {
+            return disableAnsi;
+        }
+
+        public boolean isNoConsoleNoAnsi() {
+            return noConsoleNoAnsi;
+        }
+
+        public Configuration getConfiguration() {
+            return configuration;
         }
 
         public Builder setProperties(final PatternMatch[] properties) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/PatternLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/PatternLayout.java
@@ -406,6 +406,38 @@ public final class PatternLayout extends AbstractStringLayout {
             return new PatternSelectorSerializer(patternSelector, replace);
         }
 
+        public Configuration getConfiguration() {
+            return configuration;
+        }
+
+        public RegexReplacement getReplace() {
+            return replace;
+        }
+
+        public String getPattern() {
+            return pattern;
+        }
+
+        public String getDefaultPattern() {
+            return defaultPattern;
+        }
+
+        public PatternSelector getPatternSelector() {
+            return patternSelector;
+        }
+
+        public boolean isAlwaysWriteExceptions() {
+            return alwaysWriteExceptions;
+        }
+
+        public boolean isDisableAnsi() {
+            return disableAnsi;
+        }
+
+        public boolean isNoConsoleNoAnsi() {
+            return noConsoleNoAnsi;
+        }
+
         public SerializerBuilder setConfiguration(final Configuration configuration) {
             this.configuration = configuration;
             return this;
@@ -579,6 +611,46 @@ public final class PatternLayout extends AbstractStringLayout {
             final boolean isPlatformSupportsAnsi = !properties.isOsWindows();
             final boolean isJansiRequested = !properties.getBooleanProperty(Log4jProperties.JANSI_DISABLED, true);
             return isPlatformSupportsAnsi || isJansiRequested;
+        }
+
+        public String getPattern() {
+            return pattern;
+        }
+
+        public PatternSelector getPatternSelector() {
+            return patternSelector;
+        }
+
+        public Configuration getConfiguration() {
+            return configuration;
+        }
+
+        public RegexReplacement getRegexReplacement() {
+            return regexReplacement;
+        }
+
+        public Charset getCharset() {
+            return charset;
+        }
+
+        public boolean isAlwaysWriteExceptions() {
+            return alwaysWriteExceptions;
+        }
+
+        public boolean isDisableAnsi() {
+            return disableAnsi;
+        }
+
+        public boolean isNoConsoleNoAnsi() {
+            return noConsoleNoAnsi;
+        }
+
+        public String getHeader() {
+            return header;
+        }
+
+        public String getFooter() {
+            return footer;
         }
 
         /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/PatternMatch.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/PatternMatch.java
@@ -16,8 +16,6 @@
  */
 package org.apache.logging.log4j.core.layout;
 
-import java.io.ObjectStreamException;
-
 import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Plugin;
 import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
@@ -77,6 +75,14 @@ public final class PatternMatch {
         @PluginBuilderAttribute
         private String pattern;
 
+        public String getKey() {
+            return key;
+        }
+
+        public String getPattern() {
+            return pattern;
+        }
+
         public Builder setKey(final String key) {
             this.key = key;
             return this;
@@ -92,9 +98,6 @@ public final class PatternMatch {
             return new PatternMatch(key, pattern);
         }
 
-        protected Object readResolve() throws ObjectStreamException {
-            return new PatternMatch(key, pattern);
-        }
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/Rfc5424Layout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/Rfc5424Layout.java
@@ -646,7 +646,7 @@ public final class Rfc5424Layout extends AbstractStringLayout {
                 exceptionPattern, useTlsMessageFormat, loggerFields);
     }
 
-    public static class Rfc5424LayoutBuilder {
+    public static class Rfc5424LayoutBuilder implements org.apache.logging.log4j.plugins.util.Builder<Rfc5424Layout> {
         private Configuration config;
         private Facility facility = Facility.LOCAL0;
         private String id;
@@ -666,6 +666,82 @@ public final class Rfc5424Layout extends AbstractStringLayout {
         private String exceptionPattern;
         private boolean useTLSMessageFormat;
         private LoggerFields[] loggerFields;
+
+        public Configuration getConfig() {
+            return config;
+        }
+
+        public Facility getFacility() {
+            return facility;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getEin() {
+            return ein;
+        }
+
+        public boolean isIncludeMDC() {
+            return includeMDC;
+        }
+
+        public boolean isIncludeNL() {
+            return includeNL;
+        }
+
+        public String getEscapeNL() {
+            return escapeNL;
+        }
+
+        public String getMdcId() {
+            return mdcId;
+        }
+
+        public String getMdcPrefix() {
+            return mdcPrefix;
+        }
+
+        public String getEventPrefix() {
+            return eventPrefix;
+        }
+
+        public String getAppName() {
+            return appName;
+        }
+
+        public String getMessageId() {
+            return messageId;
+        }
+
+        public String getExcludes() {
+            return excludes;
+        }
+
+        public String getIncludes() {
+            return includes;
+        }
+
+        public String getRequired() {
+            return required;
+        }
+
+        public Charset getCharset() {
+            return charset;
+        }
+
+        public String getExceptionPattern() {
+            return exceptionPattern;
+        }
+
+        public boolean isUseTLSMessageFormat() {
+            return useTLSMessageFormat;
+        }
+
+        public LoggerFields[] getLoggerFields() {
+            return loggerFields;
+        }
 
         public Rfc5424LayoutBuilder setConfig(Configuration config) {
             this.config = config;
@@ -801,7 +877,7 @@ public final class Rfc5424Layout extends AbstractStringLayout {
         }
     }
 
-    private class StructuredDataElement {
+    private static class StructuredDataElement {
 
         private final Map<String, String> fields;
         private final boolean discardIfEmpty;
@@ -815,7 +891,7 @@ public final class Rfc5424Layout extends AbstractStringLayout {
         }
 
         boolean discard() {
-            if (discardIfEmpty == false) {
+            if (!discardIfEmpty) {
                 return false;
             }
             boolean foundNotEmptyValue = false;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/SyslogLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/SyslogLayout.java
@@ -55,7 +55,7 @@ public final class SyslogLayout extends AbstractStringLayout {
      * </ul>
      * @param <B> the builder type
      */
-    public static class Builder<B extends Builder<B>> extends AbstractStringLayout.Builder<B>
+    public static class Builder extends AbstractStringLayout.Builder<Builder>
             implements org.apache.logging.log4j.plugins.util.Builder<SyslogLayout> {
 
         public Builder() {
@@ -89,26 +89,26 @@ public final class SyslogLayout extends AbstractStringLayout {
             return escapeNL;
         }
 
-        public B setFacility(final Facility facility) {
+        public Builder setFacility(final Facility facility) {
             this.facility = facility;
-            return asBuilder();
+            return this;
         }
 
-        public B setIncludeNewLine(final boolean includeNewLine) {
+        public Builder setIncludeNewLine(final boolean includeNewLine) {
             this.includeNewLine = includeNewLine;
-            return asBuilder();
+            return this;
         }
 
-        public B setEscapeNL(final String escapeNL) {
+        public Builder setEscapeNL(final String escapeNL) {
             this.escapeNL = escapeNL;
-            return asBuilder();
+            return this;
         }
 
     }
 
     @PluginFactory
-    public static <B extends Builder<B>> B newBuilder() {
-        return new Builder<B>().asBuilder();
+    public static Builder newBuilder() {
+        return new Builder();
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SocketAddress.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SocketAddress.java
@@ -16,15 +16,15 @@
  */
 package org.apache.logging.log4j.core.net;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
 import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Plugin;
 import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.plugins.validation.constraints.ValidHost;
 import org.apache.logging.log4j.plugins.validation.constraints.ValidPort;
-
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
 
 /**
  * Plugin to hold a hostname and port (socket address).
@@ -81,6 +81,14 @@ public class SocketAddress {
         @PluginBuilderAttribute
         @ValidPort
         private int port;
+
+        public InetAddress getHost() {
+            return host;
+        }
+
+        public int getPort() {
+            return port;
+        }
 
         public Builder setHost(final InetAddress host) {
             this.host = host;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SocketPerformancePreferences.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SocketPerformancePreferences.java
@@ -16,14 +16,14 @@
  */
 package org.apache.logging.log4j.core.net;
 
+import java.net.Socket;
+
 import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Plugin;
 import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.plugins.util.Builder;
 import org.apache.logging.log4j.plugins.validation.constraints.Required;
-
-import java.net.Socket;
 
 /**
  * Holds all socket options settable via {@link Socket#setPerformancePreferences(int, int, int)}.
@@ -77,16 +77,19 @@ public class SocketPerformancePreferences implements Builder<SocketPerformancePr
         return latency;
     }
 
-    public void setBandwidth(final int bandwidth) {
+    public SocketPerformancePreferences setBandwidth(final int bandwidth) {
         this.bandwidth = bandwidth;
+        return this;
     }
 
-    public void setConnectionTime(final int connectionTime) {
+    public SocketPerformancePreferences setConnectionTime(final int connectionTime) {
         this.connectionTime = connectionTime;
+        return this;
     }
 
-    public void setLatency(final int latency) {
+    public SocketPerformancePreferences setLatency(final int latency) {
         this.latency = latency;
+        return this;
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/KeyValuePair.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/KeyValuePair.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.util;
 
 import org.apache.logging.log4j.plugins.Configurable;
@@ -77,6 +76,14 @@ public final class KeyValuePair {
 
         @PluginBuilderAttribute
         private String value;
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getValue() {
+            return value;
+        }
 
         public Builder setKey(final String aKey) {
             this.key = aKey;

--- a/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/appender/ServletAppender.java
+++ b/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/appender/ServletAppender.java
@@ -16,7 +16,6 @@
  */
 package org.apache.logging.log4j.web.appender;
 
-import jakarta.servlet.ServletContext;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
@@ -30,6 +29,8 @@ import org.apache.logging.log4j.plugins.Plugin;
 import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.web.WebLoggerContextUtils;
+
+import jakarta.servlet.ServletContext;
 
 /**
  * Logs using the ServletContext's log method

--- a/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/appender/ServletAppender.java
+++ b/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/appender/ServletAppender.java
@@ -16,21 +16,20 @@
  */
 package org.apache.logging.log4j.web.appender;
 
+import jakarta.servlet.ServletContext;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 import org.apache.logging.log4j.core.config.Property;
-import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
-import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.core.layout.AbstractStringLayout;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Plugin;
+import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.web.WebLoggerContextUtils;
-
-import jakarta.servlet.ServletContext;
 
 /**
  * Logs using the ServletContext's log method
@@ -40,7 +39,7 @@ import jakarta.servlet.ServletContext;
 public class ServletAppender extends AbstractAppender {
 
     public static class Builder<B extends Builder<B>> extends AbstractAppender.Builder<B>
-            implements org.apache.logging.log4j.core.util.Builder<ServletAppender> {
+            implements org.apache.logging.log4j.plugins.util.Builder<ServletAppender> {
 
         @PluginBuilderAttribute
         private boolean logThrowables;
@@ -84,7 +83,7 @@ public class ServletAppender extends AbstractAppender {
 
     }
 
-    @PluginBuilderFactory
+    @PluginFactory
     public static <B extends Builder<B>> B newBuilder() {
         return new Builder<B>().asBuilder();
     }
@@ -101,7 +100,7 @@ public class ServletAppender extends AbstractAppender {
 
     @Override
     public void append(final LogEvent event) {
-        final String serialized = ((AbstractStringLayout) getLayout()).toSerializable(event);
+        final String serialized = getLayout().toSerializable(event);
         if (logThrowables) {
             servletContext.log(serialized, event.getThrown());
         } else {

--- a/log4j-jdbc-dbcp2/src/main/java/org/apache/logging/log4j/dbcp2/appender/PoolableConnectionFactoryConfig.java
+++ b/log4j-jdbc-dbcp2/src/main/java/org/apache/logging/log4j/dbcp2/appender/PoolableConnectionFactoryConfig.java
@@ -14,8 +14,11 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.dbcp2.appender;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 import org.apache.commons.dbcp2.PoolableConnectionFactory;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
@@ -26,10 +29,6 @@ import org.apache.logging.log4j.plugins.PluginElement;
 import org.apache.logging.log4j.plugins.PluginFactory;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
 
 /**
  * Configures an Apache Commons DBCP {@link PoolableConnectionFactory}.

--- a/log4j-jdbc-dbcp2/src/main/java/org/apache/logging/log4j/dbcp2/appender/PoolableConnectionFactoryConfig.java
+++ b/log4j-jdbc-dbcp2/src/main/java/org/apache/logging/log4j/dbcp2/appender/PoolableConnectionFactoryConfig.java
@@ -116,6 +116,70 @@ public class PoolableConnectionFactoryConfig {
                     validationQueryTimeoutSeconds);
         }
 
+        public boolean isCacheState() {
+            return cacheState;
+        }
+
+        public String[] getConnectionInitSqls() {
+            return connectionInitSqls;
+        }
+
+        public Boolean getDefaultAutoCommit() {
+            return defaultAutoCommit;
+        }
+
+        public String getDefaultCatalog() {
+            return defaultCatalog;
+        }
+
+        public Integer getDefaultQueryTimeoutSeconds() {
+            return defaultQueryTimeoutSeconds;
+        }
+
+        public Boolean getDefaultReadOnly() {
+            return defaultReadOnly;
+        }
+
+        public int getDefaultTransactionIsolation() {
+            return defaultTransactionIsolation;
+        }
+
+        public String[] getDisconnectionSqlCodes() {
+            return disconnectionSqlCodes;
+        }
+
+        public boolean isAutoCommitOnReturn() {
+            return autoCommitOnReturn;
+        }
+
+        public boolean isFastFailValidation() {
+            return fastFailValidation;
+        }
+
+        public long getMaxConnLifetimeMillis() {
+            return maxConnLifetimeMillis;
+        }
+
+        public int getMaxOpenPreparedStatements() {
+            return maxOpenPreparedStatements;
+        }
+
+        public boolean isPoolStatements() {
+            return poolStatements;
+        }
+
+        public boolean isRollbackOnReturn() {
+            return rollbackOnReturn;
+        }
+
+        public String getValidationQuery() {
+            return validationQuery;
+        }
+
+        public int getValidationQueryTimeoutSeconds() {
+            return validationQueryTimeoutSeconds;
+        }
+
         public Builder setAutoCommitOnReturn(final boolean autoCommitOnReturn) {
             this.autoCommitOnReturn = autoCommitOnReturn;
             return this;

--- a/log4j-jdbc-dbcp2/src/main/java/org/apache/logging/log4j/dbcp2/appender/PoolingDriverConnectionSource.java
+++ b/log4j-jdbc-dbcp2/src/main/java/org/apache/logging/log4j/dbcp2/appender/PoolingDriverConnectionSource.java
@@ -64,16 +64,16 @@ public final class PoolingDriverConnectionSource extends AbstractDriverManagerCo
         private String poolName = DEFAULT_POOL_NAME;
 
         @Override
-		public PoolingDriverConnectionSource build() {
-			try {
-				return new PoolingDriverConnectionSource(getDriverClassName(), getConnectionString(), getUserName(),
-						getPassword(), getProperties(), poolName, poolableConnectionFactoryConfig);
-			} catch (final SQLException e) {
-				getLogger().error("Exception constructing {} to '{}' with {}", PoolingDriverConnectionSource.class,
-						getConnectionString(), this, e);
-				return null;
-			}
-		}
+        public PoolingDriverConnectionSource build() {
+            try {
+                return new PoolingDriverConnectionSource(getDriverClassName(), getConnectionString(), getUserName(),
+                        getPassword(), getProperties(), poolName, poolableConnectionFactoryConfig);
+            } catch (final SQLException e) {
+                getLogger().error("Exception constructing {} to '{}' with {}", PoolingDriverConnectionSource.class,
+                        getConnectionString(), this, e);
+                return null;
+            }
+        }
 
         public PoolableConnectionFactoryConfig getPoolableConnectionFactoryConfig() {
             return poolableConnectionFactoryConfig;
@@ -88,17 +88,17 @@ public final class PoolingDriverConnectionSource extends AbstractDriverManagerCo
             return asBuilder();
         }
 
-		public B setPoolName(final String poolName) {
+        public B setPoolName(final String poolName) {
             this.poolName = poolName;
             return asBuilder();
         }
 
         @Override
-		public String toString() {
-			return "Builder [poolName=" + poolName + ", connectionString=" + connectionString + ", driverClassName="
-					+ driverClassName + ", properties=" + Arrays.toString(properties) + ", userName="
-					+ Arrays.toString(userName) + "]";
-		}
+        public String toString() {
+            return "Builder [poolName=" + poolName + ", connectionString=" + connectionString + ", driverClassName="
+                    + driverClassName + ", properties=" + Arrays.toString(properties) + ", userName="
+                    + Arrays.toString(userName) + "]";
+        }
     }
 
     public static final String URL_PREFIX = "jdbc:apache:commons:dbcp:";
@@ -157,10 +157,10 @@ public final class PoolingDriverConnectionSource extends AbstractDriverManagerCo
         // using the connect string passed in the command line
         // arguments.
         //
-    	final Property[] properties = getProperties();
-    	final char[] userName = getUserName();
-    	final char[] password = getPassword();
-    	final ConnectionFactory connectionFactory;
+        final Property[] properties = getProperties();
+        final char[] userName = getUserName();
+        final char[] password = getPassword();
+        final ConnectionFactory connectionFactory;
         if (properties != null && properties.length > 0) {
             if (userName != null || password != null) {
                 throw new SQLException("Either set the userName and password, or set the Properties, but not both.");

--- a/log4j-jdbc-dbcp2/src/main/java/org/apache/logging/log4j/dbcp2/appender/PoolingDriverConnectionSource.java
+++ b/log4j-jdbc-dbcp2/src/main/java/org/apache/logging/log4j/dbcp2/appender/PoolingDriverConnectionSource.java
@@ -16,6 +16,11 @@
  */
 package org.apache.logging.log4j.dbcp2.appender;
 
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.dbcp2.ConnectionFactory;
 import org.apache.commons.dbcp2.DriverManagerConnectionFactory;
 import org.apache.commons.dbcp2.PoolableConnection;
@@ -31,11 +36,6 @@ import org.apache.logging.log4j.plugins.Plugin;
 import org.apache.logging.log4j.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.plugins.PluginElement;
 import org.apache.logging.log4j.plugins.PluginFactory;
-
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link ConnectionSource} that uses a JDBC connection string, a user name, and a password to call
@@ -74,6 +74,14 @@ public final class PoolingDriverConnectionSource extends AbstractDriverManagerCo
 				return null;
 			}
 		}
+
+        public PoolableConnectionFactoryConfig getPoolableConnectionFactoryConfig() {
+            return poolableConnectionFactoryConfig;
+        }
+
+        public String getPoolName() {
+            return poolName;
+        }
 
         public B setPoolableConnectionFactoryConfig(final PoolableConnectionFactoryConfig poolableConnectionFactoryConfig) {
             this.poolableConnectionFactoryConfig = poolableConnectionFactoryConfig;

--- a/log4j-jdbc/src/main/java/org/apache/logging/log4j/jdbc/appender/ColumnConfig.java
+++ b/log4j-jdbc/src/main/java/org/apache/logging/log4j/jdbc/appender/ColumnConfig.java
@@ -98,6 +98,34 @@ public final class ColumnConfig {
             return null;
         }
 
+        public Configuration getConfiguration() {
+            return configuration;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getPattern() {
+            return pattern;
+        }
+
+        public String getLiteral() {
+            return literal;
+        }
+
+        public boolean isEventTimestamp() {
+            return isEventTimestamp;
+        }
+
+        public boolean isUnicode() {
+            return isUnicode;
+        }
+
+        public boolean isClob() {
+            return isClob;
+        }
+
         /**
          * If {@code "true"}, indicates that the column is a character LOB (CLOB).
          *

--- a/log4j-jms/src/main/java/org/apache/logging/log4j/jms/appender/JmsAppender.java
+++ b/log4j-jms/src/main/java/org/apache/logging/log4j/jms/appender/JmsAppender.java
@@ -121,6 +121,54 @@ public class JmsAppender extends AbstractAppender {
             }
         }
 
+        public String getFactoryName() {
+            return factoryName;
+        }
+
+        public String getProviderUrl() {
+            return providerUrl;
+        }
+
+        public String getUrlPkgPrefixes() {
+            return urlPkgPrefixes;
+        }
+
+        public String getSecurityPrincipalName() {
+            return securityPrincipalName;
+        }
+
+        public String getSecurityCredentials() {
+            return securityCredentials;
+        }
+
+        public String getFactoryBindingName() {
+            return factoryBindingName;
+        }
+
+        public String getDestinationBindingName() {
+            return destinationBindingName;
+        }
+
+        public String getUserName() {
+            return userName;
+        }
+
+        public char[] getPassword() {
+            return password;
+        }
+
+        public long getReconnectIntervalMillis() {
+            return reconnectIntervalMillis;
+        }
+
+        public boolean isImmediateFail() {
+            return immediateFail;
+        }
+
+        public JmsManager getJmsManager() {
+            return jmsManager;
+        }
+
         public B setDestinationBindingName(final String destinationBindingName) {
             this.destinationBindingName = destinationBindingName;
             return asBuilder();

--- a/log4j-script/src/main/java/org/apache/logging/log4j/script/appender/rolling/action/ScriptCondition.java
+++ b/log4j-script/src/main/java/org/apache/logging/log4j/script/appender/rolling/action/ScriptCondition.java
@@ -17,10 +17,16 @@
 
 package org.apache.logging.log4j.script.appender.rolling.action;
 
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.appender.rolling.action.DeleteAction;
 import org.apache.logging.log4j.core.appender.rolling.action.PathWithAttributes;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
+import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 import org.apache.logging.log4j.core.script.Script;
 import org.apache.logging.log4j.core.script.ScriptBindings;
 import org.apache.logging.log4j.core.script.ScriptConditional;
@@ -28,19 +34,16 @@ import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Plugin;
 import org.apache.logging.log4j.plugins.PluginElement;
 import org.apache.logging.log4j.plugins.PluginFactory;
+import org.apache.logging.log4j.script.ScriptFile;
 import org.apache.logging.log4j.script.ScriptManagerImpl;
 import org.apache.logging.log4j.script.ScriptRef;
 import org.apache.logging.log4j.status.StatusLogger;
-
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Objects;
 
 /**
  * A condition of the {@link DeleteAction} where a user-provided script selects the files to delete from a provided
  * list. The specified script may be a {@link Script}, a {@link ScriptFile} or a {@link ScriptRef}.
  *
- * @see #createCondition(AbstractScript, Configuration)
+ * @see #createCondition(Script, Configuration)
  */
 @Configurable(printObject = true)
 @Plugin
@@ -64,7 +67,7 @@ public class ScriptCondition implements ScriptConditional {
     /**
      * Executes the script
      *
-     * @param baseDir
+     * @param basePath
      * @param candidates
      * @return
      */
@@ -90,7 +93,7 @@ public class ScriptCondition implements ScriptConditional {
      *            <ul>
      *            <li>basePath - the directory from where the {@link DeleteAction Delete} action started scanning for
      *            files to delete. Can be used to relativize the paths in the pathList.</li>
-     *            <li>pathList - a {@code java.util.List} containing {@link PathWithAttribute} objects. (The script is
+     *            <li>pathList - a {@code java.util.List} containing {@code PathWithAttribute} objects. (The script is
      *            free to modify and return this list.)</li>
      *            <li>substitutor - a {@link StrSubstitutor} that can be used to look up variables embedded in the base
      *            dir or other properties

--- a/log4j-script/src/main/java/org/apache/logging/log4j/script/appender/rolling/action/ScriptCondition.java
+++ b/log4j-script/src/main/java/org/apache/logging/log4j/script/appender/rolling/action/ScriptCondition.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.script.appender.rolling.action;
 
 import java.nio.file.Path;

--- a/log4j-script/src/main/java/org/apache/logging/log4j/script/config/arbiter/ScriptArbiter.java
+++ b/log4j-script/src/main/java/org/apache/logging/log4j/script/config/arbiter/ScriptArbiter.java
@@ -20,14 +20,14 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.AbstractConfiguration;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.arbiters.Arbiter;
-import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
-import org.apache.logging.log4j.core.config.plugins.PluginNode;
 import org.apache.logging.log4j.core.script.Script;
 import org.apache.logging.log4j.core.script.ScriptBindings;
 import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Node;
 import org.apache.logging.log4j.plugins.Plugin;
+import org.apache.logging.log4j.plugins.PluginFactory;
+import org.apache.logging.log4j.plugins.PluginNode;
 import org.apache.logging.log4j.plugins.model.PluginType;
 import org.apache.logging.log4j.script.ScriptManagerImpl;
 import org.apache.logging.log4j.script.ScriptRef;
@@ -60,7 +60,7 @@ public class ScriptArbiter implements Arbiter {
         return Boolean.parseBoolean(object.toString());
     }
 
-    @PluginBuilderFactory
+    @PluginFactory
     public static Builder newBuilder() {
         return new Builder();
     }

--- a/log4j-script/src/main/java/org/apache/logging/log4j/script/layout/ScriptPatternSelector.java
+++ b/log4j-script/src/main/java/org/apache/logging/log4j/script/layout/ScriptPatternSelector.java
@@ -16,6 +16,10 @@
  */
 package org.apache.logging.log4j.script.layout;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
@@ -35,10 +39,6 @@ import org.apache.logging.log4j.script.AbstractScript;
 import org.apache.logging.log4j.script.ScriptManagerImpl;
 import org.apache.logging.log4j.script.ScriptRef;
 import org.apache.logging.log4j.status.StatusLogger;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Selects the pattern to use based on the result of executing a Script. The returned value will be used as the "key"
@@ -108,6 +108,34 @@ public class ScriptPatternSelector implements PatternSelector {
             }
             return new ScriptPatternSelector(script, properties, defaultPattern, alwaysWriteExceptions, disableAnsi,
                     noConsoleNoAnsi, configuration);
+        }
+
+        public AbstractScript getScript() {
+            return script;
+        }
+
+        public PatternMatch[] getProperties() {
+            return properties;
+        }
+
+        public String getDefaultPattern() {
+            return defaultPattern;
+        }
+
+        public boolean isAlwaysWriteExceptions() {
+            return alwaysWriteExceptions;
+        }
+
+        public boolean isDisableAnsi() {
+            return disableAnsi;
+        }
+
+        public boolean isNoConsoleNoAnsi() {
+            return noConsoleNoAnsi;
+        }
+
+        public Configuration getConfiguration() {
+            return configuration;
         }
 
         public Builder setScript(final AbstractScript script) {

--- a/log4j-smtp/src/main/java/org/apache/logging/log4j/smtp/appender/SmtpAppender.java
+++ b/log4j-smtp/src/main/java/org/apache/logging/log4j/smtp/appender/SmtpAppender.java
@@ -21,13 +21,10 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.core.layout.HtmlLayout;
 import org.apache.logging.log4j.core.net.ssl.SslConfiguration;
-import org.apache.logging.log4j.core.util.Booleans;
 import org.apache.logging.log4j.plugins.Configurable;
 import org.apache.logging.log4j.plugins.Plugin;
 import org.apache.logging.log4j.plugins.PluginAttribute;
@@ -46,7 +43,7 @@ import org.apache.logging.log4j.plugins.validation.constraints.ValidPort;
  * memory requirements at a reasonable level while still delivering useful
  * application context.
  *
- * By default, an email message will formatted as HTML. This can be modified by
+ * By default, an email message will be formatted as HTML. This can be modified by
  * setting a layout for the appender.
  *
  * By default, an email message will be sent when an ERROR or higher severity
@@ -115,6 +112,62 @@ public final class SmtpAppender extends AbstractAppender {
 
         @PluginElement("SSL")
         private SslConfiguration sslConfiguration;
+
+        public String getTo() {
+            return to;
+        }
+
+        public String getCc() {
+            return cc;
+        }
+
+        public String getBcc() {
+            return bcc;
+        }
+
+        public String getFrom() {
+            return from;
+        }
+
+        public String getReplyTo() {
+            return replyTo;
+        }
+
+        public String getSubject() {
+            return subject;
+        }
+
+        public String getSmtpProtocol() {
+            return smtpProtocol;
+        }
+
+        public String getSmtpHost() {
+            return smtpHost;
+        }
+
+        public int getSmtpPort() {
+            return smtpPort;
+        }
+
+        public String getSmtpUsername() {
+            return smtpUsername;
+        }
+
+        public String getSmtpPassword() {
+            return smtpPassword;
+        }
+
+        public boolean isSmtpDebug() {
+            return smtpDebug;
+        }
+
+        public int getBufferSize() {
+            return bufferSize;
+        }
+
+        public SslConfiguration getSslConfiguration() {
+            return sslConfiguration;
+        }
 
         /**
          * Comma-separated list of recipient email addresses.
@@ -268,46 +321,6 @@ public final class SmtpAppender extends AbstractAppender {
     @PluginFactory
     public static Builder newBuilder() {
         return new Builder();
-    }
-
-    /**
-     * Create a SmtpAppender.
-     * @deprecated Use {@link #newBuilder()} to create and configure a {@link Builder} instance.
-     * @see Builder
-     */
-    public static SmtpAppender createAppender(final Configuration config, final String name, final String to,
-                                              final String cc, final String bcc, final String from,
-                                              final String replyTo, final String subject, final String smtpProtocol,
-                                              final String smtpHost, final String smtpPortStr,
-                                              final String smtpUsername, final String smtpPassword,
-                                              final String smtpDebug, final String bufferSizeStr,
-                                              Layout layout, Filter filter,
-                                              final String ignore) {
-        if (name == null) {
-            LOGGER.error("No name provided for SmtpAppender");
-            return null;
-        }
-
-        final boolean ignoreExceptions = Booleans.parseBoolean(ignore, true);
-        final int smtpPort = AbstractAppender.parseInt(smtpPortStr, 0);
-        final boolean isSmtpDebug = Boolean.parseBoolean(smtpDebug);
-        final int bufferSize = bufferSizeStr == null ? DEFAULT_BUFFER_SIZE : Integer.parseInt(bufferSizeStr);
-
-        if (layout == null) {
-            layout = HtmlLayout.createDefaultLayout();
-        }
-        if (filter == null) {
-            filter = ThresholdFilter.createFilter(null, null, null);
-        }
-        final Configuration configuration = config != null ? config : new DefaultConfiguration();
-
-        final SmtpManager manager = SmtpManager.getSmtpManager(configuration, to, cc, bcc, from, replyTo, subject, smtpProtocol,
-            smtpHost, smtpPort, smtpUsername, smtpPassword, isSmtpDebug, filter.toString(),  bufferSize, null);
-        if (manager == null) {
-            return null;
-        }
-
-        return new SmtpAppender(name, filter, layout, ignoreExceptions, Property.EMPTY_ARRAY, manager);
     }
 
     /**

--- a/src/changelog/.3.x.x/1206_Replace_withers_with_setters.xml
+++ b/src/changelog/.3.x.x/1206_Replace_withers_with_setters.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry type="changed">
+  <issue id="1206" link="https://github.com/apache/logging-log4j2/issues/1206"/>
+  <author id="mattsicker"/>
+  <description format="asciidoc">Builder classes should all use setter-style methods instead of wither-style methods.</description>
+</entry>


### PR DESCRIPTION
This also removes some related deprecated methods. Some builders have been updated to remove unnecessary extensibility when used in a final class.

This fixes #1206.

Signed-off-by: Matt Sicker <mattsicker@apache.org>

