### PR TITLE
Rename POM Log4j* properties

### DIFF
--- a/log4j-distribution/pom.xml
+++ b/log4j-distribution/pom.xml
@@ -660,7 +660,7 @@
               <goal>sign</goal>
             </goals>
             <configuration>
-              <keyname>${Log4jSigningUserName}</keyname>
+              <keyname>${log4jSigningUserName}</keyname>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
     <connection>scm:git:https://github.com/apache/logging-log4j2.git</connection>
     <developerConnection>scm:git:https://github.com/apache/logging-log4j2.git</developerConnection>
     <url>https://github.com/apache/logging-log4j2</url>
-    <tag>log4j-${Log4jReleaseVersion}</tag>
+    <tag>log4j-${log4jReleaseVersion}</tag>
   </scm>
 
   <properties>
@@ -233,12 +233,12 @@
          Release-specific properties
          =========================== -->
     <log4jParentDir>${basedir}</log4jParentDir>
-    <Log4jReleaseVersion>2.20.0</Log4jReleaseVersion>
-    <Log4jReleaseVersionJava7>2.12.4</Log4jReleaseVersionJava7>
-    <Log4jReleaseVersionJava6>2.3.2</Log4jReleaseVersionJava6>
-    <Log4jReleaseManager>Ralph Goers</Log4jReleaseManager>
-    <Log4jReleaseKey>B3D8E1BA</Log4jReleaseKey>
-    <Log4jSigningUserName>rgoers@apache.org</Log4jSigningUserName>
+    <log4jReleaseVersion>2.20.0</log4jReleaseVersion>
+    <log4jReleaseVersionJava7>2.12.4</log4jReleaseVersionJava7>
+    <log4jReleaseVersionJava6>2.3.2</log4jReleaseVersionJava6>
+    <log4jReleaseManager>Ralph Goers</log4jReleaseManager>
+    <log4jReleaseKey>B3D8E1BA</log4jReleaseKey>
+    <log4jSigningUserName>rgoers@apache.org</log4jSigningUserName>
 
     <!-- =================
          Common properties
@@ -1685,14 +1685,12 @@
           <moduleExcludes>
             <xdoc>navigation.xml</xdoc>
           </moduleExcludes>
-          <asciidoc>
-            <attributes>
-              <!-- copy any site properties wanted in asciidoc files -->
-              <Log4jReleaseVersion>${Log4jReleaseVersion}</Log4jReleaseVersion>
-              <Log4jReleaseManager>${Log4jReleaseManager}</Log4jReleaseManager>
-              <Log4jReleaseKey>${Log4jReleaseKey}</Log4jReleaseKey>
-            </attributes>
-          </asciidoc>
+          <attributes>
+            <!-- copy any site properties wanted in asciidoc files -->
+            <Log4jReleaseVersion>${log4jReleaseVersion}</Log4jReleaseVersion>
+            <Log4jReleaseManager>${log4jReleaseManager}</Log4jReleaseManager>
+            <Log4jReleaseKey>${log4jReleaseKey}</Log4jReleaseKey>
+          </attributes>
         </configuration>
         <dependencies>
           <dependency>
@@ -1795,7 +1793,7 @@
               </execution>
             </executions>
             <configuration>
-              <releaseVersion>${Log4jReleaseVersion}</releaseVersion>
+              <releaseVersion>${log4jReleaseVersion}</releaseVersion>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Due to a `maven-bundle-plugin` bug, properties that start with a capital letter end up in the manifest, hence we need to rename them.
