### PR TITLE
[#1389] Added missing setter for connectionStringSource in MongoDb4Provider

### DIFF
--- a/log4j-mongodb4/src/main/java/org/apache/logging/log4j/mongodb4/MongoDb4Provider.java
+++ b/log4j-mongodb4/src/main/java/org/apache/logging/log4j/mongodb4/MongoDb4Provider.java
@@ -59,6 +59,11 @@ public final class MongoDb4Provider implements NoSqlProvider<MongoDb4Connection>
             return new MongoDb4Provider(connectionStringSource, capped, collectionSize);
         }
 
+        public B setConnectionStringSource(final String connectionStringSource) {
+            this.connectionStringSource = connectionStringSource;
+            return asBuilder();
+        }
+
         public B setCapped(final boolean isCapped) {
             this.capped = isCapped;
             return asBuilder();

--- a/src/changelog/.2.x.x/1389_Added_missing_setter_for_connectionStringSource_in_MongoDb4Provider.xml
+++ b/src/changelog/.2.x.x/1389_Added_missing_setter_for_connectionStringSource_in_MongoDb4Provider.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="fixed">
+    <issue id="1389" link="https://github.com/apache/logging-log4j2/issues/1389"/>
+    <author id="ihordz"/>
+    <description format="asciidoc">Added missing setter for `connectionStringSource` in `MongoDb4Provider` to have ability to create MongoDB4 provider programmatically</description>
+</entry>

--- a/src/changelog/.2.x.x/1389_Added_missing_setter_for_connectionStringSource_in_MongoDb4Provider.xml
+++ b/src/changelog/.2.x.x/1389_Added_missing_setter_for_connectionStringSource_in_MongoDb4Provider.xml
@@ -20,6 +20,7 @@
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
        type="fixed">
     <issue id="1389" link="https://github.com/apache/logging-log4j2/issues/1389"/>
-    <author id="ihordz"/>
-    <description format="asciidoc">Added missing setter for `connectionStringSource` in `MongoDb4Provider` to have ability to create MongoDB4 provider programmatically</description>
+    <author id="ihordz" name="Ihor Dziuba"/>
+    <author id="vy"/>
+    <description format="asciidoc">Added missing setter for `connectionStringSource` in `MongoDb4Provider` builder</description>
 </entry>


### PR DESCRIPTION
Added missing setter for `connectionStringSource` in `MongoDb4Provider` to have ability to create MongoDB4 provider programmatically

Fixes https://github.com/apache/logging-log4j2/issues/1389
