### PR TITLE
Fix JeroMqAppenderTest race conditions

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqTestClient.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqTestClient.java
@@ -20,10 +20,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.status.StatusLogger;
 import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 
 class JeroMqTestClient implements Callable<List<String>> {
+
+    private static final Logger LOGGER = StatusLogger.getLogger();
 
     private final ZMQ.Context context;
 
@@ -46,7 +50,9 @@ class JeroMqTestClient implements Callable<List<String>> {
             for (int messageNum = 0; messageNum < receiveCount
                     && !Thread.currentThread().isInterrupted(); messageNum++) {
                 // Use trim to remove the tailing '0' character
-                messages.add(subscriber.recvStr(0).trim());
+                final String message = subscriber.recvStr(0).trim();
+                LOGGER.trace("Received 0MQ message: {}.", message);
+                messages.add(message);
             }
         }
         return messages;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqTestClient.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqTestClient.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import org.apache.logging.log4j.util.Constants;
+import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
 
 class JeroMqTestClient implements Callable<List<String>> {
@@ -40,9 +40,9 @@ class JeroMqTestClient implements Callable<List<String>> {
 
     @Override
     public List<String> call() throws Exception {
-        try (final ZMQ.Socket subscriber = context.socket(ZMQ.SUB)) {
+        try (final ZMQ.Socket subscriber = context.socket(SocketType.SUB)) {
             subscriber.connect(endpoint);
-            subscriber.subscribe(Constants.EMPTY_BYTE_ARRAY);
+            subscriber.subscribe(ZMQ.SUBSCRIPTION_ALL);
             for (int messageNum = 0; messageNum < receiveCount
                     && !Thread.currentThread().isInterrupted(); messageNum++) {
                 // Use trim to remove the tailing '0' character

--- a/log4j-core-test/src/test/resources/JeroMqAppenderTest.xml
+++ b/log4j-core-test/src/test/resources/JeroMqAppenderTest.xml
@@ -18,7 +18,7 @@
 <Configuration name="JeroMQAppenderTest" status="INFO">
   <Appenders>
     <JeroMQ name="JeroMQAppender">
-      <Property name="endpoint">tcp://*:5556</Property>
+      <Property name="endpoint">tcp://*:0</Property>
       <Property name="endpoint">ipc://info-topic</Property>
       <PatternLayout pattern="%X{foo}%m"/>
     </JeroMQ>

--- a/log4j-core-test/src/test/resources/JeroMqAppenderTest.xml
+++ b/log4j-core-test/src/test/resources/JeroMqAppenderTest.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration name="JeroMQAppenderTest" status="warn">
+<Configuration name="JeroMQAppenderTest" status="INFO">
   <Appenders>
     <JeroMQ name="JeroMQAppender">
       <Property name="endpoint">tcp://*:5556</Property>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqAppender.java
@@ -173,8 +173,8 @@ public final class JeroMqAppender extends AbstractAppender {
     }
 
     // not public, handy for testing
-    byte[] recv(final int timeoutMs) {
-        return manager.recv(timeoutMs);
+    JeroMqManager getManager() {
+        return manager;
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqManager.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.core.util.ShutdownCallbackRegistry;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.zeromq.SocketType;
 import org.zeromq.ZMQ;
+import zmq.SocketBase;
 
 /**
  * Manager for publishing messages via JeroMq.
@@ -72,7 +73,7 @@ public final class JeroMqManager extends AbstractManager {
 
     private JeroMqManager(final String name, final JeroMqConfiguration config) {
         super(null, name);
-        publisher = CONTEXT.socket(SocketType.XPUB);
+        publisher = CONTEXT.socket(SocketType.PUB);
         publisher.setAffinity(config.affinity);
         publisher.setBacklog(config.backlog);
         publisher.setDelayAttachOnConnect(config.delayAttachOnConnect);
@@ -105,21 +106,15 @@ public final class JeroMqManager extends AbstractManager {
         return publisher.send(data);
     }
 
-    // not public, handy for testing
-    byte[] recv(final int timeoutMs) {
-        final int oldTimeoutMs = publisher.getReceiveTimeOut();
-        try {
-            publisher.setReceiveTimeOut(timeoutMs);
-            return publisher.recv();
-        } finally {
-            publisher.setReceiveTimeOut(oldTimeoutMs);
-        }
-    }
-
     @Override
     protected boolean releaseSub(final long timeout, final TimeUnit timeUnit) {
         publisher.close();
         return true;
+    }
+
+    // not public, handy for testing
+    SocketBase getPublisher() {
+        return publisher.base();
     }
 
     public static JeroMqManager getJeroMqManager(final String name, final long affinity, final long backlog,


### PR DESCRIPTION
This PR should eliminate the failures of `JeroMqAppenderTest` without modifying `JeroMqAppender` from `PUB` to `XPUB` (cf. commit f1b928cba5e6aec6ef3fe6e0410c2b12235595c9).

This is a prerequisite for #1703, due to the frequent CI failures due to this test.