### PR TITLE
(doc) fix the disableAnsi default value description

### DIFF
--- a/src/site/xdoc/manual/layouts.xml.vm
+++ b/src/site/xdoc/manual/layouts.xml.vm
@@ -805,7 +805,9 @@ WARN  [main]: Message 2</pre>
             <tr>
               <td>disableAnsi</td>
               <td>boolean</td>
-              <td>If <code>true</code> (default is false), do not output ANSI escape codes.</td>
+              <td>If <code>true</code>, do not output ANSI escape codes. Parameter default value is platform dependent.
+                If run on Windows, it defaults to <code>true</code>, unless system property <code>log4j.skipJansi</code>
+                is set to <code>false</code>. On other platforms, it defaults to <code>false</code>.</td>
             </tr>
             <tr>
               <td>noConsoleNoAnsi</td>


### PR DESCRIPTION
The default value of the disableAnsi parameter (attribute) was changed for Windows by https://issues.apache.org/jira/browse/LOG4J2-2087. But the user documentation was not updated appropriately.