### PR TITLE
Avoid NPE from ContextSelector.getContext() when "entry=null" is passed

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/ContextSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/ContextSelector.java
@@ -108,7 +108,7 @@ public interface ContextSelector {
     default LoggerContext getContext(String fqcn, ClassLoader loader, Map.Entry<String, Object> entry,
             boolean currentContext, URI configLocation) {
         final LoggerContext lc = getContext(fqcn, loader, currentContext, configLocation);
-        if (lc != null) {
+        if (lc != null && entry != null) {
             lc.putObject(entry.getKey(), entry.getValue());
         }
         return lc;


### PR DESCRIPTION
This fixes an apparent bug which was reported already in https://issues.apache.org/jira/browse/LOG4J2-3217.

Note that only `ClassLoaderContextSelector` provided a custom implementation of this method, where it also checks for null-ness of `entry`. So all other selector classes like `BasicContextSelector ` would throw NullPointerException when e.g.
`Configurator.initialize(String, ClassLoader, URI)` is called.