### PR TITLE
Issue #1550: remove multiple `isFiltered` invocations

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
@@ -126,15 +126,17 @@ public class AsyncLoggerConfig extends LoggerConfig {
             // This is the first AsnycLoggerConfig encountered by this LogEvent
             ASYNC_LOGGER_ENTERED.set(Boolean.TRUE);
             try {
-                // Detect the first time we encounter an AsyncLoggerConfig. We must log
-                // to all non-async loggers first.
-                super.log(event, LoggerConfigPredicate.SYNCHRONOUS_ONLY);
-                // Then pass the event to the background thread where
-                // all async logging is executed. It is important this
-                // happens at most once and after all synchronous loggers
-                // have been invoked, because we lose parameter references
-                // from reusable messages.
-                logToAsyncDelegate(event);
+                if (!isFiltered(event)) {
+                    // Detect the first time we encounter an AsyncLoggerConfig. We must log
+                    // to all non-async loggers first.
+                    processLogEvent(event, LoggerConfigPredicate.SYNCHRONOUS_ONLY);
+                    // Then pass the event to the background thread where
+                    // all async logging is executed. It is important this
+                    // happens at most once and after all synchronous loggers
+                    // have been invoked, because we lose parameter references
+                    // from reusable messages.
+                    logToAsyncDelegate(event);
+                }
             } finally {
                 ASYNC_LOGGER_ENTERED.set(Boolean.FALSE);
             }
@@ -149,13 +151,11 @@ public class AsyncLoggerConfig extends LoggerConfig {
     }
 
     private void logToAsyncDelegate(final LogEvent event) {
-        if (!isFiltered(event)) {
-            // Passes on the event to a separate thread that will call
-            // asyncCallAppenders(LogEvent).
-            populateLazilyInitializedFields(event);
-            if (!delegate.tryEnqueue(event, this)) {
-                handleQueueFull(event);
-            }
+        // Passes on the event to a separate thread that will call
+        // asyncCallAppenders(LogEvent).
+        populateLazilyInitializedFields(event);
+        if (!delegate.tryEnqueue(event, this)) {
+            handleQueueFull(event);
         }
     }
 
@@ -187,7 +187,8 @@ public class AsyncLoggerConfig extends LoggerConfig {
      * default {@link LoggerConfig} definitions), which will be invoked on the <b>calling thread</b>.
      */
     void logToAsyncLoggerConfigsOnCurrentThread(final LogEvent event) {
-        log(event, LoggerConfigPredicate.ASYNCHRONOUS_ONLY);
+        // skip the filter, which was already called on the logging thread
+        processLogEvent(event, LoggerConfigPredicate.ASYNCHRONOUS_ONLY);
     }
 
     private String displayName() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -611,9 +611,9 @@ public class LoggerConfig extends AbstractFilterable implements LocationAware {
     /**
      * Logs an event.
      *
-     * @param event The log event.
-     * @param predicate predicate for which LoggerConfig instances to append to.
-     *                  A null value is equivalent to a true predicate.
+     * @param event     The log event.
+     * @param predicate predicate for which LoggerConfig instances to append to. A
+     *                  {@literal null} value is equivalent to a true predicate.
      */
     protected void log(final LogEvent event, final LoggerConfigPredicate predicate) {
         if (!isFiltered(event)) {
@@ -631,9 +631,16 @@ public class LoggerConfig extends AbstractFilterable implements LocationAware {
         return reliabilityStrategy;
     }
 
-    private void processLogEvent(final LogEvent event, final LoggerConfigPredicate predicate) {
+    /**
+     * Logs an event, bypassing filters.
+     *
+     * @param event     The log event.
+     * @param predicate predicate for which LoggerConfig instances to append to. A
+     *                  {@literal null} value is equivalent to a true predicate.
+     */
+    protected void processLogEvent(final LogEvent event, final LoggerConfigPredicate predicate) {
         event.setIncludeLocation(isIncludeLocation());
-        if (predicate.allow(this)) {
+        if (predicate == null || predicate.allow(this)) {
             callAppenders(event);
         }
         logParent(event, predicate);

--- a/src/changelog/.2.x.x/1550_multiple_filter_invocations.xml
+++ b/src/changelog/.2.x.x/1550_multiple_filter_invocations.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="changed">
+  <issue id="1550" link="https://github.com/apache/logging-log4j2/pull/1550"/>
+  <author id="github:ppkarwasz"/>
+  <description format="asciidoc">Removes additional `isFiltered` checks in `AsyncLoggerConfig`.</description>
+</entry>


### PR DESCRIPTION
Async logger configs call `isFiltered(LogEvent)` multiple times. While this is not a problem per-se, it can cause a performance penalty if the filter is slow and creates problems to stateful filters.

This PR reduces the number of `isFiltered(LogEvent)` calls to one and closes #1550.

**Remark**: this PR changes the public API by increasing the visibility of `LoggerConfig#processLogEvent` to `protected`.
