### PR TITLE
#1367 Added missing activation policy

### DIFF
--- a/log4j-api/pom.xml
+++ b/log4j-api/pom.xml
@@ -71,6 +71,7 @@
               sun.reflect;resolution:=optional,
               *</Import-Package>
             <Bundle-Activator>org.apache.logging.log4j.util.Activator</Bundle-Activator>
+            <Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
             <_fixupmessages>"Classes found in the wrong directory";is:=warning</_fixupmessages>
           </instructions>
         </configuration>

--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -192,6 +192,7 @@
               javax.mail.util;version="[1.6,2)";resolution:=optional,
               sun.reflect;resolution:=optional,
               *</Import-Package>
+            <Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
             <Bundle-Activator>org.apache.logging.log4j.core.osgi.Activator</Bundle-Activator>
           </instructions>
         </configuration>

--- a/log4j-slf4j-impl/pom.xml
+++ b/log4j-slf4j-impl/pom.xml
@@ -111,6 +111,7 @@
           <instructions>
             <Export-Package>org.apache.logging.slf4j,
               org.slf4j.impl</Export-Package>
+            <Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
           </instructions>
         </configuration>
       </plugin>

--- a/log4j-slf4j2-impl/pom.xml
+++ b/log4j-slf4j2-impl/pom.xml
@@ -108,6 +108,7 @@
           <instructions>
             <Export-Package>org.apache.logging.slf4j,
               org.slf4j.impl</Export-Package>
+            <Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
             <Require-Capability>osgi.extender;filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
             <Provide-Capability>osgi.serviceloader;osgi.serviceloader=org.slf4j.spi.SLF4JServiceProvider</Provide-Capability>
           </instructions>

--- a/src/changelog/.2.x.x/1367_Missing-Bundle-Activation-OSGiMetadata.xml
+++ b/src/changelog/.2.x.x/1367_Missing-Bundle-Activation-OSGiMetadata.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.0.xsd"
+       type="fixed">
+  <issue id="1367" link="https://github.com/apache/logging-log4j2/issues/1367"/>
+  <author id="github:N1k145" name="Niklas Kellner"/>
+  <!-- Committer -->
+  <author name="github:ppkarwasz"/>
+  <description format="asciidoc">
+    Adapt the OSGi metadata of `log4j-api`, `log4j-core`, `log4j-slf4j-impl` and `log4j-slf4j2-impl` to activate the bundle when it is accessed.
+    To achieve that set the `Bundle-ActivationPolicy` to `lazy` for the log4j bundles.
+  </description>
+</entry>


### PR DESCRIPTION
Added the missing activation policy for #1367, this is required to start the bundle and get the bundle context in an eclipse OSGI environment.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
