### PR TITLE
[1526] Add Jakarta version of JPA appender

### DIFF
--- a/log4j-bom/pom.xml
+++ b/log4j-bom/pom.xml
@@ -114,6 +114,12 @@
         <artifactId>log4j-iostreams</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <!-- Jakarta JPA Appender Plugin -->
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-jakarta-jpa</artifactId>
+        <version>${project.version}</version>
+      </dependency>
       <!-- Jakarta SMTP Appender plugin -->
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>

--- a/log4j-distribution/pom.xml
+++ b/log4j-distribution/pom.xml
@@ -223,6 +223,18 @@
       <version>${project.version}</version>
       <classifier>sources</classifier>
     </dependency>
+    <!-- log4j-jakarta-jpa -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jakarta-jpa</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jakarta-jpa</artifactId>
+      <version>${project.version}</version>
+      <classifier>sources</classifier>
+    </dependency>
     <!-- log4j-jakarta-web -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/log4j-jakarta-jpa/pom.xml
+++ b/log4j-jakarta-jpa/pom.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.logging.log4j</groupId>
@@ -23,22 +23,21 @@
     <version>3.0.0-SNAPSHOT</version>
   </parent>
 
-  <artifactId>log4j-jpa</artifactId>
-  <name>Apache Log4j JPA</name>
-  <description>Apache Log4j Java Persistence API Appender.</description>
+  <artifactId>log4j-jakarta-jpa</artifactId>
+  <name>Apache Log4j Jakarta JPA</name>
+  <description>Apache Log4j Java Persistence API Appender, version for Jakarta EE 9.</description>
   <properties>
     <log4jParentDir>${basedir}/..</log4jParentDir>
     <docLabel>Log4j JPA Documentation</docLabel>
-    <projectDir>/log4j-jpa</projectDir>
+    <projectDir>/log4j-jakarta-jpa</projectDir>
     <module.name>org.apache.logging.log4j.jpa</module.name>
-    <org.eclipse.persistence.version>2.7.12</org.eclipse.persistence.version>
   </properties>
 
   <dependencies>
     <!-- Used for JPA appenders (needs an implementation of course) -->
     <dependency>
