### PR TITLE
Modernize QueueFullAsync* tests

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAbstractTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAbstractTest.java
@@ -18,69 +18,198 @@ package org.apache.logging.log4j.core.async;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Stack;
 import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
 
 import com.lmax.disruptor.dsl.Disruptor;
-import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AsyncAppender;
+import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.jmx.RingBufferAdmin;
+import org.apache.logging.log4j.core.util.Constants;
+import org.apache.logging.log4j.core.util.ReflectionUtil;
+import org.apache.logging.log4j.status.StatusData;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.test.ListStatusListener;
+import org.apache.logging.log4j.test.junit.UsingStatusListener;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.Timeout.ThreadMode;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests queue full scenarios abstract superclass.
  */
+@Tag("async")
+@UsingStatusListener
+@Timeout(value = 5, unit = SECONDS, threadMode = ThreadMode.SEPARATE_THREAD)
 public abstract class QueueFullAbstractTest {
-    protected static boolean TRACE = Boolean.getBoolean(QueueFullAbstractTest.class.getSimpleName() + ".TRACE");
-    protected BlockingAppender blockingAppender;
-    protected Unlocker unlocker;
 
-    protected static void TRACE(final Object msg) {
-        if (TRACE) {
-            System.out.println(msg);
-        }
-    }
+    protected static final String APPENDER_NAME = "Blocking";
+    protected static final int BUFFER_COUNT = 128;
+    protected static final int MESSAGE_COUNT = BUFFER_COUNT + 2;
+    protected static final Logger LOGGER = StatusLogger.getLogger();
 
-    class Unlocker extends Thread {
+    protected static class Unlocker extends Thread {
+
         final CountDownLatch countDownLatch;
-        Unlocker(final CountDownLatch countDownLatch) {
+        final BlockingAppender blockingAppender;
+
+        Unlocker(final CountDownLatch countDownLatch, final BlockingAppender blockingAppender) {
             this.countDownLatch = countDownLatch;
+            this.blockingAppender = blockingAppender;
         }
+
         @Override
         public void run() {
             try {
                 countDownLatch.await();
-                TRACE("Unlocker activated. Sleeping 500 millis before taking action...");
+                LOGGER.info("Unlocker activated. Sleeping 500 millis before taking action...");
                 Thread.sleep(500);
             } catch (final InterruptedException e) {
                 throw new RuntimeException(e);
             }
-            TRACE("Unlocker signalling BlockingAppender to proceed...");
+            LOGGER.info("Unlocker signalling BlockingAppender to proceed...");
             blockingAppender.countDownLatch.countDown();
         }
     }
 
-    class DomainObject {
-        private final Logger innerLogger = LogManager.getLogger(DomainObject.class);
-        final int count;
-        DomainObject(final int loggingCount) {
+    protected static class DomainObject {
+
+        private final Logger innerLogger;
+        private final Unlocker unlocker;
+        private final int count;
+
+        public DomainObject(final Logger innerLogger, final Unlocker unlocker, final int loggingCount) {
+            this.innerLogger = innerLogger;
+            this.unlocker = unlocker;
             this.count = loggingCount;
         }
 
         @Override
         public String toString() {
             for (int i = 0; i < count; i++) {
-                TRACE("DomainObject decrementing unlocker countdown latch before logging. Count was " + unlocker.countDownLatch.getCount());
+                LOGGER.info("DomainObject logging message {}. Ring buffer capacity was {}, countdown latch was {}.",
+                        i,
+                        asyncRemainingCapacity(innerLogger),
+                        unlocker.countDownLatch.getCount());
                 unlocker.countDownLatch.countDown();
-                TRACE("DomainObject logging message " + i  + ". Remaining capacity=" + asyncRemainingCapacity(innerLogger));
-                innerLogger.info("Logging in toString() #" + i);
+                innerLogger.info("Logging in toString() #{}", i);
             }
             return "Who's bad?!";
         }
+    }
+
+    private ListStatusListener statusListener;
+
+    protected void testNormalQueueFullKeepsMessagesInOrder(final LoggerContext ctx,
+                                                           final BlockingAppender blockingAppender)
+            throws Exception {
+        checkConfig(ctx);
+        final Logger logger = ctx.getLogger(getClass());
+
+        blockingAppender.countDownLatch = new CountDownLatch(1);
+        final Unlocker unlocker = new Unlocker(new CountDownLatch(MESSAGE_COUNT - 1), blockingAppender);
+        unlocker.start();
+        asyncTest(logger, unlocker, blockingAppender);
+        unlocker.join();
+    }
+
+    protected void checkConfig(final LoggerContext ctx) throws Exception {
+    }
+
+    protected static void asyncTest(final Logger logger,
+                                    final Unlocker unlocker,
+                                    final BlockingAppender blockingAppender) {
+        for (int i = 0; i < MESSAGE_COUNT; i++) {
+            LOGGER.info("Test logging message {}. Ring buffer capacity was {}, countdown latch was {}.",
+                    i,
+                    asyncRemainingCapacity(logger),
+                    unlocker.countDownLatch.getCount());
+            unlocker.countDownLatch.countDown();
+            final String param = "I'm innocent";
+            logger.info("Logging innocent object #{}: {}", i, param);
+        }
+        LOGGER.info("Waiting for message delivery: blockingAppender.logEvents.count={}.",
+                blockingAppender.logEvents.size());
+        while (blockingAppender.logEvents.size() < MESSAGE_COUNT) {
+            Thread.yield();
+        }
+        LOGGER.info("All {} message have been delivered: blockingAppender.logEvents.count={}.",
+                MESSAGE_COUNT, blockingAppender.logEvents.size());
+
+        final Stack<String> actual = transform(blockingAppender.logEvents);
+        for (int i = 0; i < MESSAGE_COUNT; i++) {
+            assertThat(actual.pop()).isEqualTo("Logging innocent object #%d: I'm innocent", i);
+        }
+        assertThat(actual).isEmpty();
+    }
+
+    public void testLoggingFromToStringCausesOutOfOrderMessages(final LoggerContext ctx,
+                                                                final BlockingAppender blockingAppender)
+            throws Exception {
+        checkConfig(ctx);
+        // Non-reusable messages will call `toString()` on the main thread and block it.
+        final Logger logger = ctx.getLogger(this.getClass());
+
+        blockingAppender.countDownLatch = new CountDownLatch(1);
+        final Unlocker unlocker = new Unlocker(new CountDownLatch(MESSAGE_COUNT - 1), blockingAppender);
+        unlocker.start();
+        asyncRecursiveTest(logger, unlocker, blockingAppender);
+        unlocker.join();
+    }
+
+    void asyncRecursiveTest(final Logger logger,
+                            final Unlocker unlocker,
+                            final BlockingAppender blockingAppender) {
+        for (int i = 0; i < 1; i++) {
+            LOGGER.info("Test logging message {}. Ring buffer capacity was {}, countdown latch was {}.",
+                    i,
+                    asyncRemainingCapacity(logger),
+                    unlocker.countDownLatch.getCount());
+            unlocker.countDownLatch.countDown();
+            final DomainObject obj = new DomainObject(logger, unlocker, MESSAGE_COUNT - 1);
+            logger.info("Logging naughty object #{}: {}", i, obj);
+        }
+
+        LOGGER.info("Waiting for message delivery: blockingAppender.logEvents.count={}.", blockingAppender.logEvents.size());
+        while (blockingAppender.logEvents.size() < MESSAGE_COUNT) {
+            Thread.yield();
+        }
+        LOGGER.info("All {} messages have been delivered: blockingAppender.logEvents.count={}.",
+                MESSAGE_COUNT, blockingAppender.logEvents.size());
+
+        final StatusData mostRecentStatusData = statusListener.findStatusData(Level.WARN)
+                .reduce((ignored, data) -> data)
+                .orElse(null);
+        assertThat(mostRecentStatusData).isNotNull();
+        assertThat(mostRecentStatusData.getLevel()).isEqualTo(Level.WARN);
+        assertThat(mostRecentStatusData.getFormattedStatus()).contains(
+                "Log4j2 logged an event out of order to prevent deadlock caused by domain " +
+                        "objects logging from their toString method when the async queue is full");
+
+        final List<String> actual = blockingAppender.logEvents.stream()
+                .map(e -> e.getMessage().getFormattedMessage())
+                .collect(Collectors.toList());
+        final String[] expected = new String[MESSAGE_COUNT];
+        for (int i = 0; i < MESSAGE_COUNT - 1; i++) {
+            expected[i]  = "Logging in toString() #" + i;
+        }
+        expected[MESSAGE_COUNT - 1] = "Logging naughty object #0: Who's bad?!";
+        assertThat(actual).hasSize(MESSAGE_COUNT)
+                .contains(expected);
     }
 
     static Stack<String> transform(final List<LogEvent> logEvents) {
@@ -120,9 +249,47 @@ public abstract class QueueFullAbstractTest {
         }
         throw new IllegalStateException("Neither Async Loggers nor AsyncAppender are configured");
     }
-    private static Field field(final Class<?> c, final String name) throws NoSuchFieldException {
+
+    protected static Field field(final Class<?> c, final String name) throws NoSuchFieldException {
         final Field f = c.getDeclaredField(name);
-        f.setAccessible(true);
+        ReflectionUtil.makeAccessible(f);
         return f;
+    }
+
+    protected static void assertAsyncAppender(final LoggerContext ctx) {
+        assertThat(ctx).isNotInstanceOf(AsyncLoggerContext.class);
+
+        final Configuration config = ctx.getConfiguration();
+        assertThat(config).isNotNull();
+        assertThat(config.getRootLogger()).isNotInstanceOf(AsyncLoggerConfig.class);
+
+        final Collection<Appender> appenders = config.getRootLogger().getAppenders().values();
+        assertThat(appenders).hasSize(1).allMatch(AsyncAppender.class::isInstance);
+    }
+
+    protected static void assertAsyncLogger(final LoggerContext ctx, final int expectedBufferSize) {
+        assertThat(ctx).isInstanceOf(AsyncLoggerContext.class);
+        final RingBufferAdmin ringBufferAdmin = ((AsyncLoggerContext) ctx).createRingBufferAdmin();
+        assertThat(ringBufferAdmin.getRemainingCapacity()).isEqualTo(expectedBufferSize);
+
+        final Configuration config = ctx.getConfiguration();
+        assertThat(config).isNotNull();
+        assertThat(config.getRootLogger()).isNotInstanceOf(AsyncLoggerConfig.class);
+    }
+
+    protected static void assertAsyncLoggerConfig(final LoggerContext ctx, final int expectedBufferSize)
+            throws ReflectiveOperationException {
+        assertThat(ctx).isNotInstanceOf(AsyncLoggerContext.class);
+
+        final Configuration config = ctx.getConfiguration();
+        assertThat(config).isNotNull();
+        assertThat(config.getRootLogger()).isInstanceOf(AsyncLoggerConfig.class);
+        final AsyncLoggerConfigDisruptor disruptor = (AsyncLoggerConfigDisruptor) config.getAsyncLoggerConfigDelegate();
+        final Field sizeField = field(AsyncLoggerConfigDisruptor.class, "ringBufferSize");
+        assertThat(sizeField.get(disruptor)).isEqualTo(expectedBufferSize);
+    }
+
+    protected static void assertFormatMessagesInBackground() {
+        assertThat(Constants.FORMAT_MESSAGES_IN_BACKGROUND).isTrue();
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncAppenderTest.java
@@ -16,78 +16,29 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import java.util.Stack;
-import java.util.concurrent.CountDownLatch;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
 
 /**
  * Tests queue full scenarios with AsyncAppender.
  */
-@RunWith(BlockJUnit4ClassRunner.class)
-@Category(AsyncLoggers.class)
 public class QueueFullAsyncAppenderTest extends QueueFullAbstractTest {
 
-    @BeforeClass
-    public static void beforeClass() {
-        System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
-                "log4j2-queueFullAsyncAppender.xml");
+    @Override
+    @Test
+    @LoggerContextSource
+    protected void testNormalQueueFullKeepsMessagesInOrder(final LoggerContext ctx,
+                                                           final @Named(APPENDER_NAME) BlockingAppender blockingAppender)
+            throws Exception {
+        super.testNormalQueueFullKeepsMessagesInOrder(ctx, blockingAppender);
     }
 
-    @Rule
-    public LoggerContextRule context = new LoggerContextRule(
-            "log4j2-queueFullAsyncAppender.xml");
-
-    @Before
-    public void before() throws Exception {
-        blockingAppender = context.getRequiredAppender("Blocking", BlockingAppender.class);
-    }
-
-
-    @Test(timeout = 5000)
-    public void testNormalQueueFullKeepsMessagesInOrder() throws InterruptedException {
-        final Logger logger = LogManager.getLogger(this.getClass());
-
-        blockingAppender.countDownLatch = new CountDownLatch(1);
-        unlocker = new Unlocker(new CountDownLatch(129));
-        unlocker.start();
-
-        asyncAppenderTest(logger, unlocker, blockingAppender);
-    }
-
-    static void asyncAppenderTest(final Logger logger,
-                                  final Unlocker unlocker,
-                                  final BlockingAppender blockingAppender) {
-        for (int i = 0; i < 130; i++) {
-            TRACE("Test logging message " + i  + ". Remaining capacity=" + asyncRemainingCapacity(logger));
-            TRACE("Test decrementing unlocker countdown latch. Count=" + unlocker.countDownLatch.getCount());
-            unlocker.countDownLatch.countDown();
-            final String param = "I'm innocent";
-            logger.info(new ParameterizedMessage("logging innocent object #{} {}", i, param));
-        }
-        TRACE("Before stop() blockingAppender.logEvents.count=" + blockingAppender.logEvents.size());
-        //CoreLoggerContexts.stopLoggerContext(false); // stop async thread
-        while (blockingAppender.logEvents.size() < 130) { Thread.yield(); }
-        TRACE("After  stop() blockingAppender.logEvents.count=" + blockingAppender.logEvents.size());
-
-        final Stack<String> actual = transform(blockingAppender.logEvents);
-        for (int i = 0; i < 130; i++) {
-            assertEquals("logging innocent object #" + i + " I'm innocent", actual.pop());
-        }
-        assertTrue(actual.isEmpty());
+    @Override
+    protected void checkConfig(final LoggerContext ctx) {
+        assertAsyncAppender(ctx);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncAppenderTest2.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncAppenderTest2.java
@@ -16,55 +16,20 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import java.util.concurrent.CountDownLatch;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
 
 /**
- * Tests queue full scenarios with AsyncAppender.
+ * Needs to be a separate class since {@link org.apache.logging.log4j.core.util.Constants#FORMAT_MESSAGES_IN_BACKGROUND}
+ * is immutable.
  */
-@RunWith(BlockJUnit4ClassRunner.class)
-@Category(AsyncLoggers.class)
-public class QueueFullAsyncAppenderTest2 extends QueueFullAbstractTest {
+@SetTestProperty(key = "log4j2.formatMsgAsync", value = "true")
+public class QueueFullAsyncAppenderTest2 extends QueueFullAsyncAppenderTest {
 
-    @BeforeClass
-    public static void beforeClass() {
-        //FORMAT_MESSAGES_IN_BACKGROUND
-        System.setProperty("log4j.format.msg.async", "true");
-
-        System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
-                "log4j2-queueFullAsyncAppender.xml");
-    }
-
-    @Rule
-    public LoggerContextRule context = new LoggerContextRule(
-            "log4j2-queueFullAsyncAppender.xml");
-
-    @Before
-    public void before() throws Exception {
-        blockingAppender = context.getRequiredAppender("Blocking", BlockingAppender.class);
-    }
-
-
-    @Test(timeout = 5000)
-    public void testNormalQueueFullKeepsMessagesInOrder() throws InterruptedException {
-        final Logger logger = LogManager.getLogger(this.getClass());
-
-        blockingAppender.countDownLatch = new CountDownLatch(1);
-        unlocker = new Unlocker(new CountDownLatch(129));
-        unlocker.start();
-
-        QueueFullAsyncAppenderTest.asyncAppenderTest(logger, unlocker, blockingAppender);
+    @Override
+    protected void checkConfig(final LoggerContext ctx) {
+        super.checkConfig(ctx);
+        assertFormatMessagesInBackground();
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest.java
@@ -16,97 +16,35 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import java.util.List;
-import java.util.Stack;
-import java.util.concurrent.CountDownLatch;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.apache.logging.log4j.util.Constants;
+import org.junit.jupiter.api.Test;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.apache.logging.log4j.status.StatusData;
-import org.apache.logging.log4j.status.StatusLogger;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
-
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.*;
-
+import static org.assertj.core.api.Assertions.*;
 /**
  * Tests queue full scenarios with AsyncLoggers in configuration.
  */
-@RunWith(BlockJUnit4ClassRunner.class)
-@Category(AsyncLoggers.class)
+@SetTestProperty(key = "log4j2.enableThreadlocals", value = "true")
+@SetTestProperty(key = "log4j2.isWebapp", value= "false")
+@SetTestProperty(key = "log4j2.asyncLoggerConfigRingBufferSize", value = "128")
 public class QueueFullAsyncLoggerConfigLoggingFromToStringTest extends QueueFullAbstractTest {
 
-    @BeforeClass
-    public static void beforeClass() {
-        System.setProperty("log4j2.enable.threadlocals", "true");
-        System.setProperty("log4j2.is.webapp", "false");
-        System.setProperty("AsyncLoggerConfig.RingBufferSize", "128");
-        System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
-                "log4j2-queueFullAsyncLoggerConfig.xml");
+    @Override
+    @Test
+    @LoggerContextSource
+    public void testLoggingFromToStringCausesOutOfOrderMessages(final LoggerContext ctx,
+                                                                final @Named(APPENDER_NAME) BlockingAppender blockingAppender)
+            throws Exception {
+        super.testLoggingFromToStringCausesOutOfOrderMessages(ctx, blockingAppender);
     }
 
-    @Rule
-    public LoggerContextRule context = new LoggerContextRule(
-            "log4j2-queueFullAsyncLoggerConfig.xml");
-
-    @Before
-    public void before() throws Exception {
-        blockingAppender = context.getRequiredAppender("Blocking", BlockingAppender.class);
-    }
-
-    @Test(timeout = 5000)
-    public void testLoggingFromToStringCausesOutOfOrderMessages() throws InterruptedException {
-        //TRACE = true;
-        final Logger logger = LogManager.getLogger(this.getClass());
-
-        blockingAppender.countDownLatch = new CountDownLatch(1);
-        unlocker = new Unlocker(new CountDownLatch(129)); // count slightly different from "pure" async loggers
-        unlocker.start();
-
-        asyncLoggerConfigRecursiveTest(logger, unlocker, blockingAppender, this);
-    }
-
-    static void asyncLoggerConfigRecursiveTest(final Logger logger,
-                                               final Unlocker unlocker,
-                                               final BlockingAppender blockingAppender,
-                                               final QueueFullAbstractTest factory) {
-        for (int i = 0; i < 1; i++) {
-            TRACE("Test logging message " + i  + ". Remaining capacity=" + asyncRemainingCapacity(logger));
-            TRACE("Test decrementing unlocker countdown latch. Count=" + unlocker.countDownLatch.getCount());
-            unlocker.countDownLatch.countDown();
-            final DomainObject obj = factory.new DomainObject(129);
-            logger.info("logging naughty object #{} {}", i, obj);
-        }
-        TRACE("Before stop() blockingAppender.logEvents.count=" + blockingAppender.logEvents.size());
-        //CoreLoggerContexts.stopLoggerContext(false); // stop async thread
-        while (blockingAppender.logEvents.size() < 130) { Thread.yield(); }
-        TRACE("After  stop() blockingAppender.logEvents.count=" + blockingAppender.logEvents.size());
-
-        final Stack<String> actual = transform(blockingAppender.logEvents);
-        assertEquals("Logging in toString() #0", actual.pop());
-        final List<StatusData> statusDataList = StatusLogger.getLogger().getStatusData();
-        assertEquals("Jumped the queue: queue full",
-                "Logging in toString() #128", actual.pop());
-        final StatusData mostRecentStatusData = statusDataList.get(statusDataList.size() - 1);
-        assertEquals("Expected warn level status message", Level.WARN, mostRecentStatusData.getLevel());
-        assertThat(mostRecentStatusData.getFormattedStatus(), containsString(
-                "Log4j2 logged an event out of order to prevent deadlock caused by domain " +
-                        "objects logging from their toString method when the async queue is full"));
-
-        for (int i = 1; i < 128; i++) {
-            assertEquals("First batch", "Logging in toString() #" + i, actual.pop());
-        }
-        assertEquals("logging naughty object #0 Who's bad?!", actual.pop());
-        assertTrue(actual.isEmpty());
+    @Override
+    protected void checkConfig(final LoggerContext ctx) throws ReflectiveOperationException {
+        assertAsyncLoggerConfig(ctx, 128);
+        assertThat(Constants.IS_WEB_APP).isFalse();
+        assertThat(Constants.ENABLE_THREADLOCALS).isTrue();
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest2.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest2.java
@@ -16,58 +16,20 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import java.util.concurrent.CountDownLatch;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
+
 
 /**
  * Tests queue full scenarios with AsyncLoggers in configuration.
  */
-@RunWith(BlockJUnit4ClassRunner.class)
-@Category(AsyncLoggers.class)
-public class QueueFullAsyncLoggerConfigLoggingFromToStringTest2 extends QueueFullAbstractTest {
+@SetTestProperty(key = "log4j2.formatMsgAsync", value = "true")
+public class QueueFullAsyncLoggerConfigLoggingFromToStringTest2 extends QueueFullAsyncLoggerConfigLoggingFromToStringTest {
 
-    @BeforeClass
-    public static void beforeClass() {
-        //FORMAT_MESSAGES_IN_BACKGROUND
-        System.setProperty("log4j.format.msg.async", "true");
-
-        System.setProperty("log4j2.enable.threadlocals", "true");
-        System.setProperty("log4j2.is.webapp", "false");
-        System.setProperty("AsyncLoggerConfig.RingBufferSize", "128");
-        System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
-                "log4j2-queueFullAsyncLoggerConfig.xml");
-    }
-
-    @Rule
-    public LoggerContextRule context = new LoggerContextRule(
-            "log4j2-queueFullAsyncLoggerConfig.xml");
-
-    @Before
-    public void before() throws Exception {
-        blockingAppender = context.getRequiredAppender("Blocking", BlockingAppender.class);
-    }
-
-    @Test(timeout = 5000)
-    public void testLoggingFromToStringCausesOutOfOrderMessages() throws InterruptedException {
-        //TRACE = true;
-        final Logger logger = LogManager.getLogger(this.getClass());
-
-        blockingAppender.countDownLatch = new CountDownLatch(1);
-        unlocker = new Unlocker(new CountDownLatch(129)); // count slightly different from "pure" async loggers
-        unlocker.start();
-
-        QueueFullAsyncLoggerConfigLoggingFromToStringTest.asyncLoggerConfigRecursiveTest(logger, unlocker, blockingAppender, this);
+    @Override
+    protected void checkConfig(final LoggerContext ctx) throws ReflectiveOperationException {
+        super.checkConfig(ctx);
+        assertFormatMessagesInBackground();
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigTest.java
@@ -16,79 +16,31 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import java.util.Stack;
-import java.util.concurrent.CountDownLatch;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
 
 /**
  * Tests queue full scenarios with AsyncLoggers in configuration.
  */
-@RunWith(BlockJUnit4ClassRunner.class)
-@Category(AsyncLoggers.class)
+@SetTestProperty(key = "log4j2.asyncLoggerConfigRingBufferSize", value = "128")
 public class QueueFullAsyncLoggerConfigTest extends QueueFullAbstractTest {
 
-    @BeforeClass
-    public static void beforeClass() {
-        System.setProperty("AsyncLoggerConfig.RingBufferSize", "128"); // minimum ringbuffer size
-        System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
-                "log4j2-queueFullAsyncLoggerConfig.xml");
+    @Override
+    @Test
+    @LoggerContextSource
+    protected void testNormalQueueFullKeepsMessagesInOrder(final LoggerContext ctx,
+                                                           final @Named(APPENDER_NAME) BlockingAppender blockingAppender)
+            throws Exception {
+        super.testNormalQueueFullKeepsMessagesInOrder(ctx, blockingAppender);
     }
 
-    @Rule
-    public LoggerContextRule context = new LoggerContextRule(
-            "log4j2-queueFullAsyncLoggerConfig.xml");
-
-    @Before
-    public void before() throws Exception {
-        blockingAppender = context.getRequiredAppender("Blocking", BlockingAppender.class);
-    }
-
-
-    @Test(timeout = 5000)
-    public void testNormalQueueFullKeepsMessagesInOrder() throws InterruptedException {
-        final Logger logger = LogManager.getLogger(this.getClass());
-
-        blockingAppender.countDownLatch = new CountDownLatch(1);
-        unlocker = new Unlocker(new CountDownLatch(129));
-        unlocker.start();
-
-        asyncLoggerConfigTest(logger, unlocker, blockingAppender);
-    }
-
-    static void asyncLoggerConfigTest(final Logger logger,
-                                      final Unlocker unlocker,
-                                      final BlockingAppender blockingAppender) {
-        for (int i = 0; i < 130; i++) {
-            TRACE("Test logging message " + i  + ". Remaining capacity=" + asyncRemainingCapacity(logger));
-            TRACE("Test decrementing unlocker countdown latch. Count=" + unlocker.countDownLatch.getCount());
-            unlocker.countDownLatch.countDown();
-            final String param = "I'm innocent";
-            logger.info(new ParameterizedMessage("logging innocent object #{} {}", i, param));
-        }
-        TRACE("Before stop() blockingAppender.logEvents.count=" + blockingAppender.logEvents.size());
-        //CoreLoggerContexts.stopLoggerContext(false); // stop async thread
-        while (blockingAppender.logEvents.size() < 130) { Thread.yield(); }
-        TRACE("After  stop() blockingAppender.logEvents.count=" + blockingAppender.logEvents.size());
-
-        final Stack<String> actual = transform(blockingAppender.logEvents);
-        for (int i = 0; i < 130; i++) {
-            assertEquals("logging innocent object #" + i + " I'm innocent", actual.pop());
-        }
-        assertTrue(actual.isEmpty());
+    @Override
+    protected void checkConfig(final LoggerContext ctx) throws ReflectiveOperationException {
+        assertAsyncLoggerConfig(ctx, 128);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigTest2.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigTest2.java
@@ -16,56 +16,20 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import java.util.concurrent.CountDownLatch;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
+
 
 /**
  * Tests queue full scenarios with AsyncLoggers in configuration.
  */
-@RunWith(BlockJUnit4ClassRunner.class)
-@Category(AsyncLoggers.class)
-public class QueueFullAsyncLoggerConfigTest2 extends QueueFullAbstractTest {
+@SetTestProperty(key = "log4j2.formatMsgAsync", value = "true")
+public class QueueFullAsyncLoggerConfigTest2 extends QueueFullAsyncLoggerConfigTest {
 
-    @BeforeClass
-    public static void beforeClass() {
-        //FORMAT_MESSAGES_IN_BACKGROUND
-        System.setProperty("log4j.format.msg.async", "true");
-
-        System.setProperty("AsyncLoggerConfig.RingBufferSize", "128"); // minimum ringbuffer size
-        System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
-                "log4j2-queueFullAsyncLoggerConfig.xml");
-    }
-
-    @Rule
-    public LoggerContextRule context = new LoggerContextRule(
-            "log4j2-queueFullAsyncLoggerConfig.xml");
-
-    @Before
-    public void before() throws Exception {
-        blockingAppender = context.getRequiredAppender("Blocking", BlockingAppender.class);
-    }
-
-
-    @Test(timeout = 5000)
-    public void testNormalQueueFullKeepsMessagesInOrder() throws InterruptedException {
-        final Logger logger = LogManager.getLogger(this.getClass());
-
-        blockingAppender.countDownLatch = new CountDownLatch(1);
-        unlocker = new Unlocker(new CountDownLatch(129));
-        unlocker.start();
-
-        QueueFullAsyncLoggerConfigTest.asyncLoggerConfigTest(logger, unlocker, blockingAppender);
+    @Override
+    protected void checkConfig(final LoggerContext ctx) throws ReflectiveOperationException {
+        super.checkConfig(ctx);
+        assertFormatMessagesInBackground();
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest.java
@@ -16,93 +16,34 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import java.util.Stack;
-import java.util.concurrent.CountDownLatch;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
 import org.apache.logging.log4j.core.util.Constants;
-import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
 
 /**
  * Tests queue full scenarios with pure AsyncLoggers (all loggers async).
  */
-@RunWith(BlockJUnit4ClassRunner.class)
-@Category(AsyncLoggers.class)
+@SetTestProperty(key = Constants.LOG4J_CONTEXT_SELECTOR, value = "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector")
+@SetTestProperty(key = "log4j2.asyncLoggerRingBufferSize", value = "128")
 public class QueueFullAsyncLoggerLoggingFromToStringTest extends QueueFullAbstractTest {
 
-    @BeforeClass
-    public static void beforeClass() {
-        System.setProperty("AsyncLogger.RingBufferSize", "128"); // minimum ringbuffer size
-        System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
-                "log4j2-queueFull.xml");
+    @Override
+    @Test
+    @LoggerContextSource
+    public void testLoggingFromToStringCausesOutOfOrderMessages(final LoggerContext ctx,
+                                                                final @Named(APPENDER_NAME) BlockingAppender blockingAppender)
+            throws Exception {
+        super.testLoggingFromToStringCausesOutOfOrderMessages(ctx, blockingAppender);
     }
 
-    @AfterClass
-    public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
+    @Override
+    protected void checkConfig(final LoggerContext ctx) {
+        assertAsyncLogger(ctx, 128);
     }
 
-    @Rule
-    public LoggerContextRule context = new LoggerContextRule(
-            "log4j2-queueFull.xml", AsyncLoggerContextSelector.class);
-
-    @Before
-    public void before() throws Exception {
-        blockingAppender = context.getRequiredAppender("Blocking", BlockingAppender.class);
-    }
-
-    @Test(timeout = 5000)
-    public void testLoggingFromToStringCausesOutOfOrderMessages() throws InterruptedException {
-        final Logger logger = LogManager.getLogger(this.getClass());
-
-        blockingAppender.countDownLatch = new CountDownLatch(1);
-        unlocker = new Unlocker(new CountDownLatch(129));
-        unlocker.start();
-
-        asyncLoggerRecursiveTest(logger, unlocker, blockingAppender, this);
-    }
-
-    static void asyncLoggerRecursiveTest(final Logger logger,
-                                         final Unlocker unlocker,
-                                         final BlockingAppender blockingAppender,
-                                         final QueueFullAbstractTest factory) {
-        for (int i = 0; i < 1; i++) {
-            TRACE("Test logging message " + i  + ". Remaining capacity=" + asyncRemainingCapacity(logger));
-            TRACE("Test decrementing unlocker countdown latch. Count=" + unlocker.countDownLatch.getCount());
-            unlocker.countDownLatch.countDown();
-            final DomainObject obj = factory.new DomainObject(129);
-            logger.info(new ParameterizedMessage("logging naughty object #{} {}", i, obj));
-        }
-        TRACE("Before stop() blockingAppender.logEvents.count=" + blockingAppender.logEvents.size());
-        CoreLoggerContexts.stopLoggerContext(false); // stop async thread
-        while (blockingAppender.logEvents.size() < 129) { Thread.yield(); }
-        TRACE("After  stop() blockingAppender.logEvents.count=" + blockingAppender.logEvents.size());
-
-        final Stack<String> actual = transform(blockingAppender.logEvents);
-        assertEquals("Jumped the queue: test(2)+domain1(65)+domain2(61)=128: queue full",
-                "Logging in toString() #127", actual.pop());
-        assertEquals("Logging in toString() #128", actual.pop());
-        assertEquals("logging naughty object #0 Who's bad?!", actual.pop());
-
-        for (int i = 0; i < 127; i++) {
-            assertEquals("First batch", "Logging in toString() #" + i, actual.pop());
-        }
-        assertTrue(actual.isEmpty());
-    }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest2.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest2.java
@@ -16,93 +16,28 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import java.util.Stack;
-import java.util.concurrent.CountDownLatch;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.CoreLoggerContexts;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.apache.logging.log4j.core.util.Constants;
-import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.junit.jupiter.api.Disabled;
 
 import static org.junit.Assert.*;
 
 /**
  * Tests queue full scenarios with pure AsyncLoggers (all loggers async).
  */
-@Ignore
-@RunWith(BlockJUnit4ClassRunner.class)
-@Category(AsyncLoggers.class)
-public class QueueFullAsyncLoggerLoggingFromToStringTest2 extends QueueFullAbstractTest {
+@SetTestProperty(key = "log4j2.formatMsgAsync", value = "true")
+public class QueueFullAsyncLoggerLoggingFromToStringTest2 extends QueueFullAsyncLoggerLoggingFromToStringTest {
 
-    @BeforeClass
-    public static void beforeClass() {
-        //FORMAT_MESSAGES_IN_BACKGROUND
-        System.setProperty("log4j.format.msg.async", "true");
-
-        System.setProperty("AsyncLogger.RingBufferSize", "128"); // minimum ringbuffer size
-        System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
-                "log4j2-queueFull.xml");
+    @Override
+    @Disabled("Causes deadlocks")
+    public void testLoggingFromToStringCausesOutOfOrderMessages(LoggerContext ctx, BlockingAppender blockingAppender) throws Exception {
+        super.testLoggingFromToStringCausesOutOfOrderMessages(ctx, blockingAppender);
     }
 
-    @AfterClass
-    public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
-    }
-
-    @Rule
-    public LoggerContextRule context = new LoggerContextRule(
-            "log4j2-queueFull.xml", AsyncLoggerContextSelector.class);
-
-    @Before
-    public void before() throws Exception {
-        blockingAppender = context.getRequiredAppender("Blocking", BlockingAppender.class);
-        TRACE = true;
-    }
-
-    @Ignore
-    @Test(timeout = 5000)
-    public void testLoggingFromToStringCausesOutOfOrderMessages() throws InterruptedException {
-        final Logger logger = LogManager.getLogger(this.getClass());
-
-        blockingAppender.countDownLatch = new CountDownLatch(1);
-        unlocker = new Unlocker(new CountDownLatch(129));
-        unlocker.start();
-
-        for (int i = 0; i < 1; i++) {
-            TRACE("Test logging message " + i  + ". Remaining capacity=" + asyncRemainingCapacity(logger));
-            TRACE("Test decrementing unlocker countdown latch. Count=" + unlocker.countDownLatch.getCount());
-            unlocker.countDownLatch.countDown();
-            final DomainObject obj = new DomainObject(129);
-            logger.info(new ParameterizedMessage("logging naughty object #{} {}", i, obj));
-        }
-        TRACE("Before stop() blockingAppender.logEvents.count=" + blockingAppender.logEvents.size());
-        CoreLoggerContexts.stopLoggerContext(false); // stop async thread
-        while (blockingAppender.logEvents.size() < 129) { Thread.yield(); }
-        TRACE("After  stop() blockingAppender.logEvents.count=" + blockingAppender.logEvents.size());
-
-        final Stack<String> actual = transform(blockingAppender.logEvents);
-        assertEquals("Jumped the queue: test(2)+domain1(65)+domain2(61)=128: queue full",
-                "Logging in toString() #127 (Log4j2 logged this message out of order to prevent deadlock caused by domain objects logging from their toString method when the async queue is full - LOG4J2-2031)", actual.pop());
-        assertEquals("Logging in toString() #128 (Log4j2 logged this message out of order to prevent deadlock caused by domain objects logging from their toString method when the async queue is full - LOG4J2-2031)", actual.pop());
-        assertEquals("logging naughty object #0 Who's bad?!", actual.pop());
-
-        for (int i = 0; i < 127; i++) {
-            assertEquals("First batch", "Logging in toString() #" + i, actual.pop());
-        }
-        assertTrue(actual.isEmpty());
+    @Override
+    protected void checkConfig(final LoggerContext ctx) {
+        super.checkConfig(ctx);
+        assertFormatMessagesInBackground();
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest.java
@@ -16,87 +16,32 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import java.util.Stack;
-import java.util.concurrent.CountDownLatch;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
 import org.apache.logging.log4j.core.util.Constants;
-import org.apache.logging.log4j.message.ParameterizedMessage;
-import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.junit.runners.BlockJUnit4ClassRunner;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
 
 /**
  * Tests queue full scenarios with pure AsyncLoggers (all loggers async).
  */
-@RunWith(BlockJUnit4ClassRunner.class)
-@Category(AsyncLoggers.class)
+@SetTestProperty(key = Constants.LOG4J_CONTEXT_SELECTOR, value = "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector")
+@SetTestProperty(key = "log4j2.asyncLoggerRingBufferSize", value = "128")
 public class QueueFullAsyncLoggerTest extends QueueFullAbstractTest {
 
-    @BeforeClass
-    public static void beforeClass() {
-        System.setProperty("AsyncLogger.RingBufferSize", "128"); // minimum ringbuffer size
-        System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
-                "log4j2-queueFull.xml");
+    @Override
+    @Test
+    @LoggerContextSource
+    protected void testNormalQueueFullKeepsMessagesInOrder(final LoggerContext ctx,
+                                                           final @Named(APPENDER_NAME) BlockingAppender blockingAppender)
+            throws Exception {
+        super.testNormalQueueFullKeepsMessagesInOrder(ctx, blockingAppender);
     }
 
-    @AfterClass
-    public static void afterClass() {
-        System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
-    }
-
-    @Rule
-    public LoggerContextRule context = new LoggerContextRule(
-            "log4j2-queueFull.xml", AsyncLoggerContextSelector.class);
-
-    @Before
-    public void before() throws Exception {
-        blockingAppender = context.getRequiredAppender("Blocking", BlockingAppender.class);
-    }
-
-
-    @Test(timeout = 5000)
-    public void testNormalQueueFullKeepsMessagesInOrder() throws InterruptedException {
-        final Logger logger = LogManager.getLogger(this.getClass());
-
-        blockingAppender.countDownLatch = new CountDownLatch(1);
-        unlocker = new Unlocker(new CountDownLatch(129));
-        unlocker.start();
-
-        asyncLoggerTest(logger, unlocker, blockingAppender);
-    }
-
-    static void asyncLoggerTest(final Logger logger,
-                                final Unlocker unlocker,
-                                final BlockingAppender blockingAppender) {
-        for (int i = 0; i < 130; i++) {
-            TRACE("Test logging message " + i  + ". Remaining capacity=" + asyncRemainingCapacity(logger));
-            TRACE("Test decrementing unlocker countdown latch. Count=" + unlocker.countDownLatch.getCount());
-            unlocker.countDownLatch.countDown();
-            final String param = "I'm innocent";
-            logger.info(new ParameterizedMessage("logging innocent object #{} {}", i, param));
-        }
-        TRACE("Before stop() blockingAppender.logEvents.count=" + blockingAppender.logEvents.size());
-        //CoreLoggerContexts.stopLoggerContext(false); // stop async thread
-        while (blockingAppender.logEvents.size() < 130) { Thread.yield(); }
-        TRACE("After  stop() blockingAppender.logEvents.count=" + blockingAppender.logEvents.size());
-
-        final Stack<String> actual = transform(blockingAppender.logEvents);
-        for (int i = 0; i < 130; i++) {
-            assertEquals("logging innocent object #" + i + " I'm innocent", actual.pop());
-        }
-        assertTrue(actual.isEmpty());
+    @Override
+    protected void checkConfig(final LoggerContext ctx) {
+        assertAsyncLogger(ctx, 128);
     }
 }

--- a/log4j-core-test/src/test/resources/org/apache/logging/log4j/core/async/QueueFullAbstractTest.xml
+++ b/log4j-core-test/src/test/resources/org/apache/logging/log4j/core/async/QueueFullAbstractTest.xml
@@ -15,17 +15,13 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="WARN">
+<Configuration status="OFF" name="QueueFullAbstractTest">
   <Appenders>
-    <Blocking name="Blocking">
-    </Blocking>
-    <Async name="async" bufferSize="128">
-      <AppenderRef ref="Blocking"/>
-    </Async>
+    <Blocking name="Blocking" />
   </Appenders>
   <Loggers>
     <Root level="debug">
-      <AppenderRef ref="async" />
+      <AppenderRef ref="Blocking" />
     </Root>
   </Loggers>
 </Configuration>

--- a/log4j-core-test/src/test/resources/org/apache/logging/log4j/core/async/QueueFullAsyncAppenderTest.xml
+++ b/log4j-core-test/src/test/resources/org/apache/logging/log4j/core/async/QueueFullAsyncAppenderTest.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="OFF" name="QueueFullAsyncAppenderTest">
+  <Appenders>
+    <Blocking name="Blocking" />
+    <Async name="async" bufferSize="128">
+      <AppenderRef ref="Blocking" />
+    </Async>
+  </Appenders>
+  <Loggers>
+    <Root level="debug">
+      <AppenderRef ref="async" />
+    </Root>
+  </Loggers>
+</Configuration>

--- a/log4j-core-test/src/test/resources/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest.xml
+++ b/log4j-core-test/src/test/resources/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest.xml
@@ -15,14 +15,13 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="WARN">
+<Configuration status="OFF" name="QueueFullAsyncLoggerConfigTest">
   <Appenders>
-    <Blocking name="Blocking">
-    </Blocking>
+    <Blocking name="Blocking" />
   </Appenders>
   <Loggers>
-    <Root level="debug">
+    <AsyncRoot level="debug">
       <AppenderRef ref="Blocking" />
-    </Root>
+    </AsyncRoot>
   </Loggers>
 </Configuration>

--- a/log4j-core-test/src/test/resources/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigTest.xml
+++ b/log4j-core-test/src/test/resources/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigTest.xml
@@ -15,10 +15,9 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="WARN">
+<Configuration status="OFF" name="QueueFullAsyncLoggerConfigTest">
   <Appenders>
-    <Blocking name="Blocking">
-    </Blocking>
+    <Blocking name="Blocking" />
   </Appenders>
   <Loggers>
     <AsyncRoot level="debug">


### PR DESCRIPTION
This PR modernizes tests that check the behavior of async components when their queue/ringbuffer is full:

 * it migrates them to JUnit5,
 * it makes them more parallelisable,
 * it moves from Hamcrest to AssertJ.
 
 It is part of the ongoing #1778 effort.
