### PR TITLE
Issue 1501: increase default StatusLogger level to warn

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -113,7 +113,7 @@ public final class StatusLogger extends AbstractLogger {
      * </p>
      * <ol>
      * <li>If the property {@value Constants#LOG4J2_DEBUG} is {@code "true"}, then use {@link Level#TRACE}, otherwise,</li>
-     * <li>Use {@link Level#ERROR}</li>
+     * <li>Use {@link Level#WARN}</li>
      * </ol>
      * <p>
      * This is now the listener level is set:
@@ -139,7 +139,7 @@ public final class StatusLogger extends AbstractLogger {
             final MessageFactory messageFactory,
             final SimpleLoggerFactory loggerFactory) {
         super(name, messageFactory);
-        final Level loggerLevel = DEBUG_ENABLED ? Level.TRACE : Level.ERROR;
+        final Level loggerLevel = DEBUG_ENABLED ? Level.TRACE : Level.WARN;
         this.logger = loggerFactory.createSimpleLogger("StatusLogger", loggerLevel, messageFactory, System.err);
         this.listenersLevel = Level.toLevel(DEFAULT_STATUS_LEVEL, Level.WARN).intLevel();
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/status/StatusConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/status/StatusConfiguration.java
@@ -39,7 +39,7 @@ public class StatusConfiguration {
 
     @SuppressWarnings("UseOfSystemOutOrSystemErr")
     private static final PrintStream DEFAULT_STREAM = System.out;
-    private static final Level DEFAULT_STATUS = Level.ERROR;
+    private static final Level DEFAULT_STATUS = Level.WARN;
     private static final Verbosity DEFAULT_VERBOSITY = Verbosity.QUIET;
 
     private final Collection<String> errorMessages = new LinkedBlockingQueue<>();
@@ -124,6 +124,7 @@ public class StatusConfiguration {
 
     /**
      * Specifies the logging level by name to use for filtering StatusLogger messages.
+     * Defaults to {@link Level#WARN} for invalid level name.
      *
      * @param status name of logger level to filter below.
      * @return {@code this}
@@ -132,8 +133,8 @@ public class StatusConfiguration {
     public StatusConfiguration withStatus(final String status) {
         this.status = Level.toLevel(status, null);
         if (this.status == null) {
-            this.error("Invalid status level specified: " + status + ". Defaulting to ERROR.");
-            this.status = Level.ERROR;
+            this.error("Invalid status level specified: " + status + ". Defaulting to WARN.");
+            this.status = Level.WARN;
         }
         return this;
     }


### PR DESCRIPTION
Fix of #1501.

1. [StatusLogger](https://github.com/apache/logging-log4j2/blob/2.x/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java) default level bumped from `ERROR` to `WARN` (used when no config active);
2. [StatusConfiguration](https://github.com/apache/logging-log4j2/blob/2.x/log4j-core/src/main/java/org/apache/logging/log4j/core/config/status/StatusConfiguration.java) default level bumped from `ERROR` to `WARN`(used as default value). It's method  [withStatus(String status)](https://github.com/apache/logging-log4j2/blob/48afa1f5ea95fd4576ddf1763482256858aa5d6a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/status/StatusConfiguration.java#L132) modified to default to `WARN` (used when `status` string value found in config file is invalid);
3. [AbstractConfiguration](https://github.com/apache/logging-log4j2/blob/2.x/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java), method `getDefaultStatus()` modified to default to `WARN`, as it is called in a.o. [JsonConfiguration](https://github.com/apache/logging-log4j2/blob/48afa1f5ea95fd4576ddf1763482256858aa5d6a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/JsonConfiguration.java#L71C25-L71C25) and does not change if there is no `status` key in config file.
