### PR TITLE
Fix archive links

### DIFF
--- a/src/site/asciidoc/support.adoc
+++ b/src/site/asciidoc/support.adoc
@@ -25,10 +25,10 @@ The individuals who contribute to Apache projects do it either as part of specif
 
 Apache Log4j project officially uses following mailing lists for discussions:
 
-`log4j-user@logging.apache.org` (public | mailto:log4j-user-subscribe@logging.apache.org[subscribe] | mailto:log4j-user-unsubscribe@logging.apache.org[unsubscribe] | mailto:log4j-user@logging.apache.org[post] | https://lists.apache.org/list.html?log4j-user%40logging.apache.org[archive])::
+`log4j-user@logging.apache.org` (public | mailto:log4j-user-subscribe@logging.apache.org[subscribe] | mailto:log4j-user-unsubscribe@logging.apache.org[unsubscribe] | mailto:log4j-user@logging.apache.org[post] | https://lists.apache.org/list.html?log4j-user@logging.apache.org[archive])::
 For _questions_ related to the usage of Log4j components
 
-`dev@logging.apache.org` (public | mailto:dev-subscribe@logging.apache.org[subscribe] | mailto:dev-unsubscribe@logging.apache.org[unsubscribe] | mailto:dev@logging.apache.org[post] | https://lists.apache.org/list.html?dev%40logging.apache.org[archive])::
+`dev@logging.apache.org` (public | mailto:dev-subscribe@logging.apache.org[subscribe] | mailto:dev-unsubscribe@logging.apache.org[unsubscribe] | mailto:dev@logging.apache.org[post] | https://lists.apache.org/list.html?dev@logging.apache.org[archive])::
 For _development_ discussions
 (Please prefix subjects with `[log4j]` when starting a new thread!)
 


### PR DESCRIPTION
The links are broken

![image](https://user-images.githubusercontent.com/2119212/223852907-96b69a78-c6fb-4ed2-b216-8df098b36ac5.png)
![image](https://user-images.githubusercontent.com/2119212/223853050-0ccad2ac-c437-41c5-8121-c88af68b4671.png)


## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `spotless:apply` and retry)
* Changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
