### PR TITLE
Switch the build to JDK 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,12 +49,15 @@ jobs:
         with:
           fetch-depth: 32
 
-      # JDK 8 and 11 is needed for the build.
+      # JDK 11 is used for the build.
+      # JDK 8 is used for the tests.
       # Search `maven-toolchains-plugin` usages for details.
       - name: Setup JDK
         uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2   # 3.12.0
         with:
           distribution: temurin
+          # The last provided Java version will be used and available globally.
+          # Other Java versions can be accessed through environment variables: `JAVA_HOME_<majorVersion>_<architecture>`
           java-version: |
             8
             11
@@ -68,9 +71,10 @@ jobs:
       - name: Build
         timeout-minutes: 60
         shell: bash
-        env:
-          JAVA_HOME: ${{ env.JAVA_HOME_8_X64 }}
-        run: ./mvnw clean install
+        run: |
+          ./mvnw \
+          -Pjava8-tests \
+          clean install
 
       - name: Upload Surefire Reports
         if: failure()
@@ -85,8 +89,6 @@ jobs:
         id: report-reproducible
         timeout-minutes: 10
         shell: bash
-        env:
-          JAVA_HOME: ${{ env.JAVA_HOME_8_X64 }}
         run: |
           ./mvnw \
           -DskipTests=true \
@@ -105,8 +107,6 @@ jobs:
       - name: Build site
         timeout-minutes: 10
         shell: bash
-        env:
-          JAVA_HOME: ${{ env.JAVA_HOME_8_X64 }}
         run: ./mvnw site
 
   merge:
@@ -138,12 +138,15 @@ jobs:
         with:
           fetch-depth: 32
 
-      # JDK 8 and 11 are needed for the build.
+      # JDK 11 is used for the build.
+      # JDK 8 is used for the tests.
       # Search `maven-toolchains-plugin` usages for details.
       - name: Setup JDK
         uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2   # 3.12.0
         with:
           distribution: temurin
+          # The last provided Java version will be used and available globally.
+          # Other Java versions can be accessed through environment variables: `JAVA_HOME_<majorVersion>_<architecture>`
           java-version: |
             8
             11
@@ -173,6 +176,5 @@ jobs:
             -DskipTests=true \
             package install:install deploy:deploy
         env:
