### PR TITLE
Avoid Locale-dependent lowercase/uppercase string conversion

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/Level.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/Level.java
@@ -21,10 +21,11 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
-import java.util.Locale;
 
 import org.apache.log4j.helpers.OptionConverter;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * Defines the minimum set of levels recognized by the system, that is
@@ -181,7 +182,7 @@ public class Level extends Priority implements Serializable {
         if (sArg == null) {
             return defaultLevel;
         }
-        final String s = sArg.toUpperCase(Locale.ROOT);
+        final String s = toRootUpperCase(sArg);
         switch (s) {
         case "ALL":
             return Level.ALL;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/BuilderManager.java
@@ -16,7 +16,6 @@
  */
 package org.apache.log4j.builders;
 
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -44,6 +43,8 @@ import org.apache.logging.log4j.core.config.plugins.util.PluginType;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
 import org.w3c.dom.Element;
+
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 
 /**
  *
@@ -95,7 +96,7 @@ public class BuilderManager {
     private <T> PluginType<T> getPlugin(final String className) {
         Objects.requireNonNull(plugins, "plugins");
         Objects.requireNonNull(className, "className");
-        final String key = className.toLowerCase(Locale.ROOT).trim();
+        final String key = toRootLowerCase(className).trim();
         final PluginType<?> pluginType = plugins.get(key);
         if (pluginType == null) {
             LOGGER.warn("Unable to load plugin class name {} with key {}", className, key);

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/DateLayout.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/DateLayout.java
@@ -25,6 +25,8 @@ import java.util.TimeZone;
 import org.apache.log4j.Layout;
 import org.apache.log4j.spi.LoggingEvent;
 
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
+
 /**
  * This abstract layout takes care of all the date related options and formatting work.
  */
@@ -156,7 +158,7 @@ abstract public class DateLayout extends Layout {
     @Deprecated
     public void setOption(final String option, final String value) {
         if (option.equalsIgnoreCase(DATE_FORMAT_OPTION)) {
-            dateFormatOption = value.toUpperCase();
+            dateFormatOption = toRootUpperCase(value);
         } else if (option.equalsIgnoreCase(TIMEZONE_OPTION)) {
             timeZoneID = value;
         }

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/OptionConverter.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/OptionConverter.java
@@ -37,6 +37,8 @@ import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.Strings;
 
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
+
 /**
  * A convenience class to convert property values to specific types.
  */
@@ -158,7 +160,7 @@ public final class OptionConverter {
     }
 
     public static org.apache.logging.log4j.Level createLevel(final Priority level) {
-        final String name = level.toString().toUpperCase() + "#" + level.getClass().getName();
+        final String name = toRootUpperCase(level.toString()) + "#" + level.getClass().getName();
         return org.apache.logging.log4j.Level.forName(name, toLog4j2Level(level.toInt()));
     }
 
@@ -493,7 +495,7 @@ public final class OptionConverter {
             return defaultValue;
         }
 
-        String s = value.trim().toUpperCase();
+        String s = toRootUpperCase(value.trim());
         long multiplier = 1;
         int index;
 
@@ -627,7 +629,7 @@ public final class OptionConverter {
 
         // Support for levels defined in Log4j2.
         if (LOG4J2_LEVEL_CLASS.equals(clazz)) {
-            final org.apache.logging.log4j.Level v2Level = org.apache.logging.log4j.Level.getLevel(levelName.toUpperCase());
+            final org.apache.logging.log4j.Level v2Level = org.apache.logging.log4j.Level.getLevel(toRootUpperCase(levelName));
             if (v2Level != null) {
                 return new LevelWrapper(v2Level);
             }

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/UtilLoggingLevel.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/UtilLoggingLevel.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 import org.apache.log4j.Level;
 
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
+
 /**
  * An extension of the Level class that provides support for java.util.logging Levels.
  */
@@ -199,7 +201,7 @@ public class UtilLoggingLevel extends Level {
             return defaultLevel;
         }
 
-        final String s = sArg.toUpperCase();
+        final String s = toRootUpperCase(sArg);
 
         if (s.equals("SEVERE")) {
             return SEVERE;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/layout/Log4j1SyslogLayout.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/layout/Log4j1SyslogLayout.java
@@ -38,6 +38,8 @@ import org.apache.logging.log4j.core.pattern.LogEventPatternConverter;
 import org.apache.logging.log4j.core.util.NetUtils;
 import org.apache.logging.log4j.util.Chars;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+
 /**
  * Port of the layout used by SyslogAppender in Log4j 1.x. Provided for
  * compatibility with existing Log4j 1 configurations.
@@ -189,7 +191,7 @@ public final class Log4j1SyslogLayout  extends AbstractStringLayout {
         }
 
         if (facilityPrinting) {
-            buf.append(facility != null ? facility.name().toLowerCase() : "user").append(':');
+            buf.append(facility != null ? toRootLowerCase(facility.name()) : "user").append(':');
         }
 
         buf.append(message);

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/xml/XLevel.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/xml/XLevel.java
@@ -18,6 +18,8 @@ package org.apache.log4j.xml;
 
 import org.apache.log4j.Level;
 
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
+
 /**
  * This class introduces a new level called TRACE. TRACE has lower level than DEBUG.
  */
@@ -55,7 +57,7 @@ public class XLevel extends Level {
         if (sArg == null) {
             return defaultValue;
         }
-        final String stringVal = sArg.toUpperCase();
+        final String stringVal = toRootUpperCase(sArg);
 
         if (stringVal.equals(TRACE_STR)) {
             return XLevel.TRACE;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
@@ -17,13 +17,14 @@
 package org.apache.logging.log4j;
 
 import java.io.Serializable;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.apache.logging.log4j.spi.StandardLevel;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * Levels used for identifying the severity of an event. Levels are organized from most specific to least:
@@ -138,7 +139,7 @@ public final class Level implements Comparable<Level>, Serializable {
         this.name = name;
         this.intLevel = intLevel;
         this.standardLevel = StandardLevel.getStandardLevel(intLevel);
-        if (LEVELS.putIfAbsent(toUpperCase(name.trim()), this) != null) {
+        if (LEVELS.putIfAbsent(toRootUpperCase(name.trim()), this) != null) {
             throw new IllegalStateException("Level " + name + " has already been defined.");
         }
     }
@@ -261,7 +262,7 @@ public final class Level implements Comparable<Level>, Serializable {
         if (Strings.isEmpty(name)) {
             throw new IllegalArgumentException("Illegal null or empty Level name.");
         }
-        final String normalizedName = toUpperCase(name.trim());
+        final String normalizedName = toRootUpperCase(name.trim());
         final Level level = LEVELS.get(normalizedName);
         if (level != null) {
             return level;
@@ -286,7 +287,7 @@ public final class Level implements Comparable<Level>, Serializable {
         if (Strings.isEmpty(name)) {
             throw new IllegalArgumentException("Illegal null or empty Level name.");
         }
-        return LEVELS.get(toUpperCase(name.trim()));
+        return LEVELS.get(toRootUpperCase(name.trim()));
     }
 
     /**
@@ -312,12 +313,8 @@ public final class Level implements Comparable<Level>, Serializable {
         if (name == null) {
             return defaultLevel;
         }
-        final Level level = LEVELS.get(toUpperCase(name.trim()));
+        final Level level = LEVELS.get(toRootUpperCase(name.trim()));
         return level == null ? defaultLevel : level;
-    }
-
-    private static String toUpperCase(final String name) {
-        return name.toUpperCase(Locale.ENGLISH);
     }
 
     /**
@@ -339,7 +336,7 @@ public final class Level implements Comparable<Level>, Serializable {
      */
     public static Level valueOf(final String name) {
         Objects.requireNonNull(name, "No level name given.");
-        final String levelName = toUpperCase(name.trim());
+        final String levelName = toRootUpperCase(name.trim());
         final Level level = LEVELS.get(levelName);
         if (level != null) {
             return level;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/EnglishEnums.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/EnglishEnums.java
@@ -16,7 +16,8 @@
  */
 package org.apache.logging.log4j.util;
 
-import java.util.Locale;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * <em>Consider this class private.</em>
@@ -64,7 +65,7 @@ public final class EnglishEnums {
      * @return an enum value or {@code defaultValue} if {@code name} is null.
      */
     public static <T extends Enum<T>> T valueOf(final Class<T> enumType, final String name, final T defaultValue) {
-        return name == null ? defaultValue : Enum.valueOf(enumType, name.toUpperCase(Locale.ENGLISH));
+        return name == null ? defaultValue : Enum.valueOf(enumType, toRootUpperCase(name));
     }
 
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
@@ -28,6 +28,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+
 /**
  * A source for global configuration properties.
  *
@@ -146,7 +148,7 @@ public interface PropertySource {
                 start = prefixMatcher.end();
                 final Matcher matcher = PROPERTY_TOKENIZER.matcher(value);
                 while (matcher.find(start)) {
-                    tokens.add(matcher.group(1).toLowerCase());
+                    tokens.add(toRootLowerCase(matcher.group(1)));
                     start = matcher.end();
                 }
             }

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/smtp/SmtpRequest.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/smtp/SmtpRequest.java
@@ -18,6 +18,8 @@ package org.apache.logging.log4j.core.test.smtp;
 
 import org.apache.logging.log4j.util.Strings;
 
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
+
 /**
  * Contains an SMTP client request. Handles state transitions using the following state transition table.
  * <PRE>
@@ -186,7 +188,7 @@ public class SmtpRequest {
                 }
             }
         } else {
-            final String su = s.toUpperCase();
+            final String su = toRootUpperCase(s);
             if (su.startsWith("EHLO ") || su.startsWith("HELO")) {
                 action = SmtpActionType.EHLO;
                 params = s.substring(5);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderSizeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderSizeTest.java
@@ -45,6 +45,7 @@ import org.junit.runners.Parameterized;
 
 import static org.apache.logging.log4j.core.test.hamcrest.Descriptors.that;
 import static org.apache.logging.log4j.core.test.hamcrest.FileMatchers.hasName;
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItemInArray;
 import static org.junit.Assert.assertNotNull;
@@ -148,7 +149,7 @@ public class RollingAppenderSizeTest {
                 CompressorInputStream in = null;
                 try (final FileInputStream fis = new FileInputStream(file)) {
                     try {
-                        in = new CompressorStreamFactory().createCompressorInputStream(ext.name().toLowerCase(), fis);
+                        in = new CompressorStreamFactory().createCompressorInputStream(toRootLowerCase(ext.name()), fis);
                     } catch (final CompressorException ce) {
                         ce.printStackTrace();
                         fail("Error creating input stream from " + file.toString() + ": " + ce.getMessage());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTempCompressedFilePatternTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderTempCompressedFilePatternTest.java
@@ -44,6 +44,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -106,7 +107,7 @@ public class RollingAppenderTempCompressedFilePatternTest {
                         if (ext != null) {
                             gzippedFiles++;
                             try {
-                                in = new CompressorStreamFactory().createCompressorInputStream(ext.name().toLowerCase(),
+                                in = new CompressorStreamFactory().createCompressorInputStream(toRootLowerCase(ext.name()),
                                         fis);
                             } catch (final CompressorException ce) {
                                 ce.printStackTrace();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactoryTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import java.util.Locale;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.util.PropertiesUtil;
@@ -26,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 import static org.junit.Assert.*;
 
 /**
@@ -74,7 +73,7 @@ public class AsyncQueueFullPolicyFactoryTest {
     @Test
     public void testCreateDiscardingRouterCaseInsensitive() {
         System.setProperty(AsyncQueueFullPolicyFactory.PROPERTY_NAME_ASYNC_EVENT_ROUTER,
-                AsyncQueueFullPolicyFactory.PROPERTY_VALUE_DISCARDING_ASYNC_EVENT_ROUTER.toLowerCase(Locale.ENGLISH));
+                toRootLowerCase(AsyncQueueFullPolicyFactory.PROPERTY_VALUE_DISCARDING_ASYNC_EVENT_ROUTER));
         assertEquals(Level.INFO, ((DiscardingAsyncQueueFullPolicy) AsyncQueueFullPolicyFactory.create()).
                 getThresholdLevel());
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/TestConfigurator.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/TestConfigurator.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
 import static org.apache.logging.log4j.core.test.hamcrest.MapMatchers.hasSize;
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -393,7 +394,7 @@ public class TestConfigurator {
 
         for (final String element : CHARS) {
             dir.append(element);
-            dir.append(element.toUpperCase());
+            dir.append(toRootUpperCase(element));
         }
         final String value = FILESEP.equals("/") ? dir.toString() + "/test.log" : "1:/target/bad:file.log";
         System.setProperty("testfile", value);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessorTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 import static org.junit.Assert.*;
 
 @RunWith(JUnit4.class)
@@ -54,7 +55,7 @@ public class PluginProcessorTest {
 
     @Test
     public void testFakePluginFoundWithCorrectInformation() throws Exception {
-        final PluginEntry fake = pluginCache.getCategory(p.category()).get(p.name().toLowerCase());
+        final PluginEntry fake = pluginCache.getCategory(p.category()).get(toRootLowerCase(p.name()));
         verifyFakePluginEntry(p.name(), fake);
     }
 
@@ -62,15 +63,15 @@ public class PluginProcessorTest {
     public void testFakePluginAliasesContainSameInformation() throws Exception {
         final PluginAliases aliases = FakePlugin.class.getAnnotation(PluginAliases.class);
         for (final String alias : aliases.value()) {
-            final PluginEntry fake = pluginCache.getCategory(p.category()).get(alias.toLowerCase());
+            final PluginEntry fake = pluginCache.getCategory(p.category()).get(toRootLowerCase(alias));
             verifyFakePluginEntry(alias, fake);
         }
     }
 
     private void verifyFakePluginEntry(final String name, final PluginEntry fake) {
-        assertNotNull("The plugin '" + name.toLowerCase() + "' was not found.", fake);
+        assertNotNull("The plugin '" + toRootLowerCase(name) + "' was not found.", fake);
         assertEquals(FakePlugin.class.getName(), fake.getClassName());
-        assertEquals(name.toLowerCase(), fake.getKey());
+        assertEquals(toRootLowerCase(name), fake.getKey());
         assertEquals(Plugin.EMPTY, p.elementType());
         assertEquals(name, fake.getName());
         assertEquals(p.printObject(), fake.isPrintable());
@@ -80,9 +81,9 @@ public class PluginProcessorTest {
     @Test
     public void testNestedPlugin() throws Exception {
         final Plugin p = FakePlugin.Nested.class.getAnnotation(Plugin.class);
-        final PluginEntry nested = pluginCache.getCategory(p.category()).get(p.name().toLowerCase());
+        final PluginEntry nested = pluginCache.getCategory(p.category()).get(toRootLowerCase(p.name()));
         assertNotNull(nested);
-        assertEquals(p.name().toLowerCase(), nested.getKey());
+        assertEquals(toRootLowerCase(p.name()), nested.getKey());
         assertEquals(FakePlugin.Nested.class.getName(), nested.getClassName());
         assertEquals(p.name(), nested.getName());
         assertEquals(Plugin.EMPTY, p.elementType());

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/StructuredDataLookupTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/StructuredDataLookupTest.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.message.StructuredDataMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -43,9 +44,9 @@ public class StructuredDataLookupTest {
         final LogEvent event = Log4jLogEvent.newBuilder().setLevel(Level.DEBUG).setMessage(msg).build();
 
         assertEquals("Audit", dataLookup.lookup(event, StructuredDataLookup.TYPE_KEY));
-        assertEquals("Audit", dataLookup.lookup(event, StructuredDataLookup.TYPE_KEY.toUpperCase()));
+        assertEquals("Audit", dataLookup.lookup(event, toRootUpperCase(StructuredDataLookup.TYPE_KEY)));
         assertEquals("TestId", dataLookup.lookup(event, StructuredDataLookup.ID_KEY));
-        assertEquals("TestId", dataLookup.lookup(event, StructuredDataLookup.ID_KEY.toUpperCase()));
+        assertEquals("TestId", dataLookup.lookup(event, toRootUpperCase(StructuredDataLookup.ID_KEY)));
         assertNull(dataLookup.lookup(event, "BadKey"));
         assertNull(dataLookup.lookup(event, null));
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/ColumnMapping.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/ColumnMapping.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.core.appender.db;
 
 import java.util.Date;
-import java.util.Locale;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Core;
@@ -34,6 +33,8 @@ import org.apache.logging.log4j.spi.ThreadContextMap;
 import org.apache.logging.log4j.spi.ThreadContextStack;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * A configuration element for specifying a database column name mapping.
@@ -201,7 +202,7 @@ public final class ColumnMapping {
     }
 
     public static String toKey(final String name) {
-        return name.toUpperCase(Locale.ROOT);
+        return toRootUpperCase(name);
     }
 
     private final StringLayout layout;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/LoggerNameLevelRewritePolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/LoggerNameLevelRewritePolicy.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.core.appender.rewrite;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
@@ -29,6 +28,8 @@ import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.util.KeyValuePair;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * Rewrites log event levels for a given logger name.
@@ -62,7 +63,7 @@ public final class LoggerNameLevelRewritePolicy implements RewritePolicy {
     }
 
     private static Level getLevel(final String name) {
-        return Level.getLevel(name.toUpperCase(Locale.ROOT));
+        return Level.getLevel(toRootUpperCase(name));
     }
 
     private final String loggerName;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/IdlePurgePolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/IdlePurgePolicy.java
@@ -33,6 +33,8 @@ import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
+
 /**
  * Policy is purging appenders that were not in use specified time in minutes
  */
@@ -144,7 +146,7 @@ public class IdlePurgePolicy extends AbstractLifeCycle implements PurgePolicy, R
             units = TimeUnit.MINUTES;
         } else {
             try {
-                units = TimeUnit.valueOf(timeUnit.toUpperCase());
+                units = TimeUnit.valueOf(toRootUpperCase(timeUnit));
             } catch (final Exception ex) {
                 LOGGER.error("Invalid timeUnit value {}. timeUnit set to MINUTES", timeUnit, ex);
                 units = TimeUnit.MINUTES;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/CompositeConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/CompositeConfiguration.java
@@ -39,6 +39,8 @@ import org.apache.logging.log4j.core.util.WatchManager;
 import org.apache.logging.log4j.core.util.Watcher;
 import org.apache.logging.log4j.util.PropertiesUtil;
 
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
+
 /**
  * A Composite Configuration.
  */
@@ -81,7 +83,7 @@ public class CompositeConfiguration extends AbstractConfiguration implements Rec
             final String key = entry.getKey();
             final String value = getConfigurationStrSubstitutor().replace(entry.getValue());
             if ("status".equalsIgnoreCase(key)) {
-                statusConfig.withStatus(value.toUpperCase());
+                statusConfig.withStatus(toRootUpperCase(value));
             } else if ("dest".equalsIgnoreCase(key)) {
                 statusConfig.withDestination(value);
             } else if ("shutdownHook".equalsIgnoreCase(key)) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/DefaultMergeStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/DefaultMergeStrategy.java
@@ -30,6 +30,9 @@ import org.apache.logging.log4j.core.config.plugins.util.PluginType;
 import org.apache.logging.log4j.core.filter.CompositeFilter;
 import org.apache.logging.log4j.core.util.Integers;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
+
 /**
  * The default merge strategy for composite configurations.
  * <p>
@@ -76,8 +79,8 @@ public class DefaultMergeStrategy implements MergeStrategy {
             for (final Map.Entry<String, String> targetAttribute : rootNode.getAttributes().entrySet()) {
                 if (targetAttribute.getKey().equalsIgnoreCase(attribute.getKey())) {
                     if (attribute.getKey().equalsIgnoreCase(STATUS)) {
-                        final Level targetLevel = Level.getLevel(targetAttribute.getValue().toUpperCase());
-                        final Level sourceLevel = Level.getLevel(attribute.getValue().toUpperCase());
+                        final Level targetLevel = Level.getLevel(toRootUpperCase(targetAttribute.getValue()));
+                        final Level sourceLevel = Level.getLevel(toRootUpperCase(attribute.getValue()));
                         if (targetLevel != null && sourceLevel != null) {
                             if (sourceLevel.isLessSpecificThan(targetLevel)) {
                                 targetAttribute.setValue(attribute.getValue());
@@ -142,7 +145,7 @@ public class DefaultMergeStrategy implements MergeStrategy {
                     continue;
                 }
 
-                switch (targetChildNode.getName().toLowerCase()) {
+                switch (toRootLowerCase(targetChildNode.getName())) {
                     case PROPERTIES:
                     case SCRIPTS:
                     case APPENDERS: {
@@ -277,11 +280,11 @@ public class DefaultMergeStrategy implements MergeStrategy {
 
     private boolean isSameName(final Node node1, final Node node2) {
         final String value = node1.getAttributes().get(NAME);
-        return value != null && value.toLowerCase().equals(node2.getAttributes().get(NAME).toLowerCase());
+        return value != null && toRootLowerCase(value).equals(toRootLowerCase(node2.getAttributes().get(NAME)));
     }
 
     private boolean isSameReference(final Node node1, final Node node2) {
         final String value = node1.getAttributes().get(REF);
-        return value != null && value.toLowerCase().equals(node2.getAttributes().get(REF).toLowerCase());
+        return value != null && toRootLowerCase(value).equals(toRootLowerCase(node2.getAttributes().get(REF)));
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverters.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverters.java
@@ -41,6 +41,8 @@ import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.LoaderUtil;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+
 /**
  * Collection of basic TypeConverter implementations. May be used to register additional TypeConverters or find
  * registered TypeConverters.
@@ -177,7 +179,7 @@ public final class TypeConverters {
     public static class ClassConverter implements TypeConverter<Class<?>> {
         @Override
         public Class<?> convert(final String s) throws ClassNotFoundException {
-            switch (s.toLowerCase()) {
+            switch (toRootLowerCase(s)) {
                 case "boolean":
                     return boolean.class;
                 case "byte":

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginCache.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginCache.java
@@ -27,6 +27,8 @@ import java.util.Enumeration;
 import java.util.Map;
 import java.util.TreeMap;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+
 /**
  *
  */
@@ -51,7 +53,7 @@ public class PluginCache {
      * @return plugin mapping of names to plugin entries.
      */
     public Map<String, PluginEntry> getCategory(final String category) {
-        final String key = category.toLowerCase();
+        final String key = toRootLowerCase(category);
         return categories.computeIfAbsent(key, ignored -> new TreeMap<>());
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessor.java
@@ -21,7 +21,6 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -43,6 +42,8 @@ import javax.tools.StandardLocation;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAliases;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 
 /**
  * Annotation processor for pre-scanning Log4j 2 plugins.
@@ -136,7 +137,7 @@ public class PluginProcessor extends AbstractProcessor {
         public PluginEntry visitType(final TypeElement e, final Plugin plugin) {
             Objects.requireNonNull(plugin, "Plugin annotation is null.");
             final PluginEntry entry = new PluginEntry();
-            entry.setKey(plugin.name().toLowerCase(Locale.US));
+            entry.setKey(toRootLowerCase(plugin.name()));
             entry.setClassName(elements.getBinaryName(e).toString());
             entry.setName(Plugin.EMPTY.equals(plugin.elementType()) ? plugin.name() : plugin.elementType());
             entry.setPrintable(plugin.printObject());
@@ -167,7 +168,7 @@ public class PluginProcessor extends AbstractProcessor {
             final Collection<PluginEntry> entries = new ArrayList<>(aliases.value().length);
             for (final String alias : aliases.value()) {
                 final PluginEntry entry = new PluginEntry();
-                entry.setKey(alias.toLowerCase(Locale.US));
+                entry.setKey(toRootLowerCase(alias));
                 entry.setClassName(elements.getBinaryName(e).toString());
                 entry.setName(Plugin.EMPTY.equals(plugin.elementType()) ? alias : plugin.elementType());
                 entry.setPrintable(plugin.printObject());

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/PluginManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/PluginManager.java
@@ -27,6 +27,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+
 /**
  * Loads and manages all the plugins.
  */
@@ -98,7 +100,7 @@ public class PluginManager {
      * @return The plugin's type.
      */
     public PluginType<?> getPluginType(final String name) {
-        return plugins.get(name.toLowerCase());
+        return plugins.get(toRootLowerCase(name));
     }
 
     /**
@@ -127,7 +129,7 @@ public class PluginManager {
         if (isNotEmpty(packages) || isNotEmpty(PACKAGES)) {
             LOGGER.warn("The use of package scanning to locate plugins is deprecated and will be removed in a future release");
         }
-        final String categoryLowerCase = category.toLowerCase();
+        final String categoryLowerCase = toRootLowerCase(category);
         final Map<String, PluginType<?>> newPlugins = new LinkedHashMap<>();
 
         // First, iterate the Log4j2Plugin.dat files found in the main CLASSPATH

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/PluginRegistry.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/PluginRegistry.java
@@ -40,6 +40,8 @@ import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+
 /**
  * Registry singleton for PluginType maps partitioned by source type and then by category names.
  */
@@ -226,7 +228,7 @@ public final class PluginRegistry {
         final Map<String, List<PluginType<?>>> newPluginsByCategory = new HashMap<>();
         for (final Class<?> clazz : resolver.getClasses()) {
             final Plugin plugin = clazz.getAnnotation(Plugin.class);
-            final String categoryLowerCase = plugin.category().toLowerCase();
+            final String categoryLowerCase = toRootLowerCase(plugin.category());
             List<PluginType<?>> list = newPluginsByCategory.get(categoryLowerCase);
             if (list == null) {
                 newPluginsByCategory.put(categoryLowerCase, list = new ArrayList<>());
@@ -234,7 +236,7 @@ public final class PluginRegistry {
             final PluginEntry mainEntry = new PluginEntry();
             final String mainElementName = plugin.elementType().equals(
                 Plugin.EMPTY) ? plugin.name() : plugin.elementType();
-            mainEntry.setKey(plugin.name().toLowerCase());
+            mainEntry.setKey(toRootLowerCase(plugin.name()));
             mainEntry.setName(plugin.name());
             mainEntry.setCategory(plugin.category());
             mainEntry.setClassName(clazz.getName());
@@ -248,7 +250,7 @@ public final class PluginRegistry {
                     final PluginEntry aliasEntry = new PluginEntry();
                     final String aliasElementName = plugin.elementType().equals(
                         Plugin.EMPTY) ? alias.trim() : plugin.elementType();
-                    aliasEntry.setKey(alias.trim().toLowerCase());
+                    aliasEntry.setKey(toRootLowerCase(alias.trim()));
                     aliasEntry.setName(plugin.name());
                     aliasEntry.setCategory(plugin.category());
                     aliasEntry.setClassName(clazz.getName());

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
@@ -34,6 +34,8 @@ import org.apache.logging.log4j.core.net.JndiManager;
 import org.apache.logging.log4j.core.util.ReflectionUtil;
 import org.apache.logging.log4j.status.StatusLogger;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+
 /**
  * Proxies all the other {@link StrLookup}s.
  */
@@ -83,7 +85,7 @@ public class Interpolator extends AbstractConfigurationAwareLookup implements Lo
             try {
                 final Class<? extends StrLookup> clazz = entry.getValue().getPluginClass().asSubclass(StrLookup.class);
                 if (!clazz.getName().equals("org.apache.logging.log4j.core.lookup.JndiLookup") || JndiManager.isJndiLookupEnabled()) {
-                    strLookupMap.put(entry.getKey().toLowerCase(), ReflectionUtil.instantiate(clazz));
+                    strLookupMap.put(toRootLowerCase(entry.getKey()), ReflectionUtil.instantiate(clazz));
                 }
             } catch (final Throwable t) {
                 handleError(entry.getKey(), t);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/Interpolator.java
@@ -20,7 +20,6 @@ import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import org.apache.logging.log4j.Logger;
@@ -186,7 +185,7 @@ public class Interpolator extends AbstractConfigurationAwareLookup implements Lo
 
         final int prefixPos = var.indexOf(PREFIX_SEPARATOR);
         if (prefixPos >= 0) {
-            final String prefix = var.substring(0, prefixPos).toLowerCase(Locale.US);
+            final String prefix = toRootLowerCase(var.substring(0, prefixPos));
             final String name = var.substring(prefixPos + 1);
             final StrLookup lookup = strLookupMap.get(prefix);
             if (lookup instanceof ConfigurationAware) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/LowerLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/LowerLookup.java
@@ -19,6 +19,8 @@ package org.apache.logging.log4j.core.lookup;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+
 /**
  * Converts values to lower case. The passed in "key" should be the value of another lookup.
  */
@@ -32,7 +34,7 @@ public class LowerLookup implements StrLookup {
      */
     @Override
     public String lookup(final String key) {
-        return key != null ? key.toLowerCase() : null;
+        return key != null ? toRootLowerCase(key) : null;
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/UpperLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/UpperLookup.java
@@ -19,6 +19,8 @@ package org.apache.logging.log4j.core.lookup;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
+
 /**
  * Converts values to upper case. The passed in "key" should be the value of another lookup.
  */
@@ -32,7 +34,7 @@ public class UpperLookup implements StrLookup {
      */
     @Override
     public String lookup(final String key) {
-        return key != null ? key.toUpperCase() : null;
+        return key != null ? toRootUpperCase(key) : null;
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/UrlConnectionFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/UrlConnectionFactory.java
@@ -24,7 +24,6 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 import javax.net.ssl.HttpsURLConnection;
 
@@ -35,6 +34,8 @@ import org.apache.logging.log4j.core.net.ssl.SslConfigurationFactory;
 import org.apache.logging.log4j.core.util.AuthorizationProvider;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 
 /**
  * Constructs an HTTPURLConnection. This class should be considered to be internal
@@ -60,8 +61,8 @@ public class UrlConnectionFactory {
             final SslConfiguration sslConfiguration, final AuthorizationProvider authorizationProvider)
         throws IOException {
         final PropertiesUtil props = PropertiesUtil.getProperties();
-        final List<String> allowed = Arrays.asList(Strings.splitList(props
-                .getStringProperty(ALLOWED_PROTOCOLS, DEFAULT_ALLOWED_PROTOCOLS).toLowerCase(Locale.ROOT)));
+        final List<String> allowed = Arrays.asList(Strings.splitList(toRootLowerCase(props
+                .getStringProperty(ALLOWED_PROTOCOLS, DEFAULT_ALLOWED_PROTOCOLS))));
         if (allowed.size() == 1 && NO_PROTOCOLS.equals(allowed.get(0))) {
             throw new ProtocolException("No external protocols have been enabled");
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/AnsiEscape.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/AnsiEscape.java
@@ -18,13 +18,14 @@ package org.apache.logging.log4j.core.pattern;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 import org.apache.logging.log4j.core.util.Patterns;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.EnglishEnums;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * Converts text into ANSI escape sequences.
@@ -426,7 +427,7 @@ public enum AnsiEscape {
         for (final String string : values) {
             final String[] keyValue = string.split(Patterns.toWhitespaceSeparator("="));
             if (keyValue.length > 1) {
-                final String key = keyValue[0].toUpperCase(Locale.ENGLISH);
+                final String key = toRootUpperCase(keyValue[0]);
                 final String value = keyValue[1];
                 final boolean escape = Arrays.binarySearch(sortedIgnoreKeys, key) < 0;
                 map.put(key, escape ? createSequence(value.split("\\s")) : value);
@@ -459,7 +460,7 @@ public enum AnsiEscape {
                 }
                 first = false;
                 String hexColor = null;
-                final String trimmedName = name.trim().toUpperCase(Locale.ENGLISH);
+                final String trimmedName = toRootUpperCase(name.trim());
                 if (trimmedName.startsWith("#")) {
                     sb.append("38");
                     sb.append(SEPARATOR.getCode());

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/HighlightConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/HighlightConverter.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.core.pattern;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
@@ -29,6 +28,8 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.util.PerformanceSensitive;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * Highlight pattern converter. Formats the result of a pattern using a color appropriate for the Level in the LogEvent.
@@ -152,10 +153,10 @@ public final class HighlightConverter extends LogEventPatternConverter implement
         final Map<String, String> styles = AnsiEscape.createMap(string, new String[] {STYLE_KEY});
         final Map<String, String> levelStyles = new HashMap<>(DEFAULT_STYLES);
         for (final Map.Entry<String, String> entry : styles.entrySet()) {
-            final String key = entry.getKey().toUpperCase(Locale.ENGLISH);
+            final String key = toRootUpperCase(entry.getKey());
             final String value = entry.getValue();
             if (STYLE_KEY.equalsIgnoreCase(key)) {
-                final Map<String, String> enumMap = STYLES.get(value.toUpperCase(Locale.ENGLISH));
+                final Map<String, String> enumMap = STYLES.get(toRootUpperCase(value));
                 if (enumMap == null) {
                     LOGGER.error("Unknown level style: " + value + ". Use one of " +
                         Arrays.toString(STYLES.keySet().toArray()));

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/JAnsiTextRenderer.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/JAnsiTextRenderer.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.core.pattern;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 import org.apache.logging.log4j.status.StatusLogger;
@@ -26,6 +25,7 @@ import org.fusesource.jansi.Ansi;
 import org.fusesource.jansi.AnsiRenderer;
 import org.fusesource.jansi.AnsiRenderer.Code;
 
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 import static org.fusesource.jansi.AnsiRenderer.Code.BG_RED;
 import static org.fusesource.jansi.AnsiRenderer.Code.BOLD;
 import static org.fusesource.jansi.AnsiRenderer.Code.RED;
@@ -320,7 +320,7 @@ public final class JAnsiTextRenderer implements TextRenderer {
     }
 
     private Code toCode(final String name) {
-        return Code.valueOf(name.toUpperCase(Locale.ENGLISH));
+        return Code.valueOf(toRootUpperCase(name));
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/LevelPatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/LevelPatternConverter.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.core.pattern;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
@@ -26,6 +25,8 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.util.Integers;
 import org.apache.logging.log4j.core.util.Patterns;
 import org.apache.logging.log4j.util.PerformanceSensitive;
+
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 
 /**
  * Returns the event's level in a StringBuilder.
@@ -92,7 +93,7 @@ public abstract class LevelPatternConverter extends LogEventPatternConverter {
         for (final Level level : Level.values()) {
             if (!levelMap.containsKey(level)) {
                 final String left = left(level, length);
-                levelMap.put(level, lowerCase ? left.toLowerCase(Locale.US) : left);
+                levelMap.put(level, lowerCase ? toRootLowerCase(left) : left);
             }
         }
         return new LevelMapLevelPatternConverter(levelMap);
@@ -130,7 +131,7 @@ public abstract class LevelPatternConverter extends LogEventPatternConverter {
     @Override
     public String getStyleClass(final Object e) {
         if (e instanceof LogEvent) {
-            return "level " + ((LogEvent) e).getLevel().name().toLowerCase(Locale.ENGLISH);
+            return "level " + toRootLowerCase(((LogEvent) e).getLevel().name());
         }
 
         return "level";

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MessagePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MessagePatternConverter.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.core.pattern;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
@@ -31,6 +30,8 @@ import org.apache.logging.log4j.util.MultiFormatStringBuilderFormattable;
 import org.apache.logging.log4j.util.PerformanceSensitive;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * Returns the event's rendered message in a StringBuilder.
@@ -50,7 +51,7 @@ public abstract class MessagePatternConverter extends LogEventPatternConverter {
     private static TextRenderer loadMessageRenderer(final String[] options) {
         if (options != null) {
             for (final String option : options) {
-                switch (option.toUpperCase(Locale.ROOT)) {
+                switch (toRootUpperCase(option)) {
                 case "ANSI":
                     if (Loader.isJansiAvailable()) {
                         return new JAnsiTextRenderer(options, JAnsiTextRenderer.DefaultMessageStyleMap);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/script/ScriptManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/script/ScriptManager.java
@@ -22,7 +22,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,6 +43,8 @@ import org.apache.logging.log4j.core.util.FileWatcher;
 import org.apache.logging.log4j.core.util.WatchManager;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 
 /**
  * Manages the scripts use by the Configuration.
@@ -80,7 +81,7 @@ public class ScriptManager implements FileWatcher {
         this.configuration = configuration;
         this.watchManager = watchManager;
         final List<ScriptEngineFactory> factories = manager.getEngineFactories();
-        allowedLanguages = Arrays.stream(Strings.splitList(scriptLanguages)).map(String::toLowerCase)
+        allowedLanguages = Arrays.stream(Strings.splitList(scriptLanguages)).map(Strings::toRootLowerCase)
                 .collect(Collectors.toSet());
         if (logger.isDebugEnabled()) {
             final StringBuilder sb = new StringBuilder();
@@ -94,7 +95,7 @@ public class ScriptManager implements FileWatcher {
                 final StringBuilder names = new StringBuilder();
                 final List<String> languageNames = factory.getNames();
                 for (final String name : languageNames) {
-                    if (allowedLanguages.contains(name.toLowerCase(Locale.ROOT))) {
+                    if (allowedLanguages.contains(toRootLowerCase(name))) {
                         if (names.length() > 0) {
                             names.append(", ");
                         }
@@ -117,7 +118,7 @@ public class ScriptManager implements FileWatcher {
             final StringBuilder names = new StringBuilder();
             for (final ScriptEngineFactory factory : factories) {
                 for (final String name : factory.getNames()) {
-                    if (allowedLanguages.contains(name.toLowerCase(Locale.ROOT))) {
+                    if (allowedLanguages.contains(toRootLowerCase(name))) {
                         if (names.length() > 0) {
                             names.append(", ");
                         }
@@ -134,7 +135,7 @@ public class ScriptManager implements FileWatcher {
     }
 
     public boolean addScript(final AbstractScript script) {
-        if (allowedLanguages.contains(script.getLanguage().toLowerCase(Locale.ROOT))) {
+        if (allowedLanguages.contains(toRootLowerCase(script.getLanguage()))) {
             final ScriptEngine engine = manager.getEngineByName(script.getLanguage());
             if (engine == null) {
                 logger.error("No ScriptEngine found for language " + script.getLanguage() + ". Available languages are: "

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/picocli/CommandLine.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/picocli/CommandLine.java
@@ -70,11 +70,10 @@ import org.apache.logging.log4j.core.tools.picocli.CommandLine.Help.Ansi.Style;
 import org.apache.logging.log4j.core.tools.picocli.CommandLine.Help.Ansi.Text;
 import org.apache.logging.log4j.core.util.Integers;
 
-import static java.util.Locale.ENGLISH;
-
 import static org.apache.logging.log4j.core.tools.picocli.CommandLine.Help.Column.Overflow.SPAN;
 import static org.apache.logging.log4j.core.tools.picocli.CommandLine.Help.Column.Overflow.TRUNCATE;
 import static org.apache.logging.log4j.core.tools.picocli.CommandLine.Help.Column.Overflow.WRAP;
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
@@ -4363,8 +4362,8 @@ public class CommandLine {
                  * @return the IStyle for the specified converter
                  */
                 public static IStyle fg(final String str) {
-                    try { return Style.valueOf(str.toLowerCase(ENGLISH)); } catch (final Exception ignored) {}
-                    try { return Style.valueOf("fg_" + str.toLowerCase(ENGLISH)); } catch (final Exception ignored) {}
+                    try { return Style.valueOf(toRootLowerCase(str)); } catch (final Exception ignored) {}
+                    try { return Style.valueOf("fg_" + toRootLowerCase(str)); } catch (final Exception ignored) {}
                     return new Palette256Color(true, str);
                 }
                 /** Parses the specified style markup and returns the associated style.
@@ -4375,8 +4374,8 @@ public class CommandLine {
                  * @return the IStyle for the specified converter
                  */
                 public static IStyle bg(final String str) {
-                    try { return Style.valueOf(str.toLowerCase(ENGLISH)); } catch (final Exception ignored) {}
-                    try { return Style.valueOf("bg_" + str.toLowerCase(ENGLISH)); } catch (final Exception ignored) {}
+                    try { return Style.valueOf(toRootLowerCase(str)); } catch (final Exception ignored) {}
+                    try { return Style.valueOf("bg_" + toRootLowerCase(str)); } catch (final Exception ignored) {}
                     return new Palette256Color(false, str);
                 }
                 /** Parses the specified comma-separated sequence of style descriptors and returns the associated
@@ -4389,10 +4388,10 @@ public class CommandLine {
                     final String[] codes = commaSeparatedCodes.split(",");
                     final IStyle[] styles = new IStyle[codes.length];
                     for(int i = 0; i < codes.length; ++i) {
-                        if (codes[i].toLowerCase(ENGLISH).startsWith("fg(")) {
+                        if (toRootLowerCase(codes[i]).startsWith("fg(")) {
                             final int end = codes[i].indexOf(')');
                             styles[i] = Style.fg(codes[i].substring(3, end < 0 ? codes[i].length() : end));
-                        } else if (codes[i].toLowerCase(ENGLISH).startsWith("bg(")) {
+                        } else if (toRootLowerCase(codes[i]).startsWith("bg(")) {
                             final int end = codes[i].indexOf(')');
                             styles[i] = Style.bg(codes[i].substring(3, end < 0 ? codes[i].length() : end));
                         } else {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/picocli/CommandLine.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/picocli/CommandLine.java
@@ -75,6 +75,7 @@ import static java.util.Locale.ENGLISH;
 import static org.apache.logging.log4j.core.tools.picocli.CommandLine.Help.Column.Overflow.SPAN;
 import static org.apache.logging.log4j.core.tools.picocli.CommandLine.Help.Column.Overflow.TRUNCATE;
 import static org.apache.logging.log4j.core.tools.picocli.CommandLine.Help.Column.Overflow.WRAP;
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * <p>
@@ -3881,7 +3882,7 @@ public class CommandLine {
                 if (o1 == null) { return 1; } else if (o2 == null) { return -1; } // options before params
                 final String[] names1 = ShortestFirst.sort(o1.names());
                 final String[] names2 = ShortestFirst.sort(o2.names());
-                int result = names1[0].toUpperCase().compareTo(names2[0].toUpperCase()); // case insensitive sort
+                int result = toRootUpperCase(names1[0]).compareTo(toRootUpperCase(names2[0])); // case insensitive sort
                 result = result == 0 ? -names1[0].compareTo(names2[0]) : result; // lower case before upper case
                 return o1.help() == o2.help() ? result : o2.help() ? -1 : 1; // help options come last
             }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/CronExpression.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/CronExpression.java
@@ -26,12 +26,13 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Locale;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.StringTokenizer;
 import java.util.TimeZone;
 import java.util.TreeSet;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * Provides a parser and evaluator for unix-like cron expressions. Cron
@@ -272,7 +273,7 @@ public final class CronExpression {
             throw new IllegalArgumentException("cronExpression cannot be null");
         }
 
-        this.cronExpression = cronExpression.toUpperCase(Locale.US);
+        this.cronExpression = toRootUpperCase(cronExpression);
 
         buildExpression(this.cronExpression);
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/OptionConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/OptionConverter.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.core.util;
 import java.io.InterruptedIOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Properties;
 
 import org.apache.logging.log4j.Level;
@@ -27,6 +26,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * A convenience class to convert property values to specific types.
@@ -234,7 +235,7 @@ public final class OptionConverter {
             return defaultValue;
         }
 
-        String str = value.trim().toUpperCase(Locale.ENGLISH);
+        String str = toRootUpperCase(value.trim());
         long multiplier = 1;
         int index;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/FastDateParser.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/FastDateParser.java
@@ -41,6 +41,8 @@ import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.core.util.Integers;
 
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
+
 /**
  * <p>FastDateParser is a fast and thread-safe version of
  * {@link java.text.SimpleDateFormat}.</p>
@@ -893,7 +895,7 @@ public class FastDateParser implements DateParser, Serializable {
                 final TimeZone tz = TimeZone.getTimeZone("GMT" + value);
                 cal.setTimeZone(tz);
             } else if (value.regionMatches(true, 0, "GMT", 0, 3)) {
-                final TimeZone tz = TimeZone.getTimeZone(value.toUpperCase());
+                final TimeZone tz = TimeZone.getTimeZone(toRootUpperCase(value));
                 cal.setTimeZone(tz);
             } else {
                 final TzInfo tzInfo = tzNames.get(value.toLowerCase(locale));

--- a/log4j-couchdb/src/main/java/org/apache/logging/log4j/couchdb/CouchDbProvider.java
+++ b/log4j-couchdb/src/main/java/org/apache/logging/log4j/couchdb/CouchDbProvider.java
@@ -32,6 +32,8 @@ import org.apache.logging.log4j.util.Strings;
 import org.lightcouch.CouchDbClient;
 import org.lightcouch.CouchDbProperties;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+
 /**
  * The Apache CouchDB implementation of {@link NoSqlProvider}.
  */
@@ -130,7 +132,7 @@ public final class CouchDbProvider implements NoSqlProvider<CouchDbConnection> {
             }
         } else if (Strings.isNotEmpty(databaseName)) {
             if (protocol != null && protocol.length() > 0) {
-                protocol = protocol.toLowerCase();
+                protocol = toRootLowerCase(protocol);
                 if (!protocol.equals("http") && !protocol.equals("https")) {
                     LOGGER.error("Only protocols [http] and [https] are supported, [{}] specified.", protocol);
                     return null;

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAppender.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAppender.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.flume.appender;
 
 import java.io.Serializable;
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.core.Appender;
@@ -36,6 +35,8 @@ import org.apache.logging.log4j.core.net.Facility;
 import org.apache.logging.log4j.core.util.Booleans;
 import org.apache.logging.log4j.core.util.Integers;
 import org.apache.logging.log4j.util.Timer;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * An Appender that uses the Avro protocol to route events to Flume.
@@ -72,7 +73,7 @@ public final class FlumeAppender extends AbstractAppender implements FlumeEventF
         AVRO, EMBEDDED, PERSISTENT;
 
         public static ManagerType getType(final String type) {
-            return valueOf(type.toUpperCase(Locale.US));
+            return valueOf(toRootUpperCase(type));
         }
     }
 

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeEmbeddedManager.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeEmbeddedManager.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.flume.appender;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -31,6 +30,8 @@ import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.util.NameUtil;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 public class FlumeEmbeddedManager extends AbstractFlumeManager {
 
@@ -250,9 +251,9 @@ public class FlumeEmbeddedManager extends AbstractFlumeManager {
                         throw new ConfigurationException(msg);
                     }
 
-                    final String upperKey = key.toUpperCase(Locale.ENGLISH);
+                    final String upperKey = toRootUpperCase(key);
 
-                    if (upperKey.startsWith(name.toUpperCase(Locale.ENGLISH))) {
+                    if (upperKey.startsWith(toRootUpperCase(name))) {
                         final String msg =
                             "Specification of the agent name is not allowed in Flume Appender configuration: " + key;
                         LOGGER.error(msg);

--- a/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/Log4jServletContextListener.java
+++ b/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/Log4jServletContextListener.java
@@ -16,7 +16,6 @@
  */
 package org.apache.logging.log4j.web;
 
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.servlet.ServletContext;
@@ -27,6 +26,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LifeCycle2;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * In environments older than Servlet 3.0, this initializer is responsible for starting up Log4j logging before anything
@@ -84,7 +85,7 @@ public class Log4jServletContextListener implements ServletContextListener {
                     : Long.parseLong(stopTimeoutStr);
             final String timeoutTimeUnitStr = servletContext.getInitParameter(KEY_STOP_TIMEOUT_TIMEUNIT);
             final TimeUnit timeoutTimeUnit = Strings.isEmpty(timeoutTimeUnitStr) ? DEFAULT_STOP_TIMEOUT_TIMEUNIT
-                    : TimeUnit.valueOf(timeoutTimeUnitStr.toUpperCase(Locale.ROOT));
+                    : TimeUnit.valueOf(toRootUpperCase(timeoutTimeUnitStr));
             ((LifeCycle2) this.initializer).stop(stopTimeout, timeoutTimeUnit);
         } else {
             this.initializer.stop();

--- a/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/Log4jShutdownOnContextDestroyedListener.java
+++ b/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/Log4jShutdownOnContextDestroyedListener.java
@@ -16,7 +16,6 @@
  */
 package org.apache.logging.log4j.web;
 
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import jakarta.servlet.ServletContext;
@@ -27,6 +26,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LifeCycle2;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 public class Log4jShutdownOnContextDestroyedListener implements ServletContextListener {
 
@@ -71,7 +72,7 @@ public class Log4jShutdownOnContextDestroyedListener implements ServletContextLi
                     : Long.parseLong(stopTimeoutStr);
             final String timeoutTimeUnitStr = servletContext.getInitParameter(KEY_STOP_TIMEOUT_TIMEUNIT);
             final TimeUnit timeoutTimeUnit = Strings.isEmpty(timeoutTimeUnitStr) ? DEFAULT_STOP_TIMEOUT_TIMEUNIT
-                    : TimeUnit.valueOf(timeoutTimeUnitStr.toUpperCase(Locale.ROOT));
+                    : TimeUnit.valueOf(toRootUpperCase(timeoutTimeUnitStr));
             ((LifeCycle2) this.initializer).stop(stopTimeout, timeoutTimeUnit);
         } else {
             this.initializer.stop();

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/Uris.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/Uris.java
@@ -34,6 +34,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+
 public final class Uris {
 
     private Uris() {}
@@ -79,7 +81,7 @@ public final class Uris {
             final URI uri,
             final Charset charset)
             throws Exception {
-        final String uriScheme = uri.getScheme().toLowerCase();
+        final String uriScheme = toRootLowerCase(uri.getScheme());
         switch (uriScheme) {
             case "classpath":
                 return readClassPathUri(uri, charset);

--- a/log4j-spring-boot/src/main/java/org/apache/logging/log4j/spring/boot/SpringLookup.java
+++ b/log4j-spring-boot/src/main/java/org/apache/logging/log4j/spring/boot/SpringLookup.java
@@ -29,6 +29,8 @@ import org.apache.logging.log4j.core.util.Integers;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.springframework.core.env.Environment;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+
 /**
  * Lookup for Spring properties.
  */
@@ -47,7 +49,7 @@ public class SpringLookup implements LoggerContextAware, StrLookup {
     @Override
     public String lookup(final String key) {
         if (environment != null) {
-            final String lowerKey = key.toLowerCase();
+            final String lowerKey = toRootLowerCase(key);
             if (lowerKey.startsWith(ACTIVE)) {
                 switch (environment.getActiveProfiles().length) {
                     case 0: {

--- a/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/TagUtilsLevelTest.java
+++ b/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/TagUtilsLevelTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
@@ -42,7 +43,7 @@ public class TagUtilsLevelTest {
         final Collection<Object[]> params = new ArrayList<>();
         // this is perhaps the laziest way to test all the known levels
         for (final Level level : Level.values()) {
-            params.add(new Object[]{level, level.name().toLowerCase()});
+            params.add(new Object[]{level, toRootLowerCase(level.name())});
         }
         return params;
     }

--- a/log4j-web/src/main/java/org/apache/logging/log4j/web/Log4jServletContextListener.java
+++ b/log4j-web/src/main/java/org/apache/logging/log4j/web/Log4jServletContextListener.java
@@ -16,7 +16,6 @@
  */
 package org.apache.logging.log4j.web;
 
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.ServletContext;
@@ -27,6 +26,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LifeCycle2;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * In environments older than Servlet 3.0, this initializer is responsible for starting up Log4j logging before anything
@@ -84,7 +85,7 @@ public class Log4jServletContextListener implements ServletContextListener {
                     : Long.parseLong(stopTimeoutStr);
             final String timeoutTimeUnitStr = servletContext.getInitParameter(KEY_STOP_TIMEOUT_TIMEUNIT);
             final TimeUnit timeoutTimeUnit = Strings.isEmpty(timeoutTimeUnitStr) ? DEFAULT_STOP_TIMEOUT_TIMEUNIT
-                    : TimeUnit.valueOf(timeoutTimeUnitStr.toUpperCase(Locale.ROOT));
+                    : TimeUnit.valueOf(toRootUpperCase(timeoutTimeUnitStr));
             ((LifeCycle2) this.initializer).stop(stopTimeout, timeoutTimeUnit);
         } else {
             this.initializer.stop();

--- a/log4j-web/src/main/java/org/apache/logging/log4j/web/Log4jShutdownOnContextDestroyedListener.java
+++ b/log4j-web/src/main/java/org/apache/logging/log4j/web/Log4jShutdownOnContextDestroyedListener.java
@@ -16,7 +16,6 @@
  */
 package org.apache.logging.log4j.web;
 
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import javax.servlet.ServletContext;
@@ -27,6 +26,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LifeCycle2;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
+
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 public class Log4jShutdownOnContextDestroyedListener implements ServletContextListener {
 
@@ -71,7 +72,7 @@ public class Log4jShutdownOnContextDestroyedListener implements ServletContextLi
                     : Long.parseLong(stopTimeoutStr);
             final String timeoutTimeUnitStr = servletContext.getInitParameter(KEY_STOP_TIMEOUT_TIMEUNIT);
             final TimeUnit timeoutTimeUnit = Strings.isEmpty(timeoutTimeUnitStr) ? DEFAULT_STOP_TIMEOUT_TIMEUNIT
-                    : TimeUnit.valueOf(timeoutTimeUnitStr.toUpperCase(Locale.ROOT));
+                    : TimeUnit.valueOf(toRootUpperCase(timeoutTimeUnitStr));
             ((LifeCycle2) this.initializer).stop(stopTimeout, timeoutTimeUnit);
         } else {
             this.initializer.stop();

--- a/src/changelog/.2.x.x/1281_remove_locale-dependent_toLowerCase.xml
+++ b/src/changelog/.2.x.x/1281_remove_locale-dependent_toLowerCase.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="fixed">
+  <issue id="1281" link="https://github.com/apache/logging-log4j2/pull/1281"/>
+  <author id="github:aawad6" name="Ammar Awad"/>
+  <!-- Committer -->
+  <author id="github:ppkarwasz"/>
+  <description format="asciidoc">Remove locale-dependent `toLowerCase/toUpperCase` calls.</description>
+</entry>


### PR DESCRIPTION
As there're remaining locale-dependent calls of String#toLowerCase and String#toUpperCase. These calls are replaced with Strings#toRootLowerCase and Strings#toRootUpperCase.

Issue https://github.com/apache/logging-log4j2/issues/1281.