### PR TITLE
[#1229] Disable write access by default

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jmx/LoggerConfigAdminTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jmx/LoggerConfigAdminTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.jmx;
+
+import java.net.URISyntaxException;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class LoggerConfigAdminTest {
+
+    @Test
+    @SetTestProperty(key = Server.PROPERTY_JMX_READ_ONLY, value="true")
+    public void testReadOnly() {
+        final LoggerContext ctx = createLoggerContext();
+        final LoggerConfig config = createLoggerConfig();
+        final LoggerConfigAdminMBean mbean = new LoggerConfigAdmin(ctx, config);
+        assertThrows(UnsupportedOperationException.class, () -> mbean.setAdditive(false));
+        assertThrows(UnsupportedOperationException.class, () -> mbean.setLevel("DEBUG"));
+    }
+
+    @Test
+    @SetTestProperty(key = Server.PROPERTY_JMX_READ_ONLY, value="false")
+    public void testWriteAccess() throws URISyntaxException {
+        final LoggerContext ctx = createLoggerContext();
+        final LoggerConfig config = createLoggerConfig();
+        final LoggerConfigAdminMBean mbean = new LoggerConfigAdmin(ctx, config);
+        verify(ctx).getName();
+        verify(config).getName();
+        assertDoesNotThrow(() -> mbean.setAdditive(false));
+        verify(config).setAdditive(false);
+        verify(ctx).updateLoggers();
+        assertDoesNotThrow(() -> mbean.setLevel("DEBUG"));
+        verify(config).setLevel(Level.DEBUG);
+        verify(ctx, times(2)).updateLoggers();
+        verifyNoMoreInteractions(config);
+        verifyNoMoreInteractions(ctx);
+    }
+
+    private LoggerContext createLoggerContext() {
+        final LoggerContext ctx = mock(LoggerContext.class);
+        when(ctx.getName()).thenReturn(LoggerConfigAdminTest.class.getName());
+        return ctx;
+    }
+
+    private LoggerConfig createLoggerConfig() {
+        final LoggerConfig config = mock(LoggerConfig.class);
+        when(config.getName()).thenReturn(LoggerConfigAdminTest.class.getName());
+        return config;
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jmx/LoggerContextAdminTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jmx/LoggerContextAdminTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.jmx;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class LoggerContextAdminTest {
+
+    @Test
+    @SetTestProperty(key = Server.PROPERTY_JMX_READ_ONLY, value="true")
+    public void testReadOnly() {
+        final LoggerContext ctx = createLoggerContext();
+        final LoggerContextAdminMBean mbean = new LoggerContextAdmin(ctx, null);
+        assertThrows(UnsupportedOperationException.class, () -> mbean.setConfigLocationUri(null));
+        assertThrows(UnsupportedOperationException.class, () -> mbean.setConfigText(null, null));
+    }
+
+    @Test
+    @SetTestProperty(key = Server.PROPERTY_JMX_READ_ONLY, value="false")
+    public void testWriteAccess() throws URISyntaxException {
+        final LoggerContext ctx = createLoggerContext();
+        final LoggerContextAdmin mbean = new LoggerContextAdmin(ctx, null);
+        verify(ctx).getName();
+        verify(ctx).addPropertyChangeListener(mbean);
+        URI location = getClass().getResource("/log4j-console.xml").toURI();
+        assertDoesNotThrow(() -> mbean.setConfigLocationUri(location.toString()));
+        assertDoesNotThrow(() -> mbean.setConfigText("<Configuration><Loggers><Root/></Loggers></Configuration>", "UTF-8"));
+        verify(ctx, times(2)).start(any(Configuration.class));
+        verifyNoMoreInteractions(ctx);
+    }
+
+    private LoggerContext createLoggerContext() {
+        final LoggerContext ctx = mock(LoggerContext.class);
+        when(ctx.getName()).thenReturn(LoggerContextAdminTest.class.getName());
+        return ctx;
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jmx/ServerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/jmx/ServerTest.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.jmx;
 
 import javax.management.ObjectName;
@@ -116,5 +115,10 @@ public class ServerTest {
         assertEquals("\"a\\nc\"", ctxName);
         new ObjectName(String.format(LoggerContextAdminMBean.PATTERN, ctxName));
         // no MalformedObjectNameException = success
+    }
+
+    @Test
+    public void testReadOnlyDefaultValue() {
+        assertThrows(UnsupportedOperationException.class, () -> Server.checkWriteAccess());
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/LoggerConfigAdmin.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/LoggerConfigAdmin.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.core.jmx;
 
 import java.util.List;
 import java.util.Objects;
-
 import javax.management.ObjectName;
 
 import org.apache.logging.log4j.Level;
@@ -78,6 +77,7 @@ public class LoggerConfigAdmin implements LoggerConfigAdminMBean {
 
     @Override
     public void setLevel(final String level) {
+        Server.checkWriteAccess();
         loggerConfig.setLevel(Level.getLevel(level));
         loggerContext.updateLoggers();
     }
@@ -89,6 +89,7 @@ public class LoggerConfigAdmin implements LoggerConfigAdminMBean {
 
     @Override
     public void setAdditive(final boolean additive) {
+        Server.checkWriteAccess();
         loggerConfig.setAdditive(additive);
         loggerContext.updateLoggers();
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/LoggerContextAdmin.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/LoggerContextAdmin.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
-
 import javax.management.MBeanNotificationInfo;
 import javax.management.Notification;
 import javax.management.NotificationBroadcasterSupport;
@@ -117,6 +116,7 @@ public class LoggerContextAdmin extends NotificationBroadcasterSupport implement
 
     @Override
     public void setConfigLocationUri(final String configLocation) throws URISyntaxException, IOException {
+        Server.checkWriteAccess();
         if (configLocation == null || configLocation.isEmpty()) {
             throw new IllegalArgumentException("Missing configuration location");
         }
@@ -191,6 +191,7 @@ public class LoggerContextAdmin extends NotificationBroadcasterSupport implement
 
     @Override
     public void setConfigText(final String configText, final String charsetName) {
+        Server.checkWriteAccess();
         LOGGER.debug("---------");
         LOGGER.debug("Remote request to reconfigure from config text.");
 

--- a/src/changelog/.2.x.x/1229_disable_JMX_write_access.xml
+++ b/src/changelog/.2.x.x/1229_disable_JMX_write_access.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry type="fixed">
+  <issue id="1229" link="https://github.com/apache/logging-log4j2/pull/1229"/>
+  <author id="pkarwasz"/>
+  <description format="asciidoc">
+    Introduces a `log4j2.jmxReadOnly` property to disable JMX write access.
+  </description>
+</entry>


### PR DESCRIPTION
This PR introduces a `log4j2.jmxReadOnly` property with a default value of `true` that disables all JMX setters. This solves #1229.
