### PR TITLE
Updated default fileIndex for rollover strategy in log4j1

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/RollingFileAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/RollingFileAppenderBuilder.java
@@ -156,6 +156,7 @@ public class RollingFileAppenderBuilder extends AbstractBuilder implements Appen
         final RolloverStrategy strategy = DefaultRolloverStrategy.newBuilder()
                 .withConfig(config)
                 .withMax(maxBackups)
+                .withFileIndex("min")
                 .build();
         return AppenderWrapper.adapt(RollingFileAppender.newBuilder()
                 .setName(name)

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationParser.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationParser.java
@@ -241,8 +241,10 @@ public class Log4j1ConfigurationParser {
         final ComponentBuilder<?> triggeringPolicy = builder.newComponent("Policies")
                 .addComponent(builder.newComponent("TimeBasedTriggeringPolicy").addAttribute("modulate", true));
         appenderBuilder.addComponent(triggeringPolicy);
-        appenderBuilder
-                .addComponent(builder.newComponent("DefaultRolloverStrategy").addAttribute("max", Integer.MAX_VALUE));
+        appenderBuilder.addComponent(builder.newComponent("DefaultRolloverStrategy")
+                .addAttribute("max", Integer.MAX_VALUE)
+                .addAttribute("fileIndex", "min")
+        );
         builder.add(appenderBuilder);
     }
 
@@ -258,7 +260,10 @@ public class Log4j1ConfigurationParser {
                 builder.newComponent("SizeBasedTriggeringPolicy").addAttribute("size", maxFileSizeString));
         appenderBuilder.addComponent(triggeringPolicy);
         appenderBuilder.addComponent(
-                builder.newComponent("DefaultRolloverStrategy").addAttribute("max", maxBackupIndexString));
+                builder.newComponent("DefaultRolloverStrategy")
+                    .addAttribute("max", maxBackupIndexString)
+                    .addAttribute("fileIndex", "min")
+        );
         builder.add(appenderBuilder);
     }
 

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -207,6 +207,9 @@ public abstract class AbstractLog4j1ConfigurationTest {
         assertEquals(name, appender.getName());
         assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
         final RollingFileAppender rfa = (RollingFileAppender) appender;
+
+        assertTrue("defaultRolloverStrategy", rfa.getManager().getRolloverStrategy() instanceof DefaultRolloverStrategy);
+        assertFalse("rolloverStrategy", ((DefaultRolloverStrategy) rfa.getManager().getRolloverStrategy()).isUseMax());
         assertEquals("append", false, getAppendProperty(rfa));
         assertEquals("bufferSize", 1000, rfa.getManager().getBufferSize());
         assertEquals("immediateFlush", false, rfa.getImmediateFlush());


### PR DESCRIPTION
For #1650 

Added default fileIndex of `min` when parsing Log4j1 configuration and when building from scratch using the provided builders (changes are only in the log4j1 packages) - modified test to check for the rollover strategy for v1 to check that it is not using `max`.

