### PR TITLE
Fix Spotbugs alerts up to rank 9

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/WriterAppender.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/WriterAppender.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 
 import org.apache.log4j.helpers.QuietWriter;
@@ -242,12 +243,8 @@ public class WriterAppender extends AppenderSkeleton {
         if (enc != null) {
             try {
                 retval = new OutputStreamWriter(os, enc);
-            } catch (IOException e) {
-                if (e instanceof InterruptedIOException) {
-                    Thread.currentThread().interrupt();
-                }
-                LOGGER.warn("Error initializing output writer.");
-                LOGGER.warn("Unsupported encoding?");
+            } catch (final UnsupportedEncodingException e) {
+                LOGGER.warn("Error initializing output writer: encoding {} is not supported.", enc, e);
             }
         }
         if (retval == null) {

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/spi/LocationInfo.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/spi/LocationInfo.java
@@ -19,6 +19,8 @@ package org.apache.log4j.spi;
 import java.io.Serializable;
 import java.util.Objects;
 
+import org.apache.logging.log4j.core.util.Integers;
+
 /**
  * The internal representation of caller location information.
  *
@@ -101,35 +103,40 @@ public class LocationInfo implements Serializable {
                 prevClass = thisClass;
             }
         }
-        this.stackTraceElement = new StackTraceElement(declaringClass, methodName, file, Integer.parseInt(line));
-        this.fullInfo = stackTraceElement.toString();
+        if (declaringClass != null && methodName != null) {
+            this.stackTraceElement = new StackTraceElement(declaringClass, methodName, file, Integers.parseInt(line));
+            this.fullInfo = stackTraceElement.toString();
+        } else {
+            this.stackTraceElement = null;
+            this.fullInfo = null;
+        }
     }
 
     /**
      * Gets the fully qualified class name of the caller making the logging request.
      */
     public String getClassName() {
-        return stackTraceElement.getClassName();
+        return stackTraceElement != null ? stackTraceElement.getClassName() : NA;
     }
 
     /**
      * Gets the file name of the caller.
      */
     public String getFileName() {
-        return stackTraceElement.getFileName();
+        return stackTraceElement != null ? stackTraceElement.getFileName() : NA;
     }
 
     /**
      * Gets the line number of the caller.
      */
     public String getLineNumber() {
-        return Integer.toString(stackTraceElement.getLineNumber());
+        return stackTraceElement != null ? Integer.toString(stackTraceElement.getLineNumber()) : NA;
     }
 
     /**
      * Gets the method name of the caller.
      */
     public String getMethodName() {
-        return stackTraceElement.getMethodName();
+        return stackTraceElement != null ? stackTraceElement.getMethodName() : NA;
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.logging.log4j.status.StatusLogger;
 
 /**
@@ -545,6 +546,8 @@ public class SortedArrayStringMap implements IndexedStringMap {
         }
     }
 
+    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Object deserialization uses either Java 9 " +
+            "native filter or our custom filter to limit the kinds of classes deserialized.")
     private static Object unmarshall(final byte[] data, final ObjectInputStream inputStream)
             throws IOException, ClassNotFoundException {
         final ByteArrayInputStream bin = new ByteArrayInputStream(data);

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/db/jdbc/JdbcH2TestHelper.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/appender/db/jdbc/JdbcH2TestHelper.java
@@ -23,6 +23,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.file.PathUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.core.appender.db.jdbc.AbstractConnectionSource;
@@ -67,10 +68,12 @@ public class JdbcH2TestHelper {
         }
     }
 
+    @SuppressFBWarnings(value = "DMI_EMPTY_DB_PASSWORD")
     public static Connection getConnectionInMemory() throws SQLException {
         return DriverManager.getConnection(CONNECTION_STRING_IN_MEMORY, USER_NAME, PASSWORD);
     }
 
+    @SuppressFBWarnings(value = "DMI_EMPTY_DB_PASSWORD")
     public static Connection getConnectionTempDir() throws SQLException {
         return DriverManager.getConnection(CONNECTION_STRING_TEMP_DIR, USER_NAME, PASSWORD);
     }

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAvroManager.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeAvroManager.java
@@ -205,7 +205,7 @@ public class FlumeAvroManager extends AbstractFlumeManager {
         } else {
             int eventCount;
             BatchEvent batch = null;
-            synchronized(batchEvent) {
+            synchronized(this) {
                 batchEvent.addEvent(event);
                 eventCount = batchEvent.size();
                 final long now = System.nanoTime();

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/AnnotationVsMarkerInterface.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/AnnotationVsMarkerInterface.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.perf.jmh;
 
 import java.util.concurrent.TimeUnit;
 
-import org.apache.logging.log4j.util.PerformanceSensitive;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.StringMap;
@@ -58,7 +57,7 @@ public class AnnotationVsMarkerInterface {
     @BenchmarkMode({Mode.Throughput, Mode.AverageTime, Mode.SampleTime, Mode.SingleShotTime})
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
     public Object annotationMissing() {
-        return map.getClass().isAnnotationPresent(PerformanceSensitive.class);
+        return map.getClass().isAnnotationPresent(State.class);
     }
 
     @Benchmark

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/JdbcAppenderBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/JdbcAppenderBenchmark.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.concurrent.TimeUnit;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -185,6 +186,7 @@ public class JdbcAppenderBenchmark {
     /**
      * Referred from log4j2-jdbc-appender.xml.
      */
+    @SuppressFBWarnings("DMI_EMPTY_DB_PASSWORD")
     public static Connection getConnectionH2() throws Exception {
         Class.forName("org.h2.Driver");
         return DriverManager.getConnection("jdbc:h2:mem:Log4j", "sa", "");
@@ -193,6 +195,7 @@ public class JdbcAppenderBenchmark {
     /**
      * Referred from log4j2-jdbc-appender.xml.
      */
+    @SuppressFBWarnings("DMI_EMPTY_DB_PASSWORD")
     public static Connection getConnectionHSQLDB() throws Exception {
         Class.forName("org.hsqldb.jdbcDriver");
         return DriverManager.getConnection("jdbc:hsqldb:mem:Log4j", "sa", "");

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/JpaAppenderBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/JpaAppenderBenchmark.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.concurrent.TimeUnit;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -165,6 +166,7 @@ public class JpaAppenderBenchmark {
     /**
      * Referred from log4j2-jdbc-appender.xml.
      */
+    @SuppressFBWarnings("DMI_EMPTY_DB_PASSWORD")
     public static Connection getConnectionH2() throws Exception {
         Class.forName("org.h2.Driver");
         final Connection connection = DriverManager.getConnection("jdbc:h2:mem:Log4j;MODE=PostgreSQL", "sa", "");
@@ -182,6 +184,7 @@ public class JpaAppenderBenchmark {
     /**
      * Referred from log4j2-jdbc-appender.xml.
      */
+    @SuppressFBWarnings("DMI_EMPTY_DB_PASSWORD")
     public static Connection getConnectionHSQLDB() throws Exception {
         Class.forName("org.hsqldb.jdbcDriver");
         final Connection connection = DriverManager.getConnection("jdbc:hsqldb:mem:Log4j", "sa", "");

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/ThreadsafeDateFormatBenchmark.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/jmh/ThreadsafeDateFormatBenchmark.java
@@ -90,7 +90,7 @@ public class ThreadsafeDateFormatBenchmark {
         }
     }
 
-    private class FormatterSimple {
+    private static class FormatterSimple {
         private final SimpleDateFormat format = new SimpleDateFormat("HH:mm:ss.SSS");
         private long timestamp;
         private String formatted;
@@ -108,7 +108,7 @@ public class ThreadsafeDateFormatBenchmark {
         }
     }
 
-    private class FormatterFixedReuseBuffer {
+    private static class FormatterFixedReuseBuffer {
         private final FixedDateFormat customFormat = FixedDateFormat.createIfSupported("HH:mm:ss.SSS");
         private long timestamp;
         private String formatted;

--- a/log4j-perf/src/main/java/org/apache/logging/log4j/perf/nogc/NoGcMessage.java
+++ b/log4j-perf/src/main/java/org/apache/logging/log4j/perf/nogc/NoGcMessage.java
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.message.Message;
  * Reusable Message..
  */
 public class NoGcMessage implements Message {
-    class InternalState {
+    static class InternalState {
         private final Object[] params = new Object[10];
         private int paramCount;
         private final StringBuilder buffer = new StringBuilder(2048);

--- a/pom.xml
+++ b/pom.xml
@@ -314,8 +314,7 @@
     <docLabel>Site Documentation</docLabel>
     <projectDir />
     <module.name />
-    <!-- TODO: fix errors and reenable SpotBugs -->
-    <spotbugs.skip>true</spotbugs.skip>
+    <spotbugs.maxRank>9</spotbugs.maxRank>
 
     <!-- ========================
          Site-specific properties
@@ -1307,6 +1306,12 @@
     <dependency>
       <groupId>biz.aQute.bnd</groupId>
       <artifactId>biz.aQute.bnd.annotation</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
This fixes Spotbugs alerts up to rank 9 (the "scary" category).

Most are false positives or problems in the tests. The `LocationInfo` fix in `log4j-1.2-api` prevents an NPE though.
