### PR TITLE
Issue 1445 - Fix RollingFileManager and FileRenameAction

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/FileRenameActionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/FileRenameActionTest.java
@@ -46,7 +46,8 @@ public class FileRenameActionTest {
 
         final File dest = new File(tempDir, "newFile.log");
         final FileRenameAction action = new FileRenameAction(file, dest, false);
-        action.execute();
+        boolean renameResult = action.execute();
+        assertTrue(renameResult, "Rename action returned false");
         assertTrue(dest.exists(), "Renamed file does not exist");
         assertFalse(file.exists(), "Old file exists");
     }
@@ -60,7 +61,8 @@ public class FileRenameActionTest {
         assertTrue(file.exists(), "File to rename does not exist");
         final File dest = new File(tempDir, "newFile.log");
         final FileRenameAction action = new FileRenameAction(file, dest, false);
-        action.execute();
+        boolean renameResult = action.execute();
+        assertTrue(renameResult, "Rename action returned false");
         assertFalse(dest.exists(), "Renamed file should not exist");
         assertFalse(file.exists(), "Old file still exists");
     }
@@ -74,7 +76,8 @@ public class FileRenameActionTest {
         assertTrue(file.exists(), "File to rename does not exist");
         final File dest = new File(tempDir, "newFile.log");
         final FileRenameAction action = new FileRenameAction(file, dest, true);
-        action.execute();
+        boolean renameResult = action.execute();
+        assertTrue(renameResult, "Rename action returned false");
         assertTrue(dest.exists(), "Renamed file should exist");
         assertFalse(file.exists(), "Old file still exists");
     }
@@ -91,7 +94,8 @@ public class FileRenameActionTest {
 
         final File dest = new File(tempDir, "newFile.log");
         final FileRenameAction action = new FileRenameAction(file, dest, false);
-        action.execute();
+        boolean renameResult = action.execute();
+        assertTrue(renameResult, "Rename action returned false");
         assertTrue(dest.exists(), "Renamed file does not exist");
         assertFalse(file.exists(), "Old file exists");
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
@@ -520,7 +520,7 @@ public class RollingFileManager extends FileManager {
                     asyncExecutor.execute(new AsyncAction(descriptor.getAsynchronous(), this));
                     releaseRequired = false;
                 }
-                return true;
+                return success;
             }
             return false;
         } finally {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/FileRenameAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/FileRenameAction.java
@@ -163,7 +163,7 @@ public class FileRenameAction extends AbstractAction {
             }
         } else {
             try {
-                source.delete();
+                return source.delete();
             } catch (final Exception exDelete) {
                 LOGGER.error("Unable to delete empty file {}: {} {}", source.getAbsolutePath(),
                         exDelete.getClass().getName(), exDelete.getMessage());

--- a/src/changelog/.2.x.x/1445_fix_synchronous_rolling_file_manager.xml
+++ b/src/changelog/.2.x.x/1445_fix_synchronous_rolling_file_manager.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="fixed">
+  <issue id="1445" link="https://github.com/apache/logging-log4j2/issues/1445"/>
+  <author id="thisdudeiknew" name="Timothy Pfeifer"/>
+  <description format="asciidoc">
+    Fixed `RollingFileManager` to propagate failed synchronous actions correctly.
+  </description>
+</entry>


### PR DESCRIPTION
Fixes #1445.
Fix RollingFileManager and FileRenameAction to correctly propagate synchronous action failures

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
