### PR TITLE
Add OSGi package versioning and fix API breaking changes

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/package-info.java
@@ -16,7 +16,9 @@
  */
 @ExportTo("org.apache.logging.log4j.core")
 @Open("org.apache.logging.log4j.core")
+@Version("2.20.1")
 package org.apache.log4j.builders;
 
 import aQute.bnd.annotation.jpms.ExportTo;
 import aQute.bnd.annotation.jpms.Open;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/package-info.java
@@ -18,8 +18,10 @@
  * Log4j 1.x compatibility layer.
  */
 @Export
+@Version("2.20.1")
 @Open("org.apache.logging.log4j.core")
 package org.apache.log4j.config;
 
 import aQute.bnd.annotation.jpms.Open;
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/OptionConverter.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/OptionConverter.java
@@ -42,7 +42,7 @@ import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 /**
  * A convenience class to convert property values to specific types.
  */
-public final class OptionConverter {
+public class OptionConverter {
 
     private static class CharMap {
         final char key;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 1.x compatibility layer.
  */
 @Export
+@Version("2.20.1")
 package org.apache.log4j.helpers;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/jmx/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/jmx/package-info.java
@@ -18,6 +18,8 @@
  * This package lets you manage log4j settings using JMX. It is unfortunately not of production quality.
  */
 @Export
+@Version("2.20.1")
 package org.apache.log4j.jmx;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/or/jms/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/or/jms/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.log4j.or.jms;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/or/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/or/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.log4j.or;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 1.x compatibility layer.
  */
 @Export
+@Version("2.20.1")
 package org.apache.log4j;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/pattern/Log4j1LevelPatternConverter.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/pattern/Log4j1LevelPatternConverter.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.core.pattern.PatternConverter;
  */
 @Plugin(name = "Log4j1LevelPatternConverter", category = PatternConverter.CATEGORY)
 @ConverterKeys({"v1Level"})
-public final class Log4j1LevelPatternConverter extends LogEventPatternConverter {
+public class Log4j1LevelPatternConverter extends LogEventPatternConverter {
 
     private static final Log4j1LevelPatternConverter INSTANCE = new Log4j1LevelPatternConverter();
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/pattern/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/pattern/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.log4j.pattern;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/rewrite/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/rewrite/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.log4j.rewrite;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/spi/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/spi/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 1.x compatibility layer.
  */
 @Export
+@Version("2.20.1")
 package org.apache.log4j.spi;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/varia/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/varia/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.log4j.varia;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/xml/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/xml/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 1.x compatibility layer.
  */
 @Export
+@Version("2.20.1")
 package org.apache.log4j.xml;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/ListStatusListener.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/ListStatusListener.java
@@ -21,10 +21,12 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.status.StatusData;
 import org.apache.logging.log4j.status.StatusListener;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * A {@link StatusListener}
+ * A {@link StatusListener} that collects messages for further inspection.
  */
+@ProviderType
 public interface ListStatusListener extends StatusListener {
 
     void clear();

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/SerialUtil.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/SerialUtil.java
@@ -25,7 +25,8 @@ import java.io.Serializable;
 /**
  * Utility class to facilitate serializing and deserializing objects.
  */
-public final class SerialUtil {
+public class SerialUtil {
+
     private SerialUtil() {
     }
 

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/package-info.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.test.junit;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/package-info.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.test;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/util/package-info.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/util/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.test.util;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/CloseableThreadContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/CloseableThreadContext.java
@@ -34,7 +34,7 @@ import java.util.Map;
  *
  * @since 2.6
  */
-public final class CloseableThreadContext {
+public class CloseableThreadContext {
 
     private CloseableThreadContext() {
     }
@@ -100,7 +100,7 @@ public final class CloseableThreadContext {
         return new CloseableThreadContext.Instance().putAll(values);
     }
 
-    public static final class Instance implements AutoCloseable {
+    public static class Instance implements AutoCloseable {
 
         private int pushCount = 0;
         private final Map<String, String> originalValues = new HashMap<>();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/package-info.java
@@ -19,6 +19,8 @@
  * Public Message Types used for Log4j 2. Users may implement their own Messages.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.message;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/package-info.java
@@ -32,6 +32,8 @@
  * @see <a href="http://logging.apache.org/log4j/2.x/manual/api.html">Log4j 2 API manual</a>
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/package-info.java
@@ -20,6 +20,8 @@
  * Providers are able to be loaded at runtime.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.simple;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/package-info.java
@@ -19,6 +19,8 @@
  * API classes.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.spi;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/package-info.java
@@ -19,6 +19,8 @@
  * used by applications reporting on the status of the logging system
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.status;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
@@ -46,7 +46,7 @@ import org.apache.logging.log4j.status.StatusLogger;
  * @since 2.6
  */
 @PerformanceSensitive("allocation")
-public final class Unbox {
+public class Unbox {
     private static final Logger LOGGER = StatusLogger.getLogger();
     private static final int BITS_PER_INT = 32;
     private static final int RINGBUFFER_MIN_SIZE = 32;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/package-info.java
@@ -20,6 +20,8 @@
  * There are no guarantees for binary or logical compatibility in this package.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.util;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-appserver/src/main/java/org/apache/logging/log4j/appserver/jetty/package-info.java
+++ b/log4j-appserver/src/main/java/org/apache/logging/log4j/appserver/jetty/package-info.java
@@ -19,7 +19,9 @@
  */
 @Open
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.appserver.jetty;
 
 import aQute.bnd.annotation.jpms.Open;
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-appserver/src/main/java/org/apache/logging/log4j/appserver/tomcat/package-info.java
+++ b/log4j-appserver/src/main/java/org/apache/logging/log4j/appserver/tomcat/package-info.java
@@ -18,6 +18,8 @@
  * Log4j integration with Apache Tomcat 8.5 or greater.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.appserver.tomcat;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-cassandra/src/main/java/org/apache/logging/log4j/cassandra/CassandraAppender.java
+++ b/log4j-cassandra/src/main/java/org/apache/logging/log4j/cassandra/CassandraAppender.java
@@ -38,7 +38,7 @@ import org.apache.logging.log4j.core.util.Clock;
  * @see ColumnMapping
  */
 @Plugin(name = "Cassandra", category = Core.CATEGORY_NAME, elementType = CassandraAppender.ELEMENT_TYPE, printObject = true)
-public final class CassandraAppender extends AbstractDatabaseAppender<CassandraManager> {
+public class CassandraAppender extends AbstractDatabaseAppender<CassandraManager> {
 
     private CassandraAppender(final String name, final Filter filter, final boolean ignoreExceptions,
                               final Property[] properties, final CassandraManager manager) {

--- a/log4j-cassandra/src/main/java/org/apache/logging/log4j/cassandra/CassandraManager.java
+++ b/log4j-cassandra/src/main/java/org/apache/logging/log4j/cassandra/CassandraManager.java
@@ -42,7 +42,7 @@ import org.apache.logging.log4j.util.Strings;
 /**
  * Manager for a Cassandra appender instance.
  */
-public final class CassandraManager extends AbstractDatabaseManager {
+public class CassandraManager extends AbstractDatabaseManager {
 
     private static final int DEFAULT_PORT = 9042;
 

--- a/log4j-cassandra/src/main/java/org/apache/logging/log4j/cassandra/package-info.java
+++ b/log4j-cassandra/src/main/java/org/apache/logging/log4j/cassandra/package-info.java
@@ -22,7 +22,9 @@
  */
 @Export
 @Open("org.apache.logging.log4j.core")
+@Version("2.20.1")
 package org.apache.logging.log4j.cassandra;
 
 import aQute.bnd.annotation.jpms.Open;
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core-its/pom.xml
+++ b/log4j-core-its/pom.xml
@@ -30,6 +30,7 @@
   <properties>
     <docLabel>Core Documentation</docLabel>
     <projectDir>/core</projectDir>
+    <bnd.baseline.skip>true</bnd.baseline.skip>
     <maven.deploy.skip>true</maven.deploy.skip>
     <maven.install.skip>true</maven.install.skip>
   </properties>

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/GcFreeLoggingTestUtil.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/GcFreeLoggingTestUtil.java
@@ -42,7 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Utility methods for the GC-free logging tests.
  */
-public class GcFreeLoggingTestUtil {
+public enum GcFreeLoggingTestUtil {
+    ;
 
     public static void executeLogging(final String configurationFile,
                                       final Class<?> testClass) throws Exception {

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/AlwaysFailAppender.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/AlwaysFailAppender.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.core.config.plugins.validation.constraints.Requi
  *
  */
 @Plugin(name = "AlwaysFail", category = "Core", elementType = Appender.ELEMENT_TYPE, printObject = true)
-public final class AlwaysFailAppender extends AbstractAppender {
+public class AlwaysFailAppender extends AbstractAppender {
 
     private AlwaysFailAppender(final String name) {
         super(name, null, null, false, Property.EMPTY_ARRAY);

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/BlockingAppender.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/BlockingAppender.java
@@ -31,7 +31,7 @@ import org.apache.logging.log4j.core.config.plugins.validation.constraints.Requi
  *
  */
 @Plugin(name = "Block", category = "Core", elementType = Appender.ELEMENT_TYPE, printObject = true)
-public final class BlockingAppender extends AbstractAppender {
+public class BlockingAppender extends AbstractAppender {
     public volatile boolean running = true;
 
     private BlockingAppender(final String name) {

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/FailOnceAppender.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/FailOnceAppender.java
@@ -35,7 +35,7 @@ import org.apache.logging.log4j.core.util.Throwables;
  * An {@link Appender} that fails on the first use and works for the rest.
  */
 @Plugin(name = "FailOnce", category = "Core", elementType = Appender.ELEMENT_TYPE, printObject = true)
-public final class FailOnceAppender extends AbstractAppender {
+public class FailOnceAppender extends AbstractAppender {
 
     private final Supplier<Throwable> throwableSupplier;
 

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/db/jdbc/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/db/jdbc/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.test.appender.db.jdbc;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.test.appender;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/rolling/action/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/rolling/action/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.test.appender.rolling.action;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/categories/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/categories/package-info.java
@@ -20,6 +20,8 @@
  * integration tests, an appropriate category interface should be specified.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.test.categories;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/hamcrest/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/hamcrest/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.test.hamcrest;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/URLStreamHandlerFactoryRule.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/URLStreamHandlerFactoryRule.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.test.junit;
+
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+import java.util.Hashtable;
+
+import org.junit.Assert;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Installs and restores the URL URLStreamHandlerFactory before and after tests.
+ * <p>
+ * Might need tweaking for different JREs.
+ * </p>
+ * <p>
+ *     Will be remove in version 3.x.
+ * </p>
+ */
+@Deprecated
+public class URLStreamHandlerFactoryRule implements TestRule {
+
+    public URLStreamHandlerFactoryRule() {
+        this(null);
+    }
+
+    public URLStreamHandlerFactoryRule(final URLStreamHandlerFactory newURLStreamHandlerFactory) {
+        this.newURLStreamHandlerFactory = newURLStreamHandlerFactory;
+    }
+
+    private final URLStreamHandlerFactory newURLStreamHandlerFactory;
+
+    void clearURLHandlers() throws Exception {
+        final Field handlersFields = URL.class.getDeclaredField("handlers");
+        if (handlersFields != null) {
+            if (!handlersFields.isAccessible()) {
+                handlersFields.setAccessible(true);
+            }
+            @SuppressWarnings("unchecked")
+            final
+            Hashtable<String, URLStreamHandler> handlers = (Hashtable<String, URLStreamHandler>) handlersFields
+                    .get(null);
+            if (handlers != null) {
+                handlers.clear();
+            }
+        }
+    }
+
+    @Override
+    public Statement apply(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Field factoryField = null;
+                int matches = 0;
+                URLStreamHandlerFactory oldFactory = null;
+                for (final Field field : URL.class.getDeclaredFields()) {
+                    if (URLStreamHandlerFactory.class.equals(field.getType())) {
+                        factoryField = field;
+                        matches++;
+                        factoryField.setAccessible(true);
+                        oldFactory = (URLStreamHandlerFactory) factoryField.get(null);
+                        break;
+                    }
+                }
+                Assert.assertNotNull("java.net URL does not declare a java.net.URLStreamHandlerFactory field",
+                        factoryField);
+                Assert.assertEquals("java.net.URL declares multiple java.net.URLStreamHandlerFactory fields.", 1,
+                        matches); // FIXME There is a break in the loop so always 0 or 1
+                URL.setURLStreamHandlerFactory(newURLStreamHandlerFactory);
+                try {
+                    base.evaluate();
+                } finally {
+                    clearURLHandlers();
+                    factoryField.set(null, null);
+                    URL.setURLStreamHandlerFactory(oldFactory);
+                }
+            }
+        };
+    }
+}

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/package-info.java
@@ -20,6 +20,8 @@
  * @see org.junit.rules.TestRule
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.core.test.junit;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/layout/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/layout/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.test.layout;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockSyslogServer.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/MockSyslogServer.java
@@ -43,7 +43,7 @@ public abstract class MockSyslogServer extends Thread {
 
     public abstract int getLocalPort();
 
-    public abstract void shutdown();
+    public void shutdown() {}
 
     public int getNumberOfReceivedMessages() {
         return messageList.size();

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/mock/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.core.test.net.mock;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/ssl/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/net/ssl/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.test.net.ssl;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.core.test;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/smtp/SmtpActionType.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/smtp/SmtpActionType.java
@@ -19,7 +19,7 @@ package org.apache.logging.log4j.core.test.smtp;
 /**
  * Represents an SMTP action or command.
  */
-public final class SmtpActionType {
+public class SmtpActionType {
     /**
      * Internal value for the action type.
      */

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/smtp/SmtpState.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/smtp/SmtpState.java
@@ -19,7 +19,7 @@ package org.apache.logging.log4j.core.test.smtp;
 /**
  * SMTP server state.
  */
-public final class SmtpState {
+public class SmtpState {
     /**
      * Internal representation of the state.
      */

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/smtp/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/smtp/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.test.smtp;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/util/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/util/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.test.util;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -214,6 +214,26 @@
   </dependencies>
   <build>
     <plugins>
+
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-baseline-maven-plugin</artifactId>
+        <configuration>
+          <!--
+            ~ These packages are documented as internal and were removed
+            ~ from the public OSGi exports.
+            -->
+          <diffpackages>
+            <diffpackage>!org.apache.logging.log4j.core.layout.internal</diffpackage>
+            <diffpackage>!org.apache.logging.log4j.core.message</diffpackage>
+            <diffpackage>!org.apache.logging.log4j.core.time.internal</diffpackage>
+            <diffpackage>!org.apache.logging.log4j.core.tools.picocli</diffpackage>
+            <diffpackage>!org.apache.logging.log4j.core.util.internal</diffpackage>
+            <diffpackage>*</diffpackage>
+          </diffpackages>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
@@ -232,6 +252,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
@@ -268,6 +289,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -297,6 +319,7 @@
           </execution>
         </executions>
       </plugin>
+
     </plugins>
   </build>
 </project>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AppenderSet.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AppenderSet.java
@@ -35,7 +35,7 @@ import org.apache.logging.log4j.status.StatusLogger;
  * A deferred plugin for appenders.
  */
 @Plugin(name = "AppenderSet", category = Core.CATEGORY_NAME, printObject = true, deferChildren = true)
-public final class AppenderSet {
+public class AppenderSet {
 
     public static class Builder implements org.apache.logging.log4j.core.util.Builder<AppenderSet> {
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/NullAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/NullAppender.java
@@ -29,7 +29,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginFactory;
  * and handy for composing a {@link ScriptAppenderSelector}.
  */
 @Plugin(name = NullAppender.PLUGIN_NAME, category = Core.CATEGORY_NAME, elementType = Appender.ELEMENT_TYPE, printObject = true)
-public final class NullAppender extends AbstractAppender {
+public class NullAppender extends AbstractAppender {
 
     public static final String PLUGIN_NAME = "Null";
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ScriptAppenderSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ScriptAppenderSelector.java
@@ -38,7 +38,7 @@ import org.apache.logging.log4j.core.script.AbstractScript;
 import org.apache.logging.log4j.core.script.ScriptManager;
 
 @Plugin(name = "ScriptAppenderSelector", category = Core.CATEGORY_NAME, elementType = Appender.ELEMENT_TYPE, printObject = true)
-public final class ScriptAppenderSelector extends AbstractAppender {
+public class ScriptAppenderSelector extends AbstractAppender {
 
     /**
      * Builds an appender.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/ColumnMapping.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/ColumnMapping.java
@@ -43,7 +43,7 @@ import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
  * @since 2.8
  */
 @Plugin(name = "ColumnMapping", category = Core.CATEGORY_NAME, printObject = true)
-public final class ColumnMapping {
+public class ColumnMapping {
 
     /**
      * The empty array.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/jdbc/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/jdbc/package-info.java
@@ -19,6 +19,8 @@
  * a JDBC driver on your classpath for the database you wish to log to.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.appender.db.jdbc;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/package-info.java
@@ -19,6 +19,8 @@
  * accessing databases.
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.core.appender.db;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/JmsAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/JmsAppender.java
@@ -46,7 +46,7 @@ import org.apache.logging.log4j.core.net.JndiManager;
 @PluginAliases({ "JMSQueue", "JMSTopic" })
 public class JmsAppender extends AbstractAppender {
 
-    public static final class Builder<B extends Builder<B>> extends AbstractAppender.Builder<B>
+    public static class Builder<B extends Builder<B>> extends AbstractAppender.Builder<B>
             implements org.apache.logging.log4j.core.util.Builder<JmsAppender> {
 
         public static final int DEFAULT_RECONNECT_INTERVAL_MILLIS = 5000;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/JmsManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/JmsManager.java
@@ -48,7 +48,7 @@ import org.apache.logging.log4j.status.StatusLogger;
  * involving a configured ConnectionFactory and Destination.
  * </p>
  */
-public final class JmsManager extends AbstractManager {
+public class JmsManager extends AbstractManager {
 
     public static class JmsManagerConfiguration {
         private final Properties jndiProperties;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqManager.java
@@ -41,7 +41,7 @@ import org.zeromq.ZMonitor.ZEvent;
  *
  * @since 2.6
  */
-public final class JeroMqManager extends AbstractManager {
+public class JeroMqManager extends AbstractManager {
 
     /**
      * System property to enable shutdown hook.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/jeromq/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/jeromq/package-info.java
@@ -21,6 +21,8 @@
  * @since 2.4
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.core.appender.mom.jeromq;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/kafka/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/kafka/package-info.java
@@ -21,6 +21,8 @@
  * @since 2.4
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.appender.mom.kafka;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/package-info.java
@@ -21,6 +21,8 @@
  * @since 2.1
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.appender.mom;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/nosql/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/nosql/package-info.java
@@ -22,6 +22,8 @@
  * {@link org.apache.logging.log4j.core.appender.nosql.NoSqlProvider NoSqlProvider}.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.appender.nosql;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 2 Appenders.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.appender;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/LoggerNameLevelRewritePolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/LoggerNameLevelRewritePolicy.java
@@ -37,7 +37,7 @@ import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
  * @since 2.4
  */
 @Plugin(name = "LoggerNameLevelRewritePolicy", category = Core.CATEGORY_NAME, elementType = "rewritePolicy", printObject = true)
-public final class LoggerNameLevelRewritePolicy implements RewritePolicy {
+public class LoggerNameLevelRewritePolicy implements RewritePolicy {
 
     /**
      * Creates a policy to rewrite levels for a given logger name.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/package-info.java
@@ -18,6 +18,8 @@
  * Apache Flume Appender. Requires the user specifically include Flume and its dependencies.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.appender.rewrite;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/OnStartupTriggeringPolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/OnStartupTriggeringPolicy.java
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.status.StatusLogger;
  * Triggers a rollover on every restart, but only if the file size is greater than zero.
  */
 @Plugin(name = "OnStartupTriggeringPolicy", category = Core.CATEGORY_NAME, printObject = true)
-public final class OnStartupTriggeringPolicy extends AbstractTriggeringPolicy {
+public class OnStartupTriggeringPolicy extends AbstractTriggeringPolicy {
 
     private static final long JVM_START_TIME = initStartTime();
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/Duration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/Duration.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
  *
  * @see #parse(CharSequence)
  */
-public final class Duration implements Serializable, Comparable<Duration> {
+public class Duration implements Serializable, Comparable<Duration> {
     private static final long serialVersionUID = -3756810052716342061L;
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/PosixViewAttributeAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/PosixViewAttributeAction.java
@@ -47,7 +47,7 @@ import org.apache.logging.log4j.util.Strings;
  * Allow to define file permissions, user and group for log files on POSIX supported OS.
  */
 @Plugin(name = "PosixViewAttribute", category = Core.CATEGORY_NAME, printObject = true)
-public final class PosixViewAttributeAction extends AbstractPathAction {
+public class PosixViewAttributeAction extends AbstractPathAction {
 
     /**
      * File permissions.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/package-info.java
@@ -18,6 +18,8 @@
  * Support classes for the Rolling File Appender.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.appender.rolling.action;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/package-info.java
@@ -18,6 +18,8 @@
  * Rolling File Appender and support classes.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.appender.rolling;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/package-info.java
@@ -18,6 +18,8 @@
  * Apache Flume Appender. Requires the user specifically include Flume and its dependencies.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.appender.routing;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorBlockingQueueFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorBlockingQueueFactory.java
@@ -31,7 +31,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginFactory;
  * @since 2.7
  */
 @Plugin(name = "DisruptorBlockingQueue", category = Node.CATEGORY, elementType = BlockingQueueFactory.ELEMENT_TYPE)
-public final class DisruptorBlockingQueueFactory<E> implements BlockingQueueFactory<E> {
+public class DisruptorBlockingQueueFactory<E> implements BlockingQueueFactory<E> {
 
     private final SpinPolicy spinPolicy;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/JCToolsBlockingQueueFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/JCToolsBlockingQueueFactory.java
@@ -33,7 +33,7 @@ import org.jctools.queues.MpscArrayQueue;
  * @since 2.7
  */
 @Plugin(name = "JCToolsBlockingQueue", category = Node.CATEGORY, elementType = BlockingQueueFactory.ELEMENT_TYPE)
-public final class JCToolsBlockingQueueFactory<E> implements BlockingQueueFactory<E> {
+public class JCToolsBlockingQueueFactory<E> implements BlockingQueueFactory<E> {
 
     private final WaitStrategy waitStrategy;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/package-info.java
@@ -18,6 +18,8 @@
  * Provides Asynchronous Logger classes and interfaces for low-latency logging.
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.core.async;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/ClassArbiter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/ClassArbiter.java
@@ -27,7 +27,7 @@ import org.apache.logging.log4j.util.LoaderUtil;
  */
 @Plugin(name = "ClassArbiter", category = Node.CATEGORY, elementType = Arbiter.ELEMENT_TYPE,
         printObject = true, deferChildren = true)
-public final class ClassArbiter implements Arbiter {
+public class ClassArbiter implements Arbiter {
 
     private final String className;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/ScriptArbiter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/ScriptArbiter.java
@@ -36,7 +36,7 @@ import org.apache.logging.log4j.status.StatusLogger;
  */
 @Plugin(name = "ScriptArbiter", category = Node.CATEGORY, elementType = Arbiter.ELEMENT_TYPE,
         deferChildren = true, printObject = true)
-public final class ScriptArbiter implements Arbiter {
+public class ScriptArbiter implements Arbiter {
 
     private final AbstractScript script;
     private final Configuration configuration;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/SystemPropertyArbiter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/SystemPropertyArbiter.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
  */
 @Plugin(name = "SystemPropertyArbiter", category = Node.CATEGORY, elementType = Arbiter.ELEMENT_TYPE,
         deferChildren = true, printObject = true)
-public final class SystemPropertyArbiter implements Arbiter {
+public class SystemPropertyArbiter implements Arbiter {
 
     private final String propertyName;
     private final String propertyValue;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.core.config.arbiters;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/package-info.java
@@ -20,6 +20,8 @@
  * @since 2.4
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.builder.api;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/package-info.java
@@ -20,6 +20,8 @@
  * @since 2.4
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.builder.impl;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/package-info.java
@@ -19,6 +19,8 @@
  * Support for composite configurations.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.composite;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/package-info.java
@@ -18,6 +18,8 @@
  * Classes and interfaces supporting configuration of Log4j 2 with JSON.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.json;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/package-info.java
@@ -18,6 +18,8 @@
  * Configuration of Log4j 2.
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.core.config;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverterRegistry.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverterRegistry.java
@@ -37,7 +37,7 @@ import org.apache.logging.log4j.status.StatusLogger;
  *
  * @since 2.1
  */
-public final class TypeConverterRegistry {
+public class TypeConverterRegistry {
 
     private static final Logger LOGGER = StatusLogger.getLogger();
     private static volatile TypeConverterRegistry INSTANCE;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/package-info.java
@@ -20,6 +20,8 @@
  * attributes in plugin factory methods.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.plugins.convert;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/package-info.java
@@ -19,6 +19,8 @@
  * Annotations for Log4j 2 plugins.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.plugins;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/package-info.java
@@ -20,6 +20,8 @@
  * executable {@link org.apache.logging.log4j.core.config.plugins.util.PluginManager} class in your build process.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.plugins.processor;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/PluginRegistry.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/PluginRegistry.java
@@ -45,7 +45,7 @@ import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 /**
  * Registry singleton for PluginType maps partitioned by source type and then by category names.
  */
-public final class PluginRegistry {
+public class PluginRegistry {
 
     private static final Logger LOGGER = StatusLogger.getLogger();
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/util/package-info.java
@@ -19,6 +19,8 @@
  * Utility and manager classes for Log4j 2 plugins.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.plugins.util;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/validation/constraints/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/validation/constraints/package-info.java
@@ -21,6 +21,8 @@
  * @since 2.1
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.plugins.validation.constraints;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/validation/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/validation/package-info.java
@@ -21,6 +21,8 @@
  * @since 2.1
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.plugins.validation;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/validation/validators/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/validation/validators/package-info.java
@@ -21,6 +21,8 @@
  * @since 2.1
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.plugins.validation.validators;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/package-info.java
@@ -22,6 +22,8 @@
  * {@link org.apache.logging.log4j.core.config.plugins.PluginVisitorStrategy}.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.plugins.visitors;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/package-info.java
@@ -18,6 +18,8 @@
  * Configuration using Properties files.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.properties;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/status/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/status/package-info.java
@@ -19,6 +19,8 @@
  * Configuration classes for the {@link org.apache.logging.log4j.status.StatusLogger} API.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.status;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/package-info.java
@@ -18,6 +18,8 @@
  * Classes and interfaces supporting configuration of Log4j 2 with XML.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.xml;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/package-info.java
@@ -18,6 +18,8 @@
  * Classes and interfaces supporting configuration of Log4j 2 with YAML.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.config.yaml;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/MutableThreadContextMapFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/MutableThreadContextMapFilter.java
@@ -59,7 +59,7 @@ import org.apache.logging.log4j.util.PropertiesUtil;
 @Plugin(name = "MutableThreadContextMapFilter", category = Node.CATEGORY, elementType = Filter.ELEMENT_TYPE, printObject = true)
 @PluginAliases("MutableContextMapFilter")
 @PerformanceSensitive("allocation")
-public final class MutableThreadContextMapFilter extends AbstractFilter {
+public class MutableThreadContextMapFilter extends AbstractFilter {
 
     private static final ObjectMapper MAPPER = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/mutable/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/mutable/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.filter.mutable;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/package-info.java
@@ -22,6 +22,8 @@
  * {@link org.apache.logging.log4j.core.Filter#ELEMENT_TYPE filter}.
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.core.filter;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 2 private implementation classes.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.impl;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/package-info.java
@@ -19,6 +19,8 @@
  * library.
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.core.jackson;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 2 JMX support.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.jmx;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/HtmlLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/HtmlLayout.java
@@ -382,7 +382,7 @@ public final class HtmlLayout extends AbstractStringLayout {
         return new Builder();
     }
 
-    public static final class Builder implements org.apache.logging.log4j.core.util.Builder<HtmlLayout> {
+    public static class Builder implements org.apache.logging.log4j.core.util.Builder<HtmlLayout> {
 
         @PluginBuilderAttribute
         private boolean locationInfo = false;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/PatternLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/PatternLayout.java
@@ -623,7 +623,7 @@ public final class PatternLayout extends AbstractStringLayout {
     /**
      * Custom PatternLayout builder. Use the {@link PatternLayout#newBuilder() builder factory method} to create this.
      */
-    public static final class Builder implements org.apache.logging.log4j.core.util.Builder<PatternLayout> {
+    public static class Builder implements org.apache.logging.log4j.core.util.Builder<PatternLayout> {
 
         @PluginBuilderAttribute
         private String pattern = PatternLayout.DEFAULT_CONVERSION_PATTERN;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/ScriptPatternSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/ScriptPatternSelector.java
@@ -49,7 +49,7 @@ public class ScriptPatternSelector implements PatternSelector, LocationAware {
     /**
      * Custom ScriptPatternSelector builder. Use the {@link #newBuilder() builder factory method} to create this.
      */
-    public static final class Builder implements org.apache.logging.log4j.core.util.Builder<ScriptPatternSelector> {
+    public static class Builder implements org.apache.logging.log4j.core.util.Builder<ScriptPatternSelector> {
 
         @PluginElement("Script")
         private AbstractScript script;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/TextEncoderHelper.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/TextEncoderHelper.java
@@ -28,7 +28,7 @@ import java.nio.charset.CoderResult;
  *
  * @since 2.6
  */
-public final class TextEncoderHelper {
+public class TextEncoderHelper {
 
     private TextEncoderHelper() {
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/package-info.java
@@ -22,6 +22,8 @@
  * {@link org.apache.logging.log4j.core.Layout#ELEMENT_TYPE layout}.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.layout;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/package-info.java
@@ -21,6 +21,8 @@
  * {@link org.apache.logging.log4j.core.lookup.StrLookup#CATEGORY Lookup}.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.lookup;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/JndiManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/JndiManager.java
@@ -35,7 +35,7 @@ import org.apache.logging.log4j.util.PropertiesUtil;
  *
  * @since 2.1
  */
-public final class JndiManager extends AbstractManager {
+public class JndiManager extends AbstractManager {
 
     private static final JndiManagerFactory FACTORY = new JndiManagerFactory();
     private static final String PREFIX = "log4j2.enableJndi";

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SocketAddress.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SocketAddress.java
@@ -32,7 +32,7 @@ import org.apache.logging.log4j.core.config.plugins.validation.constraints.Valid
  * @since 2.8
  */
 @Plugin(name = "SocketAddress", category = Node.CATEGORY, printObject = true)
-public final class SocketAddress {
+public class SocketAddress {
 
     /**
      * Creates a SocketAddress corresponding to {@code localhost:0}.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/package-info.java
@@ -25,6 +25,8 @@
  * </ul>
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.net;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/SslConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/SslConfiguration.java
@@ -41,7 +41,7 @@ import org.apache.logging.log4j.status.StatusLogger;
  *  SSL Configuration
  */
 @Plugin(name = "Ssl", category = Core.CATEGORY_NAME, printObject = true)
-public final class SslConfiguration {
+public class SslConfiguration {
     private static final StatusLogger LOGGER = StatusLogger.getLogger();
     private final KeyStoreConfiguration keyStoreConfig;
     private final TrustStoreConfiguration trustStoreConfig;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/ssl/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 2 SSL support
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.net.ssl;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/osgi/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/osgi/package-info.java
@@ -19,6 +19,8 @@
  * Collection of OSGi-specific classes for bundles.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.osgi;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/package-info.java
@@ -18,6 +18,8 @@
  * Implementation of Log4j 2.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/parser/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/parser/package-info.java
@@ -18,6 +18,8 @@
  * Parsers for the output of various layouts.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.parser;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/LevelPatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/LevelPatternConverter.java
@@ -34,7 +34,7 @@ import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 @Plugin(name = "LevelPatternConverter", category = PatternConverter.CATEGORY)
 @ConverterKeys({"p", "level"})
 @PerformanceSensitive("allocation")
-public abstract class LevelPatternConverter extends LogEventPatternConverter {
+public class LevelPatternConverter extends LogEventPatternConverter {
     private static final String OPTION_LENGTH = "length";
     private static final String OPTION_LOWER = "lowerCase";
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MessagePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/MessagePatternConverter.java
@@ -39,7 +39,7 @@ import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 @Plugin(name = "MessagePatternConverter", category = PatternConverter.CATEGORY)
 @ConverterKeys({"m", "msg", "message"})
 @PerformanceSensitive("allocation")
-public abstract class MessagePatternConverter extends LogEventPatternConverter {
+public class MessagePatternConverter extends LogEventPatternConverter {
 
     private static final String LOOKUPS = "lookups";
     private static final String NOLOOKUPS = "nolookups";

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/package-info.java
@@ -18,6 +18,8 @@
  * Provides classes implementing format specifiers in conversion patterns.
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.core.pattern;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/script/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/script/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 2 Script support.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.script;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/selector/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 2 Context Selectors.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.selector;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/time/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/time/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.time;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 2 command line tools.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.tools;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/NullOutputStream.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/NullOutputStream.java
@@ -28,7 +28,7 @@ import java.io.OutputStream;
  *
  * @since 2.3
  */
-public final class NullOutputStream extends OutputStream {
+public class NullOutputStream extends OutputStream {
 
     private static final NullOutputStream INSTANCE = new NullOutputStream();
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/WatcherFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/WatcherFactory.java
@@ -34,7 +34,7 @@ import org.apache.logging.log4j.status.StatusLogger;
 /**
  * Creates Watchers of various types.
  */
-public final class WatcherFactory {
+public class WatcherFactory {
 
     private static final Logger LOGGER = StatusLogger.getLogger();
     private static final PluginManager pluginManager = new PluginManager(Watcher.CATEGORY);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormat.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/FixedDateFormat.java
@@ -23,6 +23,7 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.core.time.Instant;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * Custom time formatter that trades flexibility for performance. This formatter only supports the date patterns defined
@@ -32,6 +33,7 @@ import org.apache.logging.log4j.core.time.Instant;
  * /log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/ThreadsafeDateFormatBenchmark.java
  * </p>
  */
+@ProviderType
 public class FixedDateFormat {
 
     /**
@@ -515,7 +517,7 @@ public class FixedDateFormat {
      *
      * @return the length of the resulting formatted date and time strings
      */
-    public int getLength() {
+    public final int getLength() {
         return length;
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 2 date formatting classes.
  */
 @Export
+@Version("2.21.0")
 package org.apache.logging.log4j.core.util.datetime;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 2 helper classes.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.util;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-couchdb/src/main/java/org/apache/logging/log4j/couchdb/package-info.java
+++ b/log4j-couchdb/src/main/java/org/apache/logging/log4j/couchdb/package-info.java
@@ -19,7 +19,9 @@
  */
 @Export
 @Open("org.apache.logging.log4j.core")
+@Version("2.20.1")
 package org.apache.logging.log4j.couchdb;
 
 import aQute.bnd.annotation.jpms.Open;
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-docker/pom.xml
+++ b/log4j-docker/pom.xml
@@ -72,6 +72,22 @@
 
   <build>
     <plugins>
+
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-baseline-maven-plugin</artifactId>
+        <configuration>
+          <!--
+            ~ This packages is only used internally and was removed
+            ~ from the public OSGi exports.
+            -->
+          <diffpackages>
+            <diffpackage>!org.apache.logging.log4j.docker.model</diffpackage>
+            <diffpackage>*</diffpackage>
+          </diffpackages>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/log4j-docker/src/main/java/org/apache/logging/log4j/docker/package-info.java
+++ b/log4j-docker/src/main/java/org/apache/logging/log4j/docker/package-info.java
@@ -16,7 +16,9 @@
  */
 @Export
 @Open("org.apache.logging.log4j.core")
+@Version("2.20.1")
 package org.apache.logging.log4j.docker;
 
 import aQute.bnd.annotation.jpms.Open;
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/package-info.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/package-info.java
@@ -19,7 +19,9 @@
  */
 @Export
 @Open("org.apache.logging.log4j.core")
+@Version("2.20.1")
 package org.apache.logging.log4j.flume.appender;
 
 import aQute.bnd.annotation.jpms.Open;
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-iostreams/pom.xml
+++ b/log4j-iostreams/pom.xml
@@ -74,4 +74,24 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-baseline-maven-plugin</artifactId>
+        <configuration>
+          <!--
+            ~ This package is documented as internal and was removed
+            ~ from the public OSGi exports.
+            -->
+          <diffpackages>
+            <diffpackage>!org.apache.logging.log4j.io.internal</diffpackage>
+            <diffpackage>*</diffpackage>
+          </diffpackages>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/log4j-iostreams/src/main/java/org/apache/logging/log4j/io/package-info.java
+++ b/log4j-iostreams/src/main/java/org/apache/logging/log4j/io/package-info.java
@@ -19,6 +19,8 @@
  * TODO: introduction to IoBuilder
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.io;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-jakarta-smtp/src/main/java/org/apache/logging/log4j/smtp/package-info.java
+++ b/log4j-jakarta-smtp/src/main/java/org/apache/logging/log4j/smtp/package-info.java
@@ -1,24 +1,22 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
+ * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to you under the Apache License, Version 2.0
+ * The ASF licenses this file to You under the Apache license, Version 2.0
  * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * the License. You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
  */
 @Export
-@Open("org.apache.logging.log4j.core")
 @Version("2.20.1")
-package org.apache.logging.log4j.web.appender;
+package org.apache.logging.log4j.smtp;
 
-import aQute.bnd.annotation.Export;
-import aQute.bnd.annotation.jpms.Open;
+import org.osgi.annotation.bundle.Export;
 import org.osgi.annotation.versioning.Version;

--- a/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/package-info.java
+++ b/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/package-info.java
@@ -22,6 +22,8 @@
  * @see <a href="http://logging.apache.org/log4j/2.x/manual/webapp.html">Using Log4j 2 in Web Applications</a>
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.web;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-jcl/src/main/java/org/apache/logging/log4j/jcl/package-info.java
+++ b/log4j-jcl/src/main/java/org/apache/logging/log4j/jcl/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 2 adapter for Commons Logging.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.jcl;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-jdbc-dbcp2/src/main/java/org/apache/logging/log4j/core/appender/db/jdbc/PoolableConnectionFactoryConfig.java
+++ b/log4j-jdbc-dbcp2/src/main/java/org/apache/logging/log4j/core/appender/db/jdbc/PoolableConnectionFactoryConfig.java
@@ -36,7 +36,7 @@ import org.apache.logging.log4j.util.Strings;
  * @since 2.11.2
  */
 @Plugin(name = "PoolableConnectionFactory", category = Core.CATEGORY_NAME, printObject = true)
-public final class PoolableConnectionFactoryConfig {
+public class PoolableConnectionFactoryConfig {
 
     public static class Builder implements org.apache.logging.log4j.core.util.Builder<PoolableConnectionFactoryConfig> {
 

--- a/log4j-jdbc-dbcp2/src/main/java/org/apache/logging/log4j/core/appender/db/jdbc/package-info.java
+++ b/log4j-jdbc-dbcp2/src/main/java/org/apache/logging/log4j/core/appender/db/jdbc/package-info.java
@@ -16,7 +16,9 @@
  */
 @Export
 @Open("org.apache.logging.log4j.core")
+@Version("2.20.1")
 package org.apache.logging.log4j.core.appender.db.jdbc;
 
-import aQute.bnd.annotation.Export;
 import aQute.bnd.annotation.jpms.Open;
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-jpa/src/main/java/org/apache/logging/log4j/core/appender/db/jpa/converter/package-info.java
+++ b/log4j-jpa/src/main/java/org/apache/logging/log4j/core/appender/db/jpa/converter/package-info.java
@@ -29,6 +29,8 @@
  */
 //CHECKSTYLE:ON
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.core.appender.db.jpa.converter;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-jpa/src/main/java/org/apache/logging/log4j/core/appender/db/jpa/package-info.java
+++ b/log4j-jpa/src/main/java/org/apache/logging/log4j/core/appender/db/jpa/package-info.java
@@ -22,7 +22,9 @@
  */
 @Export
 @Open("org.apache.logging.log4j.core")
+@Version("2.20.1")
 package org.apache.logging.log4j.core.appender.db.jpa;
 
 import aQute.bnd.annotation.jpms.Open;
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-jpl/src/main/java/org/apache/logging/log4j/jpl/package-info.java
+++ b/log4j-jpl/src/main/java/org/apache/logging/log4j/jpl/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.jpl;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-jul/src/main/java/org/apache/logging/log4j/jul/package-info.java
+++ b/log4j-jul/src/main/java/org/apache/logging/log4j/jul/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the license.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.jul;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-kubernetes/src/main/java/org/apache/logging/log4j/kubernetes/package-info.java
+++ b/log4j-kubernetes/src/main/java/org/apache/logging/log4j/kubernetes/package-info.java
@@ -16,7 +16,9 @@
  */
 @Export
 @Open("org.apache.logging.log4j.core")
+@Version("2.20.1")
 package org.apache.logging.log4j.kubernetes;
 
 import aQute.bnd.annotation.jpms.Open;
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-layout-template-json-test/src/main/java/org/apache/logging/log4j/layout/template/json/package-info.java
+++ b/log4j-layout-template-json-test/src/main/java/org/apache/logging/log4j/layout/template/json/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.layout.template.json;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-layout-template-json/pom.xml
+++ b/log4j-layout-template-json/pom.xml
@@ -60,6 +60,20 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-baseline-maven-plugin</artifactId>
+        <configuration>
+          <!--
+            ~ This package has only an internal function and was removed
+            ~ from the public OSGi exports.
+            -->
+          <diffpackages>
+            <diffpackage>!org.apache.logging.log4j.layout.template.json.util</diffpackage>
+            <diffpackage>*</diffpackage>
+          </diffpackages>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayout.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayout.java
@@ -61,7 +61,7 @@ import org.apache.logging.log4j.util.Strings;
 @Plugin(name = "JsonTemplateLayout",
         category = Node.CATEGORY,
         elementType = Layout.ELEMENT_TYPE)
-public final class JsonTemplateLayout implements StringLayout, LocationAware {
+public class JsonTemplateLayout implements StringLayout, LocationAware {
 
     private static final Map<String, String> CONTENT_FORMAT =
             Collections.singletonMap("version", "1");

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/package-info.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/package-info.java
@@ -16,7 +16,9 @@
  */
 @Export
 @Open("org.apache.logging.log4j.core")
+@Version("2.21.0")
 package org.apache.logging.log4j.layout.template.json;
 
 import aQute.bnd.annotation.jpms.Open;
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/EventAdditionalFieldInterceptor.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/EventAdditionalFieldInterceptor.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.layout.template.json.util.JsonReader;
  * additional fields} after event template read.
  */
 @Plugin(name = "EventAdditionalFieldInterceptor", category = TemplateResolverInterceptor.CATEGORY)
-public final class EventAdditionalFieldInterceptor implements EventResolverInterceptor {
+public class EventAdditionalFieldInterceptor implements EventResolverInterceptor {
 
     private static final EventAdditionalFieldInterceptor INSTANCE =
             new EventAdditionalFieldInterceptor();

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/EventResolverContext.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/EventResolverContext.java
@@ -150,7 +150,7 @@ public final class EventResolverContext implements TemplateResolverContext<LogEv
         return new Builder();
     }
 
-    public static final class Builder {
+    public static class Builder {
 
         private Configuration configuration;
 

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/EventRootObjectKeyInterceptor.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/EventRootObjectKeyInterceptor.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.layout.template.json.JsonTemplateLayout;
  * @see JsonTemplateLayout.Builder#getEventTemplateRootObjectKey()
  */
 @Plugin(name = "EventRootObjectKeyInterceptor", category = TemplateResolverInterceptor.CATEGORY)
-public final class EventRootObjectKeyInterceptor implements EventResolverInterceptor {
+public class EventRootObjectKeyInterceptor implements EventResolverInterceptor {
 
     private static final EventRootObjectKeyInterceptor INSTANCE =
             new EventRootObjectKeyInterceptor();

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/TemplateResolverInterceptors.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/TemplateResolverInterceptors.java
@@ -29,7 +29,7 @@ import org.apache.logging.log4j.status.StatusLogger;
 /**
  * Utility class for {@link TemplateResolverInterceptor}.
  */
-public final class TemplateResolverInterceptors {
+public class TemplateResolverInterceptors {
 
     private static final Logger LOGGER = StatusLogger.getLogger();
 

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/package-info.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/package-info.java
@@ -16,7 +16,9 @@
  */
 @Export
 @Open("org.apache.logging.log4j.core")
+@Version("2.20.1")
 package org.apache.logging.log4j.layout.template.json.resolver;
 
 import aQute.bnd.annotation.jpms.Open;
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-mongodb3/src/main/java/org/apache/logging/log4j/mongodb3/package-info.java
+++ b/log4j-mongodb3/src/main/java/org/apache/logging/log4j/mongodb3/package-info.java
@@ -19,7 +19,9 @@
  */
 @Export
 @Open("org.apache.logging.log4j.core")
+@Version("2.20.1")
 package org.apache.logging.log4j.mongodb3;
 
 import aQute.bnd.annotation.jpms.Open;
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-mongodb4/src/main/java/org/apache/logging/log4j/mongodb4/package-info.java
+++ b/log4j-mongodb4/src/main/java/org/apache/logging/log4j/mongodb4/package-info.java
@@ -20,7 +20,9 @@
  */
 @Export
 @Open("org.apache.logging.log4j.core")
+@Version("2.21.0")
 package org.apache.logging.log4j.mongodb4;
 
 import aQute.bnd.annotation.jpms.Open;
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-osgi/pom.xml
+++ b/log4j-osgi/pom.xml
@@ -32,6 +32,9 @@
     <projectDir>/osgi</projectDir>
     <module.name>org.apache.logging.log4j.osgi</module.name>
     <skipTests>true</skipTests>
+    <bnd.baseline.skip>true</bnd.baseline.skip>
+    <maven.deploy.skip>true</maven.deploy.skip>
+    <maven.install.skip>true</maven.install.skip>
   </properties>
   <dependencies>
     <dependency>

--- a/log4j-perf/pom.xml
+++ b/log4j-perf/pom.xml
@@ -33,6 +33,7 @@
     <docLabel>Apache Log4J Performance Tests</docLabel>
     <projectDir>/log4j-perf</projectDir>
     <uberjar.name>benchmarks</uberjar.name>
+    <bnd.baseline.skip>true</bnd.baseline.skip>
     <maven.test.skip>true</maven.test.skip>
     <module.name>org.apache.logging.log4j.perf</module.name>
     <maven.compiler.release>9</maven.compiler.release>

--- a/log4j-slf4j-impl/src/main/java/org/apache/logging/slf4j/package-info.java
+++ b/log4j-slf4j-impl/src/main/java/org/apache/logging/slf4j/package-info.java
@@ -21,8 +21,10 @@
  */
 @Export
 @Header(name = Constants.BUNDLE_ACTIVATIONPOLICY, value = Constants.ACTIVATION_LAZY)
+@Version("2.21.0")
 package org.apache.logging.slf4j;
 
 import org.osgi.annotation.bundle.Export;
 import org.osgi.annotation.bundle.Header;
+import org.osgi.annotation.versioning.Version;
 import org.osgi.framework.Constants;

--- a/log4j-slf4j-impl/src/main/java/org/slf4j/impl/package-info.java
+++ b/log4j-slf4j-impl/src/main/java/org/slf4j/impl/package-info.java
@@ -18,6 +18,8 @@
  * Log4j 2.0 SLF4J Binding.
  */
 @Export
+@Version("2.20.1")
 package org.slf4j.impl;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-slf4j2-impl/src/main/java/org/apache/logging/slf4j/package-info.java
+++ b/log4j-slf4j2-impl/src/main/java/org/apache/logging/slf4j/package-info.java
@@ -21,8 +21,10 @@
  */
 @Export
 @Header(name = Constants.BUNDLE_ACTIVATIONPOLICY, value = Constants.ACTIVATION_LAZY)
+@Version("2.21.0")
 package org.apache.logging.slf4j;
 
 import org.osgi.annotation.bundle.Export;
 import org.osgi.annotation.bundle.Header;
+import org.osgi.annotation.versioning.Version;
 import org.osgi.framework.Constants;

--- a/log4j-spring-boot/src/main/java/org/apache/logging/log4j/spring/boot/package-info.java
+++ b/log4j-spring-boot/src/main/java/org/apache/logging/log4j/spring/boot/package-info.java
@@ -20,7 +20,9 @@
  */
 @Export
 @Open("org.apache.logging.log4j.core")
+@Version("2.20.1")
 package org.apache.logging.log4j.spring.boot;
 
 import aQute.bnd.annotation.jpms.Open;
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-spring-cloud-config/log4j-spring-cloud-config-client/src/main/java/org/apache/logging/log4j/spring/cloud/config/client/package-info.java
+++ b/log4j-spring-cloud-config/log4j-spring-cloud-config-client/src/main/java/org/apache/logging/log4j/spring/cloud/config/client/package-info.java
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.spring.cloud.config.client;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-taglib/src/main/java/org/apache/logging/log4j/taglib/package-info.java
+++ b/log4j-taglib/src/main/java/org/apache/logging/log4j/taglib/package-info.java
@@ -20,6 +20,8 @@
  * @since 2.0
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.taglib;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/package-info.java
+++ b/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/package-info.java
@@ -21,6 +21,8 @@
  * @author <a href="http://www.vorburger.ch">Michael Vorburger.ch</a> for Google
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.tojul;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/package-info.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/package-info.java
@@ -18,6 +18,8 @@
  * SLF4J support.
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.slf4j;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-web/src/main/java/org/apache/logging/log4j/web/appender/package-info.java
+++ b/log4j-web/src/main/java/org/apache/logging/log4j/web/appender/package-info.java
@@ -16,7 +16,9 @@
  */
 @Export
 @Open("org.apache.logging.log4j.core")
+@Version("2.20.1")
 package org.apache.logging.log4j.web.appender;
 
 import aQute.bnd.annotation.Export;
 import aQute.bnd.annotation.jpms.Open;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-web/src/main/java/org/apache/logging/log4j/web/package-info.java
+++ b/log4j-web/src/main/java/org/apache/logging/log4j/web/package-info.java
@@ -22,6 +22,8 @@
  * @see <a href="http://logging.apache.org/log4j/2.x/manual/webapp.html">Using Log4j 2 in Web Applications</a>
  */
 @Export
+@Version("2.20.1")
 package org.apache.logging.log4j.web;
 
 import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/pom.xml
+++ b/pom.xml
@@ -653,6 +653,20 @@
 
     <plugins>
 
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-baseline-maven-plugin</artifactId>
+        <version>${bnd-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>baseline</id>
+            <goals>
+              <goal>baseline</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Enable BOM flattening -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
In order to prevent API breaking changes, this:
 * adds [`bnd-baseline-maven-plugin`](https://github.com/bndtools/bnd/tree/master/maven-plugins/bnd-baseline-maven-plugin),
 * fix the API changes that would require a major version bump,
 * set the OSGi version of each packages to `2.20.1` or `2.21.0`, depending on the kind of changes the package underwent since the `2.20.0` release.

The changes detected as major by BND are mostly the addition of `final` to classes that are effectively final (have only a private constructor).