### PR TITLE
Auto-merge Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,68 @@ updates:
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: monthly
-  open-pull-requests-limit: 50
+    interval: "daily"
+  target-branch: "2.x"
+  ignore:
+    # Jetty 10.x does not have an internal logging API
+    - dependency-name: "org.eclipse.jetty:*"
+      update-types: ["version-update:semver-major"]
+    # EclipseLink 3.x is Jakarta EE 9
+    - dependency-name: "org.eclipse.persitence:*"
+      update-types: ["version-update:semver-major"]
+    # Spring 6.x is Jakarta EE 9
+    - dependency-name: "org.springframework:*"
+      update-types: ["version-update:semver-major"]
+    # Spring Boot 3.x is Jakarta EE 9
+    - dependency-name: "org.springframework.boot:*"
+      update-types: ["version-update:semver-major"]
+    # Spring Cloud 2022.x is Jakarta EE 9
+    - dependency-name: "org.springframework.cloud:*"
+      update-types: ["version-update:semver-major"]
+    # Tomcat Juli 10.1.x requires Java 11
+    - dependency-name: "org.apache.tomcat:*"
+      update-types: ["version-update:semver-major"]
+    # Always update SLF4J manually
+    - dependency-name: "org.slf4j:*"
+    # Keep Logback version 1.2.x
+    - dependency-name: "ch.qos.logback:*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
 - package-ecosystem: github-actions
-  directory: /
+  directory: "/"
   schedule:
-    interval: monthly
-  open-pull-requests-limit: 5
+    interval: "daily"
+  target-branch: "2.x"
+
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: "daily"
+  target-branch: "main"
+  ignore:
+    # Jetty 10.x does not have an internal logging API
+    - dependency-name: "org.eclipse.jetty:*"
+      update-types: ["version-update:semver-major"]
+    # EclipseLink 3.x is Jakarta EE 9
+    - dependency-name: "org.eclipse.persitence:*"
+      update-types: ["version-update:semver-major"]
+    # Spring 6.x is Jakarta EE 9
+    - dependency-name: "org.springframework:*"
+      update-types: ["version-update:semver-major"]
+    # Spring Boot 3.x is Jakarta EE 9
+    - dependency-name: "org.springframework.boot:*"
+      update-types: ["version-update:semver-major"]
+    # Spring Cloud 2022.x is Jakarta EE 9
+    - dependency-name: "org.springframework.cloud:*"
+      update-types: ["version-update:semver-major"]
+    # Always update SLF4J manually
+    - dependency-name: "org.slf4j:*"
+    # Keep Logback version 1.2.x
+    - dependency-name: "ch.qos.logback:*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: "daily"
+  target-branch: "main"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,22 @@ jobs:
             --global-toolchains ".github/workflows/maven-toolchains.xml" \
             site
 
+  merge:
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+    needs: build
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: "[dependabot] Auto-merge the PR"
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   deploy:
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
If the build succeeds, we want to automatically merge Dependabot PRs. Exceptions to the rules should be explicitly written into `dependabot.yml` (i.e. do not close Dependabot PRs, add an exception).

