### PR TITLE
Remove nonsensical documentation from `extractConverter()`

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/PatternParser.java
@@ -212,14 +212,6 @@ public final class PatternParser {
 
     /**
      * Extracts the converter identifier found at the given start position.
-     * <p>
-     * After this function returns, the variable i will point to the first char after the end of the converter
-     * identifier.
-     * </p>
-     * <p>
-     * If i points to a char which is not a character acceptable at the start of a unicode identifier, the value null is
-     * returned.
-     * </p>
      *
      * @param lastChar
      *        last processed character.


### PR DESCRIPTION
The removed documentation, introduced in 3e6bb87f72, does not make sense.
 * It states "the value null is returned", but the method return type is `int`.
 * It talks about the value of the variable `i` after the method returns, but `i` is a local variable, not a class variable that would be visible after the method returns.
