### PR TITLE
Open `FileExtension` accessors (#1365)

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/FileExtension.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/FileExtension.java
@@ -100,10 +100,10 @@ public enum FileExtension {
         this.extension = extension;
     }
 
-    abstract Action createCompressAction(String renameTo, String compressedName, boolean deleteSource,
+    public abstract Action createCompressAction(String renameTo, String compressedName, boolean deleteSource,
                                          int compressionLevel);
 
-    String getExtension() {
+    public String getExtension() {
         return extension;
     }
 
@@ -111,7 +111,7 @@ public enum FileExtension {
         return s.endsWith(this.extension);
     }
 
-    int length() {
+    public int length() {
         return extension.length();
     }
 


### PR DESCRIPTION
#1365 

Access modifier changed from `default` to `public` of `FileExtension` class in below api's

1. `createCompressAction()`
2. `getExtension()`
3. `length()`
