### PR TITLE
Allow Spring arbiter with no Spring environment present

### DIFF
--- a/log4j-spring-boot/pom.xml
+++ b/log4j-spring-boot/pom.xml
@@ -48,30 +48,38 @@
       <artifactId>log4j-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context-support</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -84,8 +92,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -101,16 +109,6 @@
     <dependency>
       <groupId>org.junit-pioneer</groupId>
       <artifactId>junit-pioneer</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-commons</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/log4j-spring-boot/src/main/java/org/apache/logging/log4j/spring/boot/SpringProfileArbiter.java
+++ b/log4j-spring-boot/src/main/java/org/apache/logging/log4j/spring/boot/SpringProfileArbiter.java
@@ -108,8 +108,7 @@ public final class SpringProfileArbiter implements Arbiter {
             if (loggerContext != null) {
                 environment = (Environment) loggerContext.getObject(Log4j2SpringBootLoggingSystem.ENVIRONMENT_KEY);
                 if (environment == null) {
-                    LOGGER.warn("Cannot create Arbiter, no Spring Environment provided");
-                    return null;
+                    LOGGER.debug("Creating Arbiter without a Spring Environment");
                 }
 
                 return new SpringProfileArbiter(profileNames, environment);

--- a/log4j-spring-boot/src/test/java/org/apache/logging/log4j/spring/boot/Log4j2SpringBootInitTest.java
+++ b/log4j-spring-boot/src/test/java/org/apache/logging/log4j/spring/boot/Log4j2SpringBootInitTest.java
@@ -42,7 +42,7 @@ public class Log4j2SpringBootInitTest {
         final ListAppender app = context.getConfiguration().getAppender("Out");
         assertNotNull(app);
         assertEquals(1, app.getMessages().size());
-        assertEquals("Started: log4j-spring-boot", app.getMessages().get(0));
+        assertEquals("prod: Started: log4j-spring-boot", app.getMessages().get(0));
     }
 
     @SpringBootApplication

--- a/log4j-spring-boot/src/test/java/org/apache/logging/log4j/spring/boot/SpringLookupTest.java
+++ b/log4j-spring-boot/src/test/java/org/apache/logging/log4j/spring/boot/SpringLookupTest.java
@@ -19,13 +19,10 @@ package org.apache.logging.log4j.spring.boot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.lookup.Interpolator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-
+import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Test SpringLookup.
  */
@@ -42,22 +39,16 @@ public class SpringLookupTest {
         final SpringLookup lookup = new SpringLookup();
         lookup.setLoggerContext(context);
         String result = lookup.lookup("profiles.active");
-        assertNotNull("No active profiles", result);
-        assertEquals("Incorrect active profile", "test", result);
+        assertThat(result).as("Incorrect active profile").isEqualTo("test");
         result = lookup.lookup("profiles.active[0]");
-        assertNotNull("No active profiles", result);
-        assertEquals("Incorrect active profile", "test", result);
+        assertThat(result).as("Incorrect active profile").isEqualTo("test");
         result = lookup.lookup("profiles.default");
-        assertNotNull("No default profiles", result);
-        assertEquals("Incorrect default profiles", "one,two", result);
+        assertThat(result).as("Incorrect default profiles").isEqualTo("one,two");
         result = lookup.lookup("profiles.default[0]");
-        assertNotNull("No default profiles", result);
-        assertEquals("Incorrect default profiles", "one", result);
+        assertThat(result).as("Incorrect default profiles").isEqualTo("one");
         result = lookup.lookup("profiles.default[2]");
-        assertNull("Did not get index out of bounds", result);
         result = lookup.lookup("app.property");
-        assertNotNull("Did not find property", result);
-        assertEquals("Incorrect property value", "test", result);
+        assertThat(result).as("Incorrect property value").isEqualTo("test");
     }
 
     @Test
@@ -71,11 +62,9 @@ public class SpringLookupTest {
         lookup.setConfiguration(context.getConfiguration());
         lookup.setLoggerContext(context);
         String result = lookup.lookup("spring:profiles.active");
-        assertNotNull("No active profiles", result);
-        assertEquals("Incorrect active profile", "test", result);
+        assertThat(result).as("Incorrect active profile").isEqualTo("test");
 
         result = lookup.lookup("spring:app.property");
-        assertNotNull("Did not find property", result);
-        assertEquals("Incorrect property value", "test", result);
+        assertThat(result).as("Incorrect property value").isEqualTo("test");
     }
 }

--- a/src/changelog/.2.x.x/1783_spring_arbiter_without_environment.xml
+++ b/src/changelog/.2.x.x/1783_spring_arbiter_without_environment.xml
@@ -15,30 +15,13 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration name="ConfigTest" status="OFF">
-  <Appenders>
-    <Select>
-      <SpringProfile name="dev | staging">
-        <Console name="Out">
-          <PatternLayout pattern="dev: %m"/>
-        </Console>
-      </SpringProfile>
-      <SpringProfile name="prod">
-        <List name="Out">
-          <PatternLayout pattern="prod: %m"/>
-        </List>
-      </SpringProfile>
-      <DefaultArbiter>
-        <List name="Out">
-          <PatternLayout pattern="none: %m"/>
-        </List>
-      </DefaultArbiter>
-    </Select>
-  </Appenders>
-  <Loggers>
-    <Logger name="org.apache.logging.log4j.core.springtest" level="trace"/>
-    <Root level="error">
-      <AppenderRef ref="Out"/>
-    </Root>
-  </Loggers>
-</Configuration>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
+       type="fixed">
+  <issue id="1783" link="https://github.com/apache/logging-log4j2/issues/1783"/>
+  <author id="github:ppkarwasz"/>
+  <description format="asciidoc">
+    Allow using Spring Arbiter without a Spring environment.
+  </description>
+</entry>


### PR DESCRIPTION
Most Log4j configurations in Spring Boot are used twice: with no environment and with an environment present. Therefore the Spring Boot arbiter should not fail with no environment.

After adding required additional assertions in `SpringProfileTest`, only `SpringLookupTest` uses JUnit 4, so we migrate it to JUnit 5.

Fixes #1783.
