### PR TITLE
Bump Fluido skin from 1.8 to 1.11.2

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -31,7 +31,7 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.8</version>
+    <version>1.11.2</version>
   </skin>
   <body>
     <links>


### PR DESCRIPTION
I don't really see any visual improvements, but there is a practical one: each link is decorated with an anchor icon, so that we can reference documentation more easily.
