### PR TITLE
LOG4J2-3663 - fix file descriptor leak on Tomcat (config in JAR file)

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationSourceTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationSourceTest.java
@@ -31,9 +31,13 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class ConfigurationSourceTest {
+    private static final Path JAR_FILE = Paths.get("target", "classes", "jarfile.jar");
+    private static final Path TEST_JARFILE = Paths.get("target", "classes", "jarfile-copy.jar");
 
     @Test
     public void testJira_LOG4J2_2770_byteArray() throws Exception {
@@ -49,17 +53,36 @@ public class ConfigurationSourceTest {
      */
     @Test
     public void testNoJarFileLeak() throws Exception {
-        final Path original = Paths.get("target", "classes", "jarfile.jar");
-        final Path copy = Paths.get("target", "classes", "jarfile-copy.jar");
-        Files.copy(original, copy);
-        final URL jarUrl = new URL("jar:" + copy.toUri().toURL() + "!/config/console.xml");
+        final URL jarConfigURL = prepareJarConfigURL();
         final long expected = getOpenFileDescriptorCount();
-        UrlConnectionFactory.createConnection(jarUrl).getInputStream().close();
+        UrlConnectionFactory.createConnection(jarConfigURL).getInputStream().close();
         // This can only fail on UNIX
         assertEquals(expected, getOpenFileDescriptorCount());
         // This can only fail on Windows
         try {
-            Files.delete(copy);
+            Files.delete(TEST_JARFILE);
+        } catch (IOException e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    public void testLoadConfigurationSourceFromJarFile() throws Exception {
+        final URL jarConfigURL = prepareJarConfigURL();
+        final long expectedFdCount = getOpenFileDescriptorCount();
+        ConfigurationSource configSource = ConfigurationSource.fromUri(jarConfigURL.toURI());
+        assertEquals(jarConfigURL.toString(), configSource.getLocation());
+        assertNull(configSource.getFile());
+        assertTrue(configSource.getLastModified() > 0);
+        assertEquals(jarConfigURL, configSource.getURL());
+        assertNotNull(configSource.getInputStream());
+        configSource.getInputStream().close();
+
+        // This can only fail on UNIX
+        assertEquals(expectedFdCount, getOpenFileDescriptorCount());
+        // This can only fail on Windows
+        try {
+            Files.delete(TEST_JARFILE);
         } catch (IOException e) {
             fail(e);
         }
@@ -72,4 +95,11 @@ public class ConfigurationSourceTest {
         }
         return 0L;
     }
+
+    private static URL prepareJarConfigURL() throws IOException {
+      if(!Files.exists(TEST_JARFILE))
+        Files.copy(JAR_FILE, TEST_JARFILE);
+      return new URL("jar:" + TEST_JARFILE.toUri().toURL() + "!/config/console.xml");
+    }
+
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
@@ -359,8 +359,9 @@ public class ConfigurationSource {
                     return new ConfigurationSource(urlConnection.getInputStream(), FileUtils.fileFromUri(url.toURI()));
                 } else if (urlConnection instanceof JarURLConnection) {
                     // Work around https://bugs.openjdk.java.net/browse/JDK-6956385.
-                    final long lastModified = new File(((JarURLConnection) urlConnection).getJarFile().getName())
-                            .lastModified();
+                    URL jarFileUrl = ((JarURLConnection)urlConnection).getJarFileURL();
+                    File jarFile = new File(jarFileUrl.getFile());
+                    long lastModified = jarFile.lastModified();
                     return new ConfigurationSource(urlConnection.getInputStream(), url, lastModified);
                 } else {
                     return new ConfigurationSource(urlConnection.getInputStream(), url, urlConnection.getLastModified());

--- a/src/changelog/.2.x.x/LOG4J2-3663_fix_file_descriptor_leak_on_Tomcat.xml
+++ b/src/changelog/.2.x.x/LOG4J2-3663_fix_file_descriptor_leak_on_Tomcat.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="fixed">
+  <issue id="LOG4J2-3663" link="https://issues.apache.org/jira/browse/LOG4J2-3663"/>
+  <author id="lenoch7" name="Radek Kraus"/>
+  <!-- Committer -->
+  <author id="pkarwasz"/>
+  <description format="asciidoc">Fix file descriptor leak on Tomcat.</description>
+</entry>


### PR DESCRIPTION
Fix problem with unclosed JAR file containing Log4j configuration (Tomcat - CachedResourceURLStreamHandler is configured), which causes that web application cannot be undeployed, because JAR file cannot be deleted (windows).

See detail description in [LOG4J2-3663](https://issues.apache.org/jira/projects/LOG4J2/issues/LOG4J2-3663).