### PR TITLE
Improves date pattern performance without threadlocals

### DIFF
--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/DatePatternConverterBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/DatePatternConverterBenchmark.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.perf.jmh;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.core.pattern.DatePatternConverter;
+import org.apache.logging.log4j.core.time.MutableInstant;
+import org.apache.logging.log4j.core.util.Clock;
+import org.apache.logging.log4j.core.util.ClockFactory;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Compares {@link DatePatternConverter} formatting and caching efficiency.
+ * <p>
+ * HOW TO RUN THIS TEST
+ * </p>
+ *
+ * <pre>
+ * java -jar target/benchmarks.jar ".*DatePatternConverterBenchmark.*" -p useThreadlocals=true,false
+ * </pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Threads(Threads.MAX)
+public class DatePatternConverterBenchmark {
+
+    @Param({ "yyyy-MM-dd'T'HH:mm:ss.SSS", "yyyy-MM-dd'T'HH:mm:ss.nnnnnn" })
+    private String pattern;
+
+    @Param({ "true", "false" })
+    private boolean useThreadlocals;
+
+    private static final ThreadLocal<MutableInstant> INSTANT = ThreadLocal.withInitial(MutableInstant::new);
+    private static final ThreadLocal<StringBuilder> STRING_BUILDER = ThreadLocal.withInitial(StringBuilder::new);
+
+    private Clock clock;
+    private DatePatternConverter converter;
+
+    @Setup
+    public void setup() {
+        System.setProperty("log4j2.enableThreadlocals", useThreadlocals ? "true" : "false");
+        clock = ClockFactory.getClock();
+        converter = DatePatternConverter.newInstance(new String[] { pattern });
+    }
+
+    @Benchmark
+    public void formatInstant(final Blackhole blackhole) {
+        final StringBuilder sb = STRING_BUILDER.get();
+        final MutableInstant instant = INSTANT.get();
+        instant.initFrom(clock);
+        sb.setLength(0);
+        converter.format(instant, sb);
+        blackhole.consume(sb.length());
+    }
+
+    @Benchmark
+    public void initInstant() {
+        final MutableInstant instant = INSTANT.get();
+        instant.initFrom(clock);
+    }
+
+}


### PR DESCRIPTION
When threadlocals are not used the last formatted date is kept in a cache synchronized between threads. As it turns out synchronization between threads is more expensive than formatting the same timestamp on multiple threads.

The cost of retrieving a timestamp on Java 17 (Linux) on my laptop is around 2.2 µs. Running the benchmark included in the PR on the current code gives me the following result:

```
Benchmark                                                       (pattern)  (useThreadlocals)  Mode  Cnt  Score   Error  Units
DatePatternConverterBenchmark.formatInstant         yyyyMMdd'T'HHmmss.SSS               true  avgt   25  2.441 ± 0.228  µs/op
DatePatternConverterBenchmark.formatInstant         yyyyMMdd'T'HHmmss.SSS              false  avgt   25  5.089 ± 0.164  µs/op
```

With the changes in this PR, the difference between using thread locals or not almost disappears:

```
Benchmark                                                       (pattern)  (useThreadlocals)  Mode  Cnt  Score   Error  Units
DatePatternConverterBenchmark.formatInstant     yyyy-MM-dd'T'HH:mm:ss.SSS               true  avgt   25  2,713 ± 0,252  µs/op
DatePatternConverterBenchmark.formatInstant     yyyy-MM-dd'T'HH:mm:ss.SSS              false  avgt   25  2,772 ± 0,351  µs/op
DatePatternConverterBenchmark.formatInstant  yyyy-MM-dd'T'HH:mm:ss.nnnnnn               true  avgt   25  2,691 ± 0,138  µs/op
DatePatternConverterBenchmark.formatInstant  yyyy-MM-dd'T'HH:mm:ss.nnnnnn              false  avgt   25  3,275 ± 0,427  µs/op
```
