### PR TITLE
[log4j-to-slf4j] Adapt OSGi metadata to work with slf4j 1 and 2

### DIFF
--- a/log4j-to-slf4j/pom.xml
+++ b/log4j-to-slf4j/pom.xml
@@ -31,6 +31,7 @@
     <docLabel>SLF4J Documentation</docLabel>
     <projectDir>/log4j-to-slf4j</projectDir>
     <module.name>org.apache.logging.slf4j</module.name>
+    <slf4j.support.bound>3</slf4j.support.bound>
   </properties>
   <dependencies>
     <dependency>
@@ -97,6 +98,7 @@
           <instructions>
             <Bundle-Activator>org.apache.logging.slf4j.Activator</Bundle-Activator>
             <Export-Package>org.apache.logging.slf4j</Export-Package>
+            <Import-Package>org.slf4j*;version="${range;[==,${slf4j.support.bound})}",*</Import-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/src/changelog/.2.x.x/1232_log4j-to-sfl4j-2-OSGiMetadata.xml
+++ b/src/changelog/.2.x.x/1232_log4j-to-sfl4j-2-OSGiMetadata.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.0.xsd"
+       type="fixed">
+  <issue id="1232" link="https://github.com/apache/logging-log4j2/issues/1232"/>
+  <author id="hanneswell"/>
+  <author name="Hannes Wellmann"/>
+  <description format="asciidoc">
+    Adapt the OSGi metadata of log4j-to-slf4j to work with slf4j 1 and 2.
+    To achieve that use a version range of `[1.7,3)` for the imported slf4j packages.	
+  </description>
+</entry>


### PR DESCRIPTION
Use the version range `[1.7,3)` for the imported slf4j packages.
See also https://bnd.bndtools.org/macros/range.html

This changes the generated OSGi `Import-Package` entries in the MANIFEST.MF from
```
Import-Package:
 org.apache.logging.log4j;version="[2.20,3)",
 org.apache.logging.log4j.message;version="[2.20,3)",
 org.apache.logging.log4j.spi;version="[2.20,3)",
 org.apache.logging.log4j.status;version="[2.20,3)",
 org.apache.logging.log4j.util;version="[2.20,3)",
 org.slf4j;version="[1.7,2)",
 org.slf4j.spi;version="[1.7,2)"
```
to 
```
Import-Package:
 org.slf4j;version="[1.7,3)",
 org.slf4j.spi;version="[1.7,3)",
 org.apache.logging.log4j;version="[2.20,3)",
 org.apache.logging.log4j.message;version="[2.20,3)",
 org.apache.logging.log4j.spi;version="[2.20,3)",
 org.apache.logging.log4j.status;version="[2.20,3)",
 org.apache.logging.log4j.util;version="[2.20,3)"
```
Besides the order, which is irrelevant, only the import package version is changed to [1.7,3) as desired.

I also created a change-log entry as requested by the checklist and hope that is fine.


@ppkarwasz please let me know if any changes are required. Thank you.

Fixes https://github.com/apache/logging-log4j2/issues/1232

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `spotless:apply` and retry)
* Changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