-      <groupId>javax.persistence</groupId>
-      <artifactId>javax.persistence-api</artifactId>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/appender/AbstractLogEventWrapperEntity.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/appender/AbstractLogEventWrapperEntity.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.appender;
+
+import java.util.Map;
+
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Transient;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.AbstractLogEvent;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.time.Instant;
+import org.apache.logging.log4j.jpa.converter.ContextDataAttributeConverter;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+
+/**
+ * <p>
+ * Users of the JPA appender MUST extend this class, using JPA annotations on the concrete class and all of its
+ * accessor methods (as needed) to map them to the proper table and columns. Accessors you do not want persisted should
+ * be annotated with {@link Transient @Transient}. All accessors should call {@link #getWrappedEvent()} and delegate the
+ * call to the underlying event. Users may want to instead extend {@link BasicLogEventEntity}, which takes care of all
+ * of this for you.
+ * </p>
+ * <p>
+ * The concrete class must have two constructors: a public no-arg constructor to convince the JPA provider that it's a
+ * valid entity, and a public constructor that takes a single {@link LogEvent event} and passes it to the parent class
+ * with {@link #AbstractLogEventWrapperEntity(LogEvent) super(event)}. Furthermore, the concrete class must be annotated
+ * {@link jakarta.persistence.Entity @Entity} and {@link jakarta.persistence.Table @Table} and must implement a fully
+ * mutable ID property annotated with {@link jakarta.persistence.Id @Id} and
+ * {@link jakarta.persistence.GeneratedValue @GeneratedValue} to tell the JPA provider how to calculate an ID for new
+ * events.
+ * </p>
+ * <p>
+ * Many of the return types of {@link LogEvent} methods (e.g., {@link StackTraceElement}, {@link Message},
+ * {@link Marker}, {@link Throwable},
+ * {@link org.apache.logging.log4j.ThreadContext.ContextStack ThreadContext.ContextStack}, and
+ * {@link Map Map&lt;String, String&gt;}) will not be recognized by the JPA provider. In conjunction with
+ * {@link jakarta.persistence.Convert @Convert}, you can use the converters in the
+ * {@link org.apache.logging.log4j.jpa.converter} package to convert these types to database columns.
+ * If you want to retrieve log events from the database, you can create a true POJO entity and also use these
+ * converters for extracting persisted values.<br>
+ * </p>
+ * <p>
+ * The mutator methods in this class not specified in {@link LogEvent} are no-op methods, implemented to satisfy the JPA
+ * requirement that accessor methods have matching mutator methods. If you create additional accessor methods, you must
+ * likewise create matching no-op mutator methods.
+ * </p>
+ *
+ * @see BasicLogEventEntity
+ */
+@MappedSuperclass
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+public abstract class AbstractLogEventWrapperEntity implements LogEvent {
+
+    private final LogEvent wrappedEvent;
+
+    /**
+     * Instantiates this base class. All concrete implementations must have a constructor matching this constructor's
+     * signature. The no-argument constructor is required for a standards-compliant JPA provider to accept this as an
+     * entity.
+     */
+    @SuppressWarnings("unused")
+    protected AbstractLogEventWrapperEntity() {
+        this(new NullLogEvent());
+    }
+
+    /**
+     * Instantiates this base class. All concrete implementations must have a constructor matching this constructor's
+     * signature. This constructor is used for wrapping this entity around a logged event.
+     *
+     * @param wrappedEvent The underlying event from which information is obtained.
+     */
+    protected AbstractLogEventWrapperEntity(final LogEvent wrappedEvent) {
+        if (wrappedEvent == null) {
+            throw new IllegalArgumentException("The wrapped event cannot be null.");
+        }
+        this.wrappedEvent = wrappedEvent;
+    }
+
+    @Override
+    public LogEvent toImmutable() {
+        return toMemento();
+    }
+
+    /**
+     * All eventual accessor methods must call this method and delegate the method call to the underlying wrapped event.
+     * Annotated {@link Transient} so as not to be included in the persisted entity.
+     *
+     * @return The underlying event from which information is obtained.
+     */
+    @Transient
+    protected final LogEvent getWrappedEvent() {
+        return this.wrappedEvent;
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param level Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setLevel(final Level level) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param loggerName Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setLoggerName(final String loggerName) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param source Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setSource(final StackTraceElement source) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param message Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setMessage(final Message message) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param marker Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setMarker(final Marker marker) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param threadId Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setThreadId(final long threadId) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param threadName Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setThreadName(final String threadName) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param threadPriority Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setThreadPriority(final int threadPriority) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param nanoTime Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setNanoTime(final long nanoTime) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param millis Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setTimeMillis(final long millis) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param instant Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setInstant(final Instant instant) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param nanoOfMillisecond Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setNanoOfMillisecond(final int nanoOfMillisecond) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param throwable Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setThrown(final Throwable throwable) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param contextData Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setContextData(final ReadOnlyStringMap contextData) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param map Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setContextMap(final Map<String, String> map) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param contextStack Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setContextStack(final ThreadContext.ContextStack contextStack) {
+        // this entity is write-only
+    }
+
+    /**
+     * A no-op mutator to satisfy JPA requirements, as this entity is write-only.
+     *
+     * @param fqcn Ignored.
+     */
+    @SuppressWarnings("unused")
+    public void setLoggerFqcn(final String fqcn) {
+        // this entity is write-only
+    }
+
+    /**
+     * Indicates whether the source of the logging request is required downstream. Annotated
+     * {@link Transient @Transient} so as to not be included in the persisted entity.
+     *
+     * @return whether the source of the logging request is required downstream.
+     */
+    @Override
+    @Transient
+    public final boolean isIncludeLocation() {
+        return this.getWrappedEvent().isIncludeLocation();
+    }
+
+    @Override
+    public final void setIncludeLocation(final boolean locationRequired) {
+        this.getWrappedEvent().setIncludeLocation(locationRequired);
+    }
+
+    /**
+     * Indicates whether this event is the last one in a batch. Annotated {@link Transient @Transient} so as to not be
+     * included in the persisted entity.
+     *
+     * @return whether this event is the last one in a batch.
+     */
+    @Override
+    @Transient
+    public final boolean isEndOfBatch() {
+        return this.getWrappedEvent().isEndOfBatch();
+    }
+
+    @Override
+    public final void setEndOfBatch(final boolean endOfBatch) {
+        this.getWrappedEvent().setEndOfBatch(endOfBatch);
+    }
+
+    /**
+     * Gets the context map. Transient, since the String version of the data is obtained via ReadOnlyStringMap.
+     *
+     * @return the context data.
+     * @see ContextDataAttributeConverter
+     * @see org.apache.logging.log4j.jpa.converter.ContextDataAttributeConverter
+     */
+    @Override
+    @Transient
+    //@Convert(converter = ContextDataAttributeConverter.class)
+    public ReadOnlyStringMap getContextData() {
+        return this.getWrappedEvent().getContextData();
+    }
+
+    /**
+     * A no-op log event class to prevent {@code NullPointerException}s. O/RMs tend to create instances of entities in
+     * order to "play around" with them.
+     */
+    private static class NullLogEvent extends AbstractLogEvent {
+
+        // Inherits everything
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/appender/BasicLogEventEntity.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/appender/BasicLogEventEntity.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.appender;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.Convert;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.Transient;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.ThrowableProxy;
+import org.apache.logging.log4j.core.time.Instant;
+import org.apache.logging.log4j.jpa.converter.ContextMapAttributeConverter;
+import org.apache.logging.log4j.jpa.converter.ContextStackAttributeConverter;
+import org.apache.logging.log4j.jpa.converter.InstantAttributeConverter;
+import org.apache.logging.log4j.jpa.converter.LevelAttributeConverter;
+import org.apache.logging.log4j.jpa.converter.MarkerAttributeConverter;
+import org.apache.logging.log4j.jpa.converter.MessageAttributeConverter;
+import org.apache.logging.log4j.jpa.converter.StackTraceElementAttributeConverter;
+import org.apache.logging.log4j.jpa.converter.ThrowableAttributeConverter;
+import org.apache.logging.log4j.message.Message;
+
+/**
+ * Users of the JPA appender may want to extend this class instead of {@link AbstractLogEventWrapperEntity}. This class
+ * implements all of the required mutator methods but does not implement a mutable entity ID property. In order to
+ * create an entity based on this class, you need only create two constructors matching this class's constructors,
+ * annotate the class {@link jakarta.persistence.Entity @Entity} and {@link jakarta.persistence.Table @Table}, and implement
+ * the fully mutable entity ID property annotated with {@link jakarta.persistence.Id @Id} and
+ * {@link jakarta.persistence.GeneratedValue @GeneratedValue} to tell the JPA provider how to calculate an ID for new
+ * events.<br>
+ * <br>
+ * The attributes in this entity use the default column names (which, according to the JPA spec, are the property names
+ * minus the "get" and "set" from the accessors/mutators). If you want to use different column names for one or more
+ * columns, override the necessary accessor methods defined in this class with the same annotations plus the
+ * {@link jakarta.persistence.Column @Column} annotation to specify the column name.<br>
+ * <br>
+ * The #getContextMap() and {@link #getContextStack()} attributes in this entity use the
+ * {@link ContextMapAttributeConverter} and {@link ContextStackAttributeConverter}, respectively. These convert the
+ * properties to simple strings that cannot be converted back to the properties. If you wish to instead convert these to
+ * a reversible JSON string, override these attributes with the same annotations but use the
+ * {@link org.apache.logging.log4j.jpa.converter.ContextMapJsonAttributeConverter} and
+ * {@link org.apache.logging.log4j.jpa.converter.ContextStackJsonAttributeConverter} instead.<br>
+ * <br>
+ * All other attributes in this entity use reversible converters that can be used for both persistence and retrieval. If
+ * there are any attributes you do not want persistent, you should override their accessor methods and annotate with
+ * {@link jakarta.persistence.Transient @Transient}.
+ *
+ * @see AbstractLogEventWrapperEntity
+ */
+@MappedSuperclass
+public abstract class BasicLogEventEntity extends AbstractLogEventWrapperEntity {
+
+    /**
+     * Instantiates this base class. All concrete implementations must have a constructor matching this constructor's
+     * signature. The no-argument constructor is required for a standards-compliant JPA provider to accept this as an
+     * entity.
+     */
+    public BasicLogEventEntity() {
+        super();
+    }
+
+    /**
+     * Instantiates this base class. All concrete implementations must have a constructor matching this constructor's
+     * signature. This constructor is used for wrapping this entity around a logged event.
+     *
+     * @param wrappedEvent The underlying event from which information is obtained.
+     */
+    public BasicLogEventEntity(final LogEvent wrappedEvent) {
+        super(wrappedEvent);
+    }
+
+    /**
+     * Gets the level. Annotated with {@code @Basic} and {@code @Enumerated(EnumType.STRING)}.
+     *
+     * @return the level.
+     */
+    @Override
+    @Convert(converter = LevelAttributeConverter.class)
+    public Level getLevel() {
+        return this.getWrappedEvent().getLevel();
+    }
+
+    /**
+     * Gets the logger name. Annotated with {@code @Basic}.
+     *
+     * @return the logger name.
+     */
+    @Override
+    @Basic
+    public String getLoggerName() {
+        return this.getWrappedEvent().getLoggerName();
+    }
+
+    /**
+     * Gets the source location information. Annotated with
+     * {@code @Convert(converter = StackTraceElementAttributeConverter.class)}.
+     *
+     * @return the source location information.
+     * @see StackTraceElementAttributeConverter
+     */
+    @Override
+    @Convert(converter = StackTraceElementAttributeConverter.class)
+    public StackTraceElement getSource() {
+        return this.getWrappedEvent().getSource();
+    }
+
+    /**
+     * Gets the message. Annotated with {@code @Convert(converter = MessageAttributeConverter.class)}.
+     *
+     * @return the message.
+     * @see MessageAttributeConverter
+     */
+    @Override
+    @Convert(converter = MessageAttributeConverter.class)
+    public Message getMessage() {
+        return this.getWrappedEvent().getMessage();
+    }
+
+    /**
+     * Gets the marker. Annotated with {@code @Convert(converter = MarkerAttributeConverter.class)}.
+     *
+     * @return the marker.
+     * @see MarkerAttributeConverter
+     */
+    @Override
+    @Convert(converter = MarkerAttributeConverter.class)
+    public Marker getMarker() {
+        return this.getWrappedEvent().getMarker();
+    }
+
+    /**
+     * Gets the thread ID. Annotated with {@code @Basic}.
+     *
+     * @return the thread ID.
+     */
+    @Override
+    @Basic
+    public long getThreadId() {
+        return this.getWrappedEvent().getThreadId();
+    }
+
+    /**
+     * Gets the thread name. Annotated with {@code @Basic}.
+     *
+     * @return the thread name.
+     */
+    @Override
+    @Basic
+    public int getThreadPriority() {
+        return this.getWrappedEvent().getThreadPriority();
+    }
+
+    /**
+     * Gets the thread name. Annotated with {@code @Basic}.
+     *
+     * @return the thread name.
+     */
+    @Override
+    @Basic
+    public String getThreadName() {
+        return this.getWrappedEvent().getThreadName();
+    }
+
+    /**
+     * Gets the number of milliseconds since JVM launch. Annotated with {@code @Basic}.
+     *
+     * @return the number of milliseconds since JVM launch.
+     */
+    @Override
+    @Basic
+    public long getTimeMillis() {
+        return this.getWrappedEvent().getTimeMillis();
+    }
+
+    @Override
+    @Convert(converter = InstantAttributeConverter.class)
+    public Instant getInstant() {
+        return this.getWrappedEvent().getInstant();
+    }
+
+    /**
+     * Returns the value of the running Java Virtual Machine's high-resolution time source when this event was created,
+     * or a dummy value if it is known that this value will not be used downstream.
+     *
+     * @return the JVM nano time
+     */
+    @Override
+    @Basic
+    public long getNanoTime() {
+        return this.getWrappedEvent().getNanoTime();
+    }
+
+    /**
+     * Gets the exception logged. Annotated with {@code @Convert(converter = ThrowableAttributeConverter.class)}.
+     *
+     * @return the exception logged.
+     * @see ThrowableAttributeConverter
+     */
+    @Override
+    @Convert(converter = ThrowableAttributeConverter.class)
+    public Throwable getThrown() {
+        return this.getWrappedEvent().getThrown();
+    }
+
+    /**
+     * Gets the exception logged. Annotated with {@code @Convert(converter = ThrowableAttributeConverter.class)}.
+     *
+     * @return the exception logged.
+     * @see ThrowableAttributeConverter
+     */
+    @Override
+    @Transient
+    public ThrowableProxy getThrownProxy() {
+        return this.getWrappedEvent().getThrownProxy();
+    }
+
+    /**
+     * Gets the context stack. Annotated with {@code @Convert(converter = ContextStackAttributeConverter.class)}.
+     *
+     * @return the context stack.
+     * @see ContextStackAttributeConverter
+     * @see org.apache.logging.log4j.jpa.converter.ContextStackJsonAttributeConverter
+     */
+    @Override
+    @Convert(converter = ContextStackAttributeConverter.class)
+    public ThreadContext.ContextStack getContextStack() {
+        return this.getWrappedEvent().getContextStack();
+    }
+
+    /**
+     * Gets the fully qualified class name of the caller of the logger API. Annotated with {@code @Basic}.
+     *
+     * @return the fully qualified class name of the caller of the logger API.
+     */
+    @Override
+    @Basic
+    public String getLoggerFqcn() {
+        return this.getWrappedEvent().getLoggerFqcn();
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/appender/JpaAppender.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/appender/JpaAppender.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.appender;
+
+import java.lang.reflect.Constructor;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.appender.db.AbstractDatabaseAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.util.Booleans;
+import org.apache.logging.log4j.plugins.Configurable;
+import org.apache.logging.log4j.plugins.Plugin;
+import org.apache.logging.log4j.plugins.PluginAttribute;
+import org.apache.logging.log4j.plugins.PluginElement;
+import org.apache.logging.log4j.plugins.PluginFactory;
+import org.apache.logging.log4j.util.LoaderUtil;
+import org.apache.logging.log4j.util.Strings;
+
+/**
+ * This Appender writes logging events to a relational database using the Java Persistence API. It requires a
+ * pre-configured JPA persistence unit and a concrete implementation of the abstract
+ * {@link AbstractLogEventWrapperEntity} class decorated with JPA annotations.
+ *
+ * @see AbstractLogEventWrapperEntity
+ */
+@Configurable(elementType = Appender.ELEMENT_TYPE, printObject = true)
+@Plugin("JPA")
+public final class JpaAppender extends AbstractDatabaseAppender<JpaDatabaseManager> {
+
+    private final String description;
+
+    private JpaAppender(final String name, final Filter filter, final boolean ignoreExceptions,
+            final Property[] properties, final JpaDatabaseManager manager) {
+        super(name, filter, null, ignoreExceptions, properties, manager);
+        this.description = this.getName() + "{ manager=" + this.getManager() + " }";
+    }
+
+    @Override
+    public String toString() {
+        return this.description;
+    }
+
+    /**
+     * Factory method for creating a JPA appender within the plugin manager.
+     *
+     * @param name The name of the appender.
+     * @param ignore If {@code "true"} (default) exceptions encountered when appending events are logged; otherwise
+     *               they are propagated to the caller.
+     * @param filter The filter, if any, to use.
+     * @param bufferSize If an integer greater than 0, this causes the appender to buffer log events and flush whenever
+     *                   the buffer reaches this size.
+     * @param entityClassName The fully qualified name of the concrete {@link AbstractLogEventWrapperEntity}
+     *                        implementation that has JPA annotations mapping it to a database table.
+     * @param persistenceUnitName The name of the JPA persistence unit that should be used for persisting log events.
+     * @return a new JPA appender.
+     */
+    @PluginFactory
+    public static JpaAppender createAppender(
+            @PluginAttribute final String name,
+            @PluginAttribute("ignoreExceptions") final String ignore,
+            @PluginElement final Filter filter,
+            @PluginAttribute final String bufferSize,
+            @PluginAttribute final String entityClassName,
+            @PluginAttribute final String persistenceUnitName) {
+        if (Strings.isEmpty(entityClassName) || Strings.isEmpty(persistenceUnitName)) {
+            LOGGER.error("Attributes entityClassName and persistenceUnitName are required for JPA Appender.");
+            return null;
+        }
+
+        final int bufferSizeInt = AbstractAppender.parseInt(bufferSize, 0);
+        final boolean ignoreExceptions = Booleans.parseBoolean(ignore, true);
+
+        try {
+            final Class<? extends AbstractLogEventWrapperEntity> entityClass =
+                LoaderUtil.loadClass(entityClassName).asSubclass(AbstractLogEventWrapperEntity.class);
+
+            try {
+                entityClass.getConstructor();
+            } catch (final NoSuchMethodException e) {
+                LOGGER.error("Entity class [{}] does not have a no-arg constructor. The JPA provider will reject it.",
+                        entityClassName);
+                return null;
+            }
+
+            final Constructor<? extends AbstractLogEventWrapperEntity> entityConstructor =
+                    entityClass.getConstructor(LogEvent.class);
+
+            final String managerName = "jpaManager{ description=" + name + ", bufferSize=" + bufferSizeInt
+                    + ", persistenceUnitName=" + persistenceUnitName + ", entityClass=" + entityClass.getName() + '}';
+
+            final JpaDatabaseManager manager = JpaDatabaseManager.getJPADatabaseManager(
+                    managerName, bufferSizeInt, entityClass, entityConstructor, persistenceUnitName
+            );
+            if (manager == null) {
+                return null;
+            }
+
+            return new JpaAppender(name, filter, ignoreExceptions, null, manager);
+        } catch (final ClassNotFoundException e) {
+            LOGGER.error("Could not load entity class [{}].", entityClassName, e);
+            return null;
+        } catch (final NoSuchMethodException e) {
+            LOGGER.error("Entity class [{}] does not have a constructor with a single argument of type LogEvent.",
+                    entityClassName);
+            return null;
+        } catch (final ClassCastException e) {
+            LOGGER.error("Entity class [{}] does not extend AbstractLogEventWrapperEntity.", entityClassName);
+            return null;
+        }
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/appender/JpaDatabaseManager.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/appender/JpaDatabaseManager.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.appender;
+
+import java.lang.reflect.Constructor;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Persistence;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AppenderLoggingException;
+import org.apache.logging.log4j.core.appender.ManagerFactory;
+import org.apache.logging.log4j.core.appender.db.AbstractDatabaseManager;
+
+/**
+ * An {@link AbstractDatabaseManager} implementation for relational databases accessed via JPA.
+ */
+public final class JpaDatabaseManager extends AbstractDatabaseManager {
+    private static final JPADatabaseManagerFactory FACTORY = new JPADatabaseManagerFactory();
+
+    private final String entityClassName;
+    private final Constructor<? extends AbstractLogEventWrapperEntity> entityConstructor;
+    private final String persistenceUnitName;
+
+    private EntityManagerFactory entityManagerFactory;
+
+    private EntityManager entityManager;
+    private EntityTransaction transaction;
+
+    private JpaDatabaseManager(final String name, final int bufferSize,
+                               final Class<? extends AbstractLogEventWrapperEntity> entityClass,
+                               final Constructor<? extends AbstractLogEventWrapperEntity> entityConstructor,
+                               final String persistenceUnitName) {
+        super(name, bufferSize);
+        this.entityClassName = entityClass.getName();
+        this.entityConstructor = entityConstructor;
+        this.persistenceUnitName = persistenceUnitName;
+    }
+
+    @Override
+    protected void startupInternal() {
+        this.entityManagerFactory = Persistence.createEntityManagerFactory(this.persistenceUnitName);
+    }
+
+    @Override
+    protected boolean shutdownInternal() {
+        boolean closed = true;
+        if (this.entityManager != null || this.transaction != null) {
+            closed &= this.commitAndClose();
+        }
+        if (this.entityManagerFactory != null && this.entityManagerFactory.isOpen()) {
+            this.entityManagerFactory.close();
+        }
+        return closed;
+    }
+
+    @Override
+    protected void connectAndStart() {
+        try {
+            this.entityManager = this.entityManagerFactory.createEntityManager();
+            this.transaction = this.entityManager.getTransaction();
+            this.transaction.begin();
+        } catch (final Exception e) {
+            throw new AppenderLoggingException(
+                    "Cannot write logging event or flush buffer; manager cannot create EntityManager or transaction.", e
+            );
+        }
+    }
+
+    @Override
+    protected void writeInternal(final LogEvent event) {
+        if (!this.isRunning() || this.entityManagerFactory == null || this.entityManager == null
+                || this.transaction == null) {
+            throw new AppenderLoggingException(
+                    "Cannot write logging event; JPA manager not connected to the database.");
+        }
+
+        AbstractLogEventWrapperEntity entity;
+        try {
+            entity = this.entityConstructor.newInstance(event);
+        } catch (final Exception e) {
+            throw new AppenderLoggingException("Failed to instantiate entity class [" + this.entityClassName + "].", e);
+        }
+
+        try {
+            this.entityManager.persist(entity);
+        } catch (final Exception e) {
+            if (this.transaction != null && this.transaction.isActive()) {
+                this.transaction.rollback();
+                this.transaction = null;
+            }
+            throw new AppenderLoggingException("Failed to insert record for log event in JPA manager: " +
+                    e.getMessage(), e);
+        }
+    }
+
+    @Override
+    protected boolean commitAndClose() {
+        boolean closed = true;
+        try {
+            if (this.transaction != null && this.transaction.isActive()) {
+                this.transaction.commit();
+            }
+        } catch (final Exception e) {
+            if (this.transaction != null && this.transaction.isActive()) {
+                this.transaction.rollback();
+            }
+        } finally {
+            this.transaction = null;
+            try {
+                if (this.entityManager != null && this.entityManager.isOpen()) {
+                    this.entityManager.close();
+                }
+            } catch (final Exception e) {
+                logWarn("Failed to close entity manager while logging event or flushing buffer", e);
+                closed = false;
+            } finally {
+                this.entityManager = null;
+            }
+        }
+        return closed;
+    }
+
+    /**
+     * Creates a JPA manager for use within the {@link JpaAppender}, or returns a suitable one if it already exists.
+     *
+     * @param name The name of the manager, which should include connection details, entity class name, etc.
+     * @param bufferSize The size of the log event buffer.
+     * @param entityClass The fully-qualified class name of the {@link AbstractLogEventWrapperEntity} concrete
+     *                    implementation.
+     * @param entityConstructor The one-arg {@link LogEvent} constructor for the concrete entity class.
+     * @param persistenceUnitName The name of the JPA persistence unit that should be used for persisting log events.
+     * @return a new or existing JPA manager as applicable.
+     */
+    public static JpaDatabaseManager getJPADatabaseManager(final String name, final int bufferSize,
+                                                           final Class<? extends AbstractLogEventWrapperEntity>
+                                                                   entityClass,
+                                                           final Constructor<? extends AbstractLogEventWrapperEntity>
+                                                                   entityConstructor,
+                                                           final String persistenceUnitName) {
+
+        return AbstractDatabaseManager.getManager(
+                name, new FactoryData(bufferSize, entityClass, entityConstructor, persistenceUnitName), FACTORY
+        );
+    }
+
+    /**
+     * Encapsulates data that {@link JPADatabaseManagerFactory} uses to create managers.
+     */
+    private static final class FactoryData extends AbstractDatabaseManager.AbstractFactoryData {
+        private final Class<? extends AbstractLogEventWrapperEntity> entityClass;
+        private final Constructor<? extends AbstractLogEventWrapperEntity> entityConstructor;
+        private final String persistenceUnitName;
+
+        protected FactoryData(final int bufferSize, final Class<? extends AbstractLogEventWrapperEntity> entityClass,
+                              final Constructor<? extends AbstractLogEventWrapperEntity> entityConstructor,
+                              final String persistenceUnitName) {
+            super(bufferSize, null);
+
+            this.entityClass = entityClass;
+            this.entityConstructor = entityConstructor;
+            this.persistenceUnitName = persistenceUnitName;
+        }
+    }
+
+    /**
+     * Creates managers.
+     */
+    private static final class JPADatabaseManagerFactory implements ManagerFactory<JpaDatabaseManager, FactoryData> {
+        @Override
+        public JpaDatabaseManager createManager(final String name, final FactoryData data) {
+            return new JpaDatabaseManager(
+                    name, data.getBufferSize(), data.entityClass, data.entityConstructor, data.persistenceUnitName
+            );
+        }
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/appender/package-info.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/appender/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+/**
+ * The JPA Appender supports writing log events to a relational database using the Java Persistence API. You will need
+ * a JDBC driver on your classpath for the database you wish to log to. You will also need the Java Persistence API 2.1
+ * and your JPA provider of choice on the class path; these Maven dependencies are optional and will not automatically
+ * be added to your classpath.
+ */
+package org.apache.logging.log4j.jpa.appender;

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ContextDataAttributeConverter.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ContextDataAttributeConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+
+/**
+ * A JPA 2.1 attribute converter for {@link ReadOnlyStringMap}s in
+ * {@link org.apache.logging.log4j.core.LogEvent}s. This converter is only capable of converting to {@link String}s. The
+ * {@link #convertToEntityAttribute(String)} method throws an {@link UnsupportedOperationException}. If you need to
+ * support converting to an entity attribute, you should use the {@link ContextMapJsonAttributeConverter} for conversion
+ * both ways.
+ */
+@Converter(autoApply = false)
+public class ContextDataAttributeConverter implements AttributeConverter<ReadOnlyStringMap, String> {
+    @Override
+    public String convertToDatabaseColumn(final ReadOnlyStringMap contextData) {
+        if (contextData == null) {
+            return null;
+        }
+
+        return contextData.toString();
+    }
+
+    @Override
+    public ReadOnlyStringMap convertToEntityAttribute(final String s) {
+        throw new UnsupportedOperationException("Log events can only be persisted, not extracted.");
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ContextDataJsonAttributeConverter.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ContextDataJsonAttributeConverter.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import jakarta.persistence.PersistenceException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.logging.log4j.core.impl.ContextDataFactory;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.apache.logging.log4j.util.StringMap;
+import org.apache.logging.log4j.util.Strings;
+
+/**
+ * A JPA 2.1 attribute converter for {@link ReadOnlyStringMap}s in
+ * {@link org.apache.logging.log4j.core.LogEvent}s. This converter is capable of converting both to and from
+ * {@link String}s.
+ *
+ * In addition to other optional dependencies required by the JPA appender, this converter requires the Jackson Data
+ * Processor.
+ */
+@Converter(autoApply = false)
+public class ContextDataJsonAttributeConverter implements AttributeConverter<ReadOnlyStringMap, String> {
+    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(final ReadOnlyStringMap contextData) {
+        if (contextData == null) {
+            return null;
+        }
+
+        try {
+            final JsonNodeFactory factory = OBJECT_MAPPER.getNodeFactory();
+            final ObjectNode root = factory.objectNode();
+            contextData.forEach((key, value) -> {
+                // we will cheat here and write the toString of the Object... meh, but ok.
+                root.put(key, String.valueOf(value));
+            });
+            return OBJECT_MAPPER.writeValueAsString(root);
+        } catch (final Exception e) {
+            throw new PersistenceException("Failed to convert contextData to JSON string.", e);
+        }
+    }
+
+    @Override
+    public ReadOnlyStringMap convertToEntityAttribute(final String s) {
+        if (Strings.isEmpty(s)) {
+            return null;
+        }
+        try {
+            final StringMap result = ContextDataFactory.createContextData();
+            final ObjectNode root = (ObjectNode) OBJECT_MAPPER.readTree(s);
+            final Iterator<Map.Entry<String, JsonNode>> entries = root.fields();
+            while (entries.hasNext()) {
+                final Map.Entry<String, JsonNode> entry = entries.next();
+
+                // Don't know what to do with non-text values.
+                // Maybe users who need this need to provide custom converter?
+                final Object value = entry.getValue().textValue();
+                result.putValue(entry.getKey(), value);
+            }
+            return result;
+        } catch (final IOException e) {
+            throw new PersistenceException("Failed to convert JSON string to map.", e);
+        }
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ContextMapAttributeConverter.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ContextMapAttributeConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import java.util.Map;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * A JPA 2.1 attribute converter for {@link Map Map&lt;String, String&gt;}s in
+ * {@link org.apache.logging.log4j.core.LogEvent}s. This converter is only capable of converting to {@link String}s. The
+ * {@link #convertToEntityAttribute(String)} method throws an {@link UnsupportedOperationException}. If you need to
+ * support converting to an entity attribute, you should use the {@link ContextMapJsonAttributeConverter} for conversion
+ * both ways.
+ */
+@Converter(autoApply = false)
+public class ContextMapAttributeConverter implements AttributeConverter<Map<String, String>, String> {
+    @Override
+    public String convertToDatabaseColumn(final Map<String, String> contextMap) {
+        if (contextMap == null) {
+            return null;
+        }
+
+        return contextMap.toString();
+    }
+
+    @Override
+    public Map<String, String> convertToEntityAttribute(final String s) {
+        throw new UnsupportedOperationException("Log events can only be persisted, not extracted.");
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ContextMapJsonAttributeConverter.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ContextMapJsonAttributeConverter.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import java.io.IOException;
+import java.util.Map;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import jakarta.persistence.PersistenceException;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.util.Strings;
+
+/**
+ * A JPA 2.1 attribute converter for {@link Map Map&lt;String, String&gt;}s in
+ * {@link org.apache.logging.log4j.core.LogEvent}s. This converter is capable of converting both to and from
+ * {@link String}s.
+ *
+ * In addition to other optional dependencies required by the JPA appender, this converter requires the Jackson Data
+ * Processor.
+ */
+@Converter(autoApply = false)
+public class ContextMapJsonAttributeConverter implements AttributeConverter<Map<String, String>, String> {
+    static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(final Map<String, String> contextMap) {
+        if (contextMap == null) {
+            return null;
+        }
+
+        try {
+            return OBJECT_MAPPER.writeValueAsString(contextMap);
+        } catch (final IOException e) {
+            throw new PersistenceException("Failed to convert map to JSON string.", e);
+        }
+    }
+
+    @Override
+    public Map<String, String> convertToEntityAttribute(final String s) {
+        if (Strings.isEmpty(s)) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.readValue(s, new TypeReference<Map<String, String>>() { });
+        } catch (final IOException e) {
+            throw new PersistenceException("Failed to convert JSON string to map.", e);
+        }
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ContextStackAttributeConverter.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ContextStackAttributeConverter.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.apache.logging.log4j.ThreadContext;
+
+/**
+ * A JPA 2.1 attribute converter for
+ * {@link org.apache.logging.log4j.ThreadContext.ContextStack ThreadContext.ContextStack}s in
+ * {@link org.apache.logging.log4j.core.LogEvent}s. This converter is only capable of converting to {@link String}s. The
+ * {@link #convertToEntityAttribute(String)} method throws an {@link UnsupportedOperationException}. If you need to
+ * support converting to an entity attribute, you should use the {@link ContextStackJsonAttributeConverter} for
+ * conversion both ways.
+ */
+@Converter(autoApply = false)
+public class ContextStackAttributeConverter implements AttributeConverter<ThreadContext.ContextStack, String> {
+    @Override
+    public String convertToDatabaseColumn(final ThreadContext.ContextStack contextStack) {
+        if (contextStack == null) {
+            return null;
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        for (final String value : contextStack.asList()) {
+            if (builder.length() > 0) {
+                builder.append('\n');
+            }
+            builder.append(value);
+        }
+        return builder.toString();
+    }
+
+    @Override
+    public ThreadContext.ContextStack convertToEntityAttribute(final String s) {
+        throw new UnsupportedOperationException("Log events can only be persisted, not extracted.");
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ContextStackJsonAttributeConverter.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ContextStackJsonAttributeConverter.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import java.io.IOException;
+import java.util.List;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import jakarta.persistence.PersistenceException;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.spi.DefaultThreadContextStack;
+import org.apache.logging.log4j.util.Strings;
+
+/**
+ * A JPA 2.1 attribute converter for
+ * {@link org.apache.logging.log4j.ThreadContext.ContextStack ThreadContext.ContextStack}s in
+ * {@link org.apache.logging.log4j.core.LogEvent}s. This converter is capable of converting both to and from
+ * {@link String}s.
+ *
+ * In addition to other optional dependencies required by the JPA appender, this converter requires the Jackson Data
+ * Processor.
+ */
+@Converter(autoApply = false)
+public class ContextStackJsonAttributeConverter implements AttributeConverter<ThreadContext.ContextStack, String> {
+    @Override
+    public String convertToDatabaseColumn(final ThreadContext.ContextStack contextStack) {
+        if (contextStack == null) {
+            return null;
+        }
+
+        try {
+            return ContextMapJsonAttributeConverter.OBJECT_MAPPER.writeValueAsString(contextStack.asList());
+        } catch (final IOException e) {
+            throw new PersistenceException("Failed to convert stack list to JSON string.", e);
+        }
+    }
+
+    @Override
+    public ThreadContext.ContextStack convertToEntityAttribute(final String s) {
+        if (Strings.isEmpty(s)) {
+            return null;
+        }
+
+        List<String> list;
+        try {
+            list = ContextMapJsonAttributeConverter.OBJECT_MAPPER.readValue(s, new TypeReference<List<String>>() { });
+        } catch (final IOException e) {
+            throw new PersistenceException("Failed to convert JSON string to list for stack.", e);
+        }
+
+        final DefaultThreadContextStack result = new DefaultThreadContextStack(true);
+        result.addAll(list);
+        return result;
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/InstantAttributeConverter.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/InstantAttributeConverter.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.apache.logging.log4j.core.time.Instant;
+import org.apache.logging.log4j.core.time.MutableInstant;
+import org.apache.logging.log4j.util.Strings;
+
+/**
+ * A JPA 2.1 attribute converter for {@link Instant}s in {@link org.apache.logging.log4j.core.LogEvent}s. This
+ * converter is capable of converting both to and from {@link String}s.
+ */
+@Converter(autoApply = false)
+public class InstantAttributeConverter implements AttributeConverter<Instant, String> {
+
+    @Override
+    public String convertToDatabaseColumn(final Instant instant) {
+        if (instant == null) {
+            return null;
+        }
+        return instant.getEpochSecond() + "," + instant.getNanoOfSecond();
+    }
+
+    @Override
+    public Instant convertToEntityAttribute(final String s) {
+        if (Strings.isEmpty(s)) {
+            return null;
+        }
+
+        final int pos = s.indexOf(",");
+        final long epochSecond = Long.parseLong(s.substring(0, pos));
+        final int nanos = Integer.parseInt(s.substring(pos + 1, s.length()));
+
+        final MutableInstant result = new MutableInstant();
+        result.initFromEpochSecond(epochSecond, nanos);
+        return result;
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/LevelAttributeConverter.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/LevelAttributeConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.util.Strings;
+
+/**
+ * A JPA 2.1 attribute converter for {@link org.apache.logging.log4j.Level}s in {@link org.apache.logging.log4j.core.LogEvent}s. This
+ * converter is capable of converting both to and from {@link String}s.
+ */
+@Converter(autoApply = false)
+public class LevelAttributeConverter implements AttributeConverter<Level, String> {
+    @Override
+    public String convertToDatabaseColumn(final Level level) {
+        if (level == null) {
+            return null;
+        }
+        return level.name();
+    }
+
+    @Override
+    public Level convertToEntityAttribute(final String s) {
+        if (Strings.isEmpty(s)) {
+            return null;
+        }
+
+        return Level.toLevel(s, null);
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/MarkerAttributeConverter.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/MarkerAttributeConverter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+import org.apache.logging.log4j.util.Strings;
+
+/**
+ * A JPA 2.1 attribute converter for {@link Marker}s in {@link org.apache.logging.log4j.core.LogEvent}s. This
+ * converter is capable of converting both to and from {@link String}s.
+ */
+@Converter(autoApply = false)
+public class MarkerAttributeConverter implements AttributeConverter<Marker, String> {
+    @Override
+    public String convertToDatabaseColumn(final Marker marker) {
+        if (marker == null) {
+            return null;
+        }
+        return marker.toString();
+    }
+
+    @Override
+    public Marker convertToEntityAttribute(final String s) {
+        if (Strings.isEmpty(s)) {
+            return null;
+        }
+
+        final int bracket = s.indexOf("[");
+
+        return bracket < 1 ? MarkerManager.getMarker(s) : MarkerManager.getMarker(s.substring(0, bracket));
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/MessageAttributeConverter.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/MessageAttributeConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Strings;
+
+/**
+ * A JPA 2.1 attribute converter for {@link Message}s in {@link org.apache.logging.log4j.core.LogEvent}s. This
+ * converter is capable of converting both to and from {@link String}s.
+ */
+@Converter(autoApply = false)
+public class MessageAttributeConverter implements AttributeConverter<Message, String> {
+    private static final StatusLogger LOGGER = StatusLogger.getLogger();
+
+    @Override
+    public String convertToDatabaseColumn(final Message message) {
+        if (message == null) {
+            return null;
+        }
+
+        return message.getFormattedMessage();
+    }
+
+    @Override
+    public Message convertToEntityAttribute(final String s) {
+        if (Strings.isEmpty(s)) {
+            return null;
+        }
+
+        return LOGGER.getMessageFactory().newMessage(s);
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/StackTraceElementAttributeConverter.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/StackTraceElementAttributeConverter.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.apache.logging.log4j.util.Strings;
+
+/**
+ * A JPA 2.1 attribute converter for {@link StackTraceElement}s in {@link org.apache.logging.log4j.core.LogEvent}s. This
+ * converter is capable of converting both to and from {@link String}s.
+ */
+@Converter(autoApply = false)
+public class StackTraceElementAttributeConverter implements AttributeConverter<StackTraceElement, String> {
+    private static final int UNKNOWN_SOURCE = -1;
+
+    private static final int NATIVE_METHOD = -2;
+
+    @Override
+    public String convertToDatabaseColumn(final StackTraceElement element) {
+        if (element == null) {
+            return null;
+        }
+
+        return element.toString();
+    }
+
+    @Override
+    public StackTraceElement convertToEntityAttribute(final String s) {
+        if (Strings.isEmpty(s)) {
+            return null;
+        }
+
+        return StackTraceElementAttributeConverter.convertString(s);
+    }
+
+    static StackTraceElement convertString(final String s) {
+        final int open = s.indexOf("(");
+
+        final String classMethod = s.substring(0, open);
+        final String className = classMethod.substring(0, classMethod.lastIndexOf("."));
+        final String methodName = classMethod.substring(classMethod.lastIndexOf(".") + 1);
+
+        final String parenthesisContents = s.substring(open + 1, s.indexOf(")"));
+
+        String fileName = null;
+        int lineNumber = UNKNOWN_SOURCE;
+        if ("Native Method".equals(parenthesisContents)) {
+            lineNumber = NATIVE_METHOD;
+        } else if (!"Unknown Source".equals(parenthesisContents)) {
+            final int colon = parenthesisContents.indexOf(":");
+            if (colon > UNKNOWN_SOURCE) {
+                fileName = parenthesisContents.substring(0, colon);
+                try {
+                    lineNumber = Integer.parseInt(parenthesisContents.substring(colon + 1));
+                } catch (final NumberFormatException ignore) {
+                    // we don't care
+                }
+            } else {
+                fileName = parenthesisContents;
+            }
+        }
+
+        return new StackTraceElement(className, methodName, fileName, lineNumber);
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ThrowableAttributeConverter.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/ThrowableAttributeConverter.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.ListIterator;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import org.apache.logging.log4j.util.LoaderUtil;
+import org.apache.logging.log4j.util.Strings;
+
+/**
+ * A JPA 2.1 attribute converter for {@link Throwable}s in {@link org.apache.logging.log4j.core.LogEvent}s. This
+ * converter is capable of converting both to and from {@link String}s.
+ */
+@Converter(autoApply = false)
+public class ThrowableAttributeConverter implements AttributeConverter<Throwable, String> {
+    private static final int CAUSED_BY_STRING_LENGTH = 10;
+
+    private static final Field THROWABLE_CAUSE;
+
+    private static final Field THROWABLE_MESSAGE;
+
+    static {
+        try {
+            THROWABLE_CAUSE = Throwable.class.getDeclaredField("cause");
+            THROWABLE_CAUSE.setAccessible(true);
+            THROWABLE_MESSAGE = Throwable.class.getDeclaredField("detailMessage");
+            THROWABLE_MESSAGE.setAccessible(true);
+        } catch (final NoSuchFieldException e) {
+            throw new IllegalStateException("Something is wrong with java.lang.Throwable.", e);
+        }
+    }
+
+    @Override
+    public String convertToDatabaseColumn(final Throwable throwable) {
+        if (throwable == null) {
+            return null;
+        }
+
+        final StringBuilder builder = new StringBuilder();
+        this.convertThrowable(builder, throwable);
+        return builder.toString();
+    }
+
+    private void convertThrowable(final StringBuilder builder, final Throwable throwable) {
+        builder.append(throwable.toString()).append('\n');
+        for (final StackTraceElement element : throwable.getStackTrace()) {
+            builder.append("\tat ").append(element).append('\n');
+        }
+        if (throwable.getCause() != null) {
+            builder.append("Caused by ");
+            this.convertThrowable(builder, throwable.getCause());
+        }
+    }
+
+    @Override
+    public Throwable convertToEntityAttribute(final String s) {
+        if (Strings.isEmpty(s)) {
+            return null;
+        }
+
+        final List<String> lines = Arrays.asList(s.split("(\n|\r\n)"));
+        return this.convertString(lines.listIterator(), false);
+    }
+
+    private Throwable convertString(final ListIterator<String> lines, final boolean removeCausedBy) {
+        String firstLine = lines.next();
+        if (removeCausedBy) {
+            firstLine = firstLine.substring(CAUSED_BY_STRING_LENGTH);
+        }
+        final int colon = firstLine.indexOf(":");
+        String throwableClassName;
+        String message = null;
+        if (colon > 1) {
+            throwableClassName = firstLine.substring(0, colon);
+            if (firstLine.length() > colon + 1) {
+                message = firstLine.substring(colon + 1).trim();
+            }
+        } else {
+            throwableClassName = firstLine;
+        }
+
+        final List<StackTraceElement> stackTrace = new ArrayList<>();
+        Throwable cause = null;
+        while (lines.hasNext()) {
+            final String line = lines.next();
+
+            if (line.startsWith("Caused by ")) {
+                lines.previous();
+                cause = convertString(lines, true);
+                break;
+            }
+
+            stackTrace.add(
+                    StackTraceElementAttributeConverter.convertString(line.trim().substring(3).trim())
+            );
+        }
+
+        return this.getThrowable(throwableClassName, message, cause,
+                stackTrace.toArray(new StackTraceElement[stackTrace.size()]));
+    }
+
+    private Throwable getThrowable(final String throwableClassName, final String message, final Throwable cause,
+                                   final StackTraceElement[] stackTrace) {
+        try {
+            @SuppressWarnings("unchecked")
+            final Class<Throwable> throwableClass = (Class<Throwable>) LoaderUtil.loadClass(throwableClassName);
+
+            if (!Throwable.class.isAssignableFrom(throwableClass)) {
+                return null;
+            }
+
+            Throwable throwable;
+            if (message != null && cause != null) {
+                throwable = this.getThrowable(throwableClass, message, cause);
+                if (throwable == null) {
+                    throwable = this.getThrowable(throwableClass, cause);
+                    if (throwable == null) {
+                        throwable = this.getThrowable(throwableClass, message);
+                        if (throwable == null) {
+                            throwable = this.getThrowable(throwableClass);
+                            if (throwable != null) {
+                                THROWABLE_MESSAGE.set(throwable, message);
+                                THROWABLE_CAUSE.set(throwable, cause);
+                            }
+                        } else {
+                            THROWABLE_CAUSE.set(throwable, cause);
+                        }
+                    } else {
+                        THROWABLE_MESSAGE.set(throwable, message);
+                    }
+                }
+            } else if (cause != null) {
+                throwable = this.getThrowable(throwableClass, cause);
+                if (throwable == null) {
+                    throwable = this.getThrowable(throwableClass);
+                    if (throwable != null) {
+                        THROWABLE_CAUSE.set(throwable, cause);
+                    }
+                }
+            } else if (message != null) {
+                throwable = this.getThrowable(throwableClass, message);
+                if (throwable == null) {
+                    throwable = this.getThrowable(throwableClass);
+                    if (throwable != null) {
+                        THROWABLE_MESSAGE.set(throwable, cause);
+                    }
+                }
+            } else {
+                throwable = this.getThrowable(throwableClass);
+            }
+
+            if (throwable == null) {
+                return null;
+            }
+            throwable.setStackTrace(stackTrace);
+            return throwable;
+        } catch (final Exception e) {
+            return null;
+        }
+    }
+
+    private Throwable getThrowable(final Class<Throwable> throwableClass, final String message, final Throwable cause) {
+        try {
+            @SuppressWarnings("unchecked")
+            final
+            Constructor<Throwable>[] constructors = (Constructor<Throwable>[]) throwableClass.getConstructors();
+            for (final Constructor<Throwable> constructor : constructors) {
+                final Class<?>[] parameterTypes = constructor.getParameterTypes();
+                if (parameterTypes.length == 2) {
+                    if (String.class == parameterTypes[0] && Throwable.class.isAssignableFrom(parameterTypes[1])) {
+                        return constructor.newInstance(message, cause);
+                    } else if (String.class == parameterTypes[1] &&
+                            Throwable.class.isAssignableFrom(parameterTypes[0])) {
+                        return constructor.newInstance(cause, message);
+                    }
+                }
+            }
+            return null;
+        } catch (final Exception e) {
+            return null;
+        }
+    }
+
+    private Throwable getThrowable(final Class<Throwable> throwableClass, final Throwable cause) {
+        try {
+            @SuppressWarnings("unchecked")
+            final
+            Constructor<Throwable>[] constructors = (Constructor<Throwable>[]) throwableClass.getConstructors();
+            for (final Constructor<Throwable> constructor : constructors) {
+                final Class<?>[] parameterTypes = constructor.getParameterTypes();
+                if (parameterTypes.length == 1 && Throwable.class.isAssignableFrom(parameterTypes[0])) {
+                    return constructor.newInstance(cause);
+                }
+            }
+            return null;
+        } catch (final Exception e) {
+            return null;
+        }
+    }
+
+    private Throwable getThrowable(final Class<Throwable> throwableClass, final String message) {
+        try {
+            return throwableClass.getConstructor(String.class).newInstance(message);
+        } catch (final Exception e) {
+            return null;
+        }
+    }
+
+    private Throwable getThrowable(final Class<Throwable> throwableClass) {
+        try {
+            return throwableClass.newInstance();
+        } catch (final Exception e) {
+            return null;
+        }
+    }
+}

--- a/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/package-info.java
+++ b/log4j-jakarta-jpa/src/main/java/org/apache/logging/log4j/jpa/converter/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+// Lines too long...
+//CHECKSTYLE:OFF
+/**
+ * The converters in this package implement the JPA 2.1 mechanism for converting non-standard types to and from
+ * database fields. Most of these types are capable of two-way conversion and can be used to both persist and retrieve
+ * entities. The
+ * {@link org.apache.logging.log4j.jpa.converter.ContextMapAttributeConverter ContextMapAttributeConverter}
+ * and {@link org.apache.logging.log4j.jpa.converter.ContextStackAttributeConverter ContextStackAttributeConverter}
+ * only support persistence and not retrieval, persisting the type as a simple string. You can use the
+ * {@link org.apache.logging.log4j.jpa.converter.ContextMapJsonAttributeConverter ContextMapJsonAttributeConverter}
+ * and {@link org.apache.logging.log4j.jpa.converter.ContextStackJsonAttributeConverter ContextStackJsonAttributeConverter}
+ * instead, which require the Jackson Data Processor dependency to also be on your class path.
+ */
+//CHECKSTYLE:ON
+package org.apache.logging.log4j.jpa.converter;

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/appender/AbstractJpaAppenderTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/appender/AbstractJpaAppenderTest.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.appender;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.DefaultConfiguration;
+import org.apache.logging.log4j.core.impl.Log4jPropertyKey;
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.PropertiesUtil;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+
+@Category(Appenders.Jpa.class)
+public abstract class AbstractJpaAppenderTest {
+    private final String databaseType;
+    private Connection connection;
+
+    public AbstractJpaAppenderTest(final String databaseType) {
+        this.databaseType = databaseType;
+    }
+
+    protected abstract Connection setUpConnection() throws SQLException;
+
+    public void setUp(final String configFileName) throws SQLException {
+        this.connection = this.setUpConnection();
+
+        final String resource = "org/apache/logging/log4j/jpa/appender/" + configFileName;
+        assertNotNull(getClass().getClassLoader().getResource(resource));
+        System.setProperty(Log4jPropertyKey.CONFIG_LOCATION.getSystemKey(), resource);
+        ((PropertiesUtil) PropertiesUtil.getProperties()).reload();
+        final LoggerContext context = LoggerContext.getContext(false);
+        if (context.getConfiguration() instanceof DefaultConfiguration) {
+            context.reconfigure();
+        }
+        StatusLogger.getLogger().reset();
+    }
+
+    public void tearDown() throws SQLException {
+        final LoggerContext context = LoggerContext.getContext(false);
+        try {
+            final String appenderName = "databaseAppender";
+            final Appender appender = context.getConfiguration().getAppender(appenderName);
+            assertNotNull("The appender '" + appenderName + "' should not be null.", appender);
+            assertTrue("The appender should be a JpaAppender.", appender instanceof JpaAppender);
+            ((JpaAppender) appender).getManager().close();
+        } finally {
+            System.clearProperty(Log4jPropertyKey.CONFIG_LOCATION.getSystemKey());
+            ((PropertiesUtil) PropertiesUtil.getProperties()).reload();
+            context.reconfigure();
+            StatusLogger.getLogger().reset();
+
+            try (final Statement statement = this.connection.createStatement();) {
+                statement.execute("SHUTDOWN");
+            }
+
+            this.connection.close();
+        }
+    }
+
+    @Test
+    public void testBaseJpaEntityAppender() throws SQLException {
+        try {
+            this.setUp("log4j2-" + this.databaseType + "-jpa-base.xml");
+
+            final RuntimeException exception = new RuntimeException("Hello, world!");
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            final PrintWriter writer = new PrintWriter(outputStream);
+            exception.printStackTrace(writer);
+            writer.close();
+            final String stackTrace = outputStream.toString().replace("\r\n", "\n");
+
+            final long millis = System.currentTimeMillis();
+
+            final Logger logger1 = LogManager.getLogger(this.getClass().getName() + ".testBaseJpaEntityAppender");
+            final Logger logger2 = LogManager.getLogger(this.getClass().getName() + ".testBaseJpaEntityAppenderAgain");
+            logger1.info("Test my message 01.");
+            logger1.error("This is another message 02.", exception);
+            logger2.warn("A final warning has been issued.");
+
+            final Statement statement = this.connection.createStatement();
+            final ResultSet resultSet = statement.executeQuery("SELECT * FROM jpaBaseLogEntry ORDER BY id");
+
+            assertTrue("There should be at least one row.", resultSet.next());
+
+            long date = resultSet.getTimestamp("eventDate").getTime();
+            assertTrue("The date should be later than pre-logging (1).", date >= millis);
+            assertTrue("The date should be earlier than now (1).", date <= System.currentTimeMillis());
+            assertEquals("The level column is not correct (1).", "INFO", resultSet.getString("level"));
+            assertEquals("The logger column is not correct (1).", logger1.getName(), resultSet.getString("logger"));
+            assertEquals("The message column is not correct (1).", "Test my message 01.",
+                    resultSet.getString("message"));
+            assertNull("The exception column is not correct (1).", resultSet.getString("exception"));
+
+            assertTrue("There should be at least two rows.", resultSet.next());
+
+            date = resultSet.getTimestamp("eventDate").getTime();
+            assertTrue("The date should be later than pre-logging (2).", date >= millis);
+            assertTrue("The date should be earlier than now (2).", date <= System.currentTimeMillis());
+            assertEquals("The level column is not correct (2).", "ERROR", resultSet.getString("level"));
+            assertEquals("The logger column is not correct (2).", logger1.getName(), resultSet.getString("logger"));
+            assertEquals("The message column is not correct (2).", "This is another message 02.",
+                    resultSet.getString("message"));
+            assertEquals("The exception column is not correct (2).", stackTrace, resultSet.getString("exception"));
+
+            assertTrue("There should be three rows.", resultSet.next());
+
+            date = resultSet.getTimestamp("eventDate").getTime();
+            assertTrue("The date should be later than pre-logging (3).", date >= millis);
+            assertTrue("The date should be earlier than now (3).", date <= System.currentTimeMillis());
+            assertEquals("The level column is not correct (3).", "WARN", resultSet.getString("level"));
+            assertEquals("The logger column is not correct (3).", logger2.getName(), resultSet.getString("logger"));
+            assertEquals("The message column is not correct (3).", "A final warning has been issued.",
+                    resultSet.getString("message"));
+            assertNull("The exception column is not correct (3).", resultSet.getString("exception"));
+
+            assertFalse("There should not be four rows.", resultSet.next());
+        } finally {
+            this.tearDown();
+        }
+    }
+
+    @Test
+    public void testBasicJpaEntityAppender() throws SQLException {
+        try {
+            this.setUp("log4j2-" + this.databaseType + "-jpa-basic.xml");
+
+            final Error exception = new Error("Goodbye, cruel world!");
+            final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            final PrintWriter writer = new PrintWriter(outputStream);
+            exception.printStackTrace(writer);
+            writer.close();
+            final String stackTrace = outputStream.toString().replace("\r\n", "\n");
+
+            final long millis = System.currentTimeMillis();
+
+            final Logger logger1 = LogManager.getLogger(this.getClass().getName() + ".testBasicJpaEntityAppender");
+            final Logger logger2 = LogManager.getLogger(this.getClass().getName() + ".testBasicJpaEntityAppenderAgain");
+            logger1.debug("Test my debug 01.");
+            logger1.warn("This is another warning 02.", exception);
+            logger2.fatal("A fatal warning has been issued.");
+
+            final Statement statement = this.connection.createStatement();
+            final ResultSet resultSet = statement.executeQuery("SELECT * FROM jpaBasicLogEntry ORDER BY id");
+
+            assertTrue("There should be at least one row.", resultSet.next());
+
+            long date = resultSet.getLong("timemillis");
+            assertTrue("The date should be later than pre-logging (1).", date >= millis);
+            assertTrue("The date should be earlier than now (1).", date <= System.currentTimeMillis());
+            assertEquals("The level column is not correct (1).", "DEBUG", resultSet.getString("level"));
+            assertEquals("The logger column is not correct (1).", logger1.getName(), resultSet.getString("loggerName"));
+            assertEquals("The message column is not correct (1).", "Test my debug 01.",
+                    resultSet.getString("message"));
+            assertNull("The exception column is not correct (1).", resultSet.getString("thrown"));
+
+            assertTrue("There should be at least two rows.", resultSet.next());
+
+            date = resultSet.getLong("timemillis");
+            assertTrue("The date should be later than pre-logging (2).", date >= millis);
+            assertTrue("The date should be earlier than now (2).", date <= System.currentTimeMillis());
+            assertEquals("The level column is not correct (2).", "WARN", resultSet.getString("level"));
+            assertEquals("The logger column is not correct (2).", logger1.getName(), resultSet.getString("loggerName"));
+            assertEquals("The message column is not correct (2).", "This is another warning 02.",
+                    resultSet.getString("message"));
+            assertEquals("The exception column is not correct (2).", stackTrace, resultSet.getString("thrown"));
+
+            assertTrue("There should be three rows.", resultSet.next());
+
+            date = resultSet.getLong("timemillis");
+            assertTrue("The date should be later than pre-logging (3).", date >= millis);
+            assertTrue("The date should be earlier than now (3).", date <= System.currentTimeMillis());
+            assertEquals("The level column is not correct (3).", "FATAL", resultSet.getString("level"));
+            assertEquals("The logger column is not correct (3).", logger2.getName(), resultSet.getString("loggerName"));
+            assertEquals("The message column is not correct (3).", "A fatal warning has been issued.",
+                    resultSet.getString("message"));
+            assertNull("The exception column is not correct (3).", resultSet.getString("thrown"));
+
+            assertFalse("There should not be four rows.", resultSet.next());
+        } finally {
+            this.tearDown();
+        }
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/appender/JpaH2AppenderTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/appender/JpaH2AppenderTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.appender;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.apache.logging.log4j.util.Strings;
+import org.junit.experimental.categories.Category;
+
+@Category(Appenders.Jpa.class)
+public class JpaH2AppenderTest extends AbstractJpaAppenderTest {
+    private static final String USER_ID = "sa";
+    private static final String PASSWORD = Strings.EMPTY;
+
+    public JpaH2AppenderTest() {
+        super("h2");
+    }
+
+    @Override
+    protected Connection setUpConnection() throws SQLException {
+        final Connection connection = DriverManager.getConnection("jdbc:h2:mem:Log4j", USER_ID, PASSWORD);
+
+        try (final Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE TABLE jpaBaseLogEntry ( "
+                    + "id INTEGER GENERATED ALWAYS AS IDENTITY, eventDate DATETIME, instant NVARCHAR(64), level NVARCHAR(10), "
+                    + "logger NVARCHAR(255), message NVARCHAR(1024), exception NVARCHAR(1048576)" + " )");
+        }
+
+        try (final Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE TABLE jpaBasicLogEntry ( "
+                    + "id INTEGER GENERATED ALWAYS AS IDENTITY, timemillis BIGINT, instant NVARCHAR(64), nanoTime BIGINT, "
+                    + "level NVARCHAR(10), loggerName NVARCHAR(255), message NVARCHAR(1024), "
+                    + "thrown NVARCHAR(1048576), contextMapJson NVARCHAR(1048576), loggerFQCN NVARCHAR(1024), "
+                    + "contextStack NVARCHAR(1048576), marker NVARCHAR(255), source NVARCHAR(2048),"
+                    + "threadId BIGINT, threadName NVARCHAR(255), threadPriority INTEGER" + " )");
+        }
+
+        return connection;
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/appender/JpaHsqldbAppenderTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/appender/JpaHsqldbAppenderTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.appender;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.apache.logging.log4j.util.Strings;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+
+@Category(Appenders.Jpa.class)
+public class JpaHsqldbAppenderTest extends AbstractJpaAppenderTest {
+    private static final String USER_ID = "sa";
+    private static final String PASSWORD = Strings.EMPTY;
+
+    public JpaHsqldbAppenderTest() {
+        super("hsqldb");
+    }
+
+    @Override
+    protected Connection setUpConnection() throws SQLException {
+        final Connection connection = DriverManager.getConnection("jdbc:hsqldb:mem:Log4j", USER_ID, PASSWORD);
+
+        try (final Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE TABLE jpaBaseLogEntry ( "
+                    + "id INTEGER IDENTITY, eventDate DATETIME, instant NVARCHAR(64), level VARCHAR(10), "
+                    + "logger VARCHAR(255), message VARCHAR(1024), exception VARCHAR(1048576)" + " )");
+        }
+
+        try (final Statement statement = connection.createStatement()) {
+            statement.executeUpdate("CREATE TABLE jpaBasicLogEntry ( "
+                    + "id INTEGER IDENTITY, timemillis BIGINT, instant NVARCHAR(64), nanoTime BIGINT, "
+                    + "level VARCHAR(10), loggerName VARCHAR(255), message VARCHAR(1024), thrown VARCHAR(1048576), "
+                    + "contextMapJson VARCHAR(1048576), loggerFQCN VARCHAR(1024), "
+                    + "contextStack VARCHAR(1048576), marker VARCHAR(255), source VARCHAR(2048),"
+                    + "threadId BIGINT, threadName NVARCHAR(255), threadPriority INTEGER" + " )");
+        }
+
+        return connection;
+    }
+
+    @Test
+    public void testNoEntityClassName() {
+        final JpaAppender appender = JpaAppender.createAppender("name", null, null, null, null, "jpaAppenderTestUnit");
+
+        assertNull("The appender should be null.", appender);
+    }
+
+    @Test
+    public void testNoPersistenceUnitName() {
+        final JpaAppender appender = JpaAppender.createAppender("name", null, null, null, TestBaseEntity.class.getName(),
+                null);
+
+        assertNull("The appender should be null.", appender);
+    }
+
+    @Test
+    public void testBadEntityClassName() {
+        final JpaAppender appender = JpaAppender.createAppender("name", null, null, null, "com.foo.Bar",
+                "jpaAppenderTestUnit");
+
+        assertNull("The appender should be null.", appender);
+    }
+
+    @Test
+    public void testNonLogEventEntity() {
+        final JpaAppender appender = JpaAppender.createAppender("name", null, null, null, Object.class.getName(),
+                "jpaAppenderTestUnit");
+
+        assertNull("The appender should be null.", appender);
+    }
+
+    @Test
+    public void testBadConstructorEntity01() {
+        final JpaAppender appender = JpaAppender.createAppender("name", null, null, null,
+                BadConstructorEntity1.class.getName(), "jpaAppenderTestUnit");
+
+        assertNull("The appender should be null.", appender);
+    }
+
+    @Test
+    public void testBadConstructorEntity02() {
+        final JpaAppender appender = JpaAppender.createAppender("name", null, null, null,
+                BadConstructorEntity2.class.getName(), "jpaAppenderTestUnit");
+
+        assertNull("The appender should be null.", appender);
+    }
+
+    @SuppressWarnings("unused")
+    public static class BadConstructorEntity1 extends TestBaseEntity {
+        private static final long serialVersionUID = 1L;
+
+        public BadConstructorEntity1(final LogEvent wrappedEvent) {
+            super(wrappedEvent);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public static class BadConstructorEntity2 extends TestBaseEntity {
+        private static final long serialVersionUID = 1L;
+
+        public BadConstructorEntity2() {
+            super(null);
+        }
+
+        public BadConstructorEntity2(final LogEvent wrappedEvent, final String badParameter) {
+            super(wrappedEvent);
+        }
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/appender/LogEventEntityTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/appender/LogEventEntityTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.appender;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.ThreadContext.ContextStack;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.ThrowableProxy;
+import org.apache.logging.log4j.core.time.Instant;
+import org.apache.logging.log4j.core.time.MutableInstant;
+import org.apache.logging.log4j.message.Message;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LogEventEntityTest {
+
+    @Test
+    public void testToImmutable_AbstractLogEventWrapperEntity() {
+        final LogEvent logEvent = new AbstractLogEventWrapperEntity() {
+
+            @Override
+            public ContextStack getContextStack() {
+                return null;
+            }
+
+            @Override
+            public Level getLevel() {
+                return null;
+            }
+
+            @Override
+            public String getLoggerFqcn() {
+                return null;
+            }
+
+            @Override
+            public String getLoggerName() {
+                return null;
+            }
+
+            @Override
+            public Marker getMarker() {
+                return null;
+            }
+
+            @Override
+            public Message getMessage() {
+                return null;
+            }
+
+            @Override
+            public Instant getInstant() {
+                return new MutableInstant();
+            }
+
+            @Override
+            public long getNanoTime() {
+                return 0;
+            }
+
+            @Override
+            public StackTraceElement getSource() {
+                return null;
+            }
+
+            @Override
+            public long getThreadId() {
+                return 0;
+            }
+
+            @Override
+            public String getThreadName() {
+                return null;
+            }
+
+            @Override
+            public int getThreadPriority() {
+                return 0;
+            }
+
+            @Override
+            public Throwable getThrown() {
+                return null;
+            }
+
+            @Override
+            public ThrowableProxy getThrownProxy() {
+                return null;
+            }
+
+            @Override
+            public long getTimeMillis() {
+                return 0;
+            }
+        };
+        Assert.assertNotSame(logEvent, logEvent.toImmutable());
+    }
+
+    @Test
+    public void testToImmutable_TestBaseEntity() {
+        final LogEvent logEvent = new TestBaseEntity();
+        Assert.assertNotSame(logEvent, logEvent.toImmutable());
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/appender/TestBaseEntity.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/appender/TestBaseEntity.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.appender;
+
+import java.util.Date;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import jakarta.persistence.Transient;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.ThrowableProxy;
+import org.apache.logging.log4j.core.time.Instant;
+import org.apache.logging.log4j.jpa.converter.InstantAttributeConverter;
+import org.apache.logging.log4j.jpa.converter.LevelAttributeConverter;
+import org.apache.logging.log4j.jpa.converter.MessageAttributeConverter;
+import org.apache.logging.log4j.jpa.converter.ThrowableAttributeConverter;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+
+@Entity
+@Table(name = "jpaBaseLogEntry")
+public class TestBaseEntity extends AbstractLogEventWrapperEntity {
+
+    private long id = 0L;
+
+    public TestBaseEntity() {
+        super();
+    }
+
+    public TestBaseEntity(final LogEvent wrappedEvent) {
+        super(wrappedEvent);
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    public long getId() {
+        return this.id;
+    }
+
+    public void setId(final long id) {
+        this.id = id;
+    }
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "eventDate")
+    public Date getEventDate() {
+        return new Date(this.getTimeMillis());
+    }
+
+    public void setEventDate(final Date date) {
+        // this entity is write-only
+    }
+
+    @Override
+    @Convert(converter = LevelAttributeConverter.class)
+    @Column(name = "level")
+    public Level getLevel() {
+        return this.getWrappedEvent().getLevel();
+    }
+
+    @Override
+    @Basic
+    @Column(name = "logger")
+    public String getLoggerName() {
+        return this.getWrappedEvent().getLoggerName();
+    }
+
+    @Override
+    @Transient
+    public StackTraceElement getSource() {
+        return this.getWrappedEvent().getSource();
+    }
+
+    @Override
+    @Convert(converter = MessageAttributeConverter.class)
+    @Column(name = "message")
+    public Message getMessage() {
+        return this.getWrappedEvent().getMessage();
+    }
+
+    @Override
+    @Transient
+    public Marker getMarker() {
+        return this.getWrappedEvent().getMarker();
+    }
+
+    @Override
+    @Transient
+    public long getThreadId() {
+        return this.getWrappedEvent().getThreadId();
+    }
+
+    @Override
+    @Transient
+    public String getThreadName() {
+        return this.getWrappedEvent().getThreadName();
+    }
+
+    @Override
+    @Transient
+    public int getThreadPriority() {
+        return this.getWrappedEvent().getThreadPriority();
+    }
+
+    @Override
+    @Transient
+    public long getTimeMillis() {
+        return this.getWrappedEvent().getTimeMillis();
+    }
+
+    @Override
+    @Convert(converter = InstantAttributeConverter.class)
+    @Column(name = "instant")
+    public Instant getInstant() {
+        return this.getWrappedEvent().getInstant();
+    }
+
+    @Override
+    @Transient
+    public long getNanoTime() {
+        return this.getWrappedEvent().getNanoTime();
+    }
+
+    @Override
+    @Convert(converter = ThrowableAttributeConverter.class)
+    @Column(name = "exception")
+    public Throwable getThrown() {
+        return this.getWrappedEvent().getThrown();
+    }
+
+    @Override
+    @Transient
+    public ThrowableProxy getThrownProxy() {
+        return this.getWrappedEvent().getThrownProxy();
+    }
+
+    @Override
+    @Transient
+    public ReadOnlyStringMap getContextData() {
+        return this.getWrappedEvent().getContextData();
+    }
+
+    @Override
+    @Transient
+    public ThreadContext.ContextStack getContextStack() {
+        return this.getWrappedEvent().getContextStack();
+    }
+
+    @Override
+    @Transient
+    public String getLoggerFqcn() {
+        return this.getWrappedEvent().getLoggerFqcn();
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/appender/TestBasicEntity.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/appender/TestBasicEntity.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.appender;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import org.apache.logging.log4j.core.LogEvent;
+
+@Entity
+@Table(name = "jpaBasicLogEntry")
+@SuppressWarnings("unused")
+public class TestBasicEntity extends BasicLogEventEntity {
+
+    private long id = 0L;
+
+    public TestBasicEntity() {
+        super();
+    }
+
+    public TestBasicEntity(final LogEvent wrapped) {
+        super(wrapped);
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    public long getId() {
+        return this.id;
+    }
+
+    public void setId(final long id) {
+        this.id = id;
+    }
+
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ContextDataAttributeConverterTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ContextDataAttributeConverterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.apache.logging.log4j.util.SortedArrayStringMap;
+import org.apache.logging.log4j.util.StringMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+
+@Category(Appenders.Jpa.class)
+public class ContextDataAttributeConverterTest {
+    private ContextDataAttributeConverter converter;
+
+    @Before
+    public void setUp() {
+        this.converter = new ContextDataAttributeConverter();
+    }
+
+    @Test
+    public void testConvertToDatabaseColumn01() {
+        final StringMap map = new SortedArrayStringMap();
+        map.putValue("test1", "another1");
+        map.putValue("key2", "value2");
+
+        assertEquals("The converted value is not correct.", map.toString(),
+                this.converter.convertToDatabaseColumn(map));
+    }
+
+    @Test
+    public void testConvertToDatabaseColumn02() {
+        final StringMap map = new SortedArrayStringMap();
+        map.putValue("someKey", "coolValue");
+        map.putValue("anotherKey", "testValue");
+        map.putValue("myKey", "yourValue");
+
+        assertEquals("The converted value is not correct.", map.toString(),
+                this.converter.convertToDatabaseColumn(map));
+    }
+
+    @Test
+    public void testConvertNullToDatabaseColumn() {
+        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testConvertToEntityAttribute() {
+        this.converter.convertToEntityAttribute(null);
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ContextDataJsonAttributeConverterTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ContextDataJsonAttributeConverterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.apache.logging.log4j.util.SortedArrayStringMap;
+import org.apache.logging.log4j.util.StringMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+
+@Category(Appenders.Jpa.class)
+public class ContextDataJsonAttributeConverterTest {
+    private ContextDataJsonAttributeConverter converter;
+
+    @Before
+    public void setUp() {
+        this.converter = new ContextDataJsonAttributeConverter();
+    }
+
+    @Test
+    public void testConvert01() {
+        final StringMap map = new SortedArrayStringMap();
+        map.putValue("test1", "another1");
+        map.putValue("key2", "value2");
+
+        final String converted = this.converter.convertToDatabaseColumn(map);
+
+        assertNotNull("The converted value should not be null.", converted);
+
+        final ReadOnlyStringMap reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The reversed value is not correct.", map, reversed);
+    }
+
+    @Test
+    public void testConvert02() {
+        final StringMap map = new SortedArrayStringMap();
+        map.putValue("someKey", "coolValue");
+        map.putValue("anotherKey", "testValue");
+        map.putValue("myKey", "yourValue");
+
+        final String converted = this.converter.convertToDatabaseColumn(map);
+
+        assertNotNull("The converted value should not be null.", converted);
+
+        final ReadOnlyStringMap reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The reversed value is not correct.", map, reversed);
+    }
+
+    @Test
+    public void testConvertNullToDatabaseColumn() {
+        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+    }
+
+    @Test
+    public void testConvertNullOrBlankToEntityAttribute() {
+        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
+        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ContextMapAttributeConverterTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ContextMapAttributeConverterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+
+@Category(Appenders.Jpa.class)
+public class ContextMapAttributeConverterTest {
+    private ContextMapAttributeConverter converter;
+
+    @Before
+    public void setUp() {
+        this.converter = new ContextMapAttributeConverter();
+    }
+
+    @Test
+    public void testConvertToDatabaseColumn01() {
+        final Map<String, String> map = new HashMap<>();
+        map.put("test1", "another1");
+        map.put("key2", "value2");
+
+        assertEquals("The converted value is not correct.", map.toString(),
+                this.converter.convertToDatabaseColumn(map));
+    }
+
+    @Test
+    public void testConvertToDatabaseColumn02() {
+        final Map<String, String> map = new HashMap<>();
+        map.put("someKey", "coolValue");
+        map.put("anotherKey", "testValue");
+        map.put("myKey", "yourValue");
+
+        assertEquals("The converted value is not correct.", map.toString(),
+                this.converter.convertToDatabaseColumn(map));
+    }
+
+    @Test
+    public void testConvertNullToDatabaseColumn() {
+        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testConvertToEntityAttribute() {
+        this.converter.convertToEntityAttribute(null);
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ContextMapJsonAttributeConverterTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ContextMapJsonAttributeConverterTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+
+@Category(Appenders.Jpa.class)
+public class ContextMapJsonAttributeConverterTest {
+    private ContextMapJsonAttributeConverter converter;
+
+    @Before
+    public void setUp() {
+        this.converter = new ContextMapJsonAttributeConverter();
+    }
+
+    @Test
+    public void testConvert01() {
+        final Map<String, String> map = new HashMap<>();
+        map.put("test1", "another1");
+        map.put("key2", "value2");
+
+        final String converted = this.converter.convertToDatabaseColumn(map);
+
+        assertNotNull("The converted value should not be null.", converted);
+
+        final Map<String, String> reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The reversed value is not correct.", map, reversed);
+    }
+
+    @Test
+    public void testConvert02() {
+        final Map<String, String> map = new HashMap<>();
+        map.put("someKey", "coolValue");
+        map.put("anotherKey", "testValue");
+        map.put("myKey", "yourValue");
+
+        final String converted = this.converter.convertToDatabaseColumn(map);
+
+        assertNotNull("The converted value should not be null.", converted);
+
+        final Map<String, String> reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The reversed value is not correct.", map, reversed);
+    }
+
+    @Test
+    public void testConvertNullToDatabaseColumn() {
+        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+    }
+
+    @Test
+    public void testConvertNullOrBlankToEntityAttribute() {
+        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
+        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ContextStackAttributeConverterTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ContextStackAttributeConverterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import java.util.Arrays;
+
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.apache.logging.log4j.spi.MutableThreadContextStack;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+
+@Category(Appenders.Jpa.class)
+public class ContextStackAttributeConverterTest {
+    private ContextStackAttributeConverter converter;
+
+    @Before
+    public void setUp() {
+        this.converter = new ContextStackAttributeConverter();
+    }
+
+    @Test
+    public void testConvertToDatabaseColumn01() {
+        final ThreadContext.ContextStack stack = new MutableThreadContextStack(
+                Arrays.asList("value1", "another2"));
+
+        assertEquals("The converted value is not correct.", "value1\nanother2",
+                this.converter.convertToDatabaseColumn(stack));
+    }
+
+    @Test
+    public void testConvertToDatabaseColumn02() {
+        final ThreadContext.ContextStack stack = new MutableThreadContextStack(
+                Arrays.asList("key1", "value2", "my3"));
+
+        assertEquals("The converted value is not correct.",
+                "key1\nvalue2\nmy3",
+                this.converter.convertToDatabaseColumn(stack));
+    }
+
+    @Test
+    public void testConvertNullToDatabaseColumn() {
+        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testConvertToEntityAttribute() {
+        this.converter.convertToEntityAttribute(null);
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ContextStackJsonAttributeConverterTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ContextStackJsonAttributeConverterTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import java.util.Arrays;
+
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.apache.logging.log4j.spi.MutableThreadContextStack;
+import org.apache.logging.log4j.test.junit.ThreadContextStackRule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@Category(Appenders.Jpa.class)
+public class ContextStackJsonAttributeConverterTest {
+    private ContextStackJsonAttributeConverter converter;
+
+    @Rule
+    public final ThreadContextStackRule threadContextRule = new ThreadContextStackRule();
+
+    @Before
+    public void setUp() {
+        this.converter = new ContextStackJsonAttributeConverter();
+    }
+
+    @Test
+    public void testConvert01() {
+        final ThreadContext.ContextStack stack = new MutableThreadContextStack(
+                Arrays.asList("value1", "another2"));
+
+        final String converted = this.converter.convertToDatabaseColumn(stack);
+
+        assertNotNull("The converted value should not be null.", converted);
+
+        final ThreadContext.ContextStack reversed = this.converter
+                .convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The reversed value is not correct.", stack.asList(),
+                reversed.asList());
+    }
+
+    @Test
+    public void testConvert02() {
+        final ThreadContext.ContextStack stack = new MutableThreadContextStack(
+                Arrays.asList("key1", "value2", "my3"));
+
+        final String converted = this.converter.convertToDatabaseColumn(stack);
+
+        assertNotNull("The converted value should not be null.", converted);
+
+        final ThreadContext.ContextStack reversed = this.converter
+                .convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The reversed value is not correct.", stack.asList(),
+                reversed.asList());
+    }
+
+    @Test
+    public void testConvertNullToDatabaseColumn() {
+        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+    }
+
+    @Test
+    public void testConvertNullOrBlankToEntityAttribute() {
+        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
+        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/InstantAttributeConverterTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/InstantAttributeConverterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.apache.logging.log4j.core.time.Instant;
+import org.apache.logging.log4j.core.time.MutableInstant;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@Category(Appenders.Jpa.class)
+public class InstantAttributeConverterTest {
+
+    private InstantAttributeConverter converter;
+
+    @Before
+    public void setUp() {
+        this.converter = new InstantAttributeConverter();
+    }
+
+    @Test
+    public void testConvert01() {
+        final MutableInstant instant = new MutableInstant();
+        instant.initFromEpochSecond(1234567, 89012);
+
+        final String converted = this.converter.convertToDatabaseColumn(instant);
+
+        assertNotNull("The converted value should not be null.", converted);
+        assertEquals("The converted value is not correct.", "1234567,89012", converted);
+
+        final Instant reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("epoch sec", 1234567, reversed.getEpochSecond());
+        assertEquals("nanoOfSecond", 89012, reversed.getNanoOfSecond());
+    }
+
+    @Test
+    public void testConvertNullToDatabaseColumn() {
+        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+    }
+
+    @Test
+    public void testConvertNullOrBlankToEntityAttribute() {
+        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
+        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/MarkerAttributeConverterTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/MarkerAttributeConverterTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+
+@Category(Appenders.Jpa.class)
+public class MarkerAttributeConverterTest {
+    private MarkerAttributeConverter converter;
+
+    @Before
+    public void setUp() {
+        this.converter = new MarkerAttributeConverter();
+    }
+
+    @Test
+    public void testConvert01() {
+        final Marker marker = MarkerManager.getMarker("testConvert01");
+
+        final String converted = this.converter.convertToDatabaseColumn(marker);
+
+        assertNotNull("The converted value should not be null.", converted);
+        assertEquals("The converted value is not correct.", "testConvert01", converted);
+
+        final Marker reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The reversed value is not correct.", "testConvert01", marker.getName());
+    }
+
+    @Test
+    public void testConvert02() {
+        Marker marker = MarkerManager.getMarker("anotherConvert02").setParents(MarkerManager.getMarker("finalConvert03"));
+        marker = MarkerManager.getMarker("testConvert02").setParents(marker);
+
+        final String converted = this.converter.convertToDatabaseColumn(marker);
+
+        assertNotNull("The converted value should not be null.", converted);
+        assertEquals("The converted value is not correct.", "testConvert02[ anotherConvert02[ finalConvert03 ] ]",
+                converted);
+
+        final Marker reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The reversed value is not correct.", "testConvert02", marker.getName());
+        final Marker[] parents = marker.getParents();
+        assertNotNull("The first parent should not be null.", parents);
+        assertNotNull("The first parent should not be null.", parents[0]);
+        assertEquals("The first parent is not correct.", "anotherConvert02", parents[0].getName());
+        assertNotNull("The second parent should not be null.", parents[0].getParents());
+        assertNotNull("The second parent should not be null.", parents[0].getParents()[0]);
+        assertEquals("The second parent is not correct.", "finalConvert03", parents[0].getParents()[0].getName());
+    }
+
+    @Test
+    public void testConvertNullToDatabaseColumn() {
+        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+    }
+
+    @Test
+    public void testConvertNullOrBlankToEntityAttribute() {
+        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
+        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/MessageAttributeConverterTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/MessageAttributeConverterTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+
+@Category(Appenders.Jpa.class)
+public class MessageAttributeConverterTest {
+    private static final StatusLogger LOGGER = StatusLogger.getLogger();
+
+    private MessageAttributeConverter converter;
+
+    @Before
+    public void setUp() {
+        this.converter = new MessageAttributeConverter();
+    }
+
+    @Test
+    public void testConvert01() {
+        final Message message = LOGGER.getMessageFactory().newMessage("Message #{} said [{}].", 3, "Hello");
+
+        final String converted = this.converter.convertToDatabaseColumn(message);
+
+        assertNotNull("The converted value should not be null.", converted);
+        assertEquals("The converted value is not correct.", "Message #3 said [Hello].", converted);
+
+        final Message reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The reversed value is not correct.", "Message #3 said [Hello].", reversed.getFormattedMessage());
+    }
+
+    @Test
+    public void testConvertNullToDatabaseColumn() {
+        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+    }
+
+    @Test
+    public void testConvertNullOrBlankToEntityAttribute() {
+        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
+        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/StackTraceElementAttributeConverterTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/StackTraceElementAttributeConverterTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+
+@Category(Appenders.Jpa.class)
+public class StackTraceElementAttributeConverterTest {
+    private StackTraceElementAttributeConverter converter;
+
+    @Before
+    public void setUp() {
+        this.converter = new StackTraceElementAttributeConverter();
+    }
+
+    @Test
+    public void testConvert01() {
+        final StackTraceElement element = new StackTraceElement("TestNoPackage", "testConvert01", "TestNoPackage.java", 1234);
+
+        final String converted = this.converter.convertToDatabaseColumn(element);
+
+        assertNotNull("The converted value should not be null.", converted);
+        assertEquals("The converted value is not correct.", "TestNoPackage.testConvert01(TestNoPackage.java:1234)",
+                converted);
+
+        final StackTraceElement reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The class name is not correct.", "TestNoPackage", reversed.getClassName());
+        assertEquals("The method name is not correct.", "testConvert01", reversed.getMethodName());
+        assertEquals("The file name is not correct.", "TestNoPackage.java", reversed.getFileName());
+        assertEquals("The line number is not correct.", 1234, reversed.getLineNumber());
+        assertFalse("The native flag should be false.", reversed.isNativeMethod());
+    }
+
+    @Test
+    public void testConvert02() {
+        final StackTraceElement element = new StackTraceElement("org.apache.logging.TestWithPackage",
+                "testConvert02", "TestWithPackage.java", -1);
+
+        final String converted = this.converter.convertToDatabaseColumn(element);
+
+        assertNotNull("The converted value should not be null.", converted);
+        assertEquals("The converted value is not correct.",
+                "org.apache.logging.TestWithPackage.testConvert02(TestWithPackage.java)",
+                converted);
+
+        final StackTraceElement reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The class name is not correct.", "org.apache.logging.TestWithPackage", reversed.getClassName());
+        assertEquals("The method name is not correct.", "testConvert02", reversed.getMethodName());
+        assertEquals("The file name is not correct.", "TestWithPackage.java", reversed.getFileName());
+        assertEquals("The line number is not correct.", -1, reversed.getLineNumber());
+        assertFalse("The native flag should be false.", reversed.isNativeMethod());
+    }
+
+    @Test
+    public void testConvert03() {
+        final StackTraceElement element = new StackTraceElement("org.apache.logging.TestNoSource",
+                "testConvert03", null, -1);
+
+        final String converted = this.converter.convertToDatabaseColumn(element);
+
+        assertNotNull("The converted value should not be null.", converted);
+        assertEquals("The converted value is not correct.",
+                "org.apache.logging.TestNoSource.testConvert03(Unknown Source)",
+                converted);
+
+        final StackTraceElement reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The class name is not correct.", "org.apache.logging.TestNoSource", reversed.getClassName());
+        assertEquals("The method name is not correct.", "testConvert03", reversed.getMethodName());
+        assertEquals("The file name is not correct.", null, reversed.getFileName());
+        assertEquals("The line number is not correct.", -1, reversed.getLineNumber());
+        assertFalse("The native flag should be false.", reversed.isNativeMethod());
+    }
+
+    @Test
+    public void testConvert04() {
+        final StackTraceElement element = new StackTraceElement("org.apache.logging.TestIsNativeMethod",
+                "testConvert04", null, -2);
+
+        final String converted = this.converter.convertToDatabaseColumn(element);
+
+        assertNotNull("The converted value should not be null.", converted);
+        assertEquals("The converted value is not correct.",
+                "org.apache.logging.TestIsNativeMethod.testConvert04(Native Method)",
+                converted);
+
+        final StackTraceElement reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The class name is not correct.", "org.apache.logging.TestIsNativeMethod",
+                reversed.getClassName());
+        assertEquals("The method name is not correct.", "testConvert04", reversed.getMethodName());
+        assertEquals("The file name is not correct.", null, reversed.getFileName());
+        assertEquals("The line number is not correct.", -2, reversed.getLineNumber());
+        assertTrue("The native flag should be true.", reversed.isNativeMethod());
+    }
+
+    @Test
+    public void testConvertNullToDatabaseColumn() {
+        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+    }
+
+    @Test
+    public void testConvertNullOrBlankToEntityAttribute() {
+        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
+        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+    }
+}

--- a/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ThrowableAttributeConverterTest.java
+++ b/log4j-jakarta-jpa/src/test/java/org/apache/logging/log4j/jpa/converter/ThrowableAttributeConverterTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jpa.converter;
+
+import java.sql.SQLException;
+
+import org.apache.logging.log4j.core.test.categories.Appenders;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+
+@Category(Appenders.Jpa.class)
+public class ThrowableAttributeConverterTest {
+    private ThrowableAttributeConverter converter;
+
+    @Before
+    public void setUp() {
+        this.converter = new ThrowableAttributeConverter();
+    }
+
+    @Test
+    public void testConvert01() {
+        final RuntimeException exception = new RuntimeException("My message 01.");
+
+        final String stackTrace = getStackTrace(exception);
+
+        final String converted = this.converter.convertToDatabaseColumn(exception);
+
+        assertNotNull("The converted value is not correct.", converted);
+        assertEquals("The converted value is not correct.", stackTrace, converted);
+
+        final Throwable reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The reversed value is not correct.", stackTrace, getStackTrace(reversed));
+    }
+
+    @Test
+    public void testConvert02() {
+        final SQLException cause2 = new SQLException("This is a test cause.");
+        final Error cause1 = new Error(cause2);
+        final RuntimeException exception = new RuntimeException("My message 01.", cause1);
+
+        final String stackTrace = getStackTrace(exception);
+
+        final String converted = this.converter.convertToDatabaseColumn(exception);
+
+        assertNotNull("The converted value is not correct.", converted);
+        assertEquals("The converted value is not correct.", stackTrace, converted);
+
+        final Throwable reversed = this.converter.convertToEntityAttribute(converted);
+
+        assertNotNull("The reversed value should not be null.", reversed);
+        assertEquals("The reversed value is not correct.", stackTrace, getStackTrace(reversed));
+    }
+
+    @Test
+    public void testConvertNullToDatabaseColumn() {
+        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+    }
+
+    @Test
+    public void testConvertNullOrBlankToEntityAttribute() {
+        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
+        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+    }
+
+    private static String getStackTrace(final Throwable throwable) {
+        String returnValue = throwable.toString() + '\n';
+
+        for (final StackTraceElement element : throwable.getStackTrace()) {
+            returnValue += "\tat " + element.toString() + '\n';
+        }
+
+        if (throwable.getCause() != null) {
+            returnValue += "Caused by " + getStackTrace(throwable.getCause());
+        }
+
+        return returnValue;
+    }
+}

--- a/log4j-jakarta-jpa/src/test/resources/META-INF/persistence.xml
+++ b/log4j-jakarta-jpa/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+                                 https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
+
+  <persistence-unit name="hyperSqlJpaAppenderTestUnit">
+    <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+    <class>org.apache.logging.log4j.jpa.converter.ContextMapAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.ContextMapJsonAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.ContextStackAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.ContextStackJsonAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.InstantAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.LevelAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.MarkerAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.MessageAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.StackTraceElementAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.ThrowableAttributeConverter</class>
+    <exclude-unlisted-classes>false</exclude-unlisted-classes>
+    <shared-cache-mode>NONE</shared-cache-mode>
+    <properties>
+      <property name="jakarta.persistence.jdbc.driver" value="org.hsqldb.jdbcDriver"/>
+      <property name="jakarta.persistence.jdbc.url" value="jdbc:hsqldb:mem:Log4j;ifexists=true"/>
+      <property name="jakarta.persistence.jdbc.user" value="sa"/>
+      <property name="jakarta.persistence.jdbc.password" value=""/>
+      <!--<property name="eclipselink.logging.level" value="FINE"/>
+      <property name="eclipselink.logging.level.sql" value="FINE"/>
+      <property name="eclipselink.logging.parameters" value="true"/> uncomment to troubleshoot SQL-->
+    </properties>
+  </persistence-unit>
+
+  <persistence-unit name="h2JpaAppenderTestUnit">
+    <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+    <class>org.apache.logging.log4j.jpa.converter.ContextMapAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.ContextMapJsonAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.ContextStackAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.ContextStackJsonAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.InstantAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.LevelAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.MarkerAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.MessageAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.StackTraceElementAttributeConverter</class>
+    <class>org.apache.logging.log4j.jpa.converter.ThrowableAttributeConverter</class>
+    <exclude-unlisted-classes>false</exclude-unlisted-classes>
+    <shared-cache-mode>NONE</shared-cache-mode>
+    <properties>
+      <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver"/>
+      <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:mem:Log4j;MODE=PostgreSQL"/>
+      <property name="jakarta.persistence.jdbc.user" value="sa"/>
+      <property name="jakarta.persistence.jdbc.password" value=""/>
+      <!--
+        Until the issue in https://github.com/eclipse-ee4j/eclipselink/issues/1393
+        we run in PostgreSQL compatibility mode.
+       -->
+      <property name="eclipselink.target-database" value="PostgreSQL"/>
+      <!--<property name="eclipselink.logging.level" value="FINE"/>
+      <property name="eclipselink.logging.level.sql" value="FINE"/>
+      <property name="eclipselink.logging.parameters" value="true"/> uncomment to troubleshoot SQL-->
+    </properties>
+  </persistence-unit>
+
+</persistence>

--- a/log4j-jakarta-jpa/src/test/resources/org/apache/logging/log4j/jpa/appender/log4j2-h2-jpa-base.xml
+++ b/log4j-jakarta-jpa/src/test/resources/org/apache/logging/log4j/jpa/appender/log4j2-h2-jpa-base.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="OFF">
+
+  <Appenders>
+    <Console name="STDOUT">
+      <PatternLayout pattern="%C{1.} %m %level MDC%X%n"/>
+    </Console>
+    <Jpa name="databaseAppender" persistenceUnitName="h2JpaAppenderTestUnit"
+         entityClassName="org.apache.logging.log4j.jpa.appender.TestBaseEntity" ignoreExceptions="false" />
+  </Appenders>
+
+  <Loggers>
+    <Logger name="org.apache.logging.log4j.jpa.appender" level="debug" additivity="false">
+      <AppenderRef ref="databaseAppender" />
+    </Logger>
+
+    <Root level="fatal">
+      <AppenderRef ref="STDOUT"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/log4j-jakarta-jpa/src/test/resources/org/apache/logging/log4j/jpa/appender/log4j2-h2-jpa-basic.xml
+++ b/log4j-jakarta-jpa/src/test/resources/org/apache/logging/log4j/jpa/appender/log4j2-h2-jpa-basic.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="OFF">
+
+  <Appenders>
+    <Console name="STDOUT">
+      <PatternLayout pattern="%C{1.} %m %level MDC%X%n"/>
+    </Console>
+    <Jpa name="databaseAppender" persistenceUnitName="h2JpaAppenderTestUnit"
+         entityClassName="org.apache.logging.log4j.jpa.appender.TestBasicEntity" ignoreExceptions="false" />
+  </Appenders>
+
+  <Loggers>
+    <Logger name="org.apache.logging.log4j.jpa.appender" level="debug" additivity="false">
+      <AppenderRef ref="databaseAppender" />
+    </Logger>
+
+    <Root level="fatal">
+      <AppenderRef ref="STDOUT"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/log4j-jakarta-jpa/src/test/resources/org/apache/logging/log4j/jpa/appender/log4j2-hsqldb-jpa-base.xml
+++ b/log4j-jakarta-jpa/src/test/resources/org/apache/logging/log4j/jpa/appender/log4j2-hsqldb-jpa-base.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="OFF">
+
+  <Appenders>
+    <Console name="STDOUT">
+      <PatternLayout pattern="%C{1.} %m %level MDC%X%n"/>
+    </Console>
+    <Jpa name="databaseAppender" persistenceUnitName="hyperSqlJpaAppenderTestUnit"
+         entityClassName="org.apache.logging.log4j.jpa.appender.TestBaseEntity" ignoreExceptions="false" />
+  </Appenders>
+
+  <Loggers>
+    <Logger name="org.apache.logging.log4j.jpa.appender" level="debug" additivity="false">
+      <AppenderRef ref="databaseAppender" />
+    </Logger>
+
+    <Root level="fatal">
+      <AppenderRef ref="STDOUT"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/log4j-jakarta-jpa/src/test/resources/org/apache/logging/log4j/jpa/appender/log4j2-hsqldb-jpa-basic.xml
+++ b/log4j-jakarta-jpa/src/test/resources/org/apache/logging/log4j/jpa/appender/log4j2-hsqldb-jpa-basic.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="OFF">
+
+  <Appenders>
+    <Console name="STDOUT">
+      <PatternLayout pattern="%C{1.} %m %level MDC%X%n"/>
+    </Console>
+    <Jpa name="databaseAppender" persistenceUnitName="hyperSqlJpaAppenderTestUnit"
+         entityClassName="org.apache.logging.log4j.jpa.appender.TestBasicEntity" ignoreExceptions="false" />
+  </Appenders>
+
+  <Loggers>
+    <Logger name="org.apache.logging.log4j.jpa.appender" level="debug" additivity="false">
+      <AppenderRef ref="databaseAppender" />
+    </Logger>
+
+    <Root level="fatal">
+      <AppenderRef ref="STDOUT"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,7 @@
     <module>log4j-flume-ng</module>
     <module>log4j-gctests</module>
     <module>log4j-iostreams</module>
+    <module>log4j-jakarta-jpa</module>
     <module>log4j-jakarta-smtp</module>
     <module>log4j-jakarta-web</module>
     <module>log4j-jcl</module>
@@ -459,7 +460,7 @@
     <netty.version>4.1.86.Final</netty.version>
     <opentest4j.version>1.2.0</opentest4j.version>
     <org.eclipse.osgi.version>3.16.200</org.eclipse.osgi.version>
-    <org.eclipse.persistence.version>2.7.11</org.eclipse.persistence.version>
+    <org.eclipse.persistence.version>3.0.3</org.eclipse.persistence.version>
     <oro.version>2.0.8</oro.version>
     <!-- The OSGi API version MUST always be the MINIMUM version Log4j supports -->
     <osgi.framework.version>1.10.0</osgi.framework.version>

--- a/src/changelog/.3.x.x/1526_Add_Jakarta_JPA_module.xml
+++ b/src/changelog/.3.x.x/1526_Add_Jakarta_JPA_module.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="added">
+  <issue id="1526" link="https://github.com/apache/logging-log4j2/issues/1526"/>
+  <author id="pkarwasz"/>
+  <description format="asciidoc">Add Jakarta version of JPA appender as new `log4j-jakarta-jpa` module.</description>
+</entry>


### PR DESCRIPTION
This adds a Jakarta version of the JPA appender as a new `log4j-jakarta-jpa` module. Closes #1526.

