### PR TITLE
Fix `MemoryMappedFileAppender` buffer unmapping on JRE 9+

### DIFF
--- a/log4j-core-java9/pom.xml
+++ b/log4j-core-java9/pom.xml
@@ -30,6 +30,7 @@
     <log4jParentDir>${basedir}/..</log4jParentDir>
     <docLabel>Log4j Implementation Documentation</docLabel>
     <projectDir>/core</projectDir>
+    <maven.compiler.release>9</maven.compiler.release>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
   <dependencies>
@@ -102,13 +103,6 @@
               <goal>compile</goal>
             </goals>
             <phase>compile</phase>
-          </execution>
-          <execution>
-            <id>default-test-compile</id>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <phase>test-compile</phase>
           </execution>
         </executions>
       </plugin>

--- a/log4j-core-java9/src/main/java/org/apache/logging/log4j/core/util/internal/UnsafeUtil.java
+++ b/log4j-core-java9/src/main/java/org/apache/logging/log4j/core/util/internal/UnsafeUtil.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.util.internal;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.status.StatusLogger;
+import sun.misc.Unsafe;
+
+/**
+ * Provides access to unsafe operations.
+ */
+public class UnsafeUtil {
+
+    private static final Logger LOGGER = StatusLogger.getLogger();
+    private static final Unsafe unsafe = findUnsafe();
+
+    private static Unsafe findUnsafe() {
+        try {
+            return AccessController.doPrivileged(new PrivilegedExceptionAction<Unsafe>() {
+
+                @Override
+                public Unsafe run() throws ReflectiveOperationException, SecurityException {
+                    final Field unsafeField = Class.forName("sun.misc.Unsafe").getDeclaredField("theUnsafe");
+                    unsafeField.setAccessible(true);
+                    return (Unsafe) unsafeField.get(null);
+                }
+            });
+        } catch (PrivilegedActionException e) {
+            final Exception wrapped = e.getException();
+            if (wrapped instanceof SecurityException) {
+                throw (SecurityException) wrapped;
+            }
+            LOGGER.warn("sun.misc.Unsafe is not available. This will impact memory usage.", e);
+        }
+        return null;
+    }
+
+    public static void clean(final ByteBuffer bb) throws Exception {
+        if (unsafe != null && bb.isDirect()) {
+            unsafe.invokeCleaner(bb);
+        }
+    }
+}

--- a/log4j-core-test/pom.xml
+++ b/log4j-core-test/pom.xml
@@ -446,4 +446,23 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>java9-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>--illegal-access=warn</argLine>
+              <jdkToolchain>
+                <version>[9, )</version>
+              </jdkToolchain>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/UnsafeUtil.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/UnsafeUtil.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.util.internal;
+
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.status.StatusLogger;
+
+/**
+ * Provides access to unsafe operations.
+ */
+public class UnsafeUtil {
+
+    private static final Logger LOGGER = StatusLogger.getLogger();
+    private static Method cleanerMethod;
+    private static Method cleanMethod;
+    static {
+        try {
+            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
+
+                @Override
+                public Void run() throws ReflectiveOperationException, SecurityException {
+                    final ByteBuffer direct = ByteBuffer.allocateDirect(1);
+                    cleanerMethod = direct.getClass().getDeclaredMethod("cleaner");
+                    cleanerMethod.setAccessible(true);
+                    final Object cleaner = cleanerMethod.invoke(direct);
+                    cleanMethod = cleaner.getClass().getMethod("clean");
+                    return null;
+                }
+            });
+        } catch (PrivilegedActionException e) {
+            final Exception wrapped = e.getException();
+            if (wrapped instanceof SecurityException) {
+                throw (SecurityException) wrapped;
+            }
+            LOGGER.warn("sun.misc.Cleaner#clean() is not accessible. This will impact memory usage.", wrapped);
+            cleanerMethod = null;
+            cleanMethod = null;
+        }
+    }
+
+    public static void clean(final ByteBuffer bb) throws Exception {
+        if (cleanerMethod != null && cleanMethod != null && bb.isDirect()) {
+            cleanMethod.invoke(cleanerMethod.invoke(bb));
+        }
+    }
+}

--- a/src/changelog/.2.x.x/1646_unsafe_cleaner.xml
+++ b/src/changelog/.2.x.x/1646_unsafe_cleaner.xml
@@ -15,20 +15,13 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<assembly>
-  <id>src</id>
-  <formats>
-    <format>zip</format>
-  </formats>
-  <baseDirectory>/</baseDirectory>
-  <fileSets>
-    <fileSet>
-      <directory>${project.build.outputDirectory}</directory>
-      <outputDirectory>/classes/META-INF/versions/9</outputDirectory>
-      <includes>
-        <include>org/apache/logging/log4j/core/util/internal/UnsafeUtil*.class</include>
-        <include>org/apache/logging/log4j/core/util/SystemClock*.class</include>
-      </includes>
-    </fileSet>
-  </fileSets>
-</assembly>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.0.xsd"
+       type="fixed">
+  <issue id="1646" link="https://github.com/apache/logging-log4j2/issues/1646"/>
+  <author id="github:ppkarwasz"/>
+  <description format="asciidoc">
+    Fix `MemoryMappedFileAppender` buffer unmapping on JRE 9+.
+  </description>
+</entry>


### PR DESCRIPTION
This moves the direct buffer unmapping logic into a new class `UnsafeUtil` for which a Java 9 version is also provided.

Closes #1646.

