### PR TITLE
fix: fix NPE in PluginElementVisitor findNamedNode

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginElementVisitor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginElementVisitor.java
@@ -98,13 +98,12 @@ public class PluginElementVisitor extends AbstractPluginVisitor<PluginElement> {
     private Node findNamedNode(final String name, final Iterable<Node> children) {
         for (final Node child : children) {
             final PluginType<?> childType = child.getType();
-            if (childType == null) {
-                //System.out.println();
-            }
-            if (name.equalsIgnoreCase(childType.getElementName()) ||
-                this.conversionType.isAssignableFrom(childType.getPluginClass())) {
-                // FIXME: check child.getObject() for null?
-                // doing so would be more consistent with the array version
+            boolean elementNameMatch = childType != null && name.equalsIgnoreCase(childType.getElementName());
+            boolean isAssignableByPluginClass = childType != null &&
+                    this.conversionType.isAssignableFrom(childType.getPluginClass());
+            // FIXME: check child.getObject() for null?
+            // doing so would be more consistent with the array version
+            if (elementNameMatch || isAssignableByPluginClass) {
                 return child;
             }
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginElementVisitor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginElementVisitor.java
@@ -101,8 +101,6 @@ public class PluginElementVisitor extends AbstractPluginVisitor<PluginElement> {
             boolean elementNameMatch = childType != null && name.equalsIgnoreCase(childType.getElementName());
             boolean isAssignableByPluginClass = childType != null &&
                     this.conversionType.isAssignableFrom(childType.getPluginClass());
-            // FIXME: check child.getObject() for null?
-            // doing so would be more consistent with the array version
             if (elementNameMatch || isAssignableByPluginClass) {
                 return child;
             }


### PR DESCRIPTION
If "childType" is null, then the "if" block just get's skipped and on line 104 nullpointer will be called for `childType.getElement` command. 

This PR fixes the #1391 issue. 