### PR TITLE
allow to override fqcn in Log4jEventBuilder

### DIFF
--- a/log4j-slf4j2-impl/src/main/java/org/apache/logging/slf4j/Log4jEventBuilder.java
+++ b/log4j-slf4j2-impl/src/main/java/org/apache/logging/slf4j/Log4jEventBuilder.java
@@ -29,9 +29,10 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogBuilder;
 import org.apache.logging.log4j.Logger;
 import org.slf4j.Marker;
+import org.slf4j.spi.CallerBoundaryAware;
 import org.slf4j.spi.LoggingEventBuilder;
 
-public class Log4jEventBuilder implements LoggingEventBuilder {
+public class Log4jEventBuilder implements LoggingEventBuilder, CallerBoundaryAware {
 
     private static final String FQCN = Log4jEventBuilder.class.getName();
 
@@ -43,6 +44,7 @@ public class Log4jEventBuilder implements LoggingEventBuilder {
     private Throwable throwable = null;
     private Map<String, String> keyValuePairs = null;
     private final Level level;
+    private String fqcn = FQCN;
 
     public Log4jEventBuilder(final Log4jMarkerFactory markerFactory, final Logger logger, final Level level) {
         this.markerFactory = markerFactory;
@@ -110,7 +112,7 @@ public class Log4jEventBuilder implements LoggingEventBuilder {
                 .withMarker(marker)
                 .withThrowable(throwable);
         if (logBuilder instanceof BridgeAware) {
-            ((BridgeAware) logBuilder).setEntryPoint(FQCN);
+            ((BridgeAware) logBuilder).setEntryPoint(fqcn);
         }
         if (keyValuePairs == null || keyValuePairs.isEmpty()) {
             logBuilder.log(message, arguments.toArray());
@@ -157,4 +159,8 @@ public class Log4jEventBuilder implements LoggingEventBuilder {
         log();
     }
 
+    @Override
+    public void setCallerBoundary(String fqcn) {
+        this.fqcn = fqcn;
+    }
 }

--- a/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/CallerInformationTest.java
+++ b/log4j-slf4j2-impl/src/test/java/org/apache/logging/slf4j/CallerInformationTest.java
@@ -24,6 +24,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.spi.CallerBoundaryAware;
+import org.slf4j.spi.LoggingEventBuilder;
 
 import static org.junit.Assert.assertEquals;
 
@@ -70,6 +72,20 @@ public class CallerInformationTest {
         assertEquals("Incorrect number of messages.", 10, messages.size());
         for (final String message : messages) {
             assertEquals("Incorrect caller method name.", "testMethodLogger", message);
+        }
+    }
+
+    @Test
+    public void testFqcnLogger() throws Exception {
+        final ListAppender app = ctx.getListAppender("Fqcn").clear();
+        final Logger logger = LoggerFactory.getLogger("FqcnLogger");
+        LoggingEventBuilder loggingEventBuilder = logger.atInfo();
+        ((CallerBoundaryAware)loggingEventBuilder).setCallerBoundary("MyFqcn");
+        loggingEventBuilder.log("A message");
+        final List<String> messages = app.getMessages();
+        assertEquals("Incorrect number of messages.", 1, messages.size());
+        for (final String message : messages) {
+            assertEquals("Incorrect fqcn.", "MyFqcn", message);
         }
     }
 }

--- a/src/changelog/.2.x.x/1533_set_fqcn_eventbuilder.xml
+++ b/src/changelog/.2.x.x/1533_set_fqcn_eventbuilder.xml
@@ -15,28 +15,15 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration name="CallerInformationTest" status="OFF">
-  <Appenders>
-    <List name="Class">
-      <PatternLayout pattern="%class"/>
-    </List>
-    <List name="Method">
-      <PatternLayout pattern="%method"/>
-    </List>
-    <List name="Fqcn">
-      <PatternLayout pattern="%fqcn"/>
-    </List>
-  </Appenders>
-  <Loggers>
-    <Logger name="ClassLogger" level="info">
-      <AppenderRef ref="Class"/>
-    </Logger>
-    <Logger name="MethodLogger" level="info">
-      <AppenderRef ref="Method"/>
-    </Logger>
-    <Logger name="FqcnLogger" level="info">
-      <AppenderRef ref="Fqcn"/>
-    </Logger>
-    <Root level="off"/>
-  </Loggers>
-</Configuration>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="fixed">
+  <issue id="1533" link="https://github.com/apache/logging-log4j2/pull/1533"/>
+  <author id="github:oshai" name="Ohad Shai"/>
+  <!-- Committer -->
+  <author name="github:pkarwasz"/>
+  <description format="asciidoc">
+    Allow to override fqcn in `Log4jEventBuilder` by implementing `CallerBoundaryAware`.
+  </description>
+</entry>


### PR DESCRIPTION
fix #1533

[A clear and concise description of what the pull request is for along with a reference to the associated issue IDs, if they exist.]

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
