### PR TITLE
[LOG4J2-3554] Switch from `com.sun.mail` to Eclipse Angus

### DIFF
--- a/log4j-jakarta-smtp/pom.xml
+++ b/log4j-jakarta-smtp/pom.xml
@@ -41,13 +41,11 @@
       <groupId>jakarta.activation</groupId>
       <artifactId>jakarta.activation-api</artifactId>
       <scope>provided</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>jakarta.mail</groupId>
       <artifactId>jakarta.mail-api</artifactId>
       <scope>provided</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -58,13 +56,13 @@
       <artifactId>log4j-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>jakarta.activation</artifactId>
+      <groupId>org.eclipse.angus</groupId>
+      <artifactId>angus-activation</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.mail</groupId>
-      <artifactId>smtp</artifactId>
+      <groupId>org.eclipse.angus</groupId>
+      <artifactId>jakarta.mail</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,8 @@
          Dependency version properties (in alphabetical order)
          ===================================================== -->
     <activemq.version>5.17.3</activemq.version>
+    <angus-activation.version>2.0.0</angus-activation.version>
+    <angus-mail.version>1.1.0</angus-mail.version>
     <assertj.version>3.23.1</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
     <bsh.version>2.0b6</bsh.version>
@@ -341,9 +343,9 @@
     <icu4j.version>72.1</icu4j.version>
     <jackson1.version>1.9.13</jackson1.version>
     <jackson-bom.version>2.14.1</jackson-bom.version>
-    <!-- Implementation of `jakarta.activation-api`: -->
-    <jakarta-activation.version>2.0.1</jakarta-activation.version>
-    <jakarta-mail.version>2.0.1</jakarta-mail.version>
+    <!-- Override the version in Jakarta EE 9 BOM: -->
+    <jakarta-activation.version>2.1.1</jakarta-activation.version>
+    <jakarta-mail.version>2.1.1</jakarta-mail.version>
     <!-- BOM with Jakarta EE 9 APIs: -->
     <jakartaee-bom.version>9.0.0</jakartaee-bom.version>
     <!-- No BOM for Java EE 8 APIs, so we list them separately: -->
@@ -492,6 +494,12 @@
         <groupId>org.apache.activemq</groupId>
         <artifactId>activemq-broker</artifactId>
         <version>${activemq.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.angus</groupId>
+        <artifactId>angus-activation</artifactId>
+        <version>${angus-activation.version}</version>
       </dependency>
 
       <dependency>
@@ -809,9 +817,21 @@
       </dependency>
 
       <dependency>
-        <groupId>com.sun.activation</groupId>
-        <artifactId>jakarta.activation</artifactId>
+        <groupId>jakarta.activation</groupId>
+        <artifactId>jakarta.activation-api</artifactId>
         <version>${jakarta-activation.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.eclipse.angus</groupId>
+        <artifactId>jakarta.mail</artifactId>
+        <version>${angus-mail.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>jakarta.mail</groupId>
+        <artifactId>jakarta.mail-api</artifactId>
+        <version>${jakarta-mail.version}</version>
       </dependency>
 
       <dependency>
@@ -1112,12 +1132,6 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-ext</artifactId>
         <version>${slf4j.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.sun.mail</groupId>
-        <artifactId>smtp</artifactId>
-        <version>${jakarta-mail.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,7 @@
          ===================================================== -->
     <activemq.version>5.17.3</activemq.version>
     <angus-activation.version>2.0.0</angus-activation.version>
-    <angus-mail.version>1.1.0</angus-mail.version>
+    <angus-mail.version>2.0.1</angus-mail.version>
     <assertj.version>3.23.1</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
     <bsh.version>2.0b6</bsh.version>

--- a/src/changelog/.2.x.x/LOG4J2-3554_switch_to_Eclipse_Angus.xml
+++ b/src/changelog/.2.x.x/LOG4J2-3554_switch_to_Eclipse_Angus.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.0.xsd"
+       type="changed">
+  <issue id="LOG4J2-3554" link="https://issues.apache.org/jira/browse/LOG4J2-3554"/>
+  <author name="Oleh Astappiev"/>
+  <author id="pkarwasz"/>
+  <description format="asciidoc">
+      Switch from `com.sun.mail` to Eclipse Angus.
+  </description>
+</entry>


### PR DESCRIPTION
The first Angus Activation releases didn't work on Java 8, since their class names collided with those embedded in the JRE. Since [eclipse-ee4j/angus-activation/11](https://github.com/eclipse-ee4j/angus-activation/pull/11) was solved in version 2.0.0, we can replace the old unmaintained `com.sun.mail` artifacts with Eclipse Angus.

Possible problems:

 * Eclipse Angus has a Jakarta EE 10 baseline (version 2.1 of Jakarta Activation and Mail API). I would prefer to keep a Jakarta EE 9 baseline.
 * Spring Boot's [`spring-boot-starter-mail`](https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-mail/3.0.2) uses Angus, so we probably can ignore the previous point.
 * We need to use the `jakarta.mail` artifact, since Spring Boot does it and nobody likes exclusions.
 * The `angus-activation` artifact must be version 2.0.0 or higher,
 * ~~The `jakarta.mail` artifact must be at most 1.1.0, since 2.0.0 was compiled with Java 9 (cf. [eclipse-ee4j/angus-mail/#76](https://github.com/eclipse-ee4j/angus-mail/issues/76))~~ (fixed in 2.0.1).