-          JAVA_HOME: ${{ env.JAVA_HOME_8_X64 }}
           NEXUS_USER: ${{ secrets.NEXUS_USER }}
           NEXUS_PW: ${{ secrets.NEXUS_PW }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -62,22 +62,17 @@ jobs:
           # Prefix the list here with "+" to use these queries and those in the config file.
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-      # JDK 8 and 11 is needed for the build.
-      # Search `maven-toolchains-plugin` usages for details.
+      # JDK 11 is used for the build.
       - name: Setup JDK
         uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2   # 3.12.0
         with:
           distribution: temurin
-          java-version: |
-            8
-            11
+          java-version: 11
           cache: maven
 
       - name: Build with Maven
         timeout-minutes: 60
         shell: bash
-        env:
-          JAVA_HOME: ${{ env.JAVA_HOME_8_X64 }}
         run: |
           ./mvnw \
           --show-version --batch-mode --errors --no-transfer-progress \

--- a/.github/workflows/log4j-kafka-test.yml
+++ b/.github/workflows/log4j-kafka-test.yml
@@ -41,7 +41,9 @@ jobs:
         uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2   # 3.12.0
         with:
           distribution: temurin
-          java-version: 8
+          java-version: |
+            8
+            11
           java-package: jdk
           architecture: x64
           cache: maven
@@ -58,4 +60,5 @@ jobs:
             --show-version --batch-mode --errors --no-transfer-progress --fail-at-end \
             -Dkafka.version=${{ matrix.version }} \
             -pl log4j-core-test -Dtest=Kafka*Test \
+            -P java8-tests \
             test

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -17,30 +17,23 @@
 
 # Requirements
 
-* JDK 8 and 9+
-* Apache Maven 3.x
+* JDK 11+
+* JDK 8 (optional)
+* Apache Maven 3.x (optional)
 * A modern Linux, OSX, or Windows host
-
-<a name="toolchains"></a>
-# Configuring Maven Toolchains
-
-Maven Toolchains is used to employ multiple JDKs required for compilation.
-You either need to have a user-level configuration in `~/.m2/toolchains.xml` or explicitly provide one to the Maven: `./mvnw --global-toolchains /path/to/toolchains.xml`.
-See [`.github/workflows/maven-toolchains.xml`](.github/workflows/maven-toolchains.xml) used by CI for a sample Maven Toolchains configuration.
-Note that this file requires `JAVA_HOME_8_X64` and `JAVA_HOME_11_X64` environment variables to be defined, though these can very well be hardcoded.
 
 <a name="building"></a>
 # Building the sources
 
 You can build and verify the sources as follows:
-
-    ./mvnw verify
-
+```sh
+./mvnw verify
+```
 `verify` goal runs validation and test steps next to building (i.e., compiling) the sources.
 To speed up the build, you can skip verification:
-
-    ./mvnw -DskipTests package
-
+```sh
+./mvnw -DskipTests package
+```
 If you want to install generated artifacts to your local Maven repository, replace above `verify` and/or `package` goals with `install`.
 
 <a name="dns"></a>
@@ -50,16 +43,46 @@ Note that if your `/etc/hosts` file does not include an entry for your computer'
 many unit tests may execute slow due to DNS lookups to translate your hostname to an IP address in
 [`InetAddress.getLocalHost()`](http://docs.oracle.com/javase/7/docs/api/java/net/InetAddress.html#getLocalHost()).
 To remedy this, you can execute the following:
+```sh
+printf '127.0.0.1 %s\n::1 %s\n' `hostname` `hostname` | sudo tee -a /etc/hosts
+```
 
-    printf '127.0.0.1 %s\n::1 %s\n' `hostname` `hostname` | sudo tee -a /etc/hosts
+<a name="java8-tests"></a>
+# Java 8 tests
+
+To test the library against the target JRE (JRE 8), you need to configure a JDK 8 toolchains as explained below and run Maven with the `java8-tests` profile:
+```sh
+./mvnw verify -Pjava8-tests
+```
+
+<a name="toolchains"></a>
+## Configuring Maven Toolchains
+
+Maven Toolchains is used to employ additional JDKs required for tests.
+You either need to have a user-level configuration in `~/.m2/toolchains.xml` or explicitly provide one to the Maven: `./mvnw --global-toolchains /path/to/toolchains.xml`.
+```xml
+<?xml version="1.0" encoding="UTF8"?>
+<toolchains>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>1.8.0_372</version>
+    </provides>
+    <configuration>
+      <jdkHome>/usr/lib/jvm/java-8-openjdk-amd64</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>
+```
 
 <a name="website"></a>
 # Building the website and manual
 
 You can build the website and manual as follows:
-
-    ./mvnw site
-
+```sh
+./mvnw site
+```
 And view it using a simple HTTP server, e.g., the one comes with the Python:
-
-    python3 -m http.server -d target/site
+```sh
+python3 -m http.server -d target/site
+```

--- a/log4j-api-java9/pom.xml
+++ b/log4j-api-java9/pom.xml
@@ -31,6 +31,7 @@
     <docLabel>API Documentation</docLabel>
     <projectDir>/api</projectDir>
     <maven.deploy.skip>true</maven.deploy.skip>
+    <maven.compiler.release>9</maven.compiler.release>
   </properties>
   <dependencies>
     <dependency>
@@ -65,6 +66,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -77,15 +79,7 @@
             <goals>
               <goal>compile</goal>
             </goals>
-            <phase>compile</phase>
-            <configuration>
-              <jdkToolchain>
-                <version>[9, )</version>
-              </jdkToolchain>
-              <release>9</release>
-            </configuration>
           </execution>
-          <!-- We explicitly compile tests using Java 8 to work around SUREFIRE-2073 -->
           <execution>
             <id>default-test-compile</id>
             <goals>
@@ -93,46 +87,41 @@
             </goals>
             <phase>test-compile</phase>
           </execution>
-          <!-- Of course the 'module-info.java' needs Java 9 -->
-          <execution>
-            <id>test-compile-module</id>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <phase>test-compile</phase>
-            <configuration>
-              <jdkToolchain>
-                <version>[9, )</version>
-              </jdkToolchain>
-              <release>9</release>
-              <compileSourceRoots>
-                <compileSourceRoot>${project.basedir}/src/test/java9</compileSourceRoot>
-              </compileSourceRoots>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <java.awt.headless>true</java.awt.headless>
-          </systemPropertyVariables>
-          <jdkToolchain>
-            <version>[9, )</version>
-          </jdkToolchain>
-        </configuration>
         <executions>
           <execution>
             <id>test</id>
             <goals>
               <goal>test</goal>
             </goals>
-            <phase>test</phase>
           </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>java8-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration combine.self="override">
+              <reuseForks>false</reuseForks>
+              <systemPropertyVariables>
+                <java.awt.headless>true</java.awt.headless>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/ModuleUtil.java
+++ b/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/ModuleUtil.java
@@ -1,18 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
+ * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache license, Version 2.0
+ * The ASF licenses this file to you under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the license for the specific language governing permissions and
- * limitations under the license.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.logging.log4j.util.java9;
 

--- a/log4j-api-test/pom.xml
+++ b/log4j-api-test/pom.xml
@@ -106,6 +106,7 @@
   </dependencies>
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -117,24 +118,7 @@
           </instructions>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>default-compile</id>
-            <!-- recompile everything for target VM except the module-info.java -->
-            <configuration>
-              <source>1.8</source>
-              <target>1.8</target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
@@ -164,6 +148,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -172,6 +157,7 @@
           <excludedGroups>performance,smoke</excludedGroups>
         </configuration>
       </plugin>
+
     </plugins>
   </build>
 </project>

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/MessageFormatMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/MessageFormatMessageTest.java
@@ -20,17 +20,22 @@ import java.util.Locale;
 
 import org.apache.logging.log4j.test.junit.Mutable;
 import org.apache.logging.log4j.util.Constants;
+import org.assertj.core.presentation.UnicodeRepresentation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
 public class MessageFormatMessageTest {
 
-    private static final String SPACE = Constants.JAVA_MAJOR_VERSION < 9 ? " " : "\u00a0";
+    private static final char SPACE = ' ';
+    private static final char NB_SPACE = '\u00a0';
+    private static final char NARROW_NB_SPACE = '\u202f';
 
     private static final int LOOP_CNT = 500;
     String[] array = new String[LOOP_CNT];
@@ -72,8 +77,10 @@ public class MessageFormatMessageTest {
         final String testMsg = "Test message {0,number,currency}";
         final MessageFormatMessage msg = new MessageFormatMessage(Locale.FRANCE, testMsg, 1234567890);
         final String result = msg.getFormattedMessage();
-        final String expected = "Test message 1 234 567 890,00" + SPACE + "€";
-        assertEquals(expected, result);
+        final char separator = Constants.JAVA_MAJOR_VERSION < 9 ? SPACE : NB_SPACE;
+        final char groupingSeparator = Constants.JAVA_MAJOR_VERSION < 17 ? NB_SPACE : NARROW_NB_SPACE;
+        assertThat(result).withRepresentation(UnicodeRepresentation.UNICODE_REPRESENTATION)
+                .isEqualTo("Test message 1%1$c234%1$c567%1$c890,00%2$c€", groupingSeparator, separator);
     }
 
     @Test

--- a/log4j-core-java9/pom.xml
+++ b/log4j-core-java9/pom.xml
@@ -55,33 +55,6 @@
   </dependencies>
   <build>
     <plugins>
-      <!-- There are no test for now.
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>test</id>
-            <phase>test</phase>
-            <goals>
-              <goal>test</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <systemPropertyVariables>
-            <java.awt.headless>true</java.awt.headless>
-          </systemPropertyVariables>
-          <includes>
-            <include>**/Test*.java</include>
-            <include>**/*Test.java</include>
-          </includes>
-          <excludes>
-            <exclude>**/*FuncTest.java</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-      -->
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
@@ -101,6 +74,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -111,24 +85,6 @@
               <goal>compile</goal>
             </goals>
             <phase>compile</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-toolchains-plugin</artifactId>
-        <configuration>
-          <toolchains>
-            <jdk>
-              <version>[9, )</version>
-            </jdk>
-          </toolchains>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>toolchain</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>

--- a/log4j-core-test/pom.xml
+++ b/log4j-core-test/pom.xml
@@ -436,6 +436,7 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <excludedGroups>org.apache.logging.log4j.categories.PerformanceTests</excludedGroups>
@@ -446,23 +447,4 @@
       </plugin>
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>java9-tests</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <argLine>--illegal-access=warn</argLine>
-              <jdkToolchain>
-                <version>[9, )</version>
-              </jdkToolchain>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/GcFreeLoggingTestUtil.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/GcFreeLoggingTestUtil.java
@@ -49,6 +49,7 @@ public enum GcFreeLoggingTestUtil {;
         System.setProperty("log4j2.enable.direct.encoders", "true");
         System.setProperty("log4j2.is.webapp", "false");
         System.setProperty("log4j.configurationFile", configurationFile);
+        System.setProperty("log4j2.clock", "SystemMillisClock");
 
         assertTrue(Constants.ENABLE_THREADLOCALS, "Constants.ENABLE_THREADLOCALS");
         assertTrue(Constants.ENABLE_DIRECT_ENCODERS, "Constants.ENABLE_DIRECT_ENCODERS");

--- a/log4j-docker/pom.xml
+++ b/log4j-docker/pom.xml
@@ -30,8 +30,6 @@
     <log4jParentDir>${basedir}/..</log4jParentDir>
     <docLabel>Log4j Docker Library Documentation</docLabel>
     <projectDir>/docker</projectDir>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
     <module.name>org.apache.logging.log4j.docker</module.name>
   </properties>
   <dependencies>
@@ -64,34 +62,10 @@
   </dependencies>
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-toolchains-plugin</artifactId>
-        <configuration>
-          <toolchains>
-            <jdk>
-              <version>[8, )</version>
-            </jdk>
-          </toolchains>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>toolchain</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>

--- a/log4j-jmx-gui/pom.xml
+++ b/log4j-jmx-gui/pom.xml
@@ -30,7 +30,6 @@
     <log4jParentDir>${basedir}/..</log4jParentDir>
     <docLabel>JMX GUI Documentation</docLabel>
     <projectDir>/jmx-gui</projectDir>
-    <jenkins.java.home>/home/jenkins/tools/java/latest1.7</jenkins.java.home>
     <module.name>org.apache.logging.log4j.jmx.gui</module.name>
   </properties>
   <dependencies>
@@ -55,75 +54,36 @@
   </dependencies>
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <configuration>
-          <instructions>
-            <Fragment-Host>org.apache.logging.log4j.core</Fragment-Host>
-            <Export-Package>org.apache.logging.log4j.jmx.gui</Export-Package>
-          </instructions>
-        </configuration>
+        <executions>
+          <execution>
+            <phase>none</phase>
+          </execution>
+        </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <!-- Exclude dummy classes -->
+            <configuration>
+              <archive>
+                <manifestFile combine.self="override" />
+              </archive>
+              <excludes>
+                <exclude>com/**</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
-  <profiles>
-    <profile>
-      <id>default-jmx-profile</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-        <file>
-          <exists>${java.home}/../lib/jconsole.jar</exists>
-        </file>
-      </activation>
-      <properties>
-        <toolsjar>${java.home}/../lib/jconsole.jar</toolsjar>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>com.sun</groupId>
-          <artifactId>jconsole</artifactId>
-          <scope>system</scope>
-          <systemPath>${java.home}/../lib/jconsole.jar</systemPath>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>mac-profile</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-        <file>
-          <exists>${java.home}/../Classes/jconsole.jar</exists>
-        </file>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>com.sun</groupId>
-          <artifactId>jconsole</artifactId>
-          <scope>system</scope>
-          <systemPath>${java.home}/../Classes/jconsole.jar</systemPath>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <id>jenkins-profile</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-        <property>
-          <name>jenkins</name>
-        </property>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>com.sun</groupId>
-          <artifactId>jconsole</artifactId>
-          <scope>system</scope>
-          <systemPath>${jenkins.java.home}/lib/jconsole.jar</systemPath>
-          <optional>true</optional>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>

--- a/log4j-jmx-gui/src/main/java/com/sun/tools/jconsole/JConsoleContext.java
+++ b/log4j-jmx-gui/src/main/java/com/sun/tools/jconsole/JConsoleContext.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.sun.tools.jconsole;
+
+import javax.management.MBeanServerConnection;
+
+/**
+ * Dummy class to allow to compile the JMX plugin without `jconsole.jar`.
+ */
+public interface JConsoleContext {
+
+    public MBeanServerConnection getMBeanServerConnection();
+}

--- a/log4j-jmx-gui/src/main/java/com/sun/tools/jconsole/JConsolePlugin.java
+++ b/log4j-jmx-gui/src/main/java/com/sun/tools/jconsole/JConsolePlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.sun.tools.jconsole;
+
+import java.util.Map;
+
+import javax.swing.JPanel;
+import javax.swing.SwingWorker;
+
+/**
+ * Dummy class to allow to compile the JMX plugin without `jconsole.jar`.
+ */
+public abstract class JConsolePlugin {
+
+    public abstract Map<String, JPanel> getTabs();
+
+    public final JConsoleContext getContext() {
+        return null;
+    }
+
+    public abstract SwingWorker<?, ?> newSwingWorker();
+}

--- a/log4j-jpl/pom.xml
+++ b/log4j-jpl/pom.xml
@@ -30,8 +30,7 @@
   <properties>
     <log4jParentDir>${basedir}/..</log4jParentDir>
     <module.name>org.apache.logging.log4j.jpl</module.name>
-    <!-- Do not upgrade until https://issues.apache.org/jira/browse/SUREFIRE-2073 is fixed -->
-    <surefire.version>2.13</surefire.version>
+    <maven.compiler.release>11</maven.compiler.release>
   </properties>
 
   <dependencies>
@@ -68,6 +67,7 @@
 
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -78,92 +78,24 @@
           </instructions>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>11</source>
-          <target>11</target>
-          <release>11</release>
-          <proc>none</proc>
-          <!-- disable errorprone -->
-          <compilerId>javac</compilerId>
-        </configuration>
-        <executions>
-          <execution>
-            <id>default-compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <phase>compile</phase>
-          </execution>
-          <execution>
-            <id>default-testCompile</id>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <phase>test-compile</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <excludes combine.self="override" />
-        </configuration>
-        <executions>
-          <execution>
-            <id>test</id>
-            <goals>
-              <goal>test</goal>
-            </goals>
-            <phase>test</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-toolchains-plugin</artifactId>
-        <configuration>
-          <toolchains>
-            <jdk>
-              <version>[11, )</version>
-            </jdk>
-          </toolchains>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>toolchain</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+
     </plugins>
   </build>
+
   <profiles>
     <profile>
-      <id>java11-module</id>
-      <activation>
-        <jdk>[11,)</jdk>
-      </activation>
+      <id>java8-tests</id>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <!-- Disable forked VM as 2.21 yields https://issues.apache.org/jira/browse/SUREFIRE-720 -->
-            <configuration combine.self="override" />
-            <executions>
-              <execution>
-                <id>test</id>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-                <phase>test</phase>
-              </execution>
-            </executions>
+            <configuration combine.self="override">
+              <reuseForks>false</reuseForks>
+              <systemPropertyVariables>
+                <java.awt.headless>true</java.awt.headless>
+              </systemPropertyVariables>
+            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/log4j-kubernetes/pom.xml
+++ b/log4j-kubernetes/pom.xml
@@ -30,8 +30,6 @@
     <log4jParentDir>${basedir}/..</log4jParentDir>
     <docLabel>Log4j Kubernetes Library Documentation</docLabel>
     <projectDir>/kubernetes</projectDir>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
     <module.name>org.apache.logging.log4j.kubernetes</module.name>
   </properties>
   <dependencies>
@@ -61,35 +59,12 @@
   </dependencies>
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
-      <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-toolchains-plugin</artifactId>
-        <configuration>
-          <toolchains>
-            <jdk>
-              <version>[8, )</version>
-            </jdk>
-          </toolchains>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>toolchain</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/GcpLayoutTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/GcpLayoutTest.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.logging.log4j.layout.template.json.TestHelpers.CONFIGURATION;
+import static org.apache.logging.log4j.layout.template.json.TestHelpers.JAVA_BASE_PREFIX;
 import static org.apache.logging.log4j.layout.template.json.TestHelpers.usingSerializedLogEventAccessor;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,7 +89,7 @@ class GcpLayoutTest {
                         .contains(logEvent.getMessage().getFormattedMessage())
                         .contains(exception.getLocalizedMessage())
                         .contains("at org.apache.logging.log4j.layout.template.json")
-                        .contains("at java.lang.reflect.Method")
+                        .contains("at " + JAVA_BASE_PREFIX + "java.lang.reflect.Method")
                         .contains("at org.junit.platform.engine");
             }
 
@@ -158,7 +159,7 @@ class GcpLayoutTest {
                         new String[]{"_exception", "stackTrace"}))
                         .contains(exception.getLocalizedMessage())
                         .contains("at org.apache.logging.log4j.layout.template.json")
-                        .contains("at java.lang.reflect.Method")
+                        .contains("at " + JAVA_BASE_PREFIX + "java.lang.reflect.Method")
                         .contains("at org.junit.platform.engine");
 
             } else {

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutGcFreeTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutGcFreeTest.java
@@ -35,6 +35,7 @@ public class JsonTemplateLayoutGcFreeTest {
     public static void main(final String[] args) throws Exception {
         System.setProperty("log4j.layout.jsonTemplate.recyclerFactory", "threadLocal");
         System.setProperty("log4j2.garbagefree.threadContextMap", "true");
+        System.setProperty("log4j2.clock", "SystemMillisClock");
         GcFreeLoggingTestUtil.executeLogging(
                 "gcFreeJsonTemplateLayoutLogging.xml",
                 JsonTemplateLayoutGcFreeTest.class);

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/TestHelpers.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/TestHelpers.java
@@ -35,10 +35,13 @@ import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.layout.template.json.util.JsonReader;
 import org.apache.logging.log4j.layout.template.json.util.JsonWriter;
 import org.apache.logging.log4j.layout.template.json.util.MapAccessor;
+import org.apache.logging.log4j.util.Constants;
 
 public final class TestHelpers {
 
     public static final Configuration CONFIGURATION = new DefaultConfiguration();
+
+    public static final String JAVA_BASE_PREFIX = Constants.JAVA_MAJOR_VERSION > 8 ? "java.base/" : "";
 
     private static final JsonWriter JSON_WRITER = JsonWriter
             .newBuilder()

--- a/log4j-perf/pom.xml
+++ b/log4j-perf/pom.xml
@@ -34,10 +34,10 @@
     <docLabel>Apache Log4J Performance Tests</docLabel>
     <projectDir>/log4j-perf</projectDir>
     <uberjar.name>benchmarks</uberjar.name>
-    <maven.deploy.skip>true</maven.deploy.skip>
-    <maven.install.skip>true</maven.install.skip>
     <maven.test.skip>true</maven.test.skip>
     <module.name>org.apache.logging.log4j.perf</module.name>
+    <maven.compiler.release>9</maven.compiler.release>
+    <surefire.jdkToolchain>[9, )</surefire.jdkToolchain>
   </properties>
 
   <dependencies>
@@ -141,6 +141,7 @@
 
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -150,15 +151,7 @@
           </instructions>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerVersion>9</compilerVersion>
-          <source>9</source>
-          <target>9</target>
-        </configuration>
-      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
@@ -208,24 +201,7 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-toolchains-plugin</artifactId>
-        <configuration>
-          <toolchains>
-            <jdk>
-              <version>[11, )</version>
-            </jdk>
-          </toolchains>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>toolchain</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/log4j-spring-boot/pom.xml
+++ b/log4j-spring-boot/pom.xml
@@ -116,6 +116,7 @@
   </dependencies>
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -126,48 +127,7 @@
           </instructions>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-        <executions>
-          <execution>
-            <id>default-compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <phase>compile</phase>
-          </execution>
-          <execution>
-            <id>default-test-compile</id>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <phase>test-compile</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-toolchains-plugin</artifactId>
-        <configuration>
-          <toolchains>
-            <jdk>
-              <version>[8, )</version>
-            </jdk>
-          </toolchains>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>toolchain</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-client/pom.xml
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-client/pom.xml
@@ -89,6 +89,7 @@
   </dependencies>
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
@@ -99,48 +100,7 @@
           </instructions>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-        <executions>
-          <execution>
-            <id>default-compile</id>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <phase>compile</phase>
-          </execution>
-          <execution>
-            <id>default-test-compile</id>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <phase>test-compile</phase>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-toolchains-plugin</artifactId>
-        <configuration>
-          <toolchains>
-            <jdk>
-              <version>[8, )</version>
-            </jdk>
-          </toolchains>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>toolchain</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -304,8 +304,10 @@
          Common properties
          ================= -->
     <manifestfile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestfile>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
+    <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
+    <!-- JDK version of the main Maven process (used in ASF parent POM) -->
+    <minimalJavaBuildVersion>[11, )</minimalJavaBuildVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Fixed `project.build.outputTimestamp` is required for reproducible builds: https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
     <project.build.outputTimestamp>1676697577</project.build.outputTimestamp>
@@ -1381,8 +1383,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <source>${maven.compiler.source}</source>
-            <target>${maven.compiler.target}</target>
+            <release>${maven.compiler.release}</release>
             <parameters>true</parameters>
             <showDeprecation>true</showDeprecation>
             <showWarnings>true</showWarnings>
@@ -1544,6 +1545,7 @@
             <exclude>**/rabbitmq.config</exclude>
             <exclude>**/MANIFEST.MF</exclude>
             <exclude>.surefire-*</exclude>
+            <exclude>.mvn/jvm.config</exclude>
             <!-- License headers in GitHub templates pollute the prompt displayed to the user: -->
             <exclude>.github/ISSUE_TEMPLATE/*.md</exclude>
             <exclude>.github/pull_request_template.md</exclude>
@@ -1613,35 +1615,12 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <java.awt.headless>true</java.awt.headless>
-          </systemPropertyVariables>
-          <argLine>-Xms256m -Xmx1024m</argLine>
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
-          <encoding>UTF-8</encoding>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <reuseForks>false</reuseForks>
           <systemPropertyVariables>
             <java.awt.headless>true</java.awt.headless>
           </systemPropertyVariables>
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
         </configuration>
       </plugin>
 
@@ -1916,6 +1895,23 @@
       <properties>
         <javadoc.opts>-Xdoclint:none</javadoc.opts>
       </properties>
+    </profile>
+
+    <profile>
+      <id>java8-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <jdkToolchain>
+                <version>[1.8, 9)</version>
+              </jdkToolchain>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
   </profiles>


### PR DESCRIPTION
This switches the build to use JDK 17 with `--release 8` (or whatever is appropriate for the module).

JDK 8 is still required for:

 * running tests under the `java8-tests` profile,
 * <s>providing `jconsole.jar` for `log4j-jmx-gui`</s>.

<s>To compile `log4j-jmx-gui` running JDK 17 a `JAVA_HOME_8_X64` environment variable must be provided and contain the location of the JDK 8 installation.</s>