### PR TITLE
Prevent resource leak

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/CommonsCompressAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/CommonsCompressAction.java
@@ -104,9 +104,9 @@ public final class CommonsCompressAction extends AbstractAction {
         }
         LOGGER.debug("Starting {} compression of {}", name, source.getPath() );
         try (final FileInputStream input = new FileInputStream(source);
+             final FileOutputStream fileOutput = new FileOutputStream(destination);
                 final BufferedOutputStream output = new BufferedOutputStream(
-                        new CompressorStreamFactory().createCompressorOutputStream(name, new FileOutputStream(
-                                destination)))) {
+                        new CompressorStreamFactory().createCompressorOutputStream(name, fileOutput))) {
             IOUtils.copy(input, output, BUF_SIZE);
             LOGGER.debug("Finished {} compression of {}", name, source.getPath() );
         } catch (final CompressorException e) {

--- a/src/changelog/.2.x.x/PreventResourceLeak.xml
+++ b/src/changelog/.2.x.x/PreventResourceLeak.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="changed">
+  <author id="mernst"/>
+  <description format="asciidoc">
+    Prevent a resource leak in `CommonsCompressAction.execute()`.
+  </description>
+</entry>


### PR DESCRIPTION
In `CommonsCompressAction.execute()`, if an exception occurs during the call to `new BufferedOutputStream` or `createCompressorOutputStream`, then the `FileOutputStream` is never closed and a resource leak occurs.  This patch refactors the code so that the `FileOutputStream` is always closed.