### PR TITLE
Fix locale-dependent toLowerCase()/toUpperCase() calls

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/Level.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/Level.java
@@ -181,7 +181,7 @@ public class Level extends Priority implements Serializable {
         if (sArg == null) {
             return defaultLevel;
         }
-        final String s = sArg.toUpperCase(Locale.ROOT);
+        final String s = sArg.toRootUpperCase(Locale.ROOT);
         switch (s) {
         case "ALL":
             return Level.ALL;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
@@ -95,7 +95,7 @@ public class BuilderManager {
     private <T> PluginType<T> getPlugin(final String className) {
         Objects.requireNonNull(plugins, "plugins");
         Objects.requireNonNull(className, "className");
-        final String key = className.toLowerCase(Locale.ROOT).trim();
+        final String key = className.toRootLowerCase(Locale.ROOT).trim();
         final PluginType<?> pluginType = plugins.get(key);
         if (pluginType == null) {
             LOGGER.warn("Unable to load plugin class name {} with key {}", className, key);

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/DateLayout.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/DateLayout.java
@@ -156,7 +156,7 @@ abstract public class DateLayout extends Layout {
     @Deprecated
     public void setOption(final String option, final String value) {
         if (option.equalsIgnoreCase(DATE_FORMAT_OPTION)) {
-            dateFormatOption = value.toUpperCase();
+            dateFormatOption = value.toRootUpperCase();
         } else if (option.equalsIgnoreCase(TIMEZONE_OPTION)) {
             timeZoneID = value;
         }

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/OptionConverter.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/OptionConverter.java
@@ -158,7 +158,7 @@ public class OptionConverter {
     }
 
     public static org.apache.logging.log4j.Level createLevel(final Priority level) {
-        final String name = level.toString().toUpperCase() + "#" + level.getClass().getName();
+        final String name = level.toString().toRootUpperCase() + "#" + level.getClass().getName();
         return org.apache.logging.log4j.Level.forName(name, toLog4j2Level(level.toInt()));
     }
 
@@ -493,7 +493,7 @@ public class OptionConverter {
             return defaultValue;
         }
 
-        String s = value.trim().toUpperCase();
+        String s = value.trim().toRootUpperCase();
         long multiplier = 1;
         int index;
 
@@ -627,7 +627,7 @@ public class OptionConverter {
 
         // Support for levels defined in Log4j2.
         if (LOG4J2_LEVEL_CLASS.equals(clazz)) {
-            final org.apache.logging.log4j.Level v2Level = org.apache.logging.log4j.Level.getLevel(levelName.toUpperCase());
+            final org.apache.logging.log4j.Level v2Level = org.apache.logging.log4j.Level.getLevel(levelName.toRootUpperCase());
             if (v2Level != null) {
                 return new LevelWrapper(v2Level);
             }

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/UtilLoggingLevel.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/UtilLoggingLevel.java
@@ -199,7 +199,7 @@ public class UtilLoggingLevel extends Level {
             return defaultLevel;
         }
 
-        final String s = sArg.toUpperCase();
+        final String s = sArg.toRootUpperCase();
 
         if (s.equals("SEVERE")) {
             return SEVERE;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/layout/Log4j1SyslogLayout.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/layout/Log4j1SyslogLayout.java
@@ -189,7 +189,7 @@ public final class Log4j1SyslogLayout  extends AbstractStringLayout {
         }
 
         if (facilityPrinting) {
-            buf.append(facility != null ? facility.name().toLowerCase() : "user").append(':');
+            buf.append(facility != null ? facility.name().toRootLowerCase() : "user").append(':');
         }
 
         buf.append(message);

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/xml/XLevel.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/xml/XLevel.java
@@ -55,7 +55,7 @@ public class XLevel extends Level {
         if (sArg == null) {
             return defaultValue;
         }
-        final String stringVal = sArg.toUpperCase();
+        final String stringVal = sArg.toRootUpperCase();
 
         if (stringVal.equals(TRACE_STR)) {
             return XLevel.TRACE;

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/StringsTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/StringsTest.java
@@ -98,7 +98,7 @@ public class StringsTest {
     }
 
     @Test
-    public void testToLowerCase() {
+    public void testtoRootLowerCase() {
         assertEquals("a", Strings.toRootLowerCase("A"));
         assertEquals("a", Strings.toRootLowerCase("a"));
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
@@ -138,7 +138,7 @@ public final class Level implements Comparable<Level>, Serializable {
         this.name = name;
         this.intLevel = intLevel;
         this.standardLevel = StandardLevel.getStandardLevel(intLevel);
-        if (LEVELS.putIfAbsent(toUpperCase(name.trim()), this) != null) {
+        if (LEVELS.putIfAbsent(toRootUpperCase(name.trim()), this) != null) {
             throw new IllegalStateException("Level " + name + " has already been defined.");
         }
     }
@@ -261,7 +261,7 @@ public final class Level implements Comparable<Level>, Serializable {
         if (Strings.isEmpty(name)) {
             throw new IllegalArgumentException("Illegal null or empty Level name.");
         }
-        final String normalizedName = toUpperCase(name.trim());
+        final String normalizedName = toRootUpperCase(name.trim());
         final Level level = LEVELS.get(normalizedName);
         if (level != null) {
             return level;
@@ -286,7 +286,7 @@ public final class Level implements Comparable<Level>, Serializable {
         if (Strings.isEmpty(name)) {
             throw new IllegalArgumentException("Illegal null or empty Level name.");
         }
-        return LEVELS.get(toUpperCase(name.trim()));
+        return LEVELS.get(toRootUpperCase(name.trim()));
     }
 
     /**
@@ -312,12 +312,12 @@ public final class Level implements Comparable<Level>, Serializable {
         if (name == null) {
             return defaultLevel;
         }
-        final Level level = LEVELS.get(toUpperCase(name.trim()));
+        final Level level = LEVELS.get(toRootUpperCase(name.trim()));
         return level == null ? defaultLevel : level;
     }
 
-    private static String toUpperCase(final String name) {
-        return name.toUpperCase(Locale.ENGLISH);
+    private static String toRootUpperCase(final String name) {
+        return name.toRootUpperCase(Locale.ENGLISH);
     }
 
     /**
@@ -339,7 +339,7 @@ public final class Level implements Comparable<Level>, Serializable {
      */
     public static Level valueOf(final String name) {
         Objects.requireNonNull(name, "No level name given.");
-        final String levelName = toUpperCase(name.trim());
+        final String levelName = toRootUpperCase(name.trim());
         final Level level = LEVELS.get(levelName);
         if (level != null) {
             return level;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/EnglishEnums.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/EnglishEnums.java
@@ -64,7 +64,7 @@ public final class EnglishEnums {
      * @return an enum value or {@code defaultValue} if {@code name} is null.
      */
     public static <T extends Enum<T>> T valueOf(final Class<T> enumType, final String name, final T defaultValue) {
-        return name == null ? defaultValue : Enum.valueOf(enumType, name.toUpperCase(Locale.ENGLISH));
+        return name == null ? defaultValue : Enum.valueOf(enumType, name.toRootUpperCase(Locale.ENGLISH));
     }
 
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/EnvironmentPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/EnvironmentPropertySource.java
@@ -69,7 +69,7 @@ public class EnvironmentPropertySource implements PropertySource {
             empty = false;
             sb.append('_');
             for (int i = 0; i < token.length(); i++) {
-                sb.append(Character.toUpperCase(token.charAt(i)));
+                sb.append(Character.toRootUpperCase(token.charAt(i)));
             }
         }
         return empty ? null : sb.toString();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
@@ -18,7 +18,7 @@ package org.apache.logging.log4j.util;
 
 import java.util.Map.Entry;
 
-import static java.lang.Character.toLowerCase;
+import static java.lang.Character.toRootLowerCase;
 
 /**
  * <em>Consider this class private.</em>
@@ -181,7 +181,7 @@ public final class StringBuilders {
                                               final CharSequence right, final int rightOffset, final int rightLength) {
         if (leftLength == rightLength) {
             for (int i = 0; i < rightLength; i++) {
-                if (toLowerCase(left.charAt(i + leftOffset)) != toLowerCase(right.charAt(i + rightOffset))) {
+                if (toRootLowerCase(left.charAt(i + leftOffset)) != toRootLowerCase(right.charAt(i + rightOffset))) {
                     return false;
                 }
             }

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/smtp/SmtpRequest.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/smtp/SmtpRequest.java
@@ -186,7 +186,7 @@ public class SmtpRequest {
                 }
             }
         } else {
-            final String su = s.toUpperCase();
+            final String su = s.toRootUpperCase();
             if (su.startsWith("EHLO ") || su.startsWith("HELO")) {
                 action = SmtpActionType.EHLO;
                 params = s.substring(5);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderSizeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderSizeTest.java
@@ -148,7 +148,7 @@ public class RollingAppenderSizeTest {
                 CompressorInputStream in = null;
                 try (FileInputStream fis = new FileInputStream(file)) {
                     try {
-                        in = new CompressorStreamFactory().createCompressorInputStream(ext.name().toLowerCase(), fis);
+                        in = new CompressorStreamFactory().createCompressorInputStream(ext.name().toRootLowerCase(), fis);
                     } catch (final CompressorException ce) {
                         ce.printStackTrace();
                         fail("Error creating input stream from " + file.toString() + ": " + ce.getMessage());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTempCompressedFilePatternTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTempCompressedFilePatternTest.java
@@ -106,7 +106,7 @@ public class RollingAppenderTempCompressedFilePatternTest {
                         if (ext != null) {
                             gzippedFiles++;
                             try {
-                                in = new CompressorStreamFactory().createCompressorInputStream(ext.name().toLowerCase(),
+                                in = new CompressorStreamFactory().createCompressorInputStream(ext.name().toRootLowerCase(),
                                         fis);
                             } catch (final CompressorException ce) {
                                 ce.printStackTrace();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactoryTest.java
@@ -74,7 +74,7 @@ public class AsyncQueueFullPolicyFactoryTest {
     @Test
     public void testCreateDiscardingRouterCaseInsensitive() {
         System.setProperty(AsyncQueueFullPolicyFactory.PROPERTY_NAME_ASYNC_EVENT_ROUTER,
-                AsyncQueueFullPolicyFactory.PROPERTY_VALUE_DISCARDING_ASYNC_EVENT_ROUTER.toLowerCase(Locale.ENGLISH));
+                AsyncQueueFullPolicyFactory.PROPERTY_VALUE_DISCARDING_ASYNC_EVENT_ROUTER.toRootLowerCase(Locale.ENGLISH));
         assertEquals(Level.INFO, ((DiscardingAsyncQueueFullPolicy) AsyncQueueFullPolicyFactory.create()).
                 getThresholdLevel());
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/TestConfigurator.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/TestConfigurator.java
@@ -393,7 +393,7 @@ public class TestConfigurator {
 
         for (final String element : CHARS) {
             dir.append(element);
-            dir.append(element.toUpperCase());
+            dir.append(element.toRootUpperCase());
         }
         final String value = FILESEP.equals("/") ? dir.toString() + "/test.log" : "1:/target/bad:file.log";
         System.setProperty("testfile", value);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessorTest.java
@@ -54,7 +54,7 @@ public class PluginProcessorTest {
 
     @Test
     public void testFakePluginFoundWithCorrectInformation() throws Exception {
-        final PluginEntry fake = pluginCache.getCategory(p.category()).get(p.name().toLowerCase());
+        final PluginEntry fake = pluginCache.getCategory(p.category()).get(p.name().toRootLowerCase());
         verifyFakePluginEntry(p.name(), fake);
     }
 
@@ -62,15 +62,15 @@ public class PluginProcessorTest {
     public void testFakePluginAliasesContainSameInformation() throws Exception {
         final PluginAliases aliases = FakePlugin.class.getAnnotation(PluginAliases.class);
         for (final String alias : aliases.value()) {
-            final PluginEntry fake = pluginCache.getCategory(p.category()).get(alias.toLowerCase());
+            final PluginEntry fake = pluginCache.getCategory(p.category()).get(alias.toRootLowerCase());
             verifyFakePluginEntry(alias, fake);
         }
     }
 
     private void verifyFakePluginEntry(final String name, final PluginEntry fake) {
-        assertNotNull("The plugin '" + name.toLowerCase() + "' was not found.", fake);
+        assertNotNull("The plugin '" + name.toRootLowerCase() + "' was not found.", fake);
         assertEquals(FakePlugin.class.getName(), fake.getClassName());
-        assertEquals(name.toLowerCase(), fake.getKey());
+        assertEquals(name.toRootLowerCase(), fake.getKey());
         assertEquals(Plugin.EMPTY, p.elementType());
         assertEquals(name, fake.getName());
         assertEquals(p.printObject(), fake.isPrintable());
@@ -80,9 +80,9 @@ public class PluginProcessorTest {
     @Test
     public void testNestedPlugin() throws Exception {
         final Plugin p = FakePlugin.Nested.class.getAnnotation(Plugin.class);
-        final PluginEntry nested = pluginCache.getCategory(p.category()).get(p.name().toLowerCase());
+        final PluginEntry nested = pluginCache.getCategory(p.category()).get(p.name().toRootLowerCase());
         assertNotNull(nested);
-        assertEquals(p.name().toLowerCase(), nested.getKey());
+        assertEquals(p.name().toRootLowerCase(), nested.getKey());
         assertEquals(FakePlugin.Nested.class.getName(), nested.getClassName());
         assertEquals(p.name(), nested.getName());
         assertEquals(Plugin.EMPTY, p.elementType());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/StructuredDataLookupTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/StructuredDataLookupTest.java
@@ -43,9 +43,9 @@ public class StructuredDataLookupTest {
         final LogEvent event = Log4jLogEvent.newBuilder().setLevel(Level.DEBUG).setMessage(msg).build();
 
         assertEquals("Audit", dataLookup.lookup(event, StructuredDataLookup.TYPE_KEY));
-        assertEquals("Audit", dataLookup.lookup(event, StructuredDataLookup.TYPE_KEY.toUpperCase()));
+        assertEquals("Audit", dataLookup.lookup(event, StructuredDataLookup.TYPE_KEY.toRootUpperCase()));
         assertEquals("TestId", dataLookup.lookup(event, StructuredDataLookup.ID_KEY));
-        assertEquals("TestId", dataLookup.lookup(event, StructuredDataLookup.ID_KEY.toUpperCase()));
+        assertEquals("TestId", dataLookup.lookup(event, StructuredDataLookup.ID_KEY.toRootUpperCase()));
         assertNull(dataLookup.lookup(event, "BadKey"));
         assertNull(dataLookup.lookup(event, null));
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FastDateParserSDFTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FastDateParserSDFTest.java
@@ -203,12 +203,12 @@ public class FastDateParserSDFTest {
 
     @Test
     public void testLowerCase() throws Exception {
-        checkParse(input.toLowerCase(locale));
+        checkParse(input.toRootLowerCase(locale));
     }
 
     @Test
     public void testLowerCasePP() throws Exception {
-        checkParsePosition(input.toLowerCase(locale));
+        checkParsePosition(input.toRootLowerCase(locale));
     }
 
     @Test
@@ -223,10 +223,10 @@ public class FastDateParserSDFTest {
 
     @Test
     public void testUpperCase() throws Exception {
-        checkParse(input.toUpperCase(locale));
+        checkParse(input.toRootUpperCase(locale));
     }
     @Test
     public void testUpperCasePP() throws Exception {
-        checkParsePosition(input.toUpperCase(locale));
+        checkParsePosition(input.toRootUpperCase(locale));
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FastDateParserTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/datetime/FastDateParserTest.java
@@ -96,8 +96,8 @@ public class FastDateParserTest {
     private void checkParse(final Locale locale, final Calendar cal, final SimpleDateFormat sdf, final DateParser fdf) throws ParseException {
         final String formattedDate= sdf.format(cal.getTime());
         checkParse(locale, sdf, fdf, formattedDate);
-        checkParse(locale, sdf, fdf, formattedDate.toLowerCase(locale));
-        checkParse(locale, sdf, fdf, formattedDate.toUpperCase(locale));
+        checkParse(locale, sdf, fdf, formattedDate.toRootLowerCase(locale));
+        checkParse(locale, sdf, fdf, formattedDate.toRootUpperCase(locale));
     }
 
     private void checkParse(final Locale locale, final SimpleDateFormat sdf, final DateParser fdf, final String formattedDate) throws ParseException {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/ColumnMapping.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/ColumnMapping.java
@@ -201,7 +201,7 @@ public class ColumnMapping {
     }
 
     public static String toKey(final String name) {
-        return name.toUpperCase(Locale.ROOT);
+        return name.toRootUpperCase(Locale.ROOT);
     }
 
     private final StringLayout layout;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/LoggerNameLevelRewritePolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/LoggerNameLevelRewritePolicy.java
@@ -62,7 +62,7 @@ public class LoggerNameLevelRewritePolicy implements RewritePolicy {
     }
 
     private static Level getLevel(final String name) {
-        return Level.getLevel(name.toUpperCase(Locale.ROOT));
+        return Level.getLevel(name.toRootUpperCase(Locale.ROOT));
     }
 
     private final String loggerName;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/IdlePurgePolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/IdlePurgePolicy.java
@@ -144,7 +144,7 @@ public class IdlePurgePolicy extends AbstractLifeCycle implements PurgePolicy, R
             units = TimeUnit.MINUTES;
         } else {
             try {
-                units = TimeUnit.valueOf(timeUnit.toUpperCase());
+                units = TimeUnit.valueOf(timeUnit.toRootUpperCase());
             } catch (final Exception ex) {
                 LOGGER.error("Invalid timeUnit value {}. timeUnit set to MINUTES", timeUnit, ex);
                 units = TimeUnit.MINUTES;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/CompositeConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/CompositeConfiguration.java
@@ -81,7 +81,7 @@ public class CompositeConfiguration extends AbstractConfiguration implements Rec
             final String key = entry.getKey();
             final String value = getConfigurationStrSubstitutor().replace(entry.getValue());
             if ("status".equalsIgnoreCase(key)) {
-                statusConfig.withStatus(value.toUpperCase());
+                statusConfig.withStatus(value.toRootUpperCase());
             } else if ("dest".equalsIgnoreCase(key)) {
                 statusConfig.withDestination(value);
             } else if ("shutdownHook".equalsIgnoreCase(key)) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/DefaultMergeStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/DefaultMergeStrategy.java
@@ -76,8 +76,8 @@ public class DefaultMergeStrategy implements MergeStrategy {
             for (final Map.Entry<String, String> targetAttribute : rootNode.getAttributes().entrySet()) {
                 if (targetAttribute.getKey().equalsIgnoreCase(attribute.getKey())) {
                     if (attribute.getKey().equalsIgnoreCase(STATUS)) {
-                        final Level targetLevel = Level.getLevel(targetAttribute.getValue().toUpperCase());
-                        final Level sourceLevel = Level.getLevel(attribute.getValue().toUpperCase());
+                        final Level targetLevel = Level.getLevel(targetAttribute.getValue().toRootUpperCase());
+                        final Level sourceLevel = Level.getLevel(attribute.getValue().toRootUpperCase());
                         if (targetLevel != null && sourceLevel != null) {
                             if (sourceLevel.isLessSpecificThan(targetLevel)) {
                                 targetAttribute.setValue(attribute.getValue());
@@ -142,7 +142,7 @@ public class DefaultMergeStrategy implements MergeStrategy {
                     continue;
                 }
 
-                switch (targetChildNode.getName().toLowerCase()) {
+                switch (targetChildNode.getName().toRootLowerCase()) {
                     case PROPERTIES:
                     case SCRIPTS:
                     case APPENDERS: {
@@ -277,11 +277,11 @@ public class DefaultMergeStrategy implements MergeStrategy {
 
     private boolean isSameName(final Node node1, final Node node2) {
         final String value = node1.getAttributes().get(NAME);
-        return value != null && value.toLowerCase().equals(node2.getAttributes().get(NAME).toLowerCase());
+        return value != null && value.toRootLowerCase().equals(node2.getAttributes().get(NAME).toRootLowerCase());
     }
 
     private boolean isSameReference(final Node node1, final Node node2) {
         final String value = node1.getAttributes().get(REF);
-        return value != null && value.toLowerCase().equals(node2.getAttributes().get(REF).toLowerCase());
+        return value != null && value.toRootLowerCase().equals(node2.getAttributes().get(REF).toRootLowerCase());
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverters.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverters.java
@@ -177,7 +177,7 @@ public final class TypeConverters {
     public static class ClassConverter implements TypeConverter<Class<?>> {
         @Override
         public Class<?> convert(final String s) throws ClassNotFoundException {
-            switch (s.toLowerCase()) {
+            switch (s.toRootLowerCase()) {
                 case "boolean":
                     return boolean.class;
                 case "byte":

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginCache.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginCache.java
@@ -51,7 +51,7 @@ public class PluginCache {
      * @return plugin mapping of names to plugin entries.
      */
     public Map<String, PluginEntry> getCategory(final String category) {
-        final String key = category.toLowerCase();
+        final String key = category.toRootLowerCase();
         return categories.computeIfAbsent(key, ignored -> new TreeMap<>());
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessor.java
@@ -136,7 +136,7 @@ public class PluginProcessor extends AbstractProcessor {
         public PluginEntry visitType(final TypeElement e, final Plugin plugin) {
             Objects.requireNonNull(plugin, "Plugin annotation is null.");
             final PluginEntry entry = new PluginEntry();
-            entry.setKey(plugin.name().toLowerCase(Locale.US));
+            entry.setKey(plugin.name().toRootLowerCase(Locale.US));
             entry.setClassName(elements.getBinaryName(e).toString());
             entry.setName(Plugin.EMPTY.equals(plugin.elementType()) ? plugin.name() : plugin.elementType());
             entry.setPrintable(plugin.printObject());
@@ -167,7 +167,7 @@ public class PluginProcessor extends AbstractProcessor {
             final Collection<PluginEntry> entries = new ArrayList<>(aliases.value().length);
             for (final String alias : aliases.value()) {
                 final PluginEntry entry = new PluginEntry();
-                entry.setKey(alias.toLowerCase(Locale.US));
+                entry.setKey(alias.toRootLowerCase(Locale.US));
                 entry.setClassName(elements.getBinaryName(e).toString());
                 entry.setName(Plugin.EMPTY.equals(plugin.elementType()) ? alias : plugin.elementType());
                 entry.setPrintable(plugin.printObject());

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/PluginManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/PluginManager.java
@@ -98,7 +98,7 @@ public class PluginManager {
      * @return The plugin's type.
      */
     public PluginType<?> getPluginType(final String name) {
-        return plugins.get(name.toLowerCase());
+        return plugins.get(name.toRootLowerCase());
     }
 
     /**
@@ -127,7 +127,7 @@ public class PluginManager {
         if (isNotEmpty(packages) || isNotEmpty(PACKAGES)) {
             LOGGER.warn("The use of package scanning to locate plugins is deprecated and will be removed in a future release");
         }
-        final String categoryLowerCase = category.toLowerCase();
+        final String categoryLowerCase = category.toRootLowerCase();
         final Map<String, PluginType<?>> newPlugins = new LinkedHashMap<>();
 
         // First, iterate the Log4j2Plugin.dat files found in the main CLASSPATH

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/PluginRegistry.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/PluginRegistry.java
@@ -226,7 +226,7 @@ public class PluginRegistry {
         final Map<String, List<PluginType<?>>> newPluginsByCategory = new HashMap<>();
         for (final Class<?> clazz : resolver.getClasses()) {
             final Plugin plugin = clazz.getAnnotation(Plugin.class);
-            final String categoryLowerCase = plugin.category().toLowerCase();
+            final String categoryLowerCase = plugin.category().toRootLowerCase();
             List<PluginType<?>> list = newPluginsByCategory.get(categoryLowerCase);
             if (list == null) {
                 newPluginsByCategory.put(categoryLowerCase, list = new ArrayList<>());
@@ -234,7 +234,7 @@ public class PluginRegistry {
             final PluginEntry mainEntry = new PluginEntry();
             final String mainElementName = plugin.elementType().equals(
                 Plugin.EMPTY) ? plugin.name() : plugin.elementType();
-            mainEntry.setKey(plugin.name().toLowerCase());
+            mainEntry.setKey(plugin.name().toRootLowerCase());
             mainEntry.setName(plugin.name());
             mainEntry.setCategory(plugin.category());
             mainEntry.setClassName(clazz.getName());
@@ -248,7 +248,7 @@ public class PluginRegistry {
                     final PluginEntry aliasEntry = new PluginEntry();
                     final String aliasElementName = plugin.elementType().equals(
                         Plugin.EMPTY) ? alias.trim() : plugin.elementType();
-                    aliasEntry.setKey(alias.trim().toLowerCase());
+                    aliasEntry.setKey(alias.trim().toRootLowerCase());
                     aliasEntry.setName(plugin.name());
                     aliasEntry.setCategory(plugin.category());
                     aliasEntry.setClassName(clazz.getName());

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/JsonLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/JsonLayout.java
@@ -242,7 +242,7 @@ public final class JsonLayout extends AbstractJacksonLayout {
      * @param headerPattern
      *            The header pattern, defaults to {@code "["} if null.
      * @param footerPattern
-     *            The header pattern, defaults to {@code "]"} if null.
+     *            The footer pattern, defaults to {@code "]"} if null.
      * @param charset
      *            The character set to use, if {@code null}, uses "UTF-8".
      * @param includeStacktrace

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/YamlLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/YamlLayout.java
@@ -167,7 +167,7 @@ public final class YamlLayout extends AbstractJacksonLayout {
      * @param headerPattern
      *            The header pattern, defaults to {@code ""} if null.
      * @param footerPattern
-     *            The header pattern, defaults to {@code ""} if null.
+     *            The footer pattern, defaults to {@code ""} if null.
      * @param charset
      *            The character set to use, if {@code null}, uses "UTF-8".
      * @param includeStacktrace

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
@@ -83,7 +83,7 @@ public class Interpolator extends AbstractConfigurationAwareLookup implements Lo
             try {
                 final Class<? extends StrLookup> clazz = entry.getValue().getPluginClass().asSubclass(StrLookup.class);
                 if (!clazz.getName().equals("org.apache.logging.log4j.core.lookup.JndiLookup") || JndiManager.isJndiLookupEnabled()) {
-                    strLookupMap.put(entry.getKey().toLowerCase(), ReflectionUtil.instantiate(clazz));
+                    strLookupMap.put(entry.getKey().toRootLowerCase(), ReflectionUtil.instantiate(clazz));
                 }
             } catch (final Throwable t) {
                 handleError(entry.getKey(), t);
@@ -184,7 +184,7 @@ public class Interpolator extends AbstractConfigurationAwareLookup implements Lo
 
         final int prefixPos = var.indexOf(PREFIX_SEPARATOR);
         if (prefixPos >= 0) {
-            final String prefix = var.substring(0, prefixPos).toLowerCase(Locale.US);
+            final String prefix = var.substring(0, prefixPos).toRootLowerCase(Locale.US);
             final String name = var.substring(prefixPos + 1);
             final StrLookup lookup = strLookupMap.get(prefix);
             if (lookup instanceof ConfigurationAware) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/LowerLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/LowerLookup.java
@@ -32,7 +32,7 @@ public class LowerLookup implements StrLookup {
      */
     @Override
     public String lookup(final String key) {
-        return key != null ? key.toLowerCase() : null;
+        return key != null ? key.toRootLowerCase() : null;
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/StrSubstitutor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/StrSubstitutor.java
@@ -827,7 +827,7 @@ public class StrSubstitutor implements ConfigurationAware {
      * with their matching values from the resolver.
      * The buffer is updated with the result.
      *
-     * @param source  the buffer to replace in, updated, null returns zero
+     * @param source  the buffer to replace in, updated, null returns false
      * @return true if altered
      */
     public boolean replaceIn(final StringBuffer source) {
@@ -846,7 +846,7 @@ public class StrSubstitutor implements ConfigurationAware {
      * The rest of the buffer is not processed, but it is not deleted.
      * </p>
      *
-     * @param source  the buffer to replace in, updated, null returns zero
+     * @param source  the buffer to replace in, updated, null returns false
      * @param offset  the start offset within the array, must be valid
      * @param length  the length within the buffer to be processed, must be valid
      * @return true if altered
@@ -865,7 +865,7 @@ public class StrSubstitutor implements ConfigurationAware {
      * </p>
      *
      * @param event the current LogEvent, if one exists.
-     * @param source  the buffer to replace in, updated, null returns zero
+     * @param source  the buffer to replace in, updated, null returns false
      * @param offset  the start offset within the array, must be valid
      * @param length  the length within the buffer to be processed, must be valid
      * @return true if altered
@@ -892,7 +892,7 @@ public class StrSubstitutor implements ConfigurationAware {
      * Replaces all the occurrences of variables within the given source
      * builder with their matching values from the resolver.
      *
-     * @param source  the builder to replace in, updated, null returns zero
+     * @param source  the builder to replace in, updated, null returns false
      * @return true if altered
      */
     public boolean replaceIn(final StringBuilder source) {
@@ -905,7 +905,7 @@ public class StrSubstitutor implements ConfigurationAware {
      * builder with their matching values from the resolver.
      *
      * @param event the current LogEvent, if one exists.
-     * @param source  the builder to replace in, updated, null returns zero
+     * @param source  the builder to replace in, updated, null returns false
      * @return true if altered
      */
     public boolean replaceIn(final LogEvent event, final StringBuilder source) {
@@ -922,7 +922,7 @@ public class StrSubstitutor implements ConfigurationAware {
      * The rest of the builder is not processed, but it is not deleted.
      * </p>
      *
-     * @param source  the builder to replace in, null returns zero
+     * @param source  the builder to replace in, null returns false
      * @param offset  the start offset within the array, must be valid
      * @param length  the length within the builder to be processed, must be valid
      * @return true if altered
@@ -940,7 +940,7 @@ public class StrSubstitutor implements ConfigurationAware {
      * </p>
      *
      * @param event   the current LogEvent, if one is present.
-     * @param source  the builder to replace in, null returns zero
+     * @param source  the builder to replace in, null returns false
      * @param offset  the start offset within the array, must be valid
      * @param length  the length within the builder to be processed, must be valid
      * @return true if altered

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/UpperLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/UpperLookup.java
@@ -32,7 +32,7 @@ public class UpperLookup implements StrLookup {
      */
     @Override
     public String lookup(final String key) {
-        return key != null ? key.toUpperCase() : null;
+        return key != null ? key.toRootUpperCase() : null;
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/Facility.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/Facility.java
@@ -207,7 +207,7 @@ public enum Facility {
     /**
      * Returns the Facility for the given string.
      *
-     * @param name The Facility enum name, case-insensitive. If null, returns, null
+     * @param name The Facility enum name, case-insensitive. If null, returns null
      * @return a Facility enum value or null if name is null
      */
     public static Facility toFacility(final String name) {
@@ -219,7 +219,7 @@ public enum Facility {
      *
      * @param name The Facility enum name, case-insensitive. If null, returns, defaultFacility
      * @param defaultFacility the Facility to return if name is null
-     * @return a Facility enum value or null if name is null
+     * @return a Facility enum value or defaultFacility if name is null
      */
     public static Facility toFacility(final String name, final Facility defaultFacility) {
         return EnglishEnums.valueOf(Facility.class, name, defaultFacility);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/UrlConnectionFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/UrlConnectionFactory.java
@@ -61,7 +61,7 @@ public class UrlConnectionFactory {
         throws IOException {
         final PropertiesUtil props = PropertiesUtil.getProperties();
         final List<String> allowed = Arrays.asList(Strings.splitList(props
-                .getStringProperty(ALLOWED_PROTOCOLS, DEFAULT_ALLOWED_PROTOCOLS).toLowerCase(Locale.ROOT)));
+                .getStringProperty(ALLOWED_PROTOCOLS, DEFAULT_ALLOWED_PROTOCOLS).toRootLowerCase(Locale.ROOT)));
         if (allowed.size() == 1 && NO_PROTOCOLS.equals(allowed.get(0))) {
             throw new ProtocolException("No external protocols have been enabled");
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/AnsiEscape.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/AnsiEscape.java
@@ -426,7 +426,7 @@ public enum AnsiEscape {
         for (final String string : values) {
             final String[] keyValue = string.split(Patterns.toWhitespaceSeparator("="));
             if (keyValue.length > 1) {
-                final String key = keyValue[0].toUpperCase(Locale.ENGLISH);
+                final String key = keyValue[0].toRootUpperCase(Locale.ENGLISH);
                 final String value = keyValue[1];
                 final boolean escape = Arrays.binarySearch(sortedIgnoreKeys, key) < 0;
                 map.put(key, escape ? createSequence(value.split("\\s")) : value);
@@ -459,7 +459,7 @@ public enum AnsiEscape {
                 }
                 first = false;
                 String hexColor = null;
-                final String trimmedName = name.trim().toUpperCase(Locale.ENGLISH);
+                final String trimmedName = name.trim().toRootUpperCase(Locale.ENGLISH);
                 if (trimmedName.startsWith("#")) {
                     sb.append("38");
                     sb.append(SEPARATOR.getCode());

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/HighlightConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/HighlightConverter.java
@@ -152,10 +152,10 @@ public final class HighlightConverter extends LogEventPatternConverter implement
         final Map<String, String> styles = AnsiEscape.createMap(string, new String[] {STYLE_KEY});
         final Map<String, String> levelStyles = new HashMap<>(DEFAULT_STYLES);
         for (final Map.Entry<String, String> entry : styles.entrySet()) {
-            final String key = entry.getKey().toUpperCase(Locale.ENGLISH);
+            final String key = entry.getKey().toRootUpperCase(Locale.ENGLISH);
             final String value = entry.getValue();
             if (STYLE_KEY.equalsIgnoreCase(key)) {
-                final Map<String, String> enumMap = STYLES.get(value.toUpperCase(Locale.ENGLISH));
+                final Map<String, String> enumMap = STYLES.get(value.toRootUpperCase(Locale.ENGLISH));
                 if (enumMap == null) {
                     LOGGER.error("Unknown level style: " + value + ". Use one of " +
                         Arrays.toString(STYLES.keySet().toArray()));

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/JAnsiTextRenderer.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/JAnsiTextRenderer.java
@@ -320,7 +320,7 @@ public final class JAnsiTextRenderer implements TextRenderer {
     }
 
     private Code toCode(final String name) {
-        return Code.valueOf(name.toUpperCase(Locale.ENGLISH));
+        return Code.valueOf(name.toRootUpperCase(Locale.ENGLISH));
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/LevelPatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/LevelPatternConverter.java
@@ -92,7 +92,7 @@ public class LevelPatternConverter extends LogEventPatternConverter {
         for (final Level level : Level.values()) {
             if (!levelMap.containsKey(level)) {
                 final String left = left(level, length);
-                levelMap.put(level, lowerCase ? left.toLowerCase(Locale.US) : left);
+                levelMap.put(level, lowerCase ? left.toRootLowerCase(Locale.US) : left);
             }
         }
         return new LevelMapLevelPatternConverter(levelMap);
@@ -130,7 +130,7 @@ public class LevelPatternConverter extends LogEventPatternConverter {
     @Override
     public String getStyleClass(final Object e) {
         if (e instanceof LogEvent) {
-            return "level " + ((LogEvent) e).getLevel().name().toLowerCase(Locale.ENGLISH);
+            return "level " + ((LogEvent) e).getLevel().name().toRootLowerCase(Locale.ENGLISH);
         }
 
         return "level";

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MessagePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MessagePatternConverter.java
@@ -50,7 +50,7 @@ public class MessagePatternConverter extends LogEventPatternConverter {
     private static TextRenderer loadMessageRenderer(final String[] options) {
         if (options != null) {
             for (final String option : options) {
-                switch (option.toUpperCase(Locale.ROOT)) {
+                switch (option.toRootUpperCase(Locale.ROOT)) {
                 case "ANSI":
                     if (Loader.isJansiAvailable()) {
                         return new JAnsiTextRenderer(options, JAnsiTextRenderer.DefaultMessageStyleMap);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/script/ScriptManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/script/ScriptManager.java
@@ -80,7 +80,7 @@ public class ScriptManager implements FileWatcher {
         this.configuration = configuration;
         this.watchManager = watchManager;
         final List<ScriptEngineFactory> factories = manager.getEngineFactories();
-        allowedLanguages = Arrays.stream(Strings.splitList(scriptLanguages)).map(String::toLowerCase)
+        allowedLanguages = Arrays.stream(Strings.splitList(scriptLanguages)).map(String::toRootLowerCase)
                 .collect(Collectors.toSet());
         if (logger.isDebugEnabled()) {
             final StringBuilder sb = new StringBuilder();
@@ -94,7 +94,7 @@ public class ScriptManager implements FileWatcher {
                 final StringBuilder names = new StringBuilder();
                 final List<String> languageNames = factory.getNames();
                 for (final String name : languageNames) {
-                    if (allowedLanguages.contains(name.toLowerCase(Locale.ROOT))) {
+                    if (allowedLanguages.contains(name.toRootLowerCase(Locale.ROOT))) {
                         if (names.length() > 0) {
                             names.append(", ");
                         }
@@ -117,7 +117,7 @@ public class ScriptManager implements FileWatcher {
             final StringBuilder names = new StringBuilder();
             for (final ScriptEngineFactory factory : factories) {
                 for (final String name : factory.getNames()) {
-                    if (allowedLanguages.contains(name.toLowerCase(Locale.ROOT))) {
+                    if (allowedLanguages.contains(name.toRootLowerCase(Locale.ROOT))) {
                         if (names.length() > 0) {
                             names.append(", ");
                         }
@@ -134,7 +134,7 @@ public class ScriptManager implements FileWatcher {
     }
 
     public boolean addScript(final AbstractScript script) {
-        if (allowedLanguages.contains(script.getLanguage().toLowerCase(Locale.ROOT))) {
+        if (allowedLanguages.contains(script.getLanguage().toRootLowerCase(Locale.ROOT))) {
             final ScriptEngine engine = manager.getEngineByName(script.getLanguage());
             if (engine == null) {
                 logger.error("No ScriptEngine found for language " + script.getLanguage() + ". Available languages are: "

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/Generate.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/Generate.java
@@ -1164,7 +1164,7 @@ public final class Generate {
                 lower = false;
                 continue;
             }
-            sb.append(lower ? Character.toLowerCase(ch) : Character.toUpperCase(ch));
+            sb.append(lower ? Character.toRootLowerCase(ch) : Character.toRootUpperCase(ch));
             lower = true;
         }
         return sb.toString();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/picocli/CommandLine.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/picocli/CommandLine.java
@@ -3858,7 +3858,7 @@ public class CommandLine {
                 if (o1 == null) { return 1; } else if (o2 == null) { return -1; } // options before params
                 final String[] names1 = ShortestFirst.sort(o1.names());
                 final String[] names2 = ShortestFirst.sort(o2.names());
-                int result = names1[0].toUpperCase().compareTo(names2[0].toUpperCase()); // case insensitive sort
+                int result = names1[0].toRootUpperCase().compareTo(names2[0].toRootUpperCase()); // case insensitive sort
                 result = result == 0 ? -names1[0].compareTo(names2[0]) : result; // lower case before upper case
                 return o1.help() == o2.help() ? result : o2.help() ? -1 : 1; // help options come last
             }
@@ -4339,8 +4339,8 @@ public class CommandLine {
                  * @return the IStyle for the specified converter
                  */
                 public static IStyle fg(final String str) {
-                    try { return Style.valueOf(str.toLowerCase(ENGLISH)); } catch (final Exception ignored) {}
-                    try { return Style.valueOf("fg_" + str.toLowerCase(ENGLISH)); } catch (final Exception ignored) {}
+                    try { return Style.valueOf(str.toRootLowerCase(ENGLISH)); } catch (final Exception ignored) {}
+                    try { return Style.valueOf("fg_" + str.toRootLowerCase(ENGLISH)); } catch (final Exception ignored) {}
                     return new Palette256Color(true, str);
                 }
                 /** Parses the specified style markup and returns the associated style.
@@ -4351,8 +4351,8 @@ public class CommandLine {
                  * @return the IStyle for the specified converter
                  */
                 public static IStyle bg(final String str) {
-                    try { return Style.valueOf(str.toLowerCase(ENGLISH)); } catch (final Exception ignored) {}
-                    try { return Style.valueOf("bg_" + str.toLowerCase(ENGLISH)); } catch (final Exception ignored) {}
+                    try { return Style.valueOf(str.toRootLowerCase(ENGLISH)); } catch (final Exception ignored) {}
+                    try { return Style.valueOf("bg_" + str.toRootLowerCase(ENGLISH)); } catch (final Exception ignored) {}
                     return new Palette256Color(false, str);
                 }
                 /** Parses the specified comma-separated sequence of style descriptors and returns the associated
@@ -4365,10 +4365,10 @@ public class CommandLine {
                     final String[] codes = commaSeparatedCodes.split(",");
                     final IStyle[] styles = new IStyle[codes.length];
                     for(int i = 0; i < codes.length; ++i) {
-                        if (codes[i].toLowerCase(ENGLISH).startsWith("fg(")) {
+                        if (codes[i].toRootLowerCase(ENGLISH).startsWith("fg(")) {
                             final int end = codes[i].indexOf(')');
                             styles[i] = Style.fg(codes[i].substring(3, end < 0 ? codes[i].length() : end));
-                        } else if (codes[i].toLowerCase(ENGLISH).startsWith("bg(")) {
+                        } else if (codes[i].toRootLowerCase(ENGLISH).startsWith("bg(")) {
                             final int end = codes[i].indexOf(')');
                             styles[i] = Style.bg(codes[i].substring(3, end < 0 ? codes[i].length() : end));
                         } else {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/CronExpression.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/CronExpression.java
@@ -272,7 +272,7 @@ public final class CronExpression {
             throw new IllegalArgumentException("cronExpression cannot be null");
         }
 
-        this.cronExpression = cronExpression.toUpperCase(Locale.US);
+        this.cronExpression = cronExpression.toRootUpperCase(Locale.US);
 
         buildExpression(this.cronExpression);
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/OptionConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/OptionConverter.java
@@ -234,7 +234,7 @@ public final class OptionConverter {
             return defaultValue;
         }
 
-        String str = value.trim().toUpperCase(Locale.ENGLISH);
+        String str = value.trim().toRootUpperCase(Locale.ENGLISH);
         long multiplier = 1;
         int index;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/FastDateParser.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/FastDateParser.java
@@ -468,7 +468,7 @@ public class FastDateParser implements DateParser, Serializable {
         final Map<String, Integer> displayNames = cal.getDisplayNames(field, Calendar.ALL_STYLES, locale);
         final TreeSet<String> sorted = new TreeSet<>(LONGER_FIRST_LOWERCASE);
         for (final Map.Entry<String, Integer> displayName : displayNames.entrySet()) {
-            final String key = displayName.getKey().toLowerCase(locale);
+            final String key = displayName.getKey().toRootLowerCase(locale);
             if (sorted.add(key)) {
                 values.put(key, displayName.getValue());
             }
@@ -716,7 +716,7 @@ public class FastDateParser implements DateParser, Serializable {
          */
         @Override
         void setCalendar(final FastDateParser parser, final Calendar cal, final String value) {
-            final Integer iVal = lKeyValues.get(value.toLowerCase(locale));
+            final Integer iVal = lKeyValues.get(value.toRootLowerCase(locale));
             cal.set(field, iVal.intValue());
         }
     }
@@ -866,7 +866,7 @@ public class FastDateParser implements DateParser, Serializable {
                         break;
                     }
                     if (zoneNames[i] != null) {
-                        final String key = zoneNames[i].toLowerCase(locale);
+                        final String key = zoneNames[i].toRootLowerCase(locale);
                         // ignore the data associated with duplicates supplied in
                         // the additional names
                         if (sorted.add(key)) {
@@ -893,10 +893,10 @@ public class FastDateParser implements DateParser, Serializable {
                 final TimeZone tz = TimeZone.getTimeZone("GMT" + value);
                 cal.setTimeZone(tz);
             } else if (value.regionMatches(true, 0, "GMT", 0, 3)) {
-                final TimeZone tz = TimeZone.getTimeZone(value.toUpperCase());
+                final TimeZone tz = TimeZone.getTimeZone(value.toRootUpperCase());
                 cal.setTimeZone(tz);
             } else {
-                final TzInfo tzInfo = tzNames.get(value.toLowerCase(locale));
+                final TzInfo tzInfo = tzNames.get(value.toRootLowerCase(locale));
                 cal.set(Calendar.DST_OFFSET, tzInfo.dstOffset);
                 cal.set(Calendar.ZONE_OFFSET, tzInfo.zone.getRawOffset());
             }

--- a/log4j-couchdb/src/main/java/org/apache/logging/log4j/couchdb/CouchDbProvider.java
+++ b/log4j-couchdb/src/main/java/org/apache/logging/log4j/couchdb/CouchDbProvider.java
@@ -130,7 +130,7 @@ public final class CouchDbProvider implements NoSqlProvider<CouchDbConnection> {
             }
         } else if (Strings.isNotEmpty(databaseName)) {
             if (protocol != null && protocol.length() > 0) {
-                protocol = protocol.toLowerCase();
+                protocol = protocol.toRootLowerCase();
                 if (!protocol.equals("http") && !protocol.equals("https")) {
                     LOGGER.error("Only protocols [http] and [https] are supported, [{}] specified.", protocol);
                     return null;

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAppender.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAppender.java
@@ -72,7 +72,7 @@ public final class FlumeAppender extends AbstractAppender implements FlumeEventF
         AVRO, EMBEDDED, PERSISTENT;
 
         public static ManagerType getType(final String type) {
-            return valueOf(type.toUpperCase(Locale.US));
+            return valueOf(type.toRootUpperCase(Locale.US));
         }
     }
 

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeEmbeddedManager.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeEmbeddedManager.java
@@ -250,9 +250,9 @@ public class FlumeEmbeddedManager extends AbstractFlumeManager {
                         throw new ConfigurationException(msg);
                     }
 
-                    final String upperKey = key.toUpperCase(Locale.ENGLISH);
+                    final String upperKey = key.toRootUpperCase(Locale.ENGLISH);
 
-                    if (upperKey.startsWith(name.toUpperCase(Locale.ENGLISH))) {
+                    if (upperKey.startsWith(name.toRootUpperCase(Locale.ENGLISH))) {
                         final String msg =
                             "Specification of the agent name is not allowed in Flume Appender configuration: " + key;
                         LOGGER.error(msg);

--- a/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/Log4jServletContextListener.java
+++ b/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/Log4jServletContextListener.java
@@ -84,7 +84,7 @@ public class Log4jServletContextListener implements ServletContextListener {
                     : Long.parseLong(stopTimeoutStr);
             final String timeoutTimeUnitStr = servletContext.getInitParameter(KEY_STOP_TIMEOUT_TIMEUNIT);
             final TimeUnit timeoutTimeUnit = Strings.isEmpty(timeoutTimeUnitStr) ? DEFAULT_STOP_TIMEOUT_TIMEUNIT
-                    : TimeUnit.valueOf(timeoutTimeUnitStr.toUpperCase(Locale.ROOT));
+                    : TimeUnit.valueOf(timeoutTimeUnitStr.toRootUpperCase(Locale.ROOT));
             ((LifeCycle2) this.initializer).stop(stopTimeout, timeoutTimeUnit);
         } else {
             this.initializer.stop();

--- a/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/Log4jShutdownOnContextDestroyedListener.java
+++ b/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/Log4jShutdownOnContextDestroyedListener.java
@@ -71,7 +71,7 @@ public class Log4jShutdownOnContextDestroyedListener implements ServletContextLi
                     : Long.parseLong(stopTimeoutStr);
             final String timeoutTimeUnitStr = servletContext.getInitParameter(KEY_STOP_TIMEOUT_TIMEUNIT);
             final TimeUnit timeoutTimeUnit = Strings.isEmpty(timeoutTimeUnitStr) ? DEFAULT_STOP_TIMEOUT_TIMEUNIT
-                    : TimeUnit.valueOf(timeoutTimeUnitStr.toUpperCase(Locale.ROOT));
+                    : TimeUnit.valueOf(timeoutTimeUnitStr.toRootUpperCase(Locale.ROOT));
             ((LifeCycle2) this.initializer).stop(stopTimeout, timeoutTimeUnit);
         } else {
             this.initializer.stop();

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/CaseConverterResolver.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/CaseConverterResolver.java
@@ -195,9 +195,9 @@ public final class CaseConverterResolver implements EventResolver {
         final Locale locale = config.getLocale("locale");
         final String _case = config.getString("case");
         if ("upper".equals(_case)) {
-            return input -> input.toUpperCase(locale);
+            return input -> input.toRootUpperCase(locale);
         } else if ("lower".equals(_case)) {
-            return input -> input.toLowerCase(locale);
+            return input -> input.toRootLowerCase(locale);
         } else {
             throw new IllegalArgumentException("invalid case: " + config);
         }

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/Uris.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/Uris.java
@@ -79,7 +79,7 @@ public final class Uris {
             final URI uri,
             final Charset charset)
             throws Exception {
-        final String uriScheme = uri.getScheme().toLowerCase();
+        final String uriScheme = uri.getScheme().toRootLowerCase();
         switch (uriScheme) {
             case "classpath":
                 return readClassPathUri(uri, charset);

--- a/log4j-spring-boot/src/main/java/org/apache/logging/log4j/spring/boot/SpringLookup.java
+++ b/log4j-spring-boot/src/main/java/org/apache/logging/log4j/spring/boot/SpringLookup.java
@@ -47,7 +47,7 @@ public class SpringLookup implements LoggerContextAware, StrLookup {
     @Override
     public String lookup(String key) {
         if (environment != null) {
-            String lowerKey = key.toLowerCase();
+            String lowerKey = key.toRootLowerCase();
             if (lowerKey.startsWith(ACTIVE)) {
                 switch (environment.getActiveProfiles().length) {
                     case 0: {

--- a/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/TagUtilsLevelTest.java
+++ b/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/TagUtilsLevelTest.java
@@ -42,7 +42,7 @@ public class TagUtilsLevelTest {
         final Collection<Object[]> params = new ArrayList<>();
         // this is perhaps the laziest way to test all the known levels
         for (final Level level : Level.values()) {
-            params.add(new Object[]{level, level.name().toLowerCase()});
+            params.add(new Object[]{level, level.name().toRootLowerCase()});
         }
         return params;
     }

--- a/log4j-web/src/main/java/org/apache/logging/log4j/web/Log4jServletContextListener.java
+++ b/log4j-web/src/main/java/org/apache/logging/log4j/web/Log4jServletContextListener.java
@@ -84,7 +84,7 @@ public class Log4jServletContextListener implements ServletContextListener {
                     : Long.parseLong(stopTimeoutStr);
             final String timeoutTimeUnitStr = servletContext.getInitParameter(KEY_STOP_TIMEOUT_TIMEUNIT);
             final TimeUnit timeoutTimeUnit = Strings.isEmpty(timeoutTimeUnitStr) ? DEFAULT_STOP_TIMEOUT_TIMEUNIT
-                    : TimeUnit.valueOf(timeoutTimeUnitStr.toUpperCase(Locale.ROOT));
+                    : TimeUnit.valueOf(timeoutTimeUnitStr.toRootUpperCase(Locale.ROOT));
             ((LifeCycle2) this.initializer).stop(stopTimeout, timeoutTimeUnit);
         } else {
             this.initializer.stop();

--- a/log4j-web/src/main/java/org/apache/logging/log4j/web/Log4jShutdownOnContextDestroyedListener.java
+++ b/log4j-web/src/main/java/org/apache/logging/log4j/web/Log4jShutdownOnContextDestroyedListener.java
@@ -71,7 +71,7 @@ public class Log4jShutdownOnContextDestroyedListener implements ServletContextLi
                     : Long.parseLong(stopTimeoutStr);
             final String timeoutTimeUnitStr = servletContext.getInitParameter(KEY_STOP_TIMEOUT_TIMEUNIT);
             final TimeUnit timeoutTimeUnit = Strings.isEmpty(timeoutTimeUnitStr) ? DEFAULT_STOP_TIMEOUT_TIMEUNIT
-                    : TimeUnit.valueOf(timeoutTimeUnitStr.toUpperCase(Locale.ROOT));
+                    : TimeUnit.valueOf(timeoutTimeUnitStr.toRootUpperCase(Locale.ROOT));
             ((LifeCycle2) this.initializer).stop(stopTimeout, timeoutTimeUnit);
         } else {
             this.initializer.stop();

--- a/src/site/xdoc/manual/customconfig.xml
+++ b/src/site/xdoc/manual/customconfig.xml
@@ -222,34 +222,36 @@ LoggerContext ctx = Configurator.initialize(builder.build());
             </p>
             <p>
               The easiest way to achieve this is to extend one of the standard Configuration classes
-              (XMLConfiguration, JSONConfiguration) and then create a new ConfigurationFactory for the extended class.
+              (XmlConfiguration, JSONConfiguration) and then create a new ConfigurationFactory for the extended class.
               After the standard configuration completes the custom configuration can be added to it.
             </p>
             <p>
-              The example below shows how to extend XMLConfiguration to manually add an Appender and a LoggerConfig
+              The example below shows how to extend XmlConfiguration to manually add an Appender and a LoggerConfig
               to the configuration.
             </p>
             <pre class="prettyprint linenums">
-@Plugin(name = "MyXMLConfigurationFactory", category = "ConfigurationFactory")
+@Plugin(name = "MyXmlConfigurationFactory", category = "ConfigurationFactory")
 @Order(10)
-public class MyXMLConfigurationFactory extends ConfigurationFactory {
+public class MyXmlConfigurationFactory extends ConfigurationFactory {
 
     /**
      * Valid file extensions for XML files.
      */
-    public static final String[] SUFFIXES = new String[] {".xml", "*"};
+    public static final String[] SUFFIXES = new String[]{".xml", "*"};
 
     /**
      * Return the Configuration.
+     *
      * @param source The InputSource.
      * @return The Configuration.
      */
-    public Configuration getConfiguration(InputSource source) {
-        return new MyXMLConfiguration(source, configFile);
+    public Configuration getConfiguration(LoggerContext loggerContext, ConfigurationSource source) {
+        return new MyXmlConfiguration(loggerContext, source);
     }
 
     /**
      * Returns the file suffixes for XML files.
+     *
      * @return An array of File extensions.
      */
     public String[] getSupportedTypes() {
@@ -257,9 +259,9 @@ public class MyXMLConfigurationFactory extends ConfigurationFactory {
     }
 }
 
-public class MyXMLConfiguration extends XMLConfiguration {
-    public MyXMLConfiguration(final ConfigurationFactory.ConfigurationSource configSource) {
-      super(configSource);
+public class MyXmlConfiguration extends XmlConfiguration {
+    public MyXmlConfiguration(final LoggerContext loggerContext, final ConfigurationSource configSource) {
+        super(loggerContext, configSource);
     }
 
     @Override
@@ -268,13 +270,16 @@ public class MyXMLConfiguration extends XMLConfiguration {
         final LoggerContext context = (LoggerContext) LogManager.getContext(false);
         final Configuration config = context.getConfiguration();
         final Layout layout = PatternLayout.createDefaultLayout(config);
-        final Appender appender = FileAppender.createAppender("target/test.log", "false", "false", "File", "true",
-              "false", "false", "4000", layout, null, "false", null, config);
-        appender.start();
-        addAppender(appender);
-        LoggerConfig loggerConfig = LoggerConfig.createLogger("false", "info", "org.apache.logging.log4j",
-              "true", refs, null, config, null );
-        loggerConfig.addAppender(appender, null, null);
+        final Appender fileAppender = FileAppender.newBuilder().setName("target/test.log").withFileName("File")
+                .withImmediateFlush(true).setIgnoreExceptions(false).withBufferedIo(false).withBufferSize(4000)
+                .setLayout(layout).withAdvertise(false).setConfiguration(config)
+                .build();
+        fileAppender.start();
+        addAppender(fileAppender);
+        AppenderRef[] refs = new AppenderRef[]{AppenderRef.createAppenderRef(fileAppender.getName(), null, null)};
+        LoggerConfig loggerConfig = LoggerConfig.createLogger(false, Level.INFO, "org.apache.logging.log4j",
+                "true", refs, null, config, null);
+        loggerConfig.addAppender(fileAppender, null, null);
         addLogger("org.apache.logging.log4j", loggerConfig);
     }
 }</pre>


### PR DESCRIPTION
As there're remaining locale-dependent calls of `String#toLowerCase` and `String#toUpperCase`. These calls are replaced with `Strings#toRootLowerCase` and `Strings#toRootUpperCase`.
