### PR TITLE
Add JUnit 5 extension for per test-class log directories

### DIFF
--- a/log4j-api-test/pom.xml
+++ b/log4j-api-test/pom.xml
@@ -54,6 +54,11 @@
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.junit-pioneer</groupId>
       <artifactId>junit-pioneer</artifactId>
     </dependency>
@@ -76,11 +81,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/DirectoryCleaner.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/DirectoryCleaner.java
@@ -49,6 +49,10 @@ class DirectoryCleaner extends AbstractFileCleaner {
 
     @Override
     boolean delete(final Path path) throws IOException {
+        return deleteDirectory(path);
+    }
+
+    static boolean deleteDirectory(final Path path) throws IOException {
         if (Files.exists(path) && Files.isDirectory(path)) {
             Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
                 @Override

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/TempLoggingDir.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/TempLoggingDir.java
@@ -14,31 +14,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.logging.log4j.test;
+package org.apache.logging.log4j.test.junit;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.CleanupMode;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * A container for per-test properties.
+ * Injects the given static field with a per test logging directory.
+ * <p>
+ * The same directory is set as "logging.path" Log4j2 property.
+ * </p>
  */
-public interface TestProperties {
+@Retention(RUNTIME)
+@Target({ ElementType.FIELD })
+@Inherited
+@Documented
+@ExtendWith(ExtensionContextAnchor.class)
+@ExtendWith(TempLoggingDirectory.class)
+public @interface TempLoggingDir {
 
-    /**
-     * Path to a directory specific to the test class,
-     */
-    public static final String LOGGING_PATH = "logging.path";
-
-    String getProperty(final String key);
-
-    boolean containsProperty(final String key);
-
-    void setProperty(final String key, final String value);
-
-    default void setProperty(final String key, final boolean value) {
-        setProperty(key, value ? "true" : "false");
-    }
-
-    default void setProperty(final String key, final int value) {
-        setProperty(key, Integer.toString(value));
-    }
-
-    void clearProperty(final String key);
+    CleanupMode cleanup() default CleanupMode.DEFAULT;
 }

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/TempLoggingDirectory.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/TempLoggingDirectory.java
@@ -64,7 +64,7 @@ public class TempLoggingDirectory implements BeforeAllCallback {
         final String baseDir = System.getProperty("basedir");
         final Path basePath = (baseDir != null ? Paths.get(baseDir, "target") : Paths.get(".")).resolve("logs");
         final Class<?> clazz = context.getRequiredTestClass();
-        final String dir = clazz.getName().replaceAll("[.$]", File.separator);
+        final String dir = clazz.getName().replaceAll("[.$]", File.separatorChar == '\\' ? "\\\\" : File.separator);
         final Path loggingPath = basePath.resolve(dir);
         Files.createDirectories(loggingPath);
         props.setProperty(TestProperties.LOGGING_PATH, loggingPath.toString());

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/TempLoggingDirectory.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/TempLoggingDirectory.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.test.junit;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.test.TestProperties;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.support.ModifierSupport;
+
+import static org.junit.jupiter.api.io.CleanupMode.NEVER;
+import static org.junit.jupiter.api.io.CleanupMode.ON_SUCCESS;
+
+public class TempLoggingDirectory implements BeforeAllCallback {
+
+    private static final Logger LOGGER = StatusLogger.getLogger();
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        final List<Field> fields = AnnotationSupport.findAnnotatedFields(context.getRequiredTestClass(),
+                TempLoggingDir.class, ModifierSupport::isStatic);
+        Path loggingPath = null;
+        for (final Field field : fields) {
+            if (loggingPath != null) {
+                LOGGER.warn("Multiple fields with @TempLoggingDir annotation are not supported.");
+            } else {
+                final CleanupMode cleanup = determineCleanupMode(field);
+                loggingPath = createLoggingPath(context, cleanup);
+            }
+            field.setAccessible(true);
+            field.set(null, loggingPath);
+        }
+    }
+
+    private Path createLoggingPath(final ExtensionContext context, final CleanupMode cleanup) throws IOException {
+        final TestProperties props = TestPropertySource.createProperties(context);
+        // Create temporary directory
+        final String baseDir = System.getProperty("basedir");
+        final Path basePath = (baseDir != null ? Paths.get(baseDir, "target") : Paths.get(".")).resolve("logs");
+        final Class<?> clazz = context.getRequiredTestClass();
+        final String dir = clazz.getName().replaceAll("[.$]", File.separator);
+        final Path loggingPath = basePath.resolve(dir);
+        Files.createDirectories(loggingPath);
+        props.setProperty(TestProperties.LOGGING_PATH, loggingPath.toString());
+        // Register deletion
+        final PathHolder holder = new PathHolder(loggingPath, cleanup, context);
+        ExtensionContextAnchor.setAttribute(PathHolder.class, holder, context);
+        return loggingPath;
+    }
+
+    private CleanupMode determineCleanupMode(final TempLoggingDir annotation) {
+        final CleanupMode mode = annotation.cleanup();
+        // TODO: use JupiterConfiguration
+        return mode != CleanupMode.DEFAULT ? mode : CleanupMode.ON_SUCCESS;
+    }
+
+    private CleanupMode determineCleanupMode(final Field field) {
+        return determineCleanupMode(field.getAnnotation(TempLoggingDir.class));
+    }
+
+    private static class PathHolder implements CloseableResource {
+
+        private final Path path;
+        private final CleanupMode cleanupMode;
+        private final ExtensionContext context;
+
+        public PathHolder(final Path path, final CleanupMode cleanup, final ExtensionContext context) {
+            this.path = path;
+            this.cleanupMode = cleanup;
+            this.context = context;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (cleanupMode == NEVER || (cleanupMode == ON_SUCCESS && context.getExecutionException().isPresent())) {
+                LOGGER.debug("Skipping cleanup of directory {}.", path);
+                return;
+            }
+            DirectoryCleaner.deleteDirectory(path);
+        }
+
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/LateConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/LateConfigTest.java
@@ -16,25 +16,34 @@
  */
 package org.apache.logging.log4j.core;
 
-import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
 
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.config.xml.XmlConfiguration;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.test.junit.TempLoggingDir;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("functional")
 public class LateConfigTest {
 
-    private static final String CONFIG = "target/test-classes/log4j-test1.xml";
+    private static final String CONFIG = "/log4j-test1.xml";
     private static LoggerContext context;
+
+    @TempLoggingDir
+    private static Path loggingPath;
 
     @BeforeAll
     public static void setupClass() {
@@ -52,9 +61,10 @@ public class LateConfigTest {
         final Configuration cfg = context.getConfiguration();
         assertNotNull(cfg, "No configuration");
         assertTrue(cfg instanceof DefaultConfiguration, "Not set to default configuration");
-        final File file = new File(CONFIG);
-        final LoggerContext loggerContext = LoggerContext.getContext(null, false, file.toURI());
+        final URI configLocation = LateConfigTest.class.getResource(CONFIG).toURI();
+        final LoggerContext loggerContext = LoggerContext.getContext(null, false, configLocation);
         assertNotNull(loggerContext, "No Logger Context");
+        assertThat(loggingPath.resolve("test-xml.log")).exists();
         final Configuration newConfig = loggerContext.getConfiguration();
         assertNotSame(cfg, newConfig, "Configuration not reset");
         assertTrue(newConfig instanceof XmlConfiguration, "Reconfiguration failed");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationFactoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationFactoryTest.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.core.config;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -32,26 +31,26 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.filter.ThreadContextMapFilter;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
-import org.apache.logging.log4j.test.junit.CleanUpFiles;
+import org.apache.logging.log4j.test.junit.TempLoggingDir;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.logging.log4j.util.Unbox.box;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@CleanUpFiles({
-        "target/test-xml.log",
-        "target/test-xinclude.log",
-        "target/test-json.log",
-        "target/test-yaml.log",
-        "target/test-properties.log"
-})
 class ConfigurationFactoryTest {
 
     static final String LOGGER_NAME = "org.apache.logging.log4j.test1.Test";
     static final String FILE_LOGGER_NAME = "org.apache.logging.log4j.test2.Test";
     static final String APPENDER_NAME = "STDOUT";
+
+    @TempLoggingDir
+    private static Path loggingPath;
 
     /**
      * Runs various configuration checks on a configured LoggerContext that should match the equivalent configuration in
@@ -93,7 +92,7 @@ class ConfigurationFactoryTest {
     @LoggerContextSource("log4j-test1.xml")
     void xml(final LoggerContext context) throws IOException {
         checkConfiguration(context);
-        final Path logFile = Paths.get("target", "test-xml.log");
+        final Path logFile = loggingPath.resolve("test-xml.log");
         checkFileLogger(context, logFile);
     }
 
@@ -101,7 +100,7 @@ class ConfigurationFactoryTest {
     @LoggerContextSource("log4j-xinclude.xml")
     void xinclude(final LoggerContext context) throws IOException {
         checkConfiguration(context);
-        final Path logFile = Paths.get("target", "test-xinclude.log");
+        final Path logFile = loggingPath.resolve("test-xinclude.log");
         checkFileLogger(context, logFile);
     }
 
@@ -110,7 +109,7 @@ class ConfigurationFactoryTest {
     @LoggerContextSource("log4j-test1.json")
     void json(final LoggerContext context) throws IOException {
         checkConfiguration(context);
-        final Path logFile = Paths.get("target", "test-json.log");
+        final Path logFile = loggingPath.resolve("test-json.log");
         checkFileLogger(context, logFile);
     }
 
@@ -119,7 +118,7 @@ class ConfigurationFactoryTest {
     @LoggerContextSource("log4j-test1.yaml")
     void yaml(final LoggerContext context) throws IOException {
         checkConfiguration(context);
-        final Path logFile = Paths.get("target", "test-yaml.log");
+        final Path logFile = loggingPath.resolve("test-yaml.log");
         checkFileLogger(context, logFile);
     }
 
@@ -127,7 +126,7 @@ class ConfigurationFactoryTest {
     @LoggerContextSource("log4j-test1.properties")
     void properties(final LoggerContext context) throws IOException {
         checkConfiguration(context);
-        final Path logFile = Paths.get("target", "test-properties.log");
+        final Path logFile = loggingPath.resolve("test-properties.log");
         checkFileLogger(context, logFile);
     }
 }

--- a/log4j-core-test/src/test/resources/log4j-test1.json
+++ b/log4j-core-test/src/test/resources/log4j-test1.json
@@ -6,7 +6,7 @@
         "properties" : {
             "property" : {
                 "name" : "filename",
-                "value": "target/test-json.log"
+                "value": "${test:logging.path}/test-json.log"
             }
         },
         "thresholdFilter" : {

--- a/log4j-core-test/src/test/resources/log4j-test1.properties
+++ b/log4j-core-test/src/test/resources/log4j-test1.properties
@@ -18,7 +18,7 @@
 status = off
 name = PropertiesConfigTest
 
-property.filename = target/test-properties.log
+property.filename = ${test:logging.path}/test-properties.log
 
 filter.threshold.type = ThresholdFilter
 filter.threshold.level = debug

--- a/log4j-core-test/src/test/resources/log4j-test1.xml
+++ b/log4j-core-test/src/test/resources/log4j-test1.xml
@@ -17,7 +17,7 @@
   -->
 <Configuration status="OFF" name="XMLConfigTest">
   <Properties>
-    <Property name="filename">target/test-xml.log</Property>
+    <Property name="filename">${test:logging.path}/test-xml.log</Property>
   </Properties>
   <ThresholdFilter level="debug"/>
 

--- a/log4j-core-test/src/test/resources/log4j-test1.yaml
+++ b/log4j-core-test/src/test/resources/log4j-test1.yaml
@@ -20,7 +20,7 @@ Configuration:
   properties:
     property:
       name: filename
-      value: target/test-yaml.log
+      value: ${test:logging.path}/test-yaml.log
   thresholdFilter:
     level: debug
   appenders:

--- a/log4j-core-test/src/test/resources/log4j-xinclude.xml
+++ b/log4j-core-test/src/test/resources/log4j-xinclude.xml
@@ -18,7 +18,7 @@
 <Configuration xmlns:xi="http://www.w3.org/2001/XInclude"
   status="OFF" name="XMLConfigTest">
   <Properties>
-    <Property name="filename">target/test-xinclude.log</Property>
+    <Property name="filename">${test:logging.path}/test-xinclude.log</Property>
   </Properties>
   <ThresholdFilter level="debug"/>
   <xi:include href="log4j-xinclude-appenders.xml" />


### PR DESCRIPTION
This PR adds a `@TempLoggingDir` extension, which is a reduced version of the standard `@TempDir` annotation.

It can be used on **static** fields and:
 * creates a directory specific for the test-class (right now in `target/logs/<fully_qualified_class_name>`,
 * injects the field with the value of the directory,
 * creates an entry in the `TestProperties` with key "logging.path",
 * deletes the directory if the test succeeds.
 
 The `TestProperties` entry is available as both a Log4j2 system property and using the `${test:logging.path}` lookup.
