### PR TITLE
Set permissions to codeql workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,8 @@ on:
   schedule:
     - cron: '32 12 * * 5'
 
+permissions: read-all
+
 jobs:
 
   analyze:


### PR DESCRIPTION
## Changes
Closes #1289 
- Set codeql workflow top level permission as read-all, according to other workflows' top level permissions.

## Checklist

- [x] Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
- [ ] `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `spotless:apply` and retry)
- [ ] Changes contain an entry file in the `src/changelog/.2.x.x` directory
    > Is it also applicable to this type of changes (on the workflows)?
- [ ] Tests for the changes are provided
- [x] [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
