### PR TITLE
Update runtime-dependencies.xml with Jakarta EE Log4j Artifacts

### DIFF
--- a/src/changelog/.2.x.x/1530_fix_runtime-dependencies_documentation.xml
+++ b/src/changelog/.2.x.x/1530_fix_runtime-dependencies_documentation.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="fixed">
+  <issue id="1530" link="https://github.com/apache/logging-log4j2/pull/1530"/>
+  <author id="github:harryssuperman"/>
+  <!-- Committer -->
+  <author id="github:ppkarwasz"/>
+  <description format="asciidoc">Fix runtime dependencies documentation.</description>
+</entry>

--- a/src/site/xdoc/runtime-dependencies.xml
+++ b/src/site/xdoc/runtime-dependencies.xml
@@ -122,6 +122,16 @@
             <td>Automatic Module</td>
           </tr>
           <tr>
+            <td>log4j-jakarta-smtp</td>
+            <td>org.apache.logging.log4j.smtp</td>
+            <td>Automatic Module</td>
+          </tr>
+          <tr>
+            <td>log4j-jakarta-web</td>
+            <td>org.apache.logging.log4j.web</td>
+            <td>Automatic Module</td>
+          </tr>
+          <tr>
             <td>log4j-jcl</td>
             <td>org.apache.logging.log4j.jcl</td>
             <td>Automatic Module</td>

--- a/src/site/xdoc/runtime-dependencies.xml
+++ b/src/site/xdoc/runtime-dependencies.xml
@@ -449,12 +449,12 @@
 		    1. org.eclipse.angus:angus-activation
 		    2. org.eclipse.angus:jakarta.mail
       </p>
-	  
+
 	  <a name="log4j-jakarta-web" />
       <h4>log4j-jakarta-web</h4>
       <p>
-        The Log4j <a href="log4j-jakarta-web.html">Jakarta-Web</a> module for Jakarta EE 9+ web servlet containers has no external dependencies.
-        This only requires the Log4j API.
+        The Log4j <a href="log4j-jakarta-web.html">Jakarta-Web</a> module for Jakarta EE 9+ web servlet containers
+        requires the Servlet API and <code>log4j-core</code>.
       </p>
 
     </section>

--- a/src/site/xdoc/runtime-dependencies.xml
+++ b/src/site/xdoc/runtime-dependencies.xml
@@ -442,6 +442,21 @@
         addition to the Log4j API.
       </p>
 
+      <a name="log4j-jakarta-smtp" />
+      <h4>log4j-jakarta-smtp</h4>
+      <p>
+        The Log4j Simple Mail Transfer Protocol (SMTP) Appender, version for Jakarta EE 9 module has 2 external runtime dependencies for the jakarta.activation-api and jakarta.mail-api.
+		    1. org.eclipse.angus:angus-activation
+		    2. org.eclipse.angus:jakarta.mail
+      </p>
+	  
+	  <a name="log4j-jakarta-web" />
+      <h4>log4j-jakarta-web</h4>
+      <p>
+        The Log4j <a href="log4j-jakarta-web.html">Jakarta-Web</a> module for Jakarta EE 9+ web servlet containers has no external dependencies.
+        This only requires the Log4j API.
+      </p>
+
     </section>
   </body>
 </document>


### PR DESCRIPTION
Updating the Website https://logging.apache.org/log4j/2.x/runtime-dependencies.html with the latest Log4j artifacts for Jakarta EE
