### PR TITLE
[1223] Change FormattedMessage pattern heuristic

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/package-info.java
@@ -19,7 +19,10 @@
  * Public Message Types used for Log4j 2. Users may implement their own Messages.
  */
 @Export
-@Version("2.20.1")
+/**
+ * Bumped to 2.21.0, since FormattedMessage behavior changed.
+ */
+@Version("2.21.0")
 package org.apache.logging.log4j.message;
 
 import org.osgi.annotation.bundle.Export;

--- a/src/changelog/.2.x.x/1223_change_formatted_message_heuristic.xml
+++ b/src/changelog/.2.x.x/1223_change_formatted_message_heuristic.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="changed">
+  <issue id="1223" link="https://github.com/apache/logging-log4j2/issues/1223"/>
+  <description format="asciidoc">
+    Change the order of evaluation of `FormattedMessage` formatters.
+    Messages are evaluated using `java.util.Format` only if they don't comply to the `java.text.MessageFormat` or `ParameterizedMessage` format.
+  </description>
+</entry>

--- a/src/site/xdoc/manual/messages.xml
+++ b/src/site/xdoc/manual/messages.xml
@@ -168,12 +168,31 @@ public class MyApp {
       <h4>FormattedMessage</h4>
         <a name="FormattedMessage"/>
         <p>
-          The message pattern passed to a
-          <a class="javadoc" href="../log4j-api/apidocs/org/apache/logging/log4j/message/FormattedMessage.html">FormattedMessage</a>
-          is first checked to see if it is a valid java.text.MessageFormat pattern. If it is, a MessageFormatMessage is
-          used to format it. If not it is next checked to see if it contains any tokens that are valid format
-          specifiers for String.format(). If so, a StringFormattedMessage is used to format it. Finally, if the
-          pattern doesn't match either of those then a ParameterizedMessage is used to format it.
+          <a class="javadoc" href="../log4j-api/apidocs/org/apache/logging/log4j/message/FormattedMessage">FormattedMessage</a>
+          is a message that supports multiple pattern formatters:
+          <ul>
+            <li>
+              if the pattern is a valid
+              <a class="javadoc" href="https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/text/MessageFormat.html">java.text.MessageFormat</a>
+              pattern, then
+              <a class="javadoc" href="https://logging.apache.org/log4j/2.x/javadoc/log4j-api/org/apache/logging/log4j/message/MessageFormatMessage.html">MessageFormatMessage</a>
+              is used to format it,
+            </li>
+            <li>
+              if the pattern contains valid unescaped <code>{}</code> specifiers, then
+              <a class="javadoc" href="https://logging.apache.org/log4j/2.x/javadoc/log4j-api/org/apache/logging/log4j/message/ParameterizedMessage">ParameterizedMessage</a>
+              is used to format it,
+            </li>
+            <li>
+              if the pattern is a valid
+              <a class="javadoc" href="https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/Formatter.html">java.uti.Formatter</a>
+              pattern, then
+              <a class="javadoc" href="https://logging.apache.org/log4j/2.x/javadoc/log4j-api/org/apache/logging/log4j/message/StringFormattedMessage">StringFormattedMessage</a>
+              is used to format it.
+            </li>
+          </ul>
+          Mixing specifiers from multiple formatters is not supported.
+          A pattern without any specifiers will use any of the above formatters.
         </p>
       <h4>LocalizedMessage</h4>
         <a name="LocalizedMessage"/>


### PR DESCRIPTION
We change the order in which `FormattedMessage` checks the format of the provided pattern: we first check for the presence of `{}` placeholders and only then for `java.util.Format` specifiers.

This eliminates the need for a potentially exponential regular expression evalutation, which was reported by Spotbugs (#1849).

The Javadoc and documentation were improved to clarify the heuristic used by `FormattedMessage`.

Closes #1223.

Remark: since `FormattedMessage` used the **same** regular expression as `java.util.Format`, if a message uses `java.util.Format` specifiers, it is still vulnerable to a ReDOS.
