### PR TITLE
Issue 1231 improve validation path condition

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/IfAllTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/IfAllTest.java
@@ -16,7 +16,18 @@
  */
 package org.apache.logging.log4j.core.appender.rolling.action;
 
+import java.util.List;
+
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.NullConfiguration;
+import org.apache.logging.log4j.core.config.plugins.processor.PluginEntry;
+import org.apache.logging.log4j.core.config.plugins.util.PluginBuilder;
+import org.apache.logging.log4j.core.config.plugins.util.PluginType;
+import org.apache.logging.log4j.status.StatusData;
+import org.apache.logging.log4j.status.StatusLogger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -46,6 +57,27 @@ public class IfAllTest {
         final IfAll and = IfAll.createAndCondition(counter, counter, counter);
         and.beforeFileTreeWalk();
         assertEquals(3, counter.getBeforeFileTreeWalkCount());
+    }
+
+    @Test
+    public void testCreateAndConditionCalledProgrammaticallyThrowsNPEWhenComponentsNotSpecified() {
+        PathCondition[] components = null;
+        assertThrows(NullPointerException.class, () -> IfAll.createAndCondition(components));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = "No components provided for IfAll")
+    public void testCreateAndConditionCalledByPluginBuilderReturnsNullAndLogsMessageWhenComponentsNotSpecified(final String expectedMessage) {
+        final PluginEntry nullEntry = null;
+        final PluginType<IfAll> type = new PluginType<>(nullEntry, IfAll.class, "Dummy");
+        final PluginBuilder builder = new PluginBuilder(type)
+                .withConfiguration(new NullConfiguration())
+                .withConfigurationNode(new Node());
+        final Object asBuilt = builder.build();
+        final List<StatusData> loggerStatusData = StatusLogger.getLogger().getStatusData();
+
+        assertNull(asBuilt);
+        assertTrue(loggerStatusData.stream().anyMatch(e -> e.getFormattedStatus().contains(expectedMessage)));
     }
 
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfAccumulatedFileSize.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfAccumulatedFileSize.java
@@ -91,7 +91,7 @@ public final class IfAccumulatedFileSize implements PathCondition {
     /**
      * Create an IfAccumulatedFileSize condition.
      *
-     * @param threshold The threshold accumulated file size from which files will be deleted.
+     * @param size The threshold accumulated file size from which files will be deleted.
      * @return An IfAccumulatedFileSize condition.
      */
     @PluginFactory

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfAll.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfAll.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
 
 /**
  * Composite {@code PathCondition} that only accepts objects that are accepted by <em>all</em> component conditions.
@@ -106,7 +107,7 @@ public final class IfAll implements PathCondition {
      */
     @PluginFactory
     public static IfAll createAndCondition(
-            @PluginElement("PathConditions") final PathCondition... components) {
+            @PluginElement("PathConditions") @Required(message = "No components provided for IfAll") final PathCondition... components) {
         return new IfAll(components);
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfAny.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfAny.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
 
 /**
  * Composite {@code PathCondition} that accepts objects that are accepted by <em>any</em> component conditions.
@@ -76,7 +77,7 @@ public final class IfAny implements PathCondition {
      */
     @PluginFactory
     public static IfAny createOrCondition(
-            @PluginElement("PathConditions") final PathCondition... components) {
+            @PluginElement("PathConditions") @Required(message = "No components provided for IfAny")final PathCondition... components) {
         return new IfAny(components);
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModified.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModified.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
 import org.apache.logging.log4j.core.util.Clock;
 import org.apache.logging.log4j.core.util.ClockFactory;
 import org.apache.logging.log4j.status.StatusLogger;
@@ -99,7 +100,7 @@ public final class IfLastModified implements PathCondition {
     @PluginFactory
     public static IfLastModified createAgeCondition(
             // @formatter:off
-            @PluginAttribute("age") final Duration age,
+            @PluginAttribute("age") @Required(message="No age provided for IfLastModified") final Duration age,
             @PluginElement("PathConditions") final PathCondition... nestedConditions) {
             // @formatter:on
         return new IfLastModified(age, nestedConditions);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfNot.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfNot.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
 
 /**
  * Wrapper {@code PathCondition} that accepts objects that are rejected by the wrapped component filter.
@@ -67,7 +68,7 @@ public final class IfNot implements PathCondition {
      */
     @PluginFactory
     public static IfNot createNotCondition(
-            @PluginElement("PathConditions") final PathCondition condition) {
+            @PluginElement("PathConditions") @Required(message = "No condition provided for IfNot") final PathCondition condition) {
         return new IfNot(condition);
     }
 

--- a/src/changelog/.2.x.x/1231_validation_path_condition.xml
+++ b/src/changelog/.2.x.x/1231_validation_path_condition.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.0.xsd"
+       type="fixed">
+  <issue id="1231" link="https://github.com/apache/logging-log4j2/issues/1231"/>
+  <author id="github:lukaszspyra" name="Łukasz Spyra"/>
+  <!-- Committer -->
+  <author id="github:ppkarwasz"/>
+  <description format="asciidoc">
+    Add validation to rolling file manager path conditions.
+  </description>
+</entry>


### PR DESCRIPTION
This adds validation to components in `org.apache.logging.log4j.core.appender.rolling`. 
Programmatic method calls causes NPE, whilst [PluginBuilder](https://logging.apache.org/log4j/2.x/log4j-core/apidocs/org/apache/logging/log4j/core/config/plugins/util/PluginBuilder.html) validates all constraints and logs the validation errors appropriately.
 Fix of [#1231 ](url)
