### PR TITLE
[LOG4J2-3624] Protects `ServiceLoaderUtil` from unchecked exceptions

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/test/BetterService.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/test/BetterService.java
@@ -14,8 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
+package org.apache.logging.log4j.test;
 
-package org.apache.logging.log4j.util.test;
-
-public class Service1 implements Service {
+public interface BetterService extends Service {
 }

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/test/Service.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/test/Service.java
@@ -14,8 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
+package org.apache.logging.log4j.test;
 
-package org.apache.logging.log4j.util.test;
-
-public interface BetterService extends Service {
+public interface Service {
 }

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/test/Service1.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/test/Service1.java
@@ -14,8 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
+package org.apache.logging.log4j.test;
 
-package org.apache.logging.log4j.util.test;
-
-public class Service2 implements BetterService {
+public class Service1 implements Service {
 }

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/test/Service2.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/test/Service2.java
@@ -14,8 +14,7 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
+package org.apache.logging.log4j.test;
 
-package org.apache.logging.log4j.util.test;
-
-public interface Service {
+public class Service2 implements BetterService {
 }

--- a/log4j-api-test/src/test/resources/META-INF/services/org.apache.logging.log4j.test.BetterService
+++ b/log4j-api-test/src/test/resources/META-INF/services/org.apache.logging.log4j.test.BetterService
@@ -13,14 +13,4 @@
 # See the license for the specific language governing permissions and
 # limitations under the license.
 
-# A correct entry
-org.apache.logging.log4j.util.test.Service1
-
-# Simulates a service retrieved from the server's classloader in a servlet environment.
-java.lang.String
-
-# Simulates a broken service.
-invalid.Service
-
-# Another correct service
-org.apache.logging.log4j.util.test.Service2
+org.apache.logging.log4j.test.Service2

--- a/log4j-api-test/src/test/resources/META-INF/services/org.apache.logging.log4j.test.Service
+++ b/log4j-api-test/src/test/resources/META-INF/services/org.apache.logging.log4j.test.Service
@@ -13,4 +13,19 @@
 # See the license for the specific language governing permissions and
 # limitations under the license.
 
-org.apache.logging.log4j.util.test.Service2
+# A correct entry
+org.apache.logging.log4j.test.Service1
+
+# Simulates a service retrieved from the server's classloader in a servlet environment.
+# The class exists but does not extend org.apache.logging.log4j.test.Service
+org.apache.logging.log4j.Logger
+
+# Simulates a broken service.
+# Should cause a ClassNotFoundError
+invalid.Service
+
+# Causes an exception not caught by ServiceLoader
+org.apache.logging.log4j.test.ForceLinkageError
+
+# Another correct service
+org.apache.logging.log4j.test.Service2

--- a/src/changelog/.2.x.x/LOG4J2-3624_Catch_unchecked_exception_from_ServiceLoader.xml
+++ b/src/changelog/.2.x.x/LOG4J2-3624_Catch_unchecked_exception_from_ServiceLoader.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.0.xsd"
+       type="fixed">
+  <issue id="LOG4J2-3624" link="https://issues.apache.org/jira/browse/LOG4J2-3624"/>
+  <author id="pkarwasz"/>
+  <description format="asciidoc">
+    Protects `ServiceLoaderUtil` from unchecked `ServiceLoader` exceptions.
+  </description>
+</entry>


### PR DESCRIPTION
Contrary to the documentation `ServiceLoader` can also throw unchecked exceptions such as `NoClassDefFoundError` or other `LinkageError`s. This should not prevent `ServiceLoaderUtil` from returning those services, which are not broken. Also `ServiceLoader.iterator().hasNext()` throws on Java 9+.

This PR:
 * add `LinkageError` to the list of `ServiceLoader` exceptions that are logged, but **ignored**,
 * logs and rethrows all other `ServiceLoader` exceptions, including `SecurityException` that users expect to be rethrown (cf. #1006, #1007 and #1008),
 * refactors the tests and adds a case which throws a `LinkageError`,
 * `ServiceLoader` from Java 9+ ignores services, which are specified in a `META-INF/services` file, but are on the modulepath. Therefore we replace the `java.lang.String` test case with a class from the classpath. This solves #1260.