### PR TITLE
Fixed logging of java.sql.Date

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
@@ -26,6 +26,7 @@ import static java.lang.Character.toLowerCase;
 public final class StringBuilders {
 
     private static final Class<?> timeClass;
+    private static final Class<?> dateClass;
 
     static {
         Class<?> clazz;
@@ -35,6 +36,13 @@ public final class StringBuilders {
             clazz = null;
         }
         timeClass = clazz;
+
+        try {
+            clazz = Class.forName("java.sql.Date");
+        } catch(ClassNotFoundException ex) {
+            clazz = null;
+        }
+        dateClass = clazz;
     }
 
     private StringBuilders() {
@@ -110,7 +118,7 @@ public final class StringBuilders {
             stringBuilder.append(((Float) obj).floatValue());
         } else if (obj instanceof Byte) {
             stringBuilder.append(((Byte) obj).byteValue());
-        } else if (isTime(obj) || obj instanceof java.time.temporal.Temporal) {
+        } else if (isTime(obj) || isDate(obj) || obj instanceof java.time.temporal.Temporal) {
             stringBuilder.append(obj);
         } else {
             return false;
@@ -119,12 +127,18 @@ public final class StringBuilders {
     }
 
     /*
-        Check to see if obj is an instance of java.sql.time without requiring the java.sql module.
+        Check to see if obj is an instance of java.sql.Time without requiring the java.sql module.
      */
     private static boolean isTime(final Object obj) {
         return timeClass != null && timeClass.isAssignableFrom(obj.getClass());
     }
 
+    /*
+        Check to see if obj is an instance of java.sql.Date without requiring the java.sql module.
+    */
+    private static boolean isDate(final Object obj) {
+        return dateClass != null && dateClass.isAssignableFrom(obj.getClass());
+    }
 
     /**
      * Returns true if the specified section of the left CharSequence equals the specified section of the right

--- a/src/changelog/.2.x.x/1366_fix_java_sql_date.xml
+++ b/src/changelog/.2.x.x/1366_fix_java_sql_date.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="fixed">
+  <issue id="1366" link="https://github.com/apache/logging-log4j2/pull/1366"/>
+  <author id="Hikarikun92"/>
+  <author name="Lucas Souza"/>
+  <description format="asciidoc">
+    Fixed logging of java.sql.Date objects by appending it before Log4J tries to call java.util.Date.toInstant() on it.
+  </description>
+</entry>


### PR DESCRIPTION
Fixed logging of java.sql.Date objects by appending it before Log4J tries to call java.util.Date.toInstant() on it (see #1366).

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `spotless:apply` and retry)
* Changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
