### PR TITLE
Change `{@literal null}` to `{@code null}`

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationParser.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationParser.java
@@ -83,7 +83,7 @@ public class Log4j1ConfigurationParser {
      *
      * @param input
      *            InputStream to read from is assumed to be ISO 8859-1, and will not be closed.
-     * @return the populated ConfigurationBuilder, never {@literal null}
+     * @return the populated ConfigurationBuilder, never {@code null}
      * @throws IOException
      *             if unable to read the input
      * @throws ConfigurationException

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
@@ -116,7 +116,7 @@ public interface LogBuilder {
      * Causes all the data collected to be logged along with the message.
      *
      * @param messageSupplier The supplier of the message to log.
-     * @return the message logger or {@literal null} if no logging occurred.
+     * @return the message logger or {@code null} if no logging occurred.
      * @since 2.20
      */
     default Message logAndGet(final Supplier<Message> messageSupplier) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/parser/LogEventParser.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/parser/LogEventParser.java
@@ -27,7 +27,7 @@ public interface LogEventParser {
      *
      * @param input  the byte array
      *
-     * @return the parsed LogEvent, never {@literal null}.
+     * @return the parsed LogEvent, never {@code null}.
      * @throws ParseException if the input is malformed and cannot be parsed as a LogEvent
      */
     LogEvent parseFrom(byte[] input) throws ParseException;
@@ -40,7 +40,7 @@ public interface LogEventParser {
      * @param offset  the initial offset
      * @param length  the length
      *
-     * @return the parsed LogEvent, never {@literal null}.
+     * @return the parsed LogEvent, never {@code null}.
      * @throws ParseException if the input is malformed and cannot be parsed as a LogEvent
      */
     LogEvent parseFrom(byte[] input, int offset, int length) throws ParseException;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/parser/TextLogEventParser.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/parser/TextLogEventParser.java
@@ -28,7 +28,7 @@ public interface TextLogEventParser extends LogEventParser {
      *
      * @param input  the string
      *
-     * @return the parsed LogEvent, never {@literal null}.
+     * @return the parsed LogEvent, never {@code null}.
      * @throws ParseException if the input is malformed and cannot be parsed as a LogEvent
      */
     LogEvent parseFrom(String input) throws ParseException;


### PR DESCRIPTION
In the formatted API documentation, both `null` and `{@literal null}` format identically, so there is no need for the latter.  `@literal` is for literal text, not for Java manifest literals such as `null`.  This pull request changes `{@literal null}` to `{@code null}`, which is used elsewhere and is probably what was intended.