### PR TITLE
Produce artifacts for reproducible builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,24 +86,16 @@ jobs:
             exit $failed
           fi
 
-      - name: Reports for report build reproducibility
+      - name: Upload reproducibility failure context artifacts
         if: failure() && steps.report-reproducible.outcome == 'failure'
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
-          name: target-artifacts-${{matrix.os}}
-          path: "**/target/*.buildcompare"
-      - name: Artifacts for report build reproducibility
-        if: failure() && steps.report-reproducible.outcome == 'failure'
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
-        with:
-          name: target-artifacts-${{matrix.os}}
-          path: "*/target/*.jar"
-      - name: Artifacts for report build reproducibility
-        if: failure() && steps.report-reproducible.outcome == 'failure'
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
-        with:
-          name: target-artifacts-${{matrix.os}}
-          path: "*/target/reference/*.jar"
+          name: reproducubility-failure-context-${{matrix.os}}
+          path: |
+            **/target/*.buildcompare
+            **/target/*.jar
+            **/target/reference/*.jar
+
       - name: Maven "verify"
         timeout-minutes: 60
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,25 +67,43 @@ jobs:
       # `clean verify artifact:compare` is required to generate the build reproducibility report.
       # For details, see: https://maven.apache.org/guides/mini/guide-reproducible-builds.html#how-to-test-my-maven-build-reproducibility
       - name: Report build reproducibility
+        id: report-reproducible
         timeout-minutes: 10
         shell: bash
         run: |
           ./mvnw \
             --show-version --batch-mode --errors --no-transfer-progress \
             -DskipTests=true \
-            clean verify artifact:compare
-
-      - name: Verify build reproducibility
-        shell: bash
-        run: |
+            clean verify artifact:compare || failed=1
           for report_file in target/*.buildcompare **/target/*.buildcompare; do
             if ! grep -q "^ko=0$" "$report_file"; then
               echo "Spotted build reproducibility failure in \`$report_file\`:"
               cat "$report_file"
-              exit 1
+              failed=1
             fi
           done
+          if [ -n "$failed" ]; then
+            exit $failed
+          fi
 
+      - name: Reports for report build reproducibility
+        if: failure() && steps.report-reproducible.outcome == 'failure'
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        with:
+          name: target-artifacts-${{matrix.os}}
+          path: "**/target/*.buildcompare"
+      - name: Artifacts for report build reproducibility
+        if: failure() && steps.report-reproducible.outcome == 'failure'
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        with:
+          name: target-artifacts-${{matrix.os}}
+          path: "*/target/*.jar"
+      - name: Artifacts for report build reproducibility
+        if: failure() && steps.report-reproducible.outcome == 'failure'
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        with:
+          name: target-artifacts-${{matrix.os}}
+          path: "*/target/reference/*.jar"
       - name: Maven "verify"
         timeout-minutes: 60
         shell: bash


### PR DESCRIPTION
* Merges The two build reproducibility steps
* Adds steps to capture the artifacts from a failed reproducibility

Fixes #1318 

## Checklist

- [x] use `main` otherwise
- [ ] `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `spotless:apply` and retry)
- [ ] Changes contain an entry file in the `src/changelog/.2.x.x` directory
- [ ] Tests for the changes are provided
- [ ] [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
