### PR TITLE
Fix serialization of common `Message` classes

### DIFF
--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/internal/DefaultObjectInputFilter.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/internal/DefaultObjectInputFilter.java
@@ -17,27 +17,11 @@
 package org.apache.logging.log4j.util.internal;
 
 import java.io.ObjectInputFilter;
-import java.util.Arrays;
-import java.util.List;
+
+import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_JAVA_CLASSES;
+import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_JAVA_PACKAGES;
 
 public class DefaultObjectInputFilter implements ObjectInputFilter {
-
-
-    private static final List<String> REQUIRED_JAVA_CLASSES = Arrays.asList(
-            "java.math.BigDecimal",
-            "java.math.BigInteger",
-            // for Message delegate
-            "java.rmi.MarshalledObject",
-            "[B"
-    );
-
-    private static final List<String> REQUIRED_JAVA_PACKAGES = Arrays.asList(
-            "java.lang.",
-            "java.time",
-            "java.util.",
-            "org.apache.logging.log4j.",
-            "[Lorg.apache.logging.log4j."
-    );
 
     private final ObjectInputFilter delegate;
 
@@ -81,6 +65,9 @@ public class DefaultObjectInputFilter implements ObjectInputFilter {
             if (isAllowedByDefault(name) || isRequiredPackage(name)) {
                 return Status.ALLOWED;
             }
+        } else {
+            // Object already deserialized
+            return Status.ALLOWED;
         }
         return Status.REJECTED;
     }

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.util.internal;
+
+import java.util.List;
+
+/**
+ * Dummy class for compilation purposes only.
+ */
+public final class SerializationUtil {
+    public static final List<String> REQUIRED_JAVA_CLASSES = List.of();
+    public static final List<String> REQUIRED_JAVA_PACKAGES = List.of();
+}

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/SerialUtil.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/SerialUtil.java
@@ -22,6 +22,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
+import org.apache.logging.log4j.util.Constants;
+import org.apache.logging.log4j.util.FilteredObjectInputStream;
+
 /**
  * Utility class to facilitate serializing and deserializing objects.
  */
