### PR TITLE
doc: fix name of properties file for LoggerContextFactory

### DIFF
--- a/src/site/xdoc/manual/extending.xml
+++ b/src/site/xdoc/manual/extending.xml
@@ -60,11 +60,11 @@
                   name of the class that implements <code>org.apache.logging.spi.Provider</code>.
                 </li>
               </ol></li>
-              <li>Setting the system property <var>log4j2.loggerContextFactory</var> to the name of the
+              <li>Setting the system property <code>log4j2.loggerContextFactory</code> to the name of the
                 <code>LoggerContextFactory</code> class to use.
               </li>
-              <li>Setting the property "log4j2.loggerContextFactory" in a properties file named
-                "log4j2.LogManager.properties" to the name of the LoggerContextFactory class to use. The properties
+              <li>Setting the property <code>log4j2.loggerContextFactory</code> in a properties file named
+                <code>log4j2.component.properties</code> to the name of the LoggerContextFactory class to use. The properties
                 file must be on the classpath.
               </li>
             </ol>


### PR DESCRIPTION
# [Extending Log4j - LoggerContextFactory](https://logging.apache.org/log4j/2.x/manual/extending.html#loggercontextfactory)
The file is called `log4j2.component.properties` not `log4j2.LogManager.properties`.
Tested it locally, it only wroks with the correct file name.

Maybe also a reference to [System Properties](https://logging.apache.org/log4j/2.x/manual/configuration.html#SystemProperties) could further improve the whole chapter.

## Source Code References

LogManager-Property:
https://github.com/apache/logging-log4j2/blob/98c3ceb655d485b0adb48e05d84c8269716f59e8/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java#L54

Loaded in:
https://github.com/apache/logging-log4j2/blob/98c3ceb655d485b0adb48e05d84c8269716f59e8/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java#L74-L75

Via PropertiesUtil:
https://github.com/apache/logging-log4j2/blob/98c3ceb655d485b0adb48e05d84c8269716f59e8/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java#L53


