### PR TITLE
Improve warning message if multi-release JARs are not supported

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -80,7 +80,7 @@ public final class StackLocator {
         } catch (final Exception | LinkageError e) {
             if (Constants.JAVA_MAJOR_VERSION > 8) {
                 LowLevelLogUtil.log(
-                        "WARNING: Runtime environment does not support multi-release JARs. This will impact location-based features.");
+                        "WARNING: Runtime environment or build system does not support multi-release JARs. This will impact location-based features.");
             } else {
                 LowLevelLogUtil.log(
                         "WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact location-based features.");


### PR DESCRIPTION
This is a follow up from my pervious PR [1]. Unfortunatly, it only occured to me after it was merged that the warning message is incomplete. In my case it was not the runtime environment which did not support multi-release JARs, but the build system. This adjusts the message accordingly.

1: https://github.com/apache/logging-log4j2/pull/1760