@@ -56,7 +59,12 @@ public class SerialUtil {
     public static <T> T deserialize(final byte[] data) {
         try {
             final ByteArrayInputStream bas = new ByteArrayInputStream(data);
-            final ObjectInputStream ois = new ObjectInputStream(bas);
+            final ObjectInputStream ois;
+            if (Constants.JAVA_MAJOR_VERSION == 8) {
+                ois = new FilteredObjectInputStream(bas);
+            } else {
+                ois = new ObjectInputStream(bas);
+            }
             return (T) ois.readObject();
         } catch (final Exception ex) {
             throw new IllegalStateException("Could not deserialize", ex);

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
@@ -16,9 +16,15 @@
  */
 package org.apache.logging.log4j.message;
 
-import org.apache.logging.log4j.test.junit.Mutable;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
 
+import org.apache.logging.log4j.test.junit.Mutable;
+import org.apache.logging.log4j.test.junit.SerialUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -141,5 +147,18 @@ public class ParameterizedMessageTest {
         param.set("000");
         final String after = msg.getFormattedMessage();
         assertEquals("Test message XYZ", after, "Should not change after rendered once");
+    }
+
+    static Stream<Object> testSerializable() {
+        return Stream.of("World", new Object(), null);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testSerializable(final Object arg) {
+        final Message expected = new ParameterizedMessage("Hello {}!", arg);
+        final Message actual = SerialUtil.deserialize(SerialUtil.serialize(expected));
+        assertThat(actual).isInstanceOf(ParameterizedMessage.class);
+        assertThat(actual.getFormattedMessage()).isEqualTo(expected.getFormattedMessage());
     }
 }

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ReusableObjectMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ReusableObjectMessageTest.java
@@ -16,8 +16,14 @@
  */
 package org.apache.logging.log4j.message;
 
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
 
+import org.apache.logging.log4j.test.junit.SerialUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -118,5 +124,19 @@ public class ReusableObjectMessageTest {
         msg.set("xyz");
         msg.formatTo(sb);
         assertEquals("xyz", sb.toString());
+    }
+
+    static Stream<Object> testSerializable() {
+        return ObjectMessageTest.testSerializable();
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testSerializable(final Object arg) {
+        final ReusableObjectMessage expected = new ReusableObjectMessage();
+        expected.set(arg);
+        final Message actual = SerialUtil.deserialize(SerialUtil.serialize(expected));
+        assertThat(actual).isInstanceOf(ObjectMessage.class);
+        assertThat(actual.getFormattedMessage()).isEqualTo(expected.getFormattedMessage());
     }
 }

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ReusableParameterizedMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ReusableParameterizedMessageTest.java
@@ -18,10 +18,15 @@ package org.apache.logging.log4j.message;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.logging.log4j.test.junit.Mutable;
+import org.apache.logging.log4j.test.junit.SerialUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -160,5 +165,19 @@ public class ReusableParameterizedMessageTest {
         final List<Object> actual = new LinkedList<>();
         msg.forEachParameter((parameter, parameterIndex, state) -> actual.add(parameter), null);
         assertEquals(expected, actual);
+    }
+
+    static Stream<Object> testSerializable() {
+        return Stream.of("World", new Object(), null);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testSerializable(final Object arg) {
+        final ReusableParameterizedMessage expected = new ReusableParameterizedMessage();
+        expected.set("Hello {}!", arg);
+        final Message actual = SerialUtil.deserialize(SerialUtil.serialize(expected));
+        assertThat(actual).isInstanceOf(ParameterizedMessage.class);
+        assertThat(actual.getFormattedMessage()).isEqualTo(expected.getFormattedMessage());
     }
 }

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ReusableSimpleMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ReusableSimpleMessageTest.java
@@ -16,9 +16,15 @@
  */
 package org.apache.logging.log4j.message;
 
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.test.junit.SerialUtil;
 import org.apache.logging.log4j.util.Constants;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -121,5 +127,19 @@ public class ReusableSimpleMessageTest {
         msg.set("xyz");
         msg.formatTo(sb);
         assertEquals("xyz", sb.toString());
+    }
+
+    static Stream<CharSequence> testSerializable() {
+        return SimpleMessageTest.testSerializable();
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testSerializable(final CharSequence arg) {
+        final ReusableSimpleMessage expected = new ReusableSimpleMessage();
+        expected.set(arg);
+        final Message actual = SerialUtil.deserialize(SerialUtil.serialize(expected));
+        assertThat(actual).isInstanceOf(SimpleMessage.class);
+        assertThat(actual.getFormattedMessage()).isEqualTo(expected.getFormattedMessage());
     }
 }

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/DeserializerHelper.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/DeserializerHelper.java
@@ -19,6 +19,9 @@ package org.apache.logging.log4j.util;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.ObjectInputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Deserializes a specified file.
@@ -28,9 +31,11 @@ import java.io.ObjectInputStream;
 public class DeserializerHelper {
     public static void main(final String... args) throws Exception {
         final File file = new File(args[0]);
+        final Collection<String> allowedExtraClasses = args.length > 1 ? Arrays.asList(args).subList(1, args.length)
+                : Collections.emptyList();
         ObjectInputStream in = null;
         try {
-            in = new FilteredObjectInputStream(new FileInputStream(file));
+            in = new FilteredObjectInputStream(new FileInputStream(file), allowedExtraClasses);
             final Object result = in.readObject();
             System.out.println(result);
         } catch (final Throwable t) {

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/SortedArrayStringMapTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/SortedArrayStringMapTest.java
@@ -129,7 +129,7 @@ public class SortedArrayStringMapTest {
         }
         final String classpath = createClassPath(SortedArrayStringMap.class, DeserializerHelper.class);
         final Process process = new ProcessBuilder("java", "-cp", classpath,
-                DeserializerHelper.class.getName(), file.getPath()).start();
+                DeserializerHelper.class.getName(), file.getPath(), "org.junit.runner.Result").start();
         final BufferedReader in = new BufferedReader(new InputStreamReader(process.getErrorStream()));
         final int exitValue = process.waitFor();
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectMessage.java
@@ -23,13 +23,14 @@ import java.io.Serializable;
 
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.StringBuilders;
+import org.apache.logging.log4j.util.internal.SerializationUtil;
 
 /**
  * Handles messages that contain an Object.
  */
 public class ObjectMessage implements Message, StringBuilderFormattable {
 
-    private static final long serialVersionUID = -5903272448334166185L;
+    private static final long serialVersionUID = -5732356316298601755L;
 
     private transient Object obj;
     private transient String objectString;
@@ -125,16 +126,14 @@ public class ObjectMessage implements Message, StringBuilderFormattable {
 
     private void writeObject(final ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
-        if (obj instanceof Serializable) {
-            out.writeObject(obj);
-        } else {
-            out.writeObject(String.valueOf(obj));
-        }
+        SerializationUtil.writeWrappedObject(obj instanceof Serializable ? (Serializable) obj : String.valueOf(obj),
+                out);
     }
 
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+        SerializationUtil.assertFiltered(in);
         in.defaultReadObject();
-        obj = in.readObject();
+        obj = SerializationUtil.readWrappedObject(in);
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.message;
 
+import java.io.Serializable;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -152,7 +153,9 @@ final class ParameterFormatter {
     /**
      * @see #analyzePattern(String, int, MessagePatternAnalysis)
      */
-    static final class MessagePatternAnalysis {
+    static final class MessagePatternAnalysis implements Serializable {
+
+        private static final long serialVersionUID = -5974082575968329887L;
 
         /**
          * The size of the {@link #placeholderCharIndices} buffer to be allocated if it is found to be null.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
@@ -135,4 +135,8 @@ public class ReusableObjectMessage implements ReusableMessage, ParameterVisitabl
     public void clear() {
         obj = null;
     }
+
+    private Object writeReplace() {
+        return memento();
+    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
@@ -347,4 +347,7 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         }
     }
 
+    private Object writeReplace() {
+        return memento();
+    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
@@ -110,4 +110,8 @@ public class ReusableSimpleMessage implements ReusableMessage, CharSequence, Par
     public void clear() {
         charSequence = null;
     }
+
+    private Object writeReplace() {
+        return memento();
+    }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/FilteredObjectInputStream.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/FilteredObjectInputStream.java
@@ -21,11 +21,11 @@ import java.io.InputStream;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+
+import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_JAVA_CLASSES;
+import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_JAVA_PACKAGES;
 
 /**
  * Extends {@link ObjectInputStream} to only allow some built-in Log4j classes and caller-specified classes to be
@@ -34,26 +34,6 @@ import java.util.Set;
  * @since 2.8.2
  */
 public class FilteredObjectInputStream extends ObjectInputStream {
-
-    private static final Set<String> REQUIRED_JAVA_CLASSES = new HashSet<>(Arrays.asList(
-    // @formatter:off
-            "java.math.BigDecimal",
-            "java.math.BigInteger",
-            // for Message delegate
-            "java.rmi.MarshalledObject",
-            "[B"
-    // @formatter:on
-    ));
-
-    private static final Set<String> REQUIRED_JAVA_PACKAGES = new HashSet<>(Arrays.asList(
-    // @formatter:off
-            "java.lang.",
-            "java.time.",
-            "java.util.",
-            "org.apache.logging.log4j.",
-            "[Lorg.apache.logging.log4j."
-    // @formatter:on
-    ));
 
     private final Collection<String> allowedExtraClasses;
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
@@ -16,14 +16,16 @@
  */
 package org.apache.logging.log4j.util;
 
-import java.io.*;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.*;
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.ConcurrentModificationException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.internal.SerializationUtil;
 
 /**
  * <em>Consider this class private.</em>
@@ -72,41 +74,6 @@ public class SortedArrayStringMap implements IndexedStringMap {
      * The number of key-value mappings contained in this map.
      */
     private transient int size;
-
-    private static final Method setObjectInputFilter;
-    private static final Method getObjectInputFilter;
-    private static final Method newObjectInputFilter;
-
-    static {
-        Method[] methods = ObjectInputStream.class.getMethods();
-        Method setMethod = null;
-        Method getMethod = null;
-        for (final Method method : methods) {
-            if (method.getName().equals("setObjectInputFilter")) {
-                setMethod = method;
-            } else if (method.getName().equals("getObjectInputFilter")) {
-                getMethod = method;
-            }
-        }
-        Method newMethod = null;
-        try {
-            if (setMethod != null) {
-                final Class<?> clazz = Class.forName("org.apache.logging.log4j.util.internal.DefaultObjectInputFilter");
-                methods = clazz.getMethods();
-                for (final Method method : methods) {
-                    if (method.getName().equals("newInstance") && Modifier.isStatic(method.getModifiers())) {
-                        newMethod = method;
-                        break;
-                    }
-                }
-            }
-        } catch (final ClassNotFoundException ex) {
-            // Ignore the exception
-        }
-        newObjectInputFilter = newMethod;
-        setObjectInputFilter = setMethod;
-        getObjectInputFilter = getMethod;
-    }
 
     /**
      * The next size value at which to resize (capacity * load factor).
@@ -513,52 +480,9 @@ public class SortedArrayStringMap implements IndexedStringMap {
         if (size > 0) {
             for (int i = 0; i < size; i++) {
                 s.writeObject(keys[i]);
-                try {
-                    s.writeObject(marshall(values[i]));
-                } catch (final Exception e) {
-                    handleSerializationException(e, i, keys[i]);
-                    s.writeObject(null);
-                }
+                SerializationUtil.writeWrappedObject((values[i] instanceof Serializable) ? (Serializable) values[i] : null,
+                        s);
             }
-        }
-    }
-
-    private static byte[] marshall(final Object obj) throws IOException {
-        if (obj == null) {
-            return null;
-        }
-        final ByteArrayOutputStream bout = new ByteArrayOutputStream();
-        try (final ObjectOutputStream oos = new ObjectOutputStream(bout)) {
-            oos.writeObject(obj);
-            oos.flush();
-            return bout.toByteArray();
-        }
-    }
-
-    @SuppressFBWarnings(value = "OBJECT_DESERIALIZATION", justification = "Object deserialization uses either Java 9 " +
-            "native filter or our custom filter to limit the kinds of classes deserialized.")
-    private static Object unmarshall(final byte[] data, final ObjectInputStream inputStream)
-            throws IOException, ClassNotFoundException {
-        final ByteArrayInputStream bin = new ByteArrayInputStream(data);
-        Collection<String> allowedClasses = null;
-        ObjectInputStream ois;
-        if (inputStream instanceof FilteredObjectInputStream) {
-            allowedClasses = ((FilteredObjectInputStream) inputStream).getAllowedClasses();
-            ois = new FilteredObjectInputStream(bin, allowedClasses);
-        } else {
-            try {
-                final Object obj = getObjectInputFilter.invoke(inputStream);
-                final Object filter = newObjectInputFilter.invoke(null, obj);
-                ois = new ObjectInputStream(bin);
-                setObjectInputFilter.invoke(ois, filter);
-            } catch (IllegalAccessException | InvocationTargetException ex) {
-                throw new StreamCorruptedException("Unable to set ObjectInputFilter on stream");
-            }
-        }
-        try {
-            return ois.readObject();
-        } finally {
-            ois.close();
         }
     }
 
@@ -580,9 +504,7 @@ public class SortedArrayStringMap implements IndexedStringMap {
      * deserialize it).
      */
     private void readObject(final java.io.ObjectInputStream s)  throws IOException, ClassNotFoundException {
-        if (!(s instanceof FilteredObjectInputStream) && setObjectInputFilter == null) {
-            throw new IllegalArgumentException("readObject requires a FilteredObjectInputStream or an ObjectInputStream that accepts an ObjectInputFilter");
-        }
+        SerializationUtil.assertFiltered(s);
         // Read in the threshold (ignored), and any hidden stuff
         s.defaultReadObject();
 
@@ -612,18 +534,8 @@ public class SortedArrayStringMap implements IndexedStringMap {
         // Read the keys and values, and put the mappings in the arrays
         for (int i = 0; i < mappings; i++) {
             keys[i] = (String) s.readObject();
-            try {
-                final byte[] marshalledObject = (byte[]) s.readObject();
-                values[i] = marshalledObject == null ? null : unmarshall(marshalledObject, s);
-            } catch (final Exception | LinkageError error) {
-                handleSerializationException(error, i, keys[i]);
-                values[i] = null;
-            }
+            values[i] = SerializationUtil.readWrappedObject(s);
         }
         size = mappings;
-    }
-
-    private void handleSerializationException(final Throwable t, final int i, final String key) {
-        StatusLogger.getLogger().warn("Ignoring {} for key[{}] ('{}')", String.valueOf(t), i, keys[i]);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.util.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.io.StreamCorruptedException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.FilteredObjectInputStream;
+
+/**
+ * Provides methods to increase the safety of object serialization/deserialization.
+ */
+public final class SerializationUtil {
+
+    private static final String DEFAULT_FILTER_CLASS= "org.apache.logging.log4j.util.internal.DefaultObjectInputFilter";
+    private static final Method setObjectInputFilter;
+    private static final Method getObjectInputFilter;
+    private static final Method newObjectInputFilter;
+
+    static {
+        Method[] methods = ObjectInputStream.class.getMethods();
+        Method setMethod = null;
+        Method getMethod = null;
+        for (final Method method : methods) {
+            if (method.getName().equals("setObjectInputFilter")) {
+                setMethod = method;
+            } else if (method.getName().equals("getObjectInputFilter")) {
+                getMethod = method;
+            }
+        }
+        Method newMethod = null;
+        try {
+            if (setMethod != null) {
+                final Class<?> clazz = Class.forName(DEFAULT_FILTER_CLASS);
+                methods = clazz.getMethods();
+                for (final Method method : methods) {
+                    if (method.getName().equals("newInstance") && Modifier.isStatic(method.getModifiers())) {
+                        newMethod = method;
+                        break;
+                    }
+                }
+            }
+        } catch (final ClassNotFoundException ex) {
+            // Ignore the exception
+        }
+        newObjectInputFilter = newMethod;
+        setObjectInputFilter = setMethod;
+        getObjectInputFilter = getMethod;
+    }
+
+    public static final List<String> REQUIRED_JAVA_CLASSES = Arrays.asList(
+            "java.math.BigDecimal",
+            "java.math.BigInteger",
+            // for Message delegate
+            "java.rmi.MarshalledObject",
+            "[B",
+            // for MessagePatternAnalysis
+            "[I"
+    );
+
+    public static final List<String> REQUIRED_JAVA_PACKAGES = Arrays.asList(
+            "java.lang.",
+            "java.time",
+            "java.util.",
+            "org.apache.logging.log4j.",
+            "[Lorg.apache.logging.log4j."
+    );
+
+    public static void writeWrappedObject(final Serializable obj, final ObjectOutputStream out) throws IOException {
+        final ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        try (final ObjectOutputStream oos = new ObjectOutputStream(bout)) {
+            oos.writeObject(obj);
+            oos.flush();
+            out.writeObject(bout.toByteArray());
+        }
+    }
+
+    @SuppressFBWarnings(
+            value = "OBJECT_DESERIALIZATION",
+            justification = "Object deserialization uses either Java 9 native filter or our custom filter to limit the kinds of classes deserialized.")
+    public static Object readWrappedObject(final ObjectInputStream in)
+            throws IOException, ClassNotFoundException {
+        assertFiltered(in);
+        final byte[] data = (byte[]) in.readObject();
+        final ByteArrayInputStream bin = new ByteArrayInputStream(data);
+        final ObjectInputStream ois;
+        if (in instanceof FilteredObjectInputStream) {
+            ois = new FilteredObjectInputStream(bin, ((FilteredObjectInputStream) in).getAllowedClasses());
+        } else {
+            try {
+                final Object obj = getObjectInputFilter.invoke(in);
+                final Object filter = newObjectInputFilter.invoke(null, obj);
+                ois = new ObjectInputStream(bin);
+                setObjectInputFilter.invoke(ois, filter);
+            } catch (IllegalAccessException | InvocationTargetException ex) {
+                throw new StreamCorruptedException("Unable to set ObjectInputFilter on stream");
+            }
+        }
+        try {
+            return ois.readObject();
+        } catch (final Exception | LinkageError e) {
+            StatusLogger.getLogger().warn("Ignoring {} during deserialization", e.getMessage());
+            return null;
+        } finally {
+            ois.close();
+        }
+    }
+
+    public static void assertFiltered(final java.io.ObjectInputStream stream) {
+        if (!(stream instanceof FilteredObjectInputStream) && setObjectInputFilter == null) {
+            throw new IllegalArgumentException("readObject requires a FilteredObjectInputStream or an ObjectInputStream that accepts an ObjectInputFilter");
+        }
+    }
+
+    private SerializationUtil() {}
+}


### PR DESCRIPTION
Although every `Message` class should be serializable, some common message classes are not:
 * `ParameterizedMessage`,
 * `ReusableObjectMessage`,
 * `ReusableSimpleMessage`,
 * `ReusableParameterizedMessage`.

Since many of these classes can have fields of arbitrary types:
 1. We harden the serialization process by requiring the usage of our `FilteredObjectInputStream` on JRE 8 and by applying filters to `ObjectInputStream` on JRE 9+. The serialization process is identical to what is already done in `SortedArrayStringMap`.
 2. We add serialization to `ParameterizedMessage`. If a parameter is not `Serializable`, it is serialized as `String`.
 3. We add serialization to the reusable messages by calling `memento()` and serializing their immutable counterparts

This change solves many serialization bugs detected by Spotbugs (#1849) and is related to #1884.

This PR introduces the new Java 8 package
`org.apache.logging.log4j.util.internal`. This package already existed in `log4j-api-java9`, but was not detected by BND. By introducing it in `log4j-api` too, this should also help solving #1896.
