### PR TITLE
Fix typo in Log4j Security Team e-mail address

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Only the most recent release of Apache Log4j 2 is supported.
 
 ## Reporting a Vulnerability
 
-If you have encountered an unlisted security vulnerability or other unexpected behaviour that has security impact, please report them privately to the [Log4j Security Team](mailto:security@logging.apache.orggs).
+If you have encountered an unlisted security vulnerability or other unexpected behaviour that has security impact, please report them privately to the [Log4j Security Team](mailto:security@logging.apache.org).
 
 ## Past Vulnerabilities
 


### PR DESCRIPTION
This PR fixes a typo in the domain for the Log4J Security team. The domain had a typo (logging.apache.orggs).

This is a trivial, documentation-only change.