### PR TITLE
(doc) Update log4j-spring-boot spring-boot min version

### DIFF
--- a/src/site/markdown/log4j-spring-boot.md
+++ b/src/site/markdown/log4j-spring-boot.md
@@ -83,5 +83,5 @@ this purpose. Below is an example:
 ## Requirements
 
 The Log4j 2 Spring Cloud Configuration integration has a dependency on Log4j 2 API, Log4j 2 Core, and 
-Spring Boot versions 2.0.3.RELEASE or 2.1.1.RELEASE or later versions it either release series.
+Spring Boot version 2.4.0 or later versions it either release series.
 For more information, see [Runtime Dependencies](runtime-dependencies.html).


### PR DESCRIPTION
Since log4j-spring-boot 2.18.0 the required Spring Boot version is now 2.4.0 since it use `LoggingSystemFactory` which is a spring boot 2.4.0 class 
[https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/logging/LoggingSystemFactory.html](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/logging/LoggingSystemFactory.html)