### PR TITLE
Fix `Log4jFixedFormatter` buffer length

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FastDateParserSDFTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FastDateParserSDFTest.java
@@ -19,109 +19,96 @@ package org.apache.logging.log4j.core.util.datetime;
 import java.text.ParseException;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Compare FastDateParser with SimpleDateFormat
  *
  * Copied from Apache Commons Lang 3 on 2016-11-16.
  */
-@RunWith(Parameterized.class)
 public class FastDateParserSDFTest {
 
-    @Parameters(name= "{index}: {0} {1} {2}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object [][]{
+    static Stream<Arguments> data() {
+        return Stream.of(
                 // General Time zone tests
-                {"z yyyy", "GMT 2010",       Locale.UK, true}, // no offset specified, but this is allowed as a TimeZone name
-                {"z yyyy", "GMT-123 2010",   Locale.UK, false},
-                {"z yyyy", "GMT-1234 2010",  Locale.UK, false},
-                {"z yyyy", "GMT-12:34 2010", Locale.UK, true},
-                {"z yyyy", "GMT-1:23 2010",  Locale.UK, true},
+                Arguments.of("z yyyy", "GMT 2010", Locale.UK, true), // no offset specified, but this is allowed as a
+                                                                     // TimeZone name
+                Arguments.of("z yyyy", "GMT-123 2010", Locale.UK, false),
+                Arguments.of("z yyyy", "GMT-1234 2010", Locale.UK, false),
+                Arguments.of("z yyyy", "GMT-12:34 2010", Locale.UK, true),
+                Arguments.of("z yyyy", "GMT-1:23 2010", Locale.UK, true),
                 // RFC 822 tests
-                {"z yyyy", "-1234 2010",     Locale.UK, true},
-                {"z yyyy", "-12:34 2010",    Locale.UK, false},
-                {"z yyyy", "-123 2010",      Locale.UK, false},
+                Arguments.of("z yyyy", "-1234 2010", Locale.UK, true),
+                Arguments.of("z yyyy", "-12:34 2010", Locale.UK, false),
+                Arguments.of("z yyyy", "-123 2010", Locale.UK, false),
                 // year tests
-                { "MM/dd/yyyy", "01/11/12",  Locale.UK, true},
-                { "MM/dd/yy", "01/11/12",    Locale.UK, true},
+                Arguments.of("MM/dd/yyyy", "01/11/12", Locale.UK, true),
+                Arguments.of("MM/dd/yy", "01/11/12", Locale.UK, true),
 
                 // LANG-1089
-                { "HH", "00",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "00",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "00",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "00",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of("HH", "00", Locale.UK, true), // Hour in day (0-23)
+                Arguments.of("KK", "00", Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of("hh", "00", Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of("kk", "00", Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "01",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "01",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "01",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "01",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of("HH", "01", Locale.UK, true), // Hour in day (0-23)
+                Arguments.of("KK", "01", Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of("hh", "01", Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of("kk", "01", Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "11",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "11",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "11",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "11",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of("HH", "11", Locale.UK, true), // Hour in day (0-23)
+                Arguments.of("KK", "11", Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of("hh", "11", Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of("kk", "11", Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "12",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "12",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "12",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "12",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of("HH", "12", Locale.UK, true), // Hour in day (0-23)
+                Arguments.of("KK", "12", Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of("hh", "12", Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of("kk", "12", Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "13",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "13",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "13",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "13",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of("HH", "13", Locale.UK, true), // Hour in day (0-23)
+                Arguments.of("KK", "13", Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of("hh", "13", Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of("kk", "13", Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "23",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "23",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "23",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "23",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of("HH", "23", Locale.UK, true), // Hour in day (0-23)
+                Arguments.of("KK", "23", Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of("hh", "23", Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of("kk", "23", Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "24",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "24",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "24",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "24",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of("HH", "24", Locale.UK, true), // Hour in day (0-23)
+                Arguments.of("KK", "24", Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of("hh", "24", Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of("kk", "24", Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "25",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "25",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "25",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "25",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
+                Arguments.of("HH", "25", Locale.UK, true), // Hour in day (0-23)
+                Arguments.of("KK", "25", Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of("hh", "25", Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of("kk", "25", Locale.UK, true), // Hour in day (1-24), i.e. midnight is 24, not 0
 
-                { "HH", "48",    Locale.UK, true}, // Hour in day (0-23)
-                { "KK", "48",    Locale.UK, true}, // Hour in am/pm (0-11)
-                { "hh", "48",    Locale.UK, true}, // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
-                { "kk", "48",    Locale.UK, true}, // Hour in day (1-24), i.e. midnight is 24, not 0
-                });
+                Arguments.of("HH", "48", Locale.UK, true), // Hour in day (0-23)
+                Arguments.of("KK", "48", Locale.UK, true), // Hour in am/pm (0-11)
+                Arguments.of("hh", "48", Locale.UK, true), // Hour in am/pm (1-12), i.e. midday/midnight is 12, not 0
+                Arguments.of("kk", "48", Locale.UK, true) // Hour in day (1-24), i.e. midnight is 24, not 0
+        );
     }
 
-    private final String format;
-    private final String input;
-    private final Locale locale;
-    private final boolean valid;
     private final TimeZone timeZone = TimeZone.getDefault();
 
-    public FastDateParserSDFTest(final String format, final String input, final Locale locale, final boolean valid) {
-        this.format = format;
-        this.input = input;
-        this.locale = locale;
-        this.valid = valid;
-    }
 
-    private void checkParse(final String formattedDate) {
+    private void checkParse(final String formattedDate, String format, String input, Locale locale, boolean valid) {
         final SimpleDateFormat sdf = new SimpleDateFormat(format, locale);
         sdf.setTimeZone(timeZone);
         final DateParser fdf = new FastDateParser(format, timeZone, locale);
@@ -156,13 +143,14 @@ public class FastDateParserSDFTest {
             fdfE = e.getClass();
         }
         if (valid) {
-            assertEquals(locale.toString()+" "+formattedDate +"\n",expectedTime, actualTime);
+            assertEquals(expectedTime, actualTime, locale.toString() + " " + formattedDate + "\n");
         } else {
-            assertEquals(locale.toString()+" "+formattedDate + " expected same Exception ", sdfE, fdfE);
+            assertEquals(sdfE, fdfE, locale.toString() + " " + formattedDate + " expected same Exception ");
         }
     }
 
-    private void checkParsePosition(final String formattedDate) {
+    private void checkParsePosition(final String formattedDate, String format, String input, Locale locale,
+            boolean valid) {
         final SimpleDateFormat sdf = new SimpleDateFormat(format, locale);
         sdf.setTimeZone(timeZone);
         final DateParser fdf = new FastDateParser(format, timeZone, locale);
@@ -171,7 +159,7 @@ public class FastDateParserSDFTest {
         final Date expectedTime = sdf.parse(formattedDate, sdfP);
         final int sdferrorIndex = sdfP.getErrorIndex();
         if (valid) {
-            assertEquals("Expected SDF error index -1 ", -1, sdferrorIndex);
+            assertEquals(-1, sdferrorIndex, "Expected SDF error index -1 ");
             final int endIndex = sdfP.getIndex();
             final int length = formattedDate.length();
             if (endIndex != length) {
@@ -189,44 +177,51 @@ public class FastDateParserSDFTest {
         final Date actualTime = fdf.parse(formattedDate, fdfP);
         final int fdferrorIndex = fdfP.getErrorIndex();
         if (valid) {
-            assertEquals("Expected FDF error index -1 ", -1, fdferrorIndex);
+            assertEquals(-1, fdferrorIndex, "Expected FDF error index -1 ");
             final int endIndex = fdfP.getIndex();
             final int length = formattedDate.length();
-            assertEquals("Expected FDF to parse full string " + fdfP, length, endIndex);
-            assertEquals(locale.toString()+" "+formattedDate +"\n", expectedTime, actualTime);
+            assertEquals(length, endIndex, "Expected FDF to parse full string " + fdfP);
+            assertEquals(expectedTime, actualTime, locale.toString() + " " + formattedDate + "\n");
         } else {
-            assertNotEquals("Test data error: expected FDF parse to fail, but got " + actualTime, -1, fdferrorIndex);
-            assertTrue("FDF error index ("+ fdferrorIndex + ") should approxiamate SDF index (" + sdferrorIndex + ")",
-                    sdferrorIndex - fdferrorIndex <= 4);
+            assertNotEquals(-1, fdferrorIndex, "Test data error: expected FDF parse to fail, but got " + actualTime);
+            assertTrue(sdferrorIndex - fdferrorIndex <= 4,
+                    "FDF error index (" + fdferrorIndex + ") should approxiamate SDF index (" + sdferrorIndex + ")");
         }
     }
 
-    @Test
-    public void testLowerCase() throws Exception {
-        checkParse(input.toLowerCase(locale));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testLowerCase(String format, String input, Locale locale, boolean valid) throws Exception {
+        checkParse(input.toLowerCase(locale), format, input, locale, valid);
     }
 
-    @Test
-    public void testLowerCasePP() throws Exception {
-        checkParsePosition(input.toLowerCase(locale));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testLowerCasePP(String format, String input, Locale locale, boolean valid) throws Exception {
+        checkParsePosition(input.toLowerCase(locale), format, input, locale, valid);
     }
 
-    @Test
-    public void testOriginal() throws Exception {
-        checkParse(input);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testOriginal(String format, String input, Locale locale, boolean valid) throws Exception {
+        checkParse(input, format, input, locale, valid);
     }
 
-    @Test
-    public void testOriginalPP() throws Exception {
-        checkParsePosition(input);
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testOriginalPP(String format, String input, Locale locale, boolean valid) throws Exception {
+        checkParsePosition(input, format, input, locale, valid);
     }
 
-    @Test
-    public void testUpperCase() throws Exception {
-        checkParse(input.toUpperCase(locale));
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpperCase(String format, String input, Locale locale, boolean valid) throws Exception {
+        checkParse(input.toUpperCase(locale), format, input, locale, valid);
     }
-    @Test
-    public void testUpperCasePP() throws Exception {
-        checkParsePosition(input.toUpperCase(locale));
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testUpperCasePP(String format, String input, Locale locale, boolean valid) throws Exception {
+        checkParsePosition(input.toUpperCase(locale), format, input, locale, valid);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FastDateParserTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FastDateParserTest.java
@@ -30,12 +30,13 @@ import java.util.TimeZone;
 
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.SerializationUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit tests {@link org.apache.commons.lang3.time.FastDateParser}.
@@ -103,7 +104,7 @@ public class FastDateParserTest {
     private void checkParse(final Locale locale, final SimpleDateFormat sdf, final DateParser fdf, final String formattedDate) throws ParseException {
         final Date expectedTime = sdf.parse(formattedDate);
         final Date actualTime = fdf.parse(formattedDate);
-        assertEquals(locale.toString()+" "+formattedDate +"\n",expectedTime, actualTime);
+        assertEquals(expectedTime, actualTime, locale.toString() + " " + formattedDate + "\n");
     }
 
     private DateParser getDateInstance(final int dateStyle, final Locale locale) {
@@ -191,19 +192,20 @@ public class FastDateParserTest {
             final String message = trial.zone.getDisplayName()+";";
 
             DateParser parser = getInstance(formatStub+"X", trial.zone);
-            assertEquals(message+trial.one, cal.getTime().getTime(), parser.parse(dateStub+trial.one).getTime()-trial.offset);
+            assertEquals(cal.getTime().getTime(), parser.parse(dateStub + trial.one).getTime() - trial.offset,
+                    message + trial.one);
 
             parser = getInstance(formatStub+"XX", trial.zone);
-            assertEquals(message+trial.two, cal.getTime(), parser.parse(dateStub+trial.two));
+            assertEquals(cal.getTime(), parser.parse(dateStub + trial.two), message + trial.two);
 
             parser = getInstance(formatStub+"XXX", trial.zone);
-            assertEquals(message+trial.three, cal.getTime(), parser.parse(dateStub+trial.three));
+            assertEquals(cal.getTime(), parser.parse(dateStub + trial.three), message + trial.three);
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void test1806Argument() {
-        getInstance("XXXX");
+        assertThrows(IllegalArgumentException.class, () -> getInstance("XXXX"));
     }
 
 
@@ -248,13 +250,13 @@ public class FastDateParserTest {
         final Calendar calendar = Calendar.getInstance();
 
         calendar.setTime(parser.parse("1"));
-        Assert.assertEquals(Calendar.MONDAY, calendar.get(Calendar.DAY_OF_WEEK));
+        assertEquals(Calendar.MONDAY, calendar.get(Calendar.DAY_OF_WEEK));
 
         calendar.setTime(parser.parse("6"));
-        Assert.assertEquals(Calendar.SATURDAY, calendar.get(Calendar.DAY_OF_WEEK));
+        assertEquals(Calendar.SATURDAY, calendar.get(Calendar.DAY_OF_WEEK));
 
         calendar.setTime(parser.parse("7"));
-        Assert.assertEquals(Calendar.SUNDAY, calendar.get(Calendar.DAY_OF_WEEK));
+        assertEquals(Calendar.SUNDAY, calendar.get(Calendar.DAY_OF_WEEK));
     }
 
     @Test
@@ -295,7 +297,7 @@ public class FastDateParserTest {
             try {
                 checkParse(locale, cal, sdf, fdf);
             } catch(final ParseException ex) {
-                Assert.fail("Locale "+locale+ " failed with "+LONG_FORMAT+"\n" + trimMessage(ex.toString()));
+                fail("Locale " + locale + " failed with " + LONG_FORMAT + "\n" + trimMessage(ex.toString()));
             }
         }
     }
@@ -318,7 +320,7 @@ public class FastDateParserTest {
 
         try {
             fdp.parse("2015");
-            Assert.fail("expected parse exception");
+            fail("expected parse exception");
         } catch (final ParseException pe) {
             // expected parse exception
         }
@@ -329,7 +331,7 @@ public class FastDateParserTest {
         cal.clear();
         cal.set(2015, 3, 29);
         Date expected = cal.getTime();
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
 
         final SimpleDateFormat df = new SimpleDateFormat("yyyyMMdd", Locale.KOREA);
         df.setTimeZone(kst);
@@ -337,7 +339,7 @@ public class FastDateParserTest {
 
         // Thu Mar 16 00:00:00 KST 81724
         actual = fdp.parse("20150429113100");
-        Assert.assertEquals(expected, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -401,7 +403,8 @@ public class FastDateParserTest {
             try {
                 checkParse(locale, cal, sdf, fdf);
             } catch(final ParseException ex) {
-                Assert.fail("Locale "+locale+ " failed with "+format+" era "+(eraBC?"BC":"AD")+"\n" + trimMessage(ex.toString()));
+                fail("Locale " + locale + " failed with " + format + " era " + (eraBC ? "BC" : "AD") + "\n"
+                        + trimMessage(ex.toString()));
             }
         }
     }
@@ -518,7 +521,7 @@ public class FastDateParserTest {
         final Calendar cal = Calendar.getInstance();
         cal.clear();
         cal.set(2015, Calendar.JULY, 4);
-        Assert.assertEquals(cal.getTime(), date);
+        assertEquals(cal.getTime(), date);
     }
 
     @Test
@@ -596,7 +599,7 @@ public class FastDateParserTest {
             sdf.setTimeZone(NEW_YORK);
             dsdf = sdf.parse(date);
             if (shouldFail) {
-                Assert.fail("Expected SDF failure, but got " + dsdf + " for ["+format+","+date+"]");
+                fail("Expected SDF failure, but got " + dsdf + " for [" + format + "," + date + "]");
             }
         } catch (final Exception e) {
             s = e;
@@ -609,7 +612,7 @@ public class FastDateParserTest {
             final DateParser fdp = getInstance(format, NEW_YORK, Locale.US);
             dfdp = fdp.parse(date);
             if (shouldFail) {
-                Assert.fail("Expected FDF failure, but got " + dfdp + " for ["+format+","+date+"]");
+                fail("Expected FDF failure, but got " + dfdp + " for [" + format + "," + date + "]");
             }
         } catch (final Exception e) {
             f = e;
@@ -618,8 +621,8 @@ public class FastDateParserTest {
             }
         }
         // SDF and FDF should produce equivalent results
-        assertTrue("Should both or neither throw Exceptions", (f==null)==(s==null));
-        assertEquals("Parsed dates should be equal", dsdf, dfdp);
+        assertTrue((f == null) == (s == null), "Should both or neither throw Exceptions");
+        assertEquals(dsdf, dfdp, "Parsed dates should be equal");
     }
 
     /**
@@ -686,7 +689,7 @@ public class FastDateParserTest {
                 final Date expected= cal.getTime();
 
                 final Date actual = fdp.parse("2000/02/10 "+tz.getDisplayName(locale));
-                Assert.assertEquals("tz:"+tz.getID()+" locale:"+locale.getDisplayName(), expected, actual);
+                assertEquals(expected, actual, "tz:" + tz.getID() + " locale:" + locale.getDisplayName());
             }
         }
     }
@@ -711,7 +714,7 @@ public class FastDateParserTest {
         final String fmt = sdf.format(in);
         try {
             final Date out = fdp.parse(fmt);
-            assertEquals(locale.toString()+" "+in+" "+ format+ " "+tz.getID(), in, out);
+            assertEquals(in, out, locale.toString() + " " + in + " " + format + " " + tz.getID());
         } catch (final ParseException pe) {
             if (year >= 1868 || !locale.getCountry().equals("JP")) {// LANG-978
                 throw pe;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FastDateParser_MoreOrLessTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FastDateParser_MoreOrLessTest.java
@@ -22,8 +22,11 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Copied from Apache Commons Lang 3 on 2016-11-16.
@@ -36,8 +39,8 @@ public class FastDateParser_MoreOrLessTest {
     public void testInputHasLessCharacters() {
         final FastDateParser parser = new FastDateParser("MM/dd/yyy", TimeZone.getDefault(), Locale.getDefault());
         final ParsePosition parsePosition = new ParsePosition(0);
-        Assert.assertNull(parser.parse("03/23", parsePosition));
-        Assert.assertEquals(5, parsePosition.getErrorIndex());
+        assertNull(parser.parse("03/23", parsePosition));
+        assertEquals(5, parsePosition.getErrorIndex());
     }
 
     @Test
@@ -45,12 +48,12 @@ public class FastDateParser_MoreOrLessTest {
         final FastDateParser parser = new FastDateParser("MM/dd", TimeZone.getDefault(), Locale.getDefault());
         final ParsePosition parsePosition = new ParsePosition(0);
         final Date date = parser.parse("3/23/61", parsePosition);
-        Assert.assertEquals(4, parsePosition.getIndex());
+        assertEquals(4, parsePosition.getIndex());
 
         final Calendar calendar = Calendar.getInstance();
         calendar.setTime(date);
-        Assert.assertEquals(2, calendar.get(Calendar.MONTH));
-        Assert.assertEquals(23, calendar.get(Calendar.DATE));
+        assertEquals(2, calendar.get(Calendar.MONTH));
+        assertEquals(23, calendar.get(Calendar.DATE));
     }
 
     @Test
@@ -58,9 +61,9 @@ public class FastDateParser_MoreOrLessTest {
         final FastDateParser parser = new FastDateParser("MM/dd", TimeZone.getDefault(), Locale.getDefault());
         final ParsePosition parsePosition = new ParsePosition(0);
         final Date date = parser.parse("A 3/23/61", parsePosition);
-        Assert.assertNull(date);
-        Assert.assertEquals(0, parsePosition.getIndex());
-        Assert.assertEquals(0, parsePosition.getErrorIndex());
+        assertNull(date);
+        assertEquals(0, parsePosition.getIndex());
+        assertEquals(0, parsePosition.getErrorIndex());
     }
 
     @Test
@@ -69,21 +72,21 @@ public class FastDateParser_MoreOrLessTest {
         //SimpleDateFormat parser = new SimpleDateFormat("M/d/y");
         final ParsePosition parsePosition = new ParsePosition(0);
         final Date date = parser.parse(" 3/ 23/ 1961", parsePosition);
-        Assert.assertEquals(12, parsePosition.getIndex());
+        assertEquals(12, parsePosition.getIndex());
 
         final Calendar calendar = Calendar.getInstance();
         calendar.setTime(date);
-        Assert.assertEquals(1961, calendar.get(Calendar.YEAR));
-        Assert.assertEquals(2, calendar.get(Calendar.MONTH));
-        Assert.assertEquals(23, calendar.get(Calendar.DATE));
+        assertEquals(1961, calendar.get(Calendar.YEAR));
+        assertEquals(2, calendar.get(Calendar.MONTH));
+        assertEquals(23, calendar.get(Calendar.DATE));
     }
 
     @Test
     public void testInputHasWrongCharacters() {
         final FastDateParser parser = new FastDateParser("MM-dd-yyy", TimeZone.getDefault(), Locale.getDefault());
         final ParsePosition parsePosition = new ParsePosition(0);
-        Assert.assertNull(parser.parse("03/23/1961", parsePosition));
-        Assert.assertEquals(2, parsePosition.getErrorIndex());
+        assertNull(parser.parse("03/23/1961", parsePosition));
+        assertEquals(2, parsePosition.getErrorIndex());
     }
 
     @Test
@@ -91,12 +94,12 @@ public class FastDateParser_MoreOrLessTest {
         final FastDateParser parser = new FastDateParser("EEEE, MM/dd/yyy", NEW_YORK, Locale.US);
         final String input = "Thursday, 03/23/61";
         final ParsePosition parsePosition = new ParsePosition(0);
-        Assert.assertNotNull(parser.parse(input, parsePosition));
-        Assert.assertEquals(input.length(), parsePosition.getIndex());
+        assertNotNull(parser.parse(input, parsePosition));
+        assertEquals(input.length(), parsePosition.getIndex());
 
         parsePosition.setIndex(0);
-        Assert.assertNull(parser.parse( "Thorsday, 03/23/61", parsePosition));
-        Assert.assertEquals(0, parsePosition.getErrorIndex());
+        assertNull(parser.parse("Thorsday, 03/23/61", parsePosition));
+        assertEquals(0, parsePosition.getErrorIndex());
     }
 
     @Test
@@ -105,11 +108,11 @@ public class FastDateParser_MoreOrLessTest {
 
         final String input = "11:23 Pacific Standard Time";
         final ParsePosition parsePosition = new ParsePosition(0);
-        Assert.assertNotNull(parser.parse(input, parsePosition));
-        Assert.assertEquals(input.length(), parsePosition.getIndex());
+        assertNotNull(parser.parse(input, parsePosition));
+        assertEquals(input.length(), parsePosition.getIndex());
 
         parsePosition.setIndex(0);
-        Assert.assertNull(parser.parse( "11:23 Pacific Standard ", parsePosition));
-        Assert.assertEquals(6, parsePosition.getErrorIndex());
+        assertNull(parser.parse("11:23 Pacific Standard ", parsePosition));
+        assertEquals(6, parsePosition.getErrorIndex());
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FastDateParser_TimeZoneStrategyTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FastDateParser_TimeZoneStrategyTest.java
@@ -22,8 +22,10 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Copied from Apache Commons Lang 3 on 2016-11-16.
@@ -36,7 +38,7 @@ public class FastDateParser_TimeZoneStrategyTest {
 
         final Date summer = parser.parse("26.10.2014 02:00:00 MESZ");
         final Date standard = parser.parse("26.10.2014 02:00:00 MEZ");
-        Assert.assertNotEquals(summer.getTime(), standard.getTime());
+        assertNotEquals(summer.getTime(), standard.getTime());
     }
 
     @Test
@@ -54,7 +56,7 @@ public class FastDateParser_TimeZoneStrategyTest {
                         parser.parse(tzDisplay);
                     }
                     catch(final Exception ex) {
-                        Assert.fail("'" + tzDisplay + "'"
+                        fail("'" + tzDisplay + "'"
                                 + " Locale: '" + locale.getDisplayName() + "'"
                                 + " TimeZone: " + zone[0]
                                 + " offset: " + t

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormatTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormatTest.java
@@ -183,10 +183,11 @@ public class FixedDateFormatTest {
 
         for (int i = 0; i < 36; i++) {
             final Date date = calendar.getTime();
-            assertEquals("SimpleDateFormat TZ=US Central", expectedDstAndNoDst[i][0], usCentral.format(date));
-            assertEquals("SimpleDateFormat TZ=UTC", expectedDstAndNoDst[i][1], utc.format(date));
-            assertEquals("FixedDateFormat TZ=US Central", expectedDstAndNoDst[i][0], fixedUsCentral.format(date.getTime()));
-            assertEquals("FixedDateFormat TZ=UTC", expectedDstAndNoDst[i][1], fixedUtc.format(date.getTime()));
+            assertEquals(expectedDstAndNoDst[i][0], usCentral.format(date), "SimpleDateFormat TZ=US Central");
+            assertEquals(expectedDstAndNoDst[i][1], utc.format(date), "SimpleDateFormat TZ=UTC");
+            assertEquals(expectedDstAndNoDst[i][0], fixedUsCentral.format(date.getTime()),
+                    "FixedDateFormat TZ=US Central");
+            assertEquals(expectedDstAndNoDst[i][1], fixedUtc.format(date.getTime()), "FixedDateFormat TZ=UTC");
             calendar.add(Calendar.HOUR_OF_DAY, 1);
         }
     }
@@ -248,10 +249,11 @@ public class FixedDateFormatTest {
         for (int i = 0; i < 36; i++) {
             final Date date = calendar.getTime();
             //System.out.println(usCentral.format(date) + ", Fixed: " + fixedUsCentral.format(date.getTime()) + ", utc: " + utc.format(date));
-            assertEquals("SimpleDateFormat TZ=US Central", expectedDstAndNoDst[i][0], usCentral.format(date));
-            assertEquals("SimpleDateFormat TZ=UTC", expectedDstAndNoDst[i][1], utc.format(date));
-            assertEquals("FixedDateFormat TZ=US Central", expectedDstAndNoDst[i][0], fixedUsCentral.format(date.getTime()));
-            assertEquals("FixedDateFormat TZ=UTC", expectedDstAndNoDst[i][1], fixedUtc.format(date.getTime()));
+            assertEquals(expectedDstAndNoDst[i][0], usCentral.format(date), "SimpleDateFormat TZ=US Central");
+            assertEquals(expectedDstAndNoDst[i][1], utc.format(date), "SimpleDateFormat TZ=UTC");
+            assertEquals(expectedDstAndNoDst[i][0], fixedUsCentral.format(date.getTime()),
+                    "FixedDateFormat TZ=US Central");
+            assertEquals(expectedDstAndNoDst[i][1], fixedUtc.format(date.getTime()), "FixedDateFormat TZ=US Central");
             calendar.add(Calendar.HOUR_OF_DAY, 1);
         }
     }
@@ -309,7 +311,7 @@ public class FixedDateFormatTest {
             for (long time = start; time < end; time += 12345) {
                 final String actual = customTF.format(time);
                 final String expected = simpleDF.format(new Date(time));
-                assertEquals(format + "(" + pattern + ")" + "/" + time, expected, actual);
+                assertEquals(expected, actual, format + "(" + pattern + ")" + "/" + time);
             }
         }
     }
@@ -329,7 +331,7 @@ public class FixedDateFormatTest {
             for (long time = end; time > start; time -= 12345) {
                 final String actual = customTF.format(time);
                 final String expected = simpleDF.format(new Date(time));
-                assertEquals(format + "(" + pattern + ")" + "/" + time, expected, actual);
+                assertEquals(expected, actual, format + "(" + pattern + ")" + "/" + time);
             }
         }
     }
@@ -357,7 +359,7 @@ public class FixedDateFormatTest {
             for (long time = end; time > start; time -= 12345) {
                 final String actual = customTF.format(time);
                 final String expected = simpleDF.format(new Date(time));
-                assertEquals(format + "(" + pattern + ")" + "/" + time, expected, actual);
+                assertEquals(expected, actual, format + "(" + pattern + ")" + "/" + time);
             }
         }
     }
@@ -381,7 +383,7 @@ public class FixedDateFormatTest {
                 final int length = customTF.format(time, buffer, 23);
                 final String actual = new String(buffer, 23, length);
                 final String expected = simpleDF.format(new Date(time));
-                assertEquals(format + "(" + pattern + ")" + "/" + time, expected, actual);
+                assertEquals(expected, actual, format + "(" + pattern + ")" + "/" + time);
             }
         }
     }
@@ -403,7 +405,7 @@ public class FixedDateFormatTest {
                 final int length = customTF.format(time, buffer, 23);
                 final String actual = new String(buffer, 23, length);
                 final String expected = simpleDF.format(new Date(time));
-                assertEquals(format + "(" + pattern + ")" + "/" + time, expected, actual);
+                assertEquals(expected, actual, format + "(" + pattern + ")" + "/" + time);
             }
         }
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormatTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormatTest.java
@@ -25,13 +25,14 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat.DEFAULT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests {@link FixedDateFormat}.
@@ -43,14 +44,14 @@ public class FixedDateFormatTest {
         return pattern.endsWith("n") || pattern.matches(".+n+X*") || pattern.matches(".+n+Z*");
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorDisallowsNullFormat() {
-        new FixedDateFormat(null, TimeZone.getDefault());
+        assertThrows(NullPointerException.class, () -> new FixedDateFormat(null, TimeZone.getDefault()));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testConstructorDisallowsNullTimeZone() {
-        new FixedDateFormat(FixedFormat.ABSOLUTE, null);
+        assertThrows(NullPointerException.class, () ->new FixedDateFormat(FixedFormat.ABSOLUTE, null));
     }
 
     @Test
@@ -89,29 +90,29 @@ public class FixedDateFormatTest {
     @Test
     public void testCreateIfSupported_nonNullIfNameMatches() {
         for (final FixedDateFormat.FixedFormat format : FixedDateFormat.FixedFormat.values()) {
-            final String[] options = {format.name()};
-            assertNotNull(format.name(), FixedDateFormat.createIfSupported(options));
+            final String[] options = { format.name() };
+            assertNotNull(FixedDateFormat.createIfSupported(options), format.name());
         }
     }
 
     @Test
     public void testCreateIfSupported_nonNullIfPatternMatches() {
         for (final FixedDateFormat.FixedFormat format : FixedDateFormat.FixedFormat.values()) {
-            final String[] options = {format.getPattern()};
-            assertNotNull(format.name(), FixedDateFormat.createIfSupported(options));
+            final String[] options = { format.getPattern() };
+            assertNotNull(FixedDateFormat.createIfSupported(options), format.name());
         }
     }
 
     @Test
     public void testCreateIfSupported_nullIfNameDoesNotMatch() {
         final String[] options = {"DEFAULT3"};
-        assertNull("DEFAULT3", FixedDateFormat.createIfSupported(options));
+        assertNull(FixedDateFormat.createIfSupported(options), "DEFAULT3");
     }
 
     @Test
     public void testCreateIfSupported_nullIfPatternDoesNotMatch() {
         final String[] options = {"y M d H m s"};
-        assertNull("y M d H m s", FixedDateFormat.createIfSupported(options));
+        assertNull(FixedDateFormat.createIfSupported(options), "y M d H m s");
     }
 
     @Test
@@ -168,7 +169,6 @@ public class FixedDateFormatTest {
                 { "2017-03-13 06:00:00,000", "2017-03-13 11:00:00,000" }, //
         };
 
-        final TimeZone tz = TimeZone.getTimeZone("US/Central");
         for (int i = 0; i < 36; i++) {
             final Date date = calendar.getTime();
             assertEquals("SimpleDateFormat TZ=US Central", expectedDstAndNoDst[i][0], usCentral.format(date));
@@ -233,7 +233,6 @@ public class FixedDateFormatTest {
                 { "2017-11-06 05:00:00,000", "2017-11-06 11:00:00,000" }, //
         };
 
-        final TimeZone tz = TimeZone.getTimeZone("US/Central");
         for (int i = 0; i < 36; i++) {
             final Date date = calendar.getTime();
             //System.out.println(usCentral.format(date) + ", Fixed: " + fixedUsCentral.format(date.getTime()) + ", utc: " + utc.format(date));

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormatTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormatTest.java
@@ -423,7 +423,7 @@ public class FixedDateFormatTest {
         ZoneId zone = ZoneId.of("Europe/Warsaw");
         long epochMillis = ZonedDateTime.of(date, time, zone).toInstant().toEpochMilli();
         MutableInstant instant = new MutableInstant();
-        instant.initFromEpochMilli(epochMillis, 0);
+        instant.initFromEpochMilli(epochMillis, 123_456);
         FixedDateFormat formatter = FixedDateFormat.create(format);
 
         String formatted = formatter.formatInstant(instant);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormat.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormat.java
@@ -163,6 +163,7 @@ public class FixedDateFormat {
         private final int millisSeparatorLength;
         private final int secondFractionDigits;
         private final FixedTimeZoneFormat fixedTimeZoneFormat;
+        private final int extraTimeZoneFormatLength;
 
         FixedFormat(final String pattern, final String datePattern, final int escapeCount, final char timeSeparator,
                     final int timeSepLength, final char millisSeparator, final int millisSepLength,
@@ -176,6 +177,12 @@ public class FixedDateFormat {
             this.escapeCount = escapeCount;
             this.secondFractionDigits = secondFractionDigits;
             this.fixedTimeZoneFormat = timeZoneFormat;
+            if (timeZoneFormat != null) {
+                // The difference between the length of the formatted timezone and the length of the format specifier.
+                this.extraTimeZoneFormatLength = timeZoneFormat.length - timeZoneFormat.ordinal() - 1;
+            } else {
+                this.extraTimeZoneFormatLength = 0;
+            }
         }
 
         /**
@@ -254,7 +261,7 @@ public class FixedDateFormat {
          * @return the length of the resulting formatted date and time strings
          */
         public int getLength() {
-            return pattern.length() - escapeCount;
+            return pattern.length() - escapeCount + extraTimeZoneFormatLength;
         }
 
         /**
@@ -501,6 +508,15 @@ public class FixedDateFormat {
      */
     public String getFormat() {
         return fixedFormat.getPattern();
+    }
+
+    /**
+     * Returns the length of the resulting formatted date and time strings.
+     *
+     * @return the length of the resulting formatted date and time strings
+     */
+    public int getLength() {
+        return length;
     }
 
     /**

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/util/InstantFormatterTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/util/InstantFormatterTest.java
@@ -19,9 +19,12 @@ package org.apache.logging.log4j.layout.template.json.util;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.time.MutableInstant;
 import org.apache.logging.log4j.core.util.datetime.FastDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
+import org.apache.logging.log4j.test.ListStatusListener;
+import org.apache.logging.log4j.test.junit.UsingStatusListener;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -104,4 +107,21 @@ class InstantFormatterTest {
 
     }
 
+    @Test
+    @UsingStatusListener
+    void FixedFormatter_large_enough_buffer(ListStatusListener listener) {
+        final String pattern = "yyyy-MM-dd'T'HH:mm:ss,SSSXXX";
+        final TimeZone timeZone = TimeZone.getTimeZone("America/Chicago");
+        final Locale locale = Locale.ENGLISH;
+        final InstantFormatter formatter = InstantFormatter.newBuilder()
+                .setPattern(pattern)
+                .setTimeZone(timeZone)
+                .setLocale(locale)
+                .build();
+
+        // On this pattern the FixedFormatter used a buffer shorter than necessary,
+        // which caused exceptions and warnings.
+        Assertions.assertThat(listener.findStatusData(Level.WARN)).hasSize(0);
+        Assertions.assertThat(formatter.getInternalImplementationClass()).asString().endsWith(".FixedDateFormat");
+    }
 }

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/InstantFormatter.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/InstantFormatter.java
@@ -323,7 +323,8 @@ public final class InstantFormatter {
 
         private Log4jFixedFormatter(final FixedDateFormat formatter) {
             this.formatter = formatter;
-            this.buffer = new char[formatter.getFormat().length()];
+            // double size for locales with lengthy DateFormatSymbols
+            this.buffer = new char[formatter.getLength() << 1];
         }
 
         @Override

--- a/src/changelog/.2.x.x/1418_fix_ArrayOutOfBound_in_Log4jFixedFormatter.xml
+++ b/src/changelog/.2.x.x/1418_fix_ArrayOutOfBound_in_Log4jFixedFormatter.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="fixed">
+  <issue id="1418" link="https://github.com/apache/logging-log4j2/pull/1418"/>
+  <author id="pkarwasz"/>
+  <description format="asciidoc">Fix buffer size in `Log4jFixedFormatter` date time formatter.</description>
+</entry>

--- a/src/changelog/.2.x.x/1418_fix_ArrayOutOfBound_in_Log4jFixedFormatter.xml
+++ b/src/changelog/.2.x.x/1418_fix_ArrayOutOfBound_in_Log4jFixedFormatter.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-   Licensed to the Apache Software Foundation (ASF) under one or more
-   contributor license agreements.  See the NOTICE file distributed with
-   this work for additional information regarding copyright ownership.
-   The ASF licenses this file to You under the Apache License, Version 2.0
-   (the "License"); you may not use this file except in compliance with
-   the License.  You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
--->
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns="http://logging.apache.org/log4j/changelog"
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"


### PR DESCRIPTION
This PR fixes #1418 .

The buffer length in `Log4jFixedFormatter` was computed base on the length of the pattern. Now it is the double of the real length of a formatted date (in the English locale).

At the same time this migrates the `FastDateFormatter` tests to JUnit 5.