### PR TITLE
Add discard buffer to prevent unsychronized access when RingBuffer almost full

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLogger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLogger.java
@@ -226,7 +226,7 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
     }
 
     private void publish(final RingBufferLogEventTranslator translator) {
-        if (!loggerDisruptor.tryPublish(translator)) {
+        if (!getAsyncLoggerDisruptor().isDiscardBufferEmpty() && !loggerDisruptor.tryPublish(translator)) {
             handleRingBufferFull(translator);
         }
     }
@@ -339,7 +339,7 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
         }
         StackTraceElement location = null;
         // calls the translateTo method on this AsyncLogger
-        if (!disruptor.getRingBuffer().tryPublishEvent(this,
+        if (!getAsyncLoggerDisruptor().isDiscardBufferEmpty() && !disruptor.getRingBuffer().tryPublishEvent(this,
                 this, // asyncLogger: 0
                 (location = calcLocationIfRequested(fqcn)), // location: 1
                 fqcn, // 2
@@ -378,7 +378,7 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
             InternalAsyncUtil.makeMessageImmutable(message);
         }
         // calls the translateTo method on this AsyncLogger
-        if (!disruptor.getRingBuffer().tryPublishEvent(this,
+        if (!getAsyncLoggerDisruptor().isDiscardBufferEmpty() && !disruptor.getRingBuffer().tryPublishEvent(this,
             this, // asyncLogger: 0
             location, // location: 1
             fqcn, // 2

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
@@ -14,7 +14,6 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.async;
 
 import java.util.Objects;
@@ -22,7 +21,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import com.lmax.disruptor.EventTranslatorVararg;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.AbstractLifeCycle;
@@ -30,14 +28,15 @@ import org.apache.logging.log4j.core.jmx.RingBufferAdmin;
 import org.apache.logging.log4j.core.util.Log4jThread;
 import org.apache.logging.log4j.core.util.Log4jThreadFactory;
 import org.apache.logging.log4j.core.util.Throwables;
+import org.apache.logging.log4j.message.Message;
 
+import com.lmax.disruptor.EventTranslatorVararg;
 import com.lmax.disruptor.ExceptionHandler;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.TimeoutException;
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
-import org.apache.logging.log4j.message.Message;
 
 /**
  * Helper class for async loggers: AsyncLoggerDisruptor handles the mechanics of working with the LMAX Disruptor, and

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
@@ -59,6 +59,7 @@ class AsyncLoggerDisruptor extends AbstractLifeCycle {
     private long backgroundThreadId;
     private AsyncQueueFullPolicy asyncQueueFullPolicy;
     private int ringBufferSize;
+    private int discardBufferSize;
     private WaitStrategy waitStrategy;
 
     AsyncLoggerDisruptor(final String contextName, final Supplier<AsyncWaitStrategyFactory> waitStrategyFactorySupplier) {
@@ -103,6 +104,8 @@ class AsyncLoggerDisruptor extends AbstractLifeCycle {
         setStarting();
         LOGGER.trace("[{}] AsyncLoggerDisruptor creating new disruptor for this context.", contextName);
         ringBufferSize = DisruptorUtil.calculateRingBufferSize("AsyncLogger.RingBufferSize");
+        // we leave 10% of the original buffer as an additional buffer for discards
+        discardBufferSize = (int) Math.ceil(ringBufferSize / 10.0);
         AsyncWaitStrategyFactory factory = waitStrategyFactorySupplier.get(); // get factory from configuration
         waitStrategy = DisruptorUtil.createWaitStrategy("AsyncLogger.WaitStrategy", factory);
 
@@ -343,5 +346,17 @@ class AsyncLoggerDisruptor extends AbstractLifeCycle {
         useThreadLocalTranslator = allow;
         LOGGER.trace("[{}] AsyncLoggers have been modified to use a {} translator", contextName,
                 useThreadLocalTranslator ? "threadlocal" : "vararg");
+    }
+
+    /**
+     * Check if the discard buffer is disabled or empty.
+     *
+     * @return true when discardBuffer is empty or is disabled
+     */
+    public boolean isDiscardBufferEmpty() {
+        if (DisruptorUtil.ASYNC_LOGGER_USE_DISCARD_BUFFER) {
+            return disruptor.getRingBuffer().hasAvailableCapacity(discardBufferSize);
+        }
+        return true;
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
@@ -48,6 +48,15 @@ final class DisruptorUtil {
             .getBooleanProperty("AsyncLogger.SynchronizeEnqueueWhenQueueFull", true);
     static final boolean ASYNC_CONFIG_SYNCHRONIZE_ENQUEUE_WHEN_QUEUE_FULL = PropertiesUtil.getProperties()
             .getBooleanProperty("AsyncLoggerConfig.SynchronizeEnqueueWhenQueueFull", true);
+    /**
+     * AsyncLogger will tryPublish to RingBuffer and if that fails it will handleRingBufferFull. HandleRingBufferFull
+     * flow makes sure that appropriate policy is applied (ENQUEUE, DISCARD, etc). SynchronizeEnqueueWhenQueueFull was
+     * added to synchronize publishing to the RingBuffer when it's full, however requests that succeed initial
+     * tryPublish avoid the synchronization. This flags introduces additional buffer that when the RingBuffer is almost
+     * full (90% capacity) routes all requests through handleRingBufferFull preventing un-sychronized access.
+     */
+    static final boolean ASYNC_LOGGER_USE_DISCARD_BUFFER = PropertiesUtil.getProperties()
+            .getBooleanProperty("AsyncLoggerConfig.UseDiscardBuffer", false);
 
     private DisruptorUtil() {
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
@@ -14,11 +14,11 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.core.async;
 
-import com.lmax.disruptor.ExceptionHandler;
-import com.lmax.disruptor.WaitStrategy;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.Integers;
@@ -26,8 +26,8 @@ import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.PropertiesUtil;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
+import com.lmax.disruptor.ExceptionHandler;
+import com.lmax.disruptor.WaitStrategy;
 
 /**
  * Utility methods for getting Disruptor related configuration.

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/ConcurrentAsyncLoggerToFileBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/ConcurrentAsyncLoggerToFileBenchmark.java
@@ -14,8 +14,13 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
-
 package org.apache.logging.log4j.perf.jmh;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -37,12 +42,6 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
-
-import java.io.File;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Tests Log4j2 Async Loggers performance with many threads producing events quickly while the background

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/ConcurrentAsyncLoggerToFileBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/ConcurrentAsyncLoggerToFileBenchmark.java
@@ -74,7 +74,8 @@ public class ConcurrentAsyncLoggerToFileBenchmark {
     @State(Scope.Benchmark)
     public static class BenchmarkState {
 
-        @Param({"ENQUEUE", "ENQUEUE_UNSYNCHRONIZED", "SYNCHRONOUS"})
+        @Param({"ENQUEUE", "ENQUEUE_UNSYNCHRONIZED", "SYNCHRONOUS",
+                "ENQUEUE_WITH_DISCARD_BUFFER", "ENQUEUE_UNSYNCHRONIZED_WITH_DISCARD_BUFFER", })
         private QueueFullPolicy queueFullPolicy;
 
         @Param({"ASYNC_CONTEXT", "ASYNC_CONFIG"})
@@ -105,6 +106,18 @@ public class ConcurrentAsyncLoggerToFileBenchmark {
                 put("log4j2.AsyncQueueFullPolicy", "Default");
                 put("AsyncLogger.SynchronizeEnqueueWhenQueueFull", "false");
                 put("AsyncLoggerConfig.SynchronizeEnqueueWhenQueueFull", "false");
+            }
+            }),
+            ENQUEUE_UNSYNCHRONIZED_WITH_DISCARD_BUFFER(new HashMap<>() {{
+                put("log4j2.AsyncQueueFullPolicy", "Default");
+                put("AsyncLogger.SynchronizeEnqueueWhenQueueFull", "false");
+                put("AsyncLoggerConfig.SynchronizeEnqueueWhenQueueFull", "false");
+                put("AsyncLoggerConfig.UseDiscardBuffer", "true");
+            }
+            }),
+            ENQUEUE_WITH_DISCARD_BUFFER(new HashMap<>() {{
+                put("log4j2.AsyncQueueFullPolicy", "Default");
+                put("AsyncLoggerConfig.UseDiscardBuffer", "true");
             }
             }),
             SYNCHRONOUS(Collections.singletonMap("log4j2.AsyncQueueFullPolicy",


### PR DESCRIPTION
A service that we maintain occasionally hangs when the rate of incoming logs is higher than the throughput of  writing logs to a disk. We have a discard policy at ERROR level and use default `SynchronizeEnqueueWhenQueueFull`.  We believe that this is due to corrupted LMAX disruptor. We did some initial attempts to produce minimal reproducer (using jcstress) but were not able to succeed so far.

While reviewing the log4j code we noticed that there are code paths that avoid SynchronizeEnqueueWhenQueueFull and may be responsible for RingBuffer corruption, I prepared a small change that should prevent any unsynchronized access and wanted to get initial feedback from log4j maintainers. I also wanted to use this pull request to pick you brain on what else we can do to troubleshoot the issue futher.


Writer threads hang on following stack trace: 

```
   java.lang.Thread.State: TIMED_WAITING (parking)                                                                                                                                                                                                                        
        at sun.misc.Unsafe.park(Native Method)                                                                                                                                                                                                                            
        at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:338)                                                                                                                                                                                         
        at com.lmax.disruptor.MultiProducerSequencer.next(MultiProducerSequencer.java:136)                                                                                                                                                                                
        at com.lmax.disruptor.MultiProducerSequencer.next(MultiProducerSequencer.java:105)                                                                                                                                                                                
        at com.lmax.disruptor.RingBuffer.publishEvent(RingBuffer.java:465)                                                                                                                                                                                                
        at com.lmax.disruptor.dsl.Disruptor.publishEvent(Disruptor.java:326)                                                                                                                                                                                              
        at org.apache.logging.log4j.core.async.AsyncLoggerDisruptor.enqueueLogMessageWhenQueueFull(AsyncLoggerDisruptor.java:236)                                                                                                                                         
        - locked <0x000000052818a2c0> (a java.lang.Object)                                                                                                                                                                                                                
        at org.apache.logging.log4j.core.async.AsyncLogger.handleRingBufferFull(AsyncLogger.java:246)                                                                                                                                                                     
        at org.apache.logging.log4j.core.async.AsyncLogger.publish(AsyncLogger.java:230)                                                                                                                                                                                  
        at org.apache.logging.log4j.core.async.AsyncLogger.logWithThreadLocalTranslator(AsyncLogger.java:225)                                                                                                                                                             
        at org.apache.logging.log4j.core.async.AsyncLogger.access$000(AsyncLogger.java:67)                                                                                                                                                                                
        at org.apache.logging.log4j.core.async.AsyncLogger$1.log(AsyncLogger.java:152)                                                                                                                                                                                    
        at org.apache.logging.log4j.core.async.AsyncLogger.log(AsyncLogger.java:136)                                                                                                                                                                                      
        at org.apache.logging.log4j.spi.AbstractLogger.tryLogMessage(AbstractLogger.java:2205)                                                                                                                                                                            
        at org.apache.logging.log4j.spi.AbstractLogger.logMessageTrackRecursion(AbstractLogger.java:2159)                                                                                                                                                                 
        at org.apache.logging.log4j.spi.AbstractLogger.logMessageSafely(AbstractLogger.java:2142)                                                                                                                                                                         
        at org.apache.logging.log4j.spi.AbstractLogger.logMessage(AbstractLogger.java:2022)                                                                                                                                                                               
        at org.apache.logging.log4j.spi.AbstractLogger.logIfEnabled(AbstractLogger.java:1875)                                                                                                                                                                             
        at org.apache.logging.slf4j.Log4jLogger.error(Log4jLogger.java:299) 
```

While the event processor is runnable, but is not making any progress, i.e. no logs are produced

```
   java.lang.Thread.State: RUNNABLE                                                                                                                                                                                                                                       
        at com.lmax.disruptor.BatchEventProcessor.processEvents(BatchEventProcessor.java:159)                                                                                                                                                                             
        at com.lmax.disruptor.BatchEventProcessor.run(BatchEventProcessor.java:125)                                                                                                                                                                                       
        at java.lang.Thread.run(Thread.java:750)
```

Benchmark results
---

I was a bit surprised, but comparing to previous results of those benchmarks, I didn't see a significant drop in performance for the `ENQUEUE_UNSYNCHRONIZED`

I was doing benchmarks on my laptop it's worth redoing them on something less heat dependent.

```
Benchmark                                                      (asyncLoggerType)                           (queueFullPolicy)   Mode  Cnt        Score         Error  Units
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads      ASYNC_CONTEXT                                     ENQUEUE  thrpt    3  1697034.508 ± 1202549.620  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads      ASYNC_CONTEXT                      ENQUEUE_UNSYNCHRONIZED  thrpt    3  1495955.531 ± 1693301.980  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads      ASYNC_CONTEXT                                 SYNCHRONOUS  thrpt    3  1034627.933 ±   45394.317  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads      ASYNC_CONTEXT                 ENQUEUE_WITH_DISCARD_BUFFER  thrpt    3  1667436.237 ± 2112652.224  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads      ASYNC_CONTEXT  ENQUEUE_UNSYNCHRONIZED_WITH_DISCARD_BUFFER  thrpt    3  1601124.413 ±  915884.976  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads       ASYNC_CONFIG                                     ENQUEUE  thrpt    3  1480767.389 ±  105373.283  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads       ASYNC_CONFIG                      ENQUEUE_UNSYNCHRONIZED  thrpt    3  1500207.421 ±  255208.676  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads       ASYNC_CONFIG                                 SYNCHRONOUS  thrpt    3  1040395.665 ±  655838.740  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads       ASYNC_CONFIG                 ENQUEUE_WITH_DISCARD_BUFFER  thrpt    3  1382197.977 ±  193412.417  ops/s
ConcurrentAsyncLoggerToFileBenchmark.concurrentLoggingThreads       ASYNC_CONFIG  ENQUEUE_UNSYNCHRONIZED_WITH_DISCARD_BUFFER  thrpt    3  1364773.371 ±  523220.133  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread           ASYNC_CONTEXT                                     ENQUEUE  thrpt    3  1889817.673 ± 1071497.633  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread           ASYNC_CONTEXT                      ENQUEUE_UNSYNCHRONIZED  thrpt    3  1913081.427 ±  727441.877  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread           ASYNC_CONTEXT                                 SYNCHRONOUS  thrpt    3  1706308.744 ±  420044.210  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread           ASYNC_CONTEXT                 ENQUEUE_WITH_DISCARD_BUFFER  thrpt    3  1922153.567 ±  296264.291  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread           ASYNC_CONTEXT  ENQUEUE_UNSYNCHRONIZED_WITH_DISCARD_BUFFER  thrpt    3  1978927.640 ±  116322.330  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread            ASYNC_CONFIG                                     ENQUEUE  thrpt    3  1557072.461 ±  858005.859  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread            ASYNC_CONFIG                      ENQUEUE_UNSYNCHRONIZED  thrpt    3  1670159.014 ±  968275.492  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread            ASYNC_CONFIG                                 SYNCHRONOUS  thrpt    3  1670925.140 ± 1193198.527  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread            ASYNC_CONFIG                 ENQUEUE_WITH_DISCARD_BUFFER  thrpt    3  1592437.737 ± 2547005.997  ops/s
ConcurrentAsyncLoggerToFileBenchmark.singleLoggingThread            ASYNC_CONFIG  ENQUEUE_UNSYNCHRONIZED_WITH_DISCARD_BUFFER  thrpt    3  1553189.872 ± 1723125.919  ops/s
```


Checklist
---

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
DONE
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `spotless:apply` and retry)
DONE
* Changes contain an entry file in the `src/changelog/.2.x.x` directory
TBD
* Tests for the changes are provided
TBD
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
