### PR TITLE
Fix concurrent date-time formatting issue in `PatternLayout`

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/DatePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/DatePatternConverter.java
@@ -325,16 +325,15 @@ public final class DatePatternConverter extends LogEventPatternConverter impleme
     }
 
     private void formatWithoutThreadLocals(final Instant instant, final StringBuilder output) {
-        CachedTime cached = cachedTime.get();
+        final CachedTime effective;
+        final CachedTime cached = cachedTime.get();
         if (instant.getEpochSecond() != cached.epochSecond || instant.getNanoOfSecond() != cached.nanoOfSecond) {
-            final CachedTime newTime = new CachedTime(instant);
-            if (cachedTime.compareAndSet(cached, newTime)) {
-                cached = newTime;
-            } else {
-                cached = cachedTime.get();
-            }
+            effective = new CachedTime(instant);
+            cachedTime.compareAndSet(cached, effective);
+        } else {
+            effective = cached;
         }
-        output.append(cached.formatted);
+        output.append(effective.formatted);
     }
 
     /**

--- a/src/changelog/.2.x.x/0_fix_DatePatternConverter_when_TL_disabled.xml
+++ b/src/changelog/.2.x.x/0_fix_DatePatternConverter_when_TL_disabled.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="fixed">
+  <issue id="0" link="https://github.com/apache/logging-log4j2/issues/0"/>
+  <author name="Stephan Markwalder" id="smarkwal"/>
+  <author id="vy"/>
+  <description format="asciidoc">Fix concurrent date-time formatting issue in `PatternLayout`</description>
+</entry>

--- a/src/changelog/.2.x.x/1485_fix_DatePatternConverter_when_TL_disabled.xml
+++ b/src/changelog/.2.x.x/1485_fix_DatePatternConverter_when_TL_disabled.xml
@@ -19,7 +19,7 @@
        xmlns="http://logging.apache.org/log4j/changelog"
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
        type="fixed">
-  <issue id="0" link="https://github.com/apache/logging-log4j2/issues/0"/>
+  <issue id="1485" link="https://github.com/apache/logging-log4j2/issues/1485"/>
   <author name="Stephan Markwalder" id="smarkwal"/>
   <author id="vy"/>
   <description format="asciidoc">Fix concurrent date-time formatting issue in `PatternLayout`</description>


### PR DESCRIPTION
Fixes the concurrency issue in `DatePatternConverter` exhibiting itself under contention and when `ThreadLocal`s are disabled. See [@smarkwal's report](https://lists.apache.org/thread/95mwcc1y1oqfk9hggsry8rq3c5ql742d) for details.