### PR TITLE
Update Log4j API doc to reflect throwable as last parameter feature.

### DIFF
--- a/src/site/xdoc/manual/api.xml
+++ b/src/site/xdoc/manual/api.xml
@@ -76,8 +76,8 @@ public class HelloWorld {
               only occur when debug logging is enabled.
             </p>
             <p>
-			  Additionally, you can pass a Throwable as the very last parameter. There's no need to add an extra substituting parameter in this case as it will be handled by the logging API automatically. For example:
-			</p>
+              Additionally, you can pass a Throwable as the very last parameter. There's no need to add an extra substituting parameter in this case as it will be handled by the logging API automatically. For example:
+            </p>
             <pre class="prettyprint">logger.debug("Logging in user {} with birthday {}", user.getName(), user.getBirthdayCalendar(), exception);</pre>
             <h4>Formatting Parameters</h4>
             <p>

--- a/src/site/xdoc/manual/api.xml
+++ b/src/site/xdoc/manual/api.xml
@@ -75,6 +75,10 @@ public class HelloWorld {
               With the code above the logging level will only be checked once and the String construction will
               only occur when debug logging is enabled.
             </p>
+            <p>
+			  Additionally, you can pass a Throwable as the very last parameter. There's no need to add an extra substituting parameter in this case as it will be handled by the logging API automatically. For example:
+			</p>
+            <pre class="prettyprint">logger.debug("Logging in user {} with birthday {}", user.getName(), user.getBirthdayCalendar(), exception);</pre>
             <h4>Formatting Parameters</h4>
             <p>
               Formatter Loggers leave formatting up to you if <code>toString()</code> is not what you want.


### PR DESCRIPTION
As discussed in Issue1569 Log4j API doc doesn't mention the feature of passing a `Throwable` as the last parameter of any of the `log` methods without adding an extra substituting parameter. 

This PR updates Log4j API documentation to reflect the throwable as the last parameter feature. 
`logger.debug("Logging in user {} with birthday {}", user.getName(), user.getBirthdayCalendar(), exception);`
