### PR TITLE
Modernized Syslog tests

### DIFF
--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderTest.java
@@ -24,7 +24,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.net.mock.MockSyslogServer;
 import org.apache.logging.log4j.core.test.net.mock.MockSyslogServerFactory;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -32,36 +31,25 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-
-/**
- * Class Description goes here.
- */
 public class SyslogAppenderTest {
 
-    // TODO Use an ephemeral port, save it in a sys prop, and update test config files.
-    private static final int PORTNUM = 9999;
-    private MockSyslogServer syslogServer;
+    private static MockSyslogServer syslogServer;
 
     @BeforeClass
-    public static void beforeClass() {
+    public static void beforeClass() throws IOException {
+        initTCPTestEnvironment(null);
+        System.setProperty("SyslogAppenderTest.port", Integer.toString(syslogServer.getLocalPort()));
         System.setProperty(ConfigurationFactory.LOG4J1_CONFIGURATION_FILE_PROPERTY, "target/test-classes/log4j1-syslog.xml");
     }
 
     @AfterClass
     public static void afterClass() {
         System.clearProperty(ConfigurationFactory.LOG4J1_CONFIGURATION_FILE_PROPERTY);
-    }
-
-    @After
-    public void teardown() {
-        if (syslogServer != null) {
-            syslogServer.shutdown();
-        }
+        syslogServer.shutdown();
     }
 
     @Test
     public void sendMessage() throws Exception {
-        initTCPTestEnvironment(null);
         final Logger logger = LogManager.getLogger(SyslogAppenderTest.class);
         logger.info("This is a test");
         List<String> messages = null;
@@ -77,8 +65,8 @@ public class SyslogAppenderTest {
     }
 
 
-    protected void initTCPTestEnvironment(final String messageFormat) throws IOException {
-        syslogServer = MockSyslogServerFactory.createTCPSyslogServer(1, PORTNUM);
+    protected static void initTCPTestEnvironment(final String messageFormat) throws IOException {
+        syslogServer = MockSyslogServerFactory.createTCPSyslogServer();
         syslogServer.start();
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderTest.java
@@ -37,7 +37,7 @@ public class SyslogAppenderTest {
     @BeforeAll
     public static void beforeClass() throws IOException {
         initTCPTestEnvironment(null);
-        System.setProperty("SyslogAppenderTest.port", Integer.toString(syslogServer.getLocalPort()));
+        System.setProperty("syslog.port", Integer.toString(syslogServer.getLocalPort()));
         System.setProperty(ConfigurationFactory.LOG4J1_CONFIGURATION_FILE_PROPERTY, "target/test-classes/log4j1-syslog.xml");
     }
 

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderTest.java
@@ -24,25 +24,24 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.net.mock.MockSyslogServer;
 import org.apache.logging.log4j.core.test.net.mock.MockSyslogServerFactory;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SyslogAppenderTest {
 
     private static MockSyslogServer syslogServer;
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() throws IOException {
         initTCPTestEnvironment(null);
         System.setProperty("SyslogAppenderTest.port", Integer.toString(syslogServer.getLocalPort()));
         System.setProperty(ConfigurationFactory.LOG4J1_CONFIGURATION_FILE_PROPERTY, "target/test-classes/log4j1-syslog.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void afterClass() {
         System.clearProperty(ConfigurationFactory.LOG4J1_CONFIGURATION_FILE_PROPERTY);
         syslogServer.shutdown();
@@ -60,8 +59,7 @@ public class SyslogAppenderTest {
                 break;
             }
         }
-        assertNotNull("No messages received", messages);
-        assertEquals("Sent message not detected", 1, messages.size());
+        assertThat(messages).hasSize(1);
     }
 
 

--- a/log4j-1.2-api/src/test/resources/log4j1-syslog-protocol-default.properties
+++ b/log4j-1.2-api/src/test/resources/log4j1-syslog-protocol-default.properties
@@ -18,7 +18,7 @@
 log4j.rootLogger=DEBUG,syslog
 log4j.appender.syslog=org.apache.log4j.net.SyslogAppender
 log4j.appender.syslog.Threshold=DEBUG
-log4j.appender.syslog.syslogHost=localhost:9999
+log4j.appender.syslog.syslogHost=localhost:${syslog.port}
 log4j.appender.syslog.header=true
 log4j.appender.syslog.Facility=LOCAL3
 log4j.appender.syslog.layout=org.apache.log4j.PatternLayout

--- a/log4j-1.2-api/src/test/resources/log4j1-syslog-protocol-tcp.properties
+++ b/log4j-1.2-api/src/test/resources/log4j1-syslog-protocol-tcp.properties
@@ -18,7 +18,7 @@
 log4j.rootLogger=DEBUG,syslog
 log4j.appender.syslog=org.apache.log4j.net.SyslogAppender
 log4j.appender.syslog.Threshold=DEBUG
-log4j.appender.syslog.syslogHost=localhost:9999
+log4j.appender.syslog.syslogHost=localhost:${syslog.port}
 log4j.appender.syslog.protocol=TCP
 log4j.appender.syslog.header=true
 log4j.appender.syslog.Facility=LOCAL3

--- a/log4j-1.2-api/src/test/resources/log4j1-syslog-protocol-tcp.xml
+++ b/log4j-1.2-api/src/test/resources/log4j1-syslog-protocol-tcp.xml
@@ -19,7 +19,7 @@
 
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
   <appender name="syslog" class="org.apache.log4j.net.SyslogAppender">
-    <param name="SyslogHost" value="localhost:9999"/>
+    <param name="SyslogHost" value="localhost:${syslog.port}"/>
     <param name="Facility" value="USER"/>
     <param name="FacilityPrinting" value="true"/>
     <param name="Threshold" value="DEBUG"/>

--- a/log4j-1.2-api/src/test/resources/log4j1-syslog-protocol-udp.properties
+++ b/log4j-1.2-api/src/test/resources/log4j1-syslog-protocol-udp.properties
@@ -18,7 +18,7 @@
 log4j.rootLogger=DEBUG,syslog
 log4j.appender.syslog=org.apache.log4j.net.SyslogAppender
 log4j.appender.syslog.Threshold=DEBUG
-log4j.appender.syslog.syslogHost=localhost:9999
+log4j.appender.syslog.syslogHost=localhost:${syslog.port}
 log4j.appender.syslog.protocol=UDP
 log4j.appender.syslog.header=true
 log4j.appender.syslog.Facility=LOCAL3

--- a/log4j-1.2-api/src/test/resources/log4j1-syslog-protocol-udp.xml
+++ b/log4j-1.2-api/src/test/resources/log4j1-syslog-protocol-udp.xml
@@ -19,7 +19,7 @@
 
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
   <appender name="syslog" class="org.apache.log4j.net.SyslogAppender">
-    <param name="SyslogHost" value="localhost:9999"/>
+    <param name="SyslogHost" value="localhost:${syslog.port}"/>
     <param name="Facility" value="USER"/>
     <param name="FacilityPrinting" value="true"/>
     <param name="Threshold" value="DEBUG"/>

--- a/log4j-1.2-api/src/test/resources/log4j1-syslog.xml
+++ b/log4j-1.2-api/src/test/resources/log4j1-syslog.xml
@@ -19,7 +19,7 @@
 
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
   <appender name="syslog" class="org.apache.log4j.net.SyslogAppender">
-    <param name="SyslogHost" value="localhost:${SyslogAppenderTest.port}"/>
+    <param name="SyslogHost" value="localhost:${syslog.port}"/>
     <param name="Facility" value="USER"/>
     <param name="FacilityPrinting" value="true"/>
     <param name="Threshold" value="DEBUG"/>

--- a/log4j-1.2-api/src/test/resources/log4j1-syslog.xml
+++ b/log4j-1.2-api/src/test/resources/log4j1-syslog.xml
@@ -19,7 +19,7 @@
 
 <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
   <appender name="syslog" class="org.apache.log4j.net.SyslogAppender">
-    <param name="SyslogHost" value="localhost:9999"/>
+    <param name="SyslogHost" value="localhost:${SyslogAppenderTest.port}"/>
     <param name="Facility" value="USER"/>
     <param name="FacilityPrinting" value="true"/>
     <param name="Threshold" value="DEBUG"/>

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockSyslogServer.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockSyslogServer.java
@@ -28,9 +28,16 @@ public abstract class MockSyslogServer extends Thread {
     protected static Logger LOGGER = StatusLogger.getLogger();
 
     protected List<String> messageList = new ArrayList<>();
+    @Deprecated
+    protected int port;
+
+    @Deprecated
+    public MockSyslogServer(final int numberOfMessagesToReceive, final int port) {
+        this();
+        this.port = port;
+    }
 
     public MockSyslogServer() {
-        super();
         setName(getClass().getSimpleName() + "-" + (++threadInitNumber));
     }
 

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockSyslogServer.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockSyslogServer.java
@@ -19,25 +19,24 @@ package org.apache.logging.log4j.core.test.net.mock;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.status.StatusLogger;
+
 public abstract class MockSyslogServer extends Thread {
-    protected List<String> messageList;
-    protected int port;
-    private final int numberOfMessagesToReceive;
 
-    public MockSyslogServer(final int numberOfMessagesToReceive, final int port) {
-        this.numberOfMessagesToReceive = numberOfMessagesToReceive;
-        this.messageList = new ArrayList<>();
-        this.port = port;
+    private static volatile int threadInitNumber;
+    protected static Logger LOGGER = StatusLogger.getLogger();
+
+    protected List<String> messageList = new ArrayList<>();
+
+    public MockSyslogServer() {
+        super();
+        setName(getClass().getSimpleName() + "-" + (++threadInitNumber));
     }
 
-    @Override
-    public void run() {
+    public abstract int getLocalPort();
 
-    }
-
-    public void shutdown() {
-
-    }
+    public abstract void shutdown();
 
     public int getNumberOfReceivedMessages() {
         return messageList.size();

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockSyslogServerFactory.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockSyslogServerFactory.java
@@ -25,12 +25,12 @@ import org.apache.logging.log4j.core.test.net.ssl.TlsSyslogMessageFormat;
 
 public class MockSyslogServerFactory {
 
-    public static MockSyslogServer createUDPSyslogServer(final int numberOfMessagesToReceive, final int port) throws SocketException {
-        return new MockUdpSyslogServer(numberOfMessagesToReceive, port);
+    public static MockSyslogServer createUDPSyslogServer() throws SocketException {
+        return new MockUdpSyslogServer();
     }
 
-    public static MockSyslogServer createTCPSyslogServer(final int numberOfMessagesToReceive, final int port) throws IOException {
-        return new MockTcpSyslogServer(numberOfMessagesToReceive, port);
+    public static MockSyslogServer createTCPSyslogServer() throws IOException {
+        return new MockTcpSyslogServer();
     }
 
     public static MockSyslogServer createTLSSyslogServer(final int numberOfMessagesToReceive, final TlsSyslogMessageFormat format, final SSLServerSocket serverSocket) {

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockSyslogServerFactory.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockSyslogServerFactory.java
@@ -25,8 +25,18 @@ import org.apache.logging.log4j.core.test.net.ssl.TlsSyslogMessageFormat;
 
 public class MockSyslogServerFactory {
 
+    public static MockSyslogServer createUDPSyslogServer(final int numberOfMessagesToReceive, final int port)
+            throws SocketException {
+        return new MockUdpSyslogServer(numberOfMessagesToReceive, port);
+    }
+
     public static MockSyslogServer createUDPSyslogServer() throws SocketException {
         return new MockUdpSyslogServer();
+    }
+
+    public static MockSyslogServer createTCPSyslogServer(final int numberOfMessagesToReceive, final int port)
+            throws IOException {
+        return new MockTcpSyslogServer(numberOfMessagesToReceive, port);
     }
 
     public static MockSyslogServer createTCPSyslogServer() throws IOException {

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockTcpSyslogServer.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockTcpSyslogServer.java
@@ -26,8 +26,17 @@ public class MockTcpSyslogServer extends MockSyslogServer {
     private volatile boolean shutdown = false;
     private Thread thread;
 
+    public MockTcpSyslogServer(final int numberOfMessagesToReceive, final int port) throws IOException {
+        this(port);
+    }
+
     public MockTcpSyslogServer() throws IOException {
-        serverSocket = new ServerSocket(0);
+        this(0);
+    }
+
+    private MockTcpSyslogServer(final int port) throws IOException {
+        super(0, port);
+        serverSocket = new ServerSocket(port);
     }
 
     @Override

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockTcpSyslogServer.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockTcpSyslogServer.java
@@ -18,48 +18,55 @@ package org.apache.logging.log4j.core.test.net.mock;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.BindException;
 import java.net.ServerSocket;
 import java.net.Socket;
 
 public class MockTcpSyslogServer extends MockSyslogServer {
-    private final ServerSocket socketServer;
+    private final ServerSocket serverSocket;
     private volatile boolean shutdown = false;
     private Thread thread;
 
-    public MockTcpSyslogServer(final int numberOfMessagesToReceive, final int port) throws IOException {
-        super(numberOfMessagesToReceive, port);
-        socketServer = new ServerSocket(port);
+    public MockTcpSyslogServer() throws IOException {
+        serverSocket = new ServerSocket(0);
+    }
+
+    @Override
+    public int getLocalPort() {
+        return serverSocket.getLocalPort();
     }
 
     @Override
     public void shutdown() {
         this.shutdown = true;
-        if (socketServer != null) {
-            try {
-                socketServer.close();
-            } catch (final IOException e) {
-                e.printStackTrace();
+        try {
+            if (serverSocket != null) {
+                try {
+                    this.serverSocket.close();
+                } catch (final Exception e) {
+                    LOGGER.error("The {} failed to close its socket.", getName(), e);
+                }
             }
+            this.interrupt();
+        } catch (final SecurityException e) {
+            LOGGER.error("Shutdown of {} failed", getName(), e);
         }
         if (thread != null) {
-            thread.interrupt();
             try {
                 thread.join(100);
-            } catch (final InterruptedException ie) {
-                System.out.println("Shutdown of TCP server thread failed.");
+            } catch (final InterruptedException e) {
+                LOGGER.error("Shutdown of {} thread failed.", getName(), e);
             }
         }
     }
 
     @Override
     public void run() {
-        System.out.println("TCP Server started");
+        LOGGER.info("{} started on port {}.", getName(), getLocalPort());
         this.thread = Thread.currentThread();
         while (!shutdown) {
             try {
                 final byte[] buffer = new byte[4096];
-                try (final Socket socket = socketServer.accept()) {
+                try (final Socket socket = serverSocket.accept()) {
                     socket.setSoLinger(true, 0);
                     final InputStream in = socket.getInputStream();
                     int i = in.read(buffer, 0, buffer.length);
@@ -69,20 +76,18 @@ public class MockTcpSyslogServer extends MockSyslogServer {
                             messageList.add(line);
                             i = in.read(buffer, 0, buffer.length);
                         } else if (i == 0) {
-                            System.out.println("No data received");
+                            LOGGER.warn("{} received no data.", getName());
                         } else {
-                            System.out.println("Message too long");
+                            LOGGER.warn("{} received a message longer than {}.", getName(), buffer.length);
                         }
                     }
-                } catch (final BindException be) {
-                    be.printStackTrace();
                 }
-            } catch (final Exception ex) {
+            } catch (final Exception e) {
                 if (!shutdown) {
-                    System.out.println("Caught exception: " + ex.getMessage());
+                    LOGGER.error("{} caught an exception.", getName(), e);
                 }
             }
         }
-        System.out.println("TCP Server stopped");
+        LOGGER.info("{} stopped.", getName());
     }
 }

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockUdpSyslogServer.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockUdpSyslogServer.java
@@ -27,8 +27,17 @@ public class MockUdpSyslogServer extends MockSyslogServer {
     private volatile boolean shutdown = false;
     private Thread thread;
 
+    public MockUdpSyslogServer(final int numberOfMessagesToReceive, final int port) throws SocketException {
+        this(port);
+    }
+
     public MockUdpSyslogServer() throws SocketException {
-        this.socket = new DatagramSocket(0);
+        this(0);
+    }
+
+    private MockUdpSyslogServer(final int port) throws SocketException {
+        super(0, port);
+        this.socket = new DatagramSocket(port);
     }
 
     @Override

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockUdpSyslogServer.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockUdpSyslogServer.java
@@ -27,9 +27,13 @@ public class MockUdpSyslogServer extends MockSyslogServer {
     private volatile boolean shutdown = false;
     private Thread thread;
 
-    public MockUdpSyslogServer(final int numberOfMessagesToReceive, final int port) throws SocketException {
-        super(numberOfMessagesToReceive, port);
-        this.socket = new DatagramSocket(port);
+    public MockUdpSyslogServer() throws SocketException {
+        this.socket = new DatagramSocket(0);
+    }
+
+    @Override
+    public int getLocalPort() {
+        return socket.getLocalPort();
     }
 
     @Override
@@ -42,29 +46,30 @@ public class MockUdpSyslogServer extends MockSyslogServer {
             thread.interrupt();
             try {
                 thread.join(100);
-            } catch (final InterruptedException ie) {
-                System.out.println("Shutdown of Log4j UDP server thread failed.");
+            } catch (final InterruptedException e) {
+                LOGGER.error("Shutdown of {} thread failed.", getName(), e);
             }
         }
     }
 
     @Override
     public void run() {
-        System.out.println("Log4j UDP Server started.");
+        LOGGER.info("{} started on port {}.", getName(), getLocalPort());
         this.thread = Thread.currentThread();
         final byte[] bytes = new byte[4096];
         final DatagramPacket packet = new DatagramPacket(bytes, bytes.length);
         try {
             while (!shutdown) {
                 socket.receive(packet);
-                final String str = new String(packet.getData(), 0, packet.getLength());
-                messageList.add(str);
+                final String message = new String(packet.getData(), 0, packet.getLength());
+                LOGGER.debug("{} received a message: {}", getName(), message);
+                messageList.add(message);
             }
         } catch (final Exception e) {
             if (!shutdown) {
                 Throwables.rethrow(e);
             }
         }
-        System.out.println("Log4j UDP server stopped.");
+        LOGGER.info("{} stopped.", getName());
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderCustomLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderCustomLayoutTest.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.appender.SyslogAppender.Builder;
 import org.apache.logging.log4j.core.layout.SyslogLayout;
 import org.apache.logging.log4j.core.net.Facility;
+import org.apache.logging.log4j.core.net.Protocol;
 
 public class SyslogAppenderCustomLayoutTest extends SyslogAppenderTest {
 
@@ -31,10 +32,14 @@ public class SyslogAppenderCustomLayoutTest extends SyslogAppenderTest {
     }
 
     @Override
-    protected Builder newSyslogAppenderBuilder(final String protocol, final String format, final boolean newLine) {
-        final Builder builder = super.newSyslogAppenderBuilder(protocol, format, newLine);
-        builder.setLayout((Layout<? extends Serializable>) SyslogLayout.newBuilder().setFacility(Facility.LOCAL3).setIncludeNewLine(true).build());
-        return builder;
+    protected Builder<?> newSyslogAppenderBuilder(final Protocol protocol, final String format,
+            final boolean newLine, final int port) {
+        final Layout<? extends Serializable> layout = SyslogLayout.newBuilder()
+                .setFacility(Facility.LOCAL3)
+                .setIncludeNewLine(true)
+                .build();
+        return super.newSyslogAppenderBuilder(protocol, format, newLine, port)
+                .setLayout(layout);
     }
 
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderCustomLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderCustomLayoutTest.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.core.appender.SyslogAppender.Builder;
 import org.apache.logging.log4j.core.layout.SyslogLayout;
 import org.apache.logging.log4j.core.net.Facility;
 import org.apache.logging.log4j.core.net.Protocol;
+import org.apache.logging.log4j.core.test.net.ssl.TlsSyslogMessageFormat;
 
 public class SyslogAppenderCustomLayoutTest extends SyslogAppenderTest {
 
@@ -32,7 +33,7 @@ public class SyslogAppenderCustomLayoutTest extends SyslogAppenderTest {
     }
 
     @Override
-    protected Builder<?> newSyslogAppenderBuilder(final Protocol protocol, final String format,
+    protected Builder<?> newSyslogAppenderBuilder(final Protocol protocol, final TlsSyslogMessageFormat format,
             final boolean newLine, final int port) {
         final Layout<? extends Serializable> layout = SyslogLayout.newBuilder()
                 .setFacility(Facility.LOCAL3)

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTest.java
@@ -22,7 +22,6 @@ import java.net.SocketException;
 import org.apache.logging.log4j.core.appender.SyslogAppender.Builder;
 import org.apache.logging.log4j.core.net.Protocol;
 import org.apache.logging.log4j.core.test.net.mock.MockSyslogServerFactory;
-import org.apache.logging.log4j.util.EnglishEnums;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -91,34 +90,37 @@ public class SyslogAppenderTest extends SyslogAppenderTestBase {
     }
 
     protected void initUDPTestEnvironment(final String messageFormat) throws SocketException {
-        syslogServer = MockSyslogServerFactory.createUDPSyslogServer(1, PORTNUM);
+        syslogServer = MockSyslogServerFactory.createUDPSyslogServer();
         syslogServer.start();
-        initAppender("udp", messageFormat);
+        initAppender(Protocol.UDP, messageFormat, syslogServer.getLocalPort());
     }
 
     protected void initTCPTestEnvironment(final String messageFormat) throws IOException {
-        syslogServer = MockSyslogServerFactory.createTCPSyslogServer(1, PORTNUM);
+        syslogServer = MockSyslogServerFactory.createTCPSyslogServer();
         syslogServer.start();
-        initAppender("tcp", messageFormat);
+        initAppender(Protocol.TCP, messageFormat, syslogServer.getLocalPort());
     }
 
-    protected void initAppender(final String transportFormat, final String messageFormat) {
-        appender = createAppender(transportFormat, messageFormat);
+    protected void initAppender(final Protocol protocol, final String messageFormat, final int port) {
+        appender = createAppender(protocol, messageFormat, port);
         validate(appender);
         appender.start();
         initRootLogger(appender);
     }
 
-    protected SyslogAppender createAppender(final String protocol, final String format) {
-        return newSyslogAppenderBuilder(protocol, format, includeNewLine).build();
+    protected SyslogAppender createAppender(final Protocol protocol, final String format, final int port) {
+        return newSyslogAppenderBuilder(protocol, format, includeNewLine, port).build();
     }
 
-    protected Builder newSyslogAppenderBuilder(final String protocol, final String format, final boolean newLine) {
+    protected Builder<?> newSyslogAppenderBuilder(final Protocol protocol, final String format, final boolean newLine,
+            final int port) {
         // @formatter:off
         return SyslogAppender.newSyslogAppenderBuilder()
-            .setPort(PORTNUM)
-            .setProtocol(EnglishEnums.valueOf(Protocol.class, protocol))
-            .setReconnectDelayMillis(-1).setName("TestApp").setIgnoreExceptions(false)
+            .setPort(port)
+            .setProtocol(protocol)
+            .setReconnectDelayMillis(-1)
+            .setName("TestApp")
+            .setIgnoreExceptions(false)
             .setId("Audit")
             .setEnterpriseNumber(18060)
             .setMdcId("RequestContext")

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTest.java
@@ -20,27 +20,29 @@ import java.io.IOException;
 import java.net.SocketException;
 
 import org.apache.logging.log4j.core.appender.SyslogAppender.Builder;
+import org.apache.logging.log4j.core.net.Facility;
 import org.apache.logging.log4j.core.net.Protocol;
 import org.apache.logging.log4j.core.test.net.mock.MockSyslogServerFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.net.ssl.TlsSyslogMessageFormat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-/**
- *
- */
-public class SyslogAppenderTest extends SyslogAppenderTestBase {
+import static org.apache.logging.log4j.core.test.net.ssl.TlsSyslogMessageFormat.LEGACY_BSD;
+import static org.apache.logging.log4j.core.test.net.ssl.TlsSyslogMessageFormat.SYSLOG;
+
+public abstract class SyslogAppenderTest extends SyslogAppenderTestBase {
 
     public SyslogAppenderTest() {
         root = ctx.getLogger("SyslogAppenderTest");
     }
 
-    @Before
+    @BeforeEach
     public void setUp() {
         sentMessages.clear();
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         removeAppenders();
         if (syslogServer != null) {
@@ -50,7 +52,7 @@ public class SyslogAppenderTest extends SyslogAppenderTestBase {
 
     @Test
     public void testTCPAppender() throws Exception {
-        initTCPTestEnvironment(null);
+        initTCPTestEnvironment(LEGACY_BSD);
 
         sendAndCheckLegacyBsdMessage("This is a test message");
         sendAndCheckLegacyBsdMessage("This is a test message 2");
@@ -58,7 +60,7 @@ public class SyslogAppenderTest extends SyslogAppenderTestBase {
 
     @Test
     public void testDefaultAppender() throws Exception {
-        initTCPTestEnvironment(null);
+        initTCPTestEnvironment(LEGACY_BSD);
 
         sendAndCheckLegacyBsdMessage("This is a test message");
         sendAndCheckLegacyBsdMessage("This is a test message 2");
@@ -66,14 +68,14 @@ public class SyslogAppenderTest extends SyslogAppenderTestBase {
 
     @Test
     public void testTCPStructuredAppender() throws Exception {
-        initTCPTestEnvironment("RFC5424");
+        initTCPTestEnvironment(SYSLOG);
 
         sendAndCheckStructuredMessage();
     }
 
     @Test
     public void testUDPAppender() throws Exception {
-        initUDPTestEnvironment("bsd");
+        initUDPTestEnvironment(LEGACY_BSD);
 
         sendAndCheckLegacyBsdMessage("This is a test message");
         root.removeAppender(appender);
@@ -82,52 +84,60 @@ public class SyslogAppenderTest extends SyslogAppenderTestBase {
 
     @Test
     public void testUDPStructuredAppender() throws Exception {
-        initUDPTestEnvironment("RFC5424");
+        initUDPTestEnvironment(SYSLOG);
 
         sendAndCheckStructuredMessage();
         root.removeAppender(appender);
         appender.stop();
     }
 
-    protected void initUDPTestEnvironment(final String messageFormat) throws SocketException {
+    protected void initUDPTestEnvironment(final TlsSyslogMessageFormat messageFormat) throws SocketException {
         syslogServer = MockSyslogServerFactory.createUDPSyslogServer();
         syslogServer.start();
         initAppender(Protocol.UDP, messageFormat, syslogServer.getLocalPort());
     }
 
-    protected void initTCPTestEnvironment(final String messageFormat) throws IOException {
+    protected void initTCPTestEnvironment(final TlsSyslogMessageFormat messageFormat) throws IOException {
         syslogServer = MockSyslogServerFactory.createTCPSyslogServer();
         syslogServer.start();
         initAppender(Protocol.TCP, messageFormat, syslogServer.getLocalPort());
     }
 
-    protected void initAppender(final Protocol protocol, final String messageFormat, final int port) {
+    protected void initAppender(final Protocol protocol, final TlsSyslogMessageFormat messageFormat, final int port) {
         appender = createAppender(protocol, messageFormat, port);
         validate(appender);
         appender.start();
         initRootLogger(appender);
     }
 
-    protected SyslogAppender createAppender(final Protocol protocol, final String format, final int port) {
+    protected SyslogAppender createAppender(final Protocol protocol, final TlsSyslogMessageFormat format,
+            final int port) {
         return newSyslogAppenderBuilder(protocol, format, includeNewLine, port).build();
     }
 
-    protected Builder<?> newSyslogAppenderBuilder(final Protocol protocol, final String format, final boolean newLine,
-            final int port) {
+    protected Builder<?> newSyslogAppenderBuilder(final Protocol protocol, final TlsSyslogMessageFormat format,
+            final boolean newLine, final int port) {
         // @formatter:off
         return SyslogAppender.newSyslogAppenderBuilder()
+            .setHost("localhost")
             .setPort(port)
             .setProtocol(protocol)
             .setReconnectDelayMillis(-1)
-            .setName("TestApp")
+            .setImmediateFail(true)
+            .setName("Test")
+            .setImmediateFlush(true)
             .setIgnoreExceptions(false)
+            .setFacility(Facility.LOCAL0)
             .setId("Audit")
-            .setEnterpriseNumber(18060)
+            .setEnterpriseNumber("18060")
+            .setIncludeMdc(true)
             .setMdcId("RequestContext")
-            .setNewLine(newLine)
+            .setNewLine(includeNewLine)
             .setAppName("TestApp")
             .setMsgId("Test")
-            .setFormat(format);
+            .setIncludes("ipAddress,loginId")
+            .setFormat(format == SYSLOG ? SyslogAppender.RFC5424 : null)
+            .setAdvertise(false);
         // @formatter:on
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTestBase.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTestBase.java
@@ -35,14 +35,16 @@ import org.apache.logging.log4j.core.net.Facility;
 import org.apache.logging.log4j.core.net.Priority;
 import org.apache.logging.log4j.core.test.net.mock.MockSyslogServer;
 import org.apache.logging.log4j.message.StructuredDataMessage;
+import org.apache.logging.log4j.test.junit.UsingStatusListener;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+@UsingStatusListener
 public abstract class SyslogAppenderTestBase {
     protected static final String line1 =
             "TestApp - Audit [Transfer@18060 Amount=\"200.00\" FromAccount=\"123457\" ToAccount=\"123456\"]" +
@@ -55,7 +57,7 @@ public abstract class SyslogAppenderTestBase {
     protected List<String> sentMessages = new ArrayList<>();
     protected boolean includeNewLine = true;
 
-    @BeforeClass
+    @BeforeAll
     public static void setupClass() throws Exception {
         LoggerContext.getContext().reconfigure();
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTestBase.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTestBase.java
@@ -39,7 +39,9 @@ import org.apache.logging.log4j.util.Strings;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public abstract class SyslogAppenderTestBase {
     protected static final String line1 =
@@ -47,7 +49,6 @@ public abstract class SyslogAppenderTestBase {
                     "[RequestContext@18060 ipAddress=\"192.168.0.120\" loginId=\"JohnDoe\"] Transfer Complete";
     protected LoggerContext ctx = LoggerContext.getContext();
     protected static final int DEFAULT_TIMEOUT_IN_MS = 100;
-    protected static final int PORTNUM = 8199;
     protected MockSyslogServer syslogServer;
     protected SyslogAppender appender;
     protected Logger root = ctx.getLogger("SyslogAppenderTest");


### PR DESCRIPTION
This PR modernizes Syslog tests:

 - switches the tests to use ephemeral ports,
 - migrates the tests to JUnit 5,
 - adds logging in case of failures.

I is related to #1703.