### PR TITLE
Tag LOG4J as origin of WARNING messages and use stderr instead of stdout

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -72,12 +72,12 @@ public final class StackLocator {
             } else {
                 o = getCallerClassMethod.invoke(null, 1);
                 if (o == sunReflectionClass) {
-                    System.out.println("WARNING: Unexpected result from sun.reflect.Reflection.getCallerClass(int), adjusting offset for future calls.");
+                    System.err.println("LOG4J WARNING: Unexpected result from sun.reflect.Reflection.getCallerClass(int), adjusting offset for future calls.");
                     java7u25CompensationOffset = 1;
                 }
             }
         } catch (final Exception | LinkageError e) {
-            System.out.println("WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.");
+            System.err.println("LOG4J WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.");
             getCallerClassMethod = null;
             java7u25CompensationOffset = -1;
         }


### PR DESCRIPTION
The "WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance." gets a lot of attention [1]. Sometimes users are confused about its origin. Therefore identify LOG4J as the originator of the warning.

1: https://www.google.com/search?q=WARNING%3A+sun.reflect.Reflection.getCallerClass+is+not+supported.+This+will+impact+performance.&oq=WARNING%3A+sun.reflect.Reflection.getCallerClass+is+not+supported.+This+will+impact+performance.