### PR TITLE
Evaluate AOSP style from Google Java Format

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/CloseableThreadContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/CloseableThreadContext.java
@@ -36,8 +36,7 @@ import java.util.Map;
  */
 public class CloseableThreadContext {
 
-    private CloseableThreadContext() {
-    }
+    private CloseableThreadContext() {}
 
     /**
      * Pushes new diagnostic context information on to the Thread Context Stack. The information will be popped off when
@@ -105,8 +104,7 @@ public class CloseableThreadContext {
         private int pushCount = 0;
         private final Map<String, String> originalValues = new HashMap<>();
 
-        private Instance() {
-        }
+        private Instance() {}
 
         /**
          * Pushes new diagnostic context information on to the Thread Context Stack.
@@ -205,7 +203,9 @@ public class CloseableThreadContext {
         }
 
         private void closeMap() {
-            for (final Iterator<Map.Entry<String, String>> it = originalValues.entrySet().iterator(); it.hasNext();) {
+            for (final Iterator<Map.Entry<String, String>> it =
+                            originalValues.entrySet().iterator();
+                    it.hasNext(); ) {
                 final Map.Entry<String, String> entry = it.next();
                 final String key = entry.getKey();
                 final String originalValue = entry.getValue();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
@@ -16,15 +16,14 @@
  */
 package org.apache.logging.log4j;
 
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
+
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
 import org.apache.logging.log4j.spi.StandardLevel;
 import org.apache.logging.log4j.util.Strings;
-
-import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * Levels used for identifying the severity of an event. Levels are organized from most specific to least:
@@ -79,7 +78,8 @@ public final class Level implements Comparable<Level>, Serializable {
 
     private static final Level[] EMPTY_ARRAY = {};
 
-    private static final ConcurrentMap<String, Level> LEVELS = new ConcurrentHashMap<>(); // SUPPRESS CHECKSTYLE
+    private static final ConcurrentMap<String, Level> LEVELS =
+            new ConcurrentHashMap<>(); // SUPPRESS CHECKSTYLE
 
     /**
      * No events will be logged.
@@ -218,6 +218,7 @@ public final class Level implements Comparable<Level>, Serializable {
     public Level clone() throws CloneNotSupportedException {
         throw new CloneNotSupportedException();
     }
+
     // CHECKSTYLE:ON
 
     @Override

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
@@ -19,14 +19,13 @@ package org.apache.logging.log4j;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.Supplier;
 
-
 /**
  * Interface for constructing log events before logging them. Instances of LogBuilders should only be created
  * by calling one of the Logger methods that return a LogBuilder.
  */
 public interface LogBuilder {
     /** NOOP Logbuilder */
-    LogBuilder NOOP = new LogBuilder() { };
+    LogBuilder NOOP = new LogBuilder() {};
 
     /**
      * Includes a Marker in the log event. Interface default method does nothing.
@@ -68,15 +67,13 @@ public interface LogBuilder {
      * Causes all the data collected to be logged along with the message. Interface default method does nothing.
      * @param message The message to log.
      */
-    default void log(CharSequence message) {
-    }
+    default void log(CharSequence message) {}
 
     /**
      * Causes all the data collected to be logged along with the message. Interface default method does nothing.
      * @param message The message to log.
      */
-    default void log(String message) {
-    }
+    default void log(String message) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -86,8 +83,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object... params) {
-    }
+    default void log(String message, Object... params) {}
 
     /**
      * Causes all the data collected to be logged along with the message and parameters.
@@ -95,22 +91,19 @@ public interface LogBuilder {
      * @param message The message.
      * @param params Parameters to the message.
      */
-    default void log(String message, Supplier<?>... params) {
-    }
+    default void log(String message, Supplier<?>... params) {}
 
     /**
      * Causes all the data collected to be logged along with the message. Interface default method does nothing.
      * @param message The message to log.
      */
-    default void log(Message message) {
-    }
+    default void log(Message message) {}
 
     /**
      * Causes all the data collected to be logged along with the message. Interface default method does nothing.
      * @param messageSupplier The supplier of the message to log.
      */
-    default void log(Supplier<Message> messageSupplier) {
-    }
+    default void log(Supplier<Message> messageSupplier) {}
 
     /**
      * Causes all the data collected to be logged along with the message.
@@ -127,8 +120,7 @@ public interface LogBuilder {
      * Causes all the data collected to be logged along with the message. Interface default method does nothing.
      * @param message The message to log.
      */
-    default void log(Object message) {
-    }
+    default void log(Object message) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -138,8 +130,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0) {
-    }
+    default void log(String message, Object p0) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -150,8 +141,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1) {
-    }
+    default void log(String message, Object p0, Object p1) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -163,8 +153,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2) {
-    }
+    default void log(String message, Object p0, Object p1, Object p2) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -177,8 +166,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3) {
-    }
+    default void log(String message, Object p0, Object p1, Object p2, Object p3) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -192,8 +180,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
-    }
+    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -208,8 +195,8 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
-    }
+    default void log(
+            String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {}
 
     /**
      * Logs a message with parameters.
@@ -225,8 +212,15 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
-    }
+    default void log(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -243,9 +237,16 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7) {
-    }
+    default void log(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -263,9 +264,17 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8) {
-    }
+    default void log(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -284,13 +293,21 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9) {
-    }
+    default void log(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9) {}
 
     /**
      * Causes all the data collected to be logged. Default implementatoin does nothing.
      */
-    default void log() {
-    }
+    default void log() {}
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
@@ -20,7 +20,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
-
 import org.apache.logging.log4j.internal.LogManagerStatus;
 import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.message.StringFormatterMessageFactory;
@@ -75,51 +74,65 @@ public class LogManager {
         final String factoryClassName = managerProps.getStringProperty(FACTORY_PROPERTY_NAME);
         if (factoryClassName != null) {
             try {
-                factory = LoaderUtil.newCheckedInstanceOf(factoryClassName, LoggerContextFactory.class);
+                factory =
+                        LoaderUtil.newCheckedInstanceOf(
+                                factoryClassName, LoggerContextFactory.class);
             } catch (final ClassNotFoundException cnfe) {
-                LOGGER.error("Unable to locate configured LoggerContextFactory {}", factoryClassName);
+                LOGGER.error(
+                        "Unable to locate configured LoggerContextFactory {}", factoryClassName);
             } catch (final Exception ex) {
-                LOGGER.error("Unable to create configured LoggerContextFactory {}", factoryClassName, ex);
+                LOGGER.error(
+                        "Unable to create configured LoggerContextFactory {}",
+                        factoryClassName,
+                        ex);
             }
         }
 
         if (factory == null) {
             final SortedMap<Integer, LoggerContextFactory> factories = new TreeMap<>();
-            // note that the following initial call to ProviderUtil may block until a Provider has been installed when
+            // note that the following initial call to ProviderUtil may block until a Provider has
+            // been installed when
             // running in an OSGi environment
             if (ProviderUtil.hasProviders()) {
                 for (final Provider provider : ProviderUtil.getProviders()) {
-                    final Class<? extends LoggerContextFactory> factoryClass = provider.loadLoggerContextFactory();
+                    final Class<? extends LoggerContextFactory> factoryClass =
+                            provider.loadLoggerContextFactory();
                     if (factoryClass != null) {
                         try {
                             factories.put(provider.getPriority(), factoryClass.newInstance());
                         } catch (final Exception e) {
-                            LOGGER.error("Unable to create class {} specified in provider URL {}",
-                                    factoryClass.getName(), provider.getUrl(), e);
+                            LOGGER.error(
+                                    "Unable to create class {} specified in provider URL {}",
+                                    factoryClass.getName(),
+                                    provider.getUrl(),
+                                    e);
                         }
                     }
                 }
 
                 if (factories.isEmpty()) {
-                    LOGGER.error("Log4j2 could not find a logging implementation. "
-                            + "Please add log4j-core to the classpath. Using SimpleLogger to log to the console...");
+                    LOGGER.error(
+                            "Log4j2 could not find a logging implementation. "
+                                    + "Please add log4j-core to the classpath. Using SimpleLogger to log to the console...");
                     factory = SimpleLoggerContextFactory.INSTANCE;
                 } else if (factories.size() == 1) {
                     factory = factories.get(factories.lastKey());
                 } else {
-                    final StringBuilder sb = new StringBuilder("Multiple logging implementations found: \n");
-                    for (final Map.Entry<Integer, LoggerContextFactory> entry : factories.entrySet()) {
+                    final StringBuilder sb =
+                            new StringBuilder("Multiple logging implementations found: \n");
+                    for (final Map.Entry<Integer, LoggerContextFactory> entry :
+                            factories.entrySet()) {
                         sb.append("Factory: ").append(entry.getValue().getClass().getName());
                         sb.append(", Weighting: ").append(entry.getKey()).append('\n');
                     }
                     factory = factories.get(factories.lastKey());
                     sb.append("Using factory: ").append(factory.getClass().getName());
                     LOGGER.warn(sb.toString());
-
                 }
             } else {
-                LOGGER.error("Log4j2 could not find a logging implementation. "
-                        + "Please add log4j-core to the classpath. Using SimpleLogger to log to the console...");
+                LOGGER.error(
+                        "Log4j2 could not find a logging implementation. "
+                                + "Please add log4j-core to the classpath. Using SimpleLogger to log to the console...");
                 factory = SimpleLoggerContextFactory.INSTANCE;
             }
         }
@@ -129,8 +142,7 @@ public class LogManager {
     /**
      * Prevents instantiation
      */
-    protected LogManager() {
-    }
+    protected LogManager() {}
 
     /**
      * Detects if a Logger with the specified name exists. This is a convenience method for porting from version 1.
@@ -176,7 +188,8 @@ public class LogManager {
             return factory.getContext(FQCN, null, null, currentContext, null, null);
         } catch (final IllegalStateException ex) {
             LOGGER.warn(ex.getMessage() + " Using SimpleLogger");
-            return SimpleLoggerContextFactory.INSTANCE.getContext(FQCN, null, null, currentContext, null, null);
+            return SimpleLoggerContextFactory.INSTANCE.getContext(
+                    FQCN, null, null, currentContext, null, null);
         }
     }
 
@@ -196,7 +209,8 @@ public class LogManager {
             return factory.getContext(FQCN, loader, null, currentContext);
         } catch (final IllegalStateException ex) {
             LOGGER.warn(ex.getMessage() + " Using SimpleLogger");
-            return SimpleLoggerContextFactory.INSTANCE.getContext(FQCN, loader, null, currentContext);
+            return SimpleLoggerContextFactory.INSTANCE.getContext(
+                    FQCN, loader, null, currentContext);
         }
     }
 
@@ -212,13 +226,14 @@ public class LogManager {
      * @param externalContext An external context (such as a ServletContext) to be associated with the LoggerContext.
      * @return a LoggerContext.
      */
-    public static LoggerContext getContext(final ClassLoader loader, final boolean currentContext,
-            final Object externalContext) {
+    public static LoggerContext getContext(
+            final ClassLoader loader, final boolean currentContext, final Object externalContext) {
         try {
             return factory.getContext(FQCN, loader, externalContext, currentContext);
         } catch (final IllegalStateException ex) {
             LOGGER.warn(ex.getMessage() + " Using SimpleLogger");
-            return SimpleLoggerContextFactory.INSTANCE.getContext(FQCN, loader, externalContext, currentContext);
+            return SimpleLoggerContextFactory.INSTANCE.getContext(
+                    FQCN, loader, externalContext, currentContext);
         }
     }
 
@@ -234,14 +249,14 @@ public class LogManager {
      * @param configLocation The URI for the configuration to use.
      * @return a LoggerContext.
      */
-    public static LoggerContext getContext(final ClassLoader loader, final boolean currentContext,
-            final URI configLocation) {
+    public static LoggerContext getContext(
+            final ClassLoader loader, final boolean currentContext, final URI configLocation) {
         try {
             return factory.getContext(FQCN, loader, null, currentContext, configLocation, null);
         } catch (final IllegalStateException ex) {
             LOGGER.warn(ex.getMessage() + " Using SimpleLogger");
-            return SimpleLoggerContextFactory.INSTANCE.getContext(FQCN, loader, null, currentContext, configLocation,
-                    null);
+            return SimpleLoggerContextFactory.INSTANCE.getContext(
+                    FQCN, loader, null, currentContext, configLocation, null);
         }
     }
 
@@ -258,14 +273,18 @@ public class LogManager {
      * @param configLocation The URI for the configuration to use.
      * @return a LoggerContext.
      */
-    public static LoggerContext getContext(final ClassLoader loader, final boolean currentContext,
-            final Object externalContext, final URI configLocation) {
+    public static LoggerContext getContext(
+            final ClassLoader loader,
+            final boolean currentContext,
+            final Object externalContext,
+            final URI configLocation) {
         try {
-            return factory.getContext(FQCN, loader, externalContext, currentContext, configLocation, null);
+            return factory.getContext(
+                    FQCN, loader, externalContext, currentContext, configLocation, null);
         } catch (final IllegalStateException ex) {
             LOGGER.warn(ex.getMessage() + " Using SimpleLogger");
-            return SimpleLoggerContextFactory.INSTANCE.getContext(FQCN, loader, externalContext, currentContext,
-                    configLocation, null);
+            return SimpleLoggerContextFactory.INSTANCE.getContext(
+                    FQCN, loader, externalContext, currentContext, configLocation, null);
         }
     }
 
@@ -283,14 +302,19 @@ public class LogManager {
      * @param name The LoggerContext name.
      * @return a LoggerContext.
      */
-    public static LoggerContext getContext(final ClassLoader loader, final boolean currentContext,
-            final Object externalContext, final URI configLocation, final String name) {
+    public static LoggerContext getContext(
+            final ClassLoader loader,
+            final boolean currentContext,
+            final Object externalContext,
+            final URI configLocation,
+            final String name) {
         try {
-            return factory.getContext(FQCN, loader, externalContext, currentContext, configLocation, name);
+            return factory.getContext(
+                    FQCN, loader, externalContext, currentContext, configLocation, name);
         } catch (final IllegalStateException ex) {
             LOGGER.warn(ex.getMessage() + " Using SimpleLogger");
-            return SimpleLoggerContextFactory.INSTANCE.getContext(FQCN, loader, externalContext, currentContext,
-                    configLocation, name);
+            return SimpleLoggerContextFactory.INSTANCE.getContext(
+                    FQCN, loader, externalContext, currentContext, configLocation, name);
         }
     }
 
@@ -325,16 +349,16 @@ public class LogManager {
      *            be returned. If true then only a single LoggerContext will be returned.
      * @return a LoggerContext.
      */
-    protected static LoggerContext getContext(final String fqcn, final ClassLoader loader,
-            final boolean currentContext) {
+    protected static LoggerContext getContext(
+            final String fqcn, final ClassLoader loader, final boolean currentContext) {
         try {
             return factory.getContext(fqcn, loader, null, currentContext);
         } catch (final IllegalStateException ex) {
             LOGGER.warn(ex.getMessage() + " Using SimpleLogger");
-            return SimpleLoggerContextFactory.INSTANCE.getContext(fqcn, loader, null, currentContext);
+            return SimpleLoggerContextFactory.INSTANCE.getContext(
+                    fqcn, loader, null, currentContext);
         }
     }
-
 
     /**
      * Returns a LoggerContext
@@ -350,13 +374,18 @@ public class LogManager {
      * @param name The LoggerContext name.
      * @return a LoggerContext.
      */
-    protected static LoggerContext getContext(final String fqcn, final ClassLoader loader,
-                                          final boolean currentContext, final URI configLocation, final String name) {
+    protected static LoggerContext getContext(
+            final String fqcn,
+            final ClassLoader loader,
+            final boolean currentContext,
+            final URI configLocation,
+            final String name) {
         try {
             return factory.getContext(fqcn, loader, null, currentContext, configLocation, name);
         } catch (final IllegalStateException ex) {
             LOGGER.warn(ex.getMessage() + " Using SimpleLogger");
-            return SimpleLoggerContextFactory.INSTANCE.getContext(fqcn, loader, null, currentContext);
+            return SimpleLoggerContextFactory.INSTANCE.getContext(
+                    fqcn, loader, null, currentContext);
         }
     }
 
@@ -411,7 +440,6 @@ public class LogManager {
     public static void shutdown(final boolean currentContext, final boolean allContexts) {
         factory.shutdown(FQCN, null, currentContext, allContexts);
     }
-
 
     /**
      * Shutdown the logging system if the logging system supports it.
@@ -497,7 +525,8 @@ public class LogManager {
      * @see StringFormatterMessageFactory
      */
     public static Logger getFormatterLogger(final Class<?> clazz) {
-        return getLogger(clazz != null ? clazz : StackLocatorUtil.getCallerClass(2),
+        return getLogger(
+                clazz != null ? clazz : StackLocatorUtil.getCallerClass(2),
                 StringFormatterMessageFactory.INSTANCE);
     }
 
@@ -529,7 +558,8 @@ public class LogManager {
      * @see StringFormatterMessageFactory
      */
     public static Logger getFormatterLogger(final Object value) {
-        return getLogger(value != null ? value.getClass() : StackLocatorUtil.getCallerClass(2),
+        return getLogger(
+                value != null ? value.getClass() : StackLocatorUtil.getCallerClass(2),
                 StringFormatterMessageFactory.INSTANCE);
     }
 
@@ -560,8 +590,9 @@ public class LogManager {
      * @see StringFormatterMessageFactory
      */
     public static Logger getFormatterLogger(final String name) {
-        return name == null ? getFormatterLogger(StackLocatorUtil.getCallerClass(2)) : getLogger(name,
-                StringFormatterMessageFactory.INSTANCE);
+        return name == null
+                ? getFormatterLogger(StackLocatorUtil.getCallerClass(2))
+                : getLogger(name, StringFormatterMessageFactory.INSTANCE);
     }
 
     private static Class<?> callerClass(final Class<?> clazz) {
@@ -570,7 +601,8 @@ public class LogManager {
         }
         final Class<?> candidate = StackLocatorUtil.getCallerClass(3);
         if (candidate == null) {
-            throw new UnsupportedOperationException("No class provided, and an appropriate one cannot be found.");
+            throw new UnsupportedOperationException(
+                    "No class provided, and an appropriate one cannot be found.");
         }
         return candidate;
     }
@@ -652,7 +684,9 @@ public class LogManager {
      *             determined.
      */
     public static Logger getLogger(final Object value, final MessageFactory messageFactory) {
-        return getLogger(value != null ? value.getClass() : StackLocatorUtil.getCallerClass(2), messageFactory);
+        return getLogger(
+                value != null ? value.getClass() : StackLocatorUtil.getCallerClass(2),
+                messageFactory);
     }
 
     /**
@@ -663,7 +697,9 @@ public class LogManager {
      * @throws UnsupportedOperationException if {@code name} is {@code null} and the calling class cannot be determined.
      */
     public static Logger getLogger(final String name) {
-        return name != null ? getContext(false).getLogger(name) : getLogger(StackLocatorUtil.getCallerClass(2));
+        return name != null
+                ? getContext(false).getLogger(name)
+                : getLogger(StackLocatorUtil.getCallerClass(2));
     }
 
     /**
@@ -676,8 +712,9 @@ public class LogManager {
      * @throws UnsupportedOperationException if {@code name} is {@code null} and the calling class cannot be determined.
      */
     public static Logger getLogger(final String name, final MessageFactory messageFactory) {
-        return name != null ? getContext(false).getLogger(name, messageFactory) : getLogger(
-                StackLocatorUtil.getCallerClass(2), messageFactory);
+        return name != null
+                ? getContext(false).getLogger(name, messageFactory)
+                : getLogger(StackLocatorUtil.getCallerClass(2), messageFactory);
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -410,7 +410,8 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      */
-    void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
+    void debug(
+            Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
     /**
      * Logs a message with parameters at debug level.
@@ -424,7 +425,15 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      */
-    void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+    void debug(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5);
 
     /**
      * Logs a message with parameters at debug level.
@@ -439,7 +448,15 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+    void debug(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
             Object p6);
 
     /**
@@ -456,7 +473,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void debug(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -474,8 +500,18 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void debug(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at debug level.
@@ -493,8 +529,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void debug(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at debug level.
@@ -571,7 +618,15 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+    void debug(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6);
 
     /**
      * Logs a message with parameters at debug level.
@@ -586,7 +641,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+    void debug(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7);
 
     /**
      * Logs a message with parameters at debug level.
@@ -602,7 +666,16 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void debug(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -620,8 +693,18 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void debug(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs entry to a method. Used when the method in question has no parameters or when the parameters should not be
@@ -966,7 +1049,8 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      */
-    void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
+    void error(
+            Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
     /**
      * Logs a message with parameters at error level.
@@ -980,7 +1064,15 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      */
-    void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+    void error(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5);
 
     /**
      * Logs a message with parameters at error level.
@@ -995,7 +1087,15 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+    void error(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
             Object p6);
 
     /**
@@ -1012,7 +1112,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void error(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -1030,8 +1139,18 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void error(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at error level.
@@ -1049,8 +1168,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void error(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at error level.
@@ -1127,7 +1257,15 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+    void error(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6);
 
     /**
      * Logs a message with parameters at error level.
@@ -1142,7 +1280,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+    void error(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7);
 
     /**
      * Logs a message with parameters at error level.
@@ -1158,7 +1305,16 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void error(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -1176,8 +1332,18 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void error(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs exit from a method. Used for methods that do not return anything.
@@ -1514,7 +1680,8 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      */
-    void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
+    void fatal(
+            Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
     /**
      * Logs a message with parameters at fatal level.
@@ -1528,7 +1695,15 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      */
-    void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+    void fatal(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5);
 
     /**
      * Logs a message with parameters at fatal level.
@@ -1543,7 +1718,15 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+    void fatal(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
             Object p6);
 
     /**
@@ -1560,7 +1743,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void fatal(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -1578,8 +1770,18 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void fatal(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at fatal level.
@@ -1597,8 +1799,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void fatal(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at fatal level.
@@ -1675,7 +1888,15 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+    void fatal(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6);
 
     /**
      * Logs a message with parameters at fatal level.
@@ -1690,7 +1911,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+    void fatal(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7);
 
     /**
      * Logs a message with parameters at fatal level.
@@ -1706,7 +1936,16 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void fatal(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -1724,8 +1963,18 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void fatal(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Gets the Level associated with the Logger.
@@ -2089,7 +2338,15 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      */
-    void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+    void info(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5);
 
     /**
      * Logs a message with parameters at info level.
@@ -2104,7 +2361,15 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+    void info(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
             Object p6);
 
     /**
@@ -2121,7 +2386,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void info(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -2139,8 +2413,18 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void info(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at info level.
@@ -2158,8 +2442,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void info(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at info level.
@@ -2236,7 +2531,15 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+    void info(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6);
 
     /**
      * Logs a message with parameters at info level.
@@ -2251,7 +2554,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+    void info(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7);
 
     /**
      * Logs a message with parameters at info level.
@@ -2267,7 +2579,16 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void info(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -2285,8 +2606,18 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void info(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Checks whether this Logger is enabled for the {@link Level#DEBUG DEBUG} Level.
@@ -2733,7 +3064,8 @@ public interface Logger {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      */
-    void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3);
+    void log(
+            Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3);
 
     /**
      * Logs a message with parameters at the specified level.
@@ -2747,7 +3079,15 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      */
-    void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
+    void log(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4);
 
     /**
      * Logs a message with parameters at the specified level.
@@ -2762,7 +3102,16 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      */
-    void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+    void log(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5);
 
     /**
      * Logs a message with parameters at the specified level.
@@ -2778,7 +3127,16 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+    void log(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
             Object p6);
 
     /**
@@ -2796,7 +3154,17 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void log(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -2815,8 +3183,19 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void log(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at the specified level.
@@ -2835,8 +3214,20 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void log(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at the specified level.
@@ -2905,7 +3296,15 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      */
-    void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+    void log(
+            Level level,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5);
 
     /**
      * Logs a message with parameters at the specified level.
@@ -2920,7 +3319,16 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+    void log(
+            Level level,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6);
 
     /**
      * Logs a message with parameters at the specified level.
@@ -2936,7 +3344,17 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+    void log(
+            Level level,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7);
 
     /**
      * Logs a message with parameters at the specified level.
@@ -2953,7 +3371,17 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void log(
+            Level level,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -2972,8 +3400,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void log(
+            Level level,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a formatted message using the specified format string and arguments.
@@ -3341,7 +3780,8 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      */
-    void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
+    void trace(
+            Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
     /**
      * Logs a message with parameters at trace level.
@@ -3355,7 +3795,15 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      */
-    void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+    void trace(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5);
 
     /**
      * Logs a message with parameters at trace level.
@@ -3370,7 +3818,15 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+    void trace(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
             Object p6);
 
     /**
@@ -3387,7 +3843,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void trace(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -3405,8 +3870,18 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void trace(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at trace level.
@@ -3424,8 +3899,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void trace(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at trace level.
@@ -3502,7 +3988,15 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+    void trace(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6);
 
     /**
      * Logs a message with parameters at trace level.
@@ -3517,7 +4011,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+    void trace(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7);
 
     /**
      * Logs a message with parameters at trace level.
@@ -3533,7 +4036,16 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void trace(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -3551,8 +4063,18 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void trace(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs entry to a method. Used when the method in question has no parameters or when the parameters should not be
@@ -4064,7 +4586,15 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      */
-    void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+    void warn(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5);
 
     /**
      * Logs a message with parameters at warn level.
@@ -4079,7 +4609,15 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+    void warn(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
             Object p6);
 
     /**
@@ -4096,7 +4634,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void warn(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -4114,8 +4661,18 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void warn(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at warn level.
@@ -4133,8 +4690,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void warn(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at warn level.
@@ -4211,7 +4779,15 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+    void warn(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6);
 
     /**
      * Logs a message with parameters at warn level.
@@ -4226,7 +4802,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+    void warn(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7);
 
     /**
      * Logs a message with parameters at warn level.
@@ -4242,7 +4827,16 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void warn(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -4260,8 +4854,18 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void warn(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a Message.
@@ -4274,8 +4878,13 @@ public interface Logger {
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @since 2.13.0
      */
-    default void logMessage(Level level, Marker marker, String fqcn, StackTraceElement location, Message message,
-        Throwable throwable) {
+    default void logMessage(
+            Level level,
+            Marker marker,
+            String fqcn,
+            StackTraceElement location,
+            Message message,
+            Throwable throwable) {
         // noop
     }
 
@@ -4351,5 +4960,4 @@ public interface Logger {
     default LogBuilder atLevel(Level level) {
         return LogBuilder.NOOP;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/MarkerManager.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/MarkerManager.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j;
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
 import org.apache.logging.log4j.util.PerformanceSensitive;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
@@ -135,7 +134,8 @@ public final class MarkerManager {
          * @throws IllegalArgumentException if the argument is {@code null}
          */
         public Log4jMarker(final String name) {
-            // we can't store null references in a ConcurrentHashMap as it is, not to mention that a null Marker
+            // we can't store null references in a ConcurrentHashMap as it is, not to mention that a
+            // null Marker
             // name seems rather pointless. To get an "anonymous" Marker, just use an empty string.
             requireNonNull(name, "Marker name cannot be null.");
             this.name = name;
@@ -147,7 +147,8 @@ public final class MarkerManager {
         @Override
         public synchronized Marker addParents(final Marker... parentMarkers) {
             requireNonNull(parentMarkers, "A parent marker must be specified");
-            // It is not strictly necessary to copy the variable here but it should perform better than
+            // It is not strictly necessary to copy the variable here but it should perform better
+            // than
             // Accessing a volatile variable multiple times.
             final Marker[] localParents = this.parents;
             // Don't add a parent that is already in the hierarchy.
@@ -172,7 +173,8 @@ public final class MarkerManager {
             }
             int index = localParents == null ? 0 : localParents.length;
             for (final Marker parent : parentMarkers) {
-                if (localParents == null || !(contains(parent, localParents) || parent.isInstanceOf(this))) {
+                if (localParents == null
+                        || !(contains(parent, localParents) || parent.isInstanceOf(this))) {
                     markers[index++] = parent;
                 }
             }
@@ -258,7 +260,8 @@ public final class MarkerManager {
                     return checkParent(localParents[0], marker);
                 }
                 if (localParentsLength == 2) {
-                    return checkParent(localParents[0], marker) || checkParent(localParents[1], marker);
+                    return checkParent(localParents[0], marker)
+                            || checkParent(localParents[1], marker);
                 }
                 // noinspection ForLoopReplaceableByForEach
                 for (int i = 0; i < localParentsLength; i++) {
@@ -290,7 +293,8 @@ public final class MarkerManager {
                     return checkParent(localParents[0], marker);
                 }
                 if (localParentsLength == 2) {
-                    return checkParent(localParents[0], marker) || checkParent(localParents[1], marker);
+                    return checkParent(localParents[0], marker)
+                            || checkParent(localParents[1], marker);
                 }
                 // noinspection ForLoopReplaceableByForEach
                 for (int i = 0; i < localParentsLength; i++) {
@@ -309,15 +313,18 @@ public final class MarkerManager {
             if (parent == marker) {
                 return true;
             }
-            final Marker[] localParents = parent instanceof Log4jMarker ? ((Log4jMarker) parent).parents : parent
-                    .getParents();
+            final Marker[] localParents =
+                    parent instanceof Log4jMarker
+                            ? ((Log4jMarker) parent).parents
+                            : parent.getParents();
             if (localParents != null) {
                 final int localParentsLength = localParents.length;
                 if (localParentsLength == 1) {
                     return checkParent(localParents[0], marker);
                 }
                 if (localParentsLength == 2) {
-                    return checkParent(localParents[0], marker) || checkParent(localParents[1], marker);
+                    return checkParent(localParents[0], marker)
+                            || checkParent(localParents[1], marker);
                 }
                 // noinspection ForLoopReplaceableByForEach
                 for (int i = 0; i < localParentsLength; i++) {
@@ -335,7 +342,8 @@ public final class MarkerManager {
          */
         @PerformanceSensitive("allocation")
         private static boolean contains(final Marker parent, final Marker... localParents) {
-            // performance tests showed a normal for loop is slightly faster than a for-each loop on some platforms
+            // performance tests showed a normal for loop is slightly faster than a for-each loop on
+            // some platforms
             // noinspection ForLoopReplaceableByForEach
             for (int i = 0, localParentsLength = localParents.length; i < localParentsLength; i++) {
                 final Marker marker = localParents[i];
@@ -365,7 +373,8 @@ public final class MarkerManager {
 
         @Override
         public String toString() {
-            // FIXME: might want to use an initial capacity; the default is 16 (or str.length() + 16)
+            // FIXME: might want to use an initial capacity; the default is 16 (or str.length() +
+            // 16)
             final StringBuilder sb = new StringBuilder();
             formatTo(sb);
             return sb.toString();
@@ -392,7 +401,10 @@ public final class MarkerManager {
                 }
                 first = false;
                 sb.append(marker.getName());
-                final Marker[] p = marker instanceof Log4jMarker ? ((Log4jMarker) marker).parents : marker.getParents();
+                final Marker[] p =
+                        marker instanceof Log4jMarker
+                                ? ((Log4jMarker) marker).parents
+                                : marker.getParents();
                 if (p != null) {
                     addParentInfo(sb, p);
                 }
@@ -401,7 +413,8 @@ public final class MarkerManager {
         }
     }
 
-    // this method wouldn't be necessary if Marker methods threw an NPE instead of an IAE for null values ;)
+    // this method wouldn't be necessary if Marker methods threw an NPE instead of an IAE for null
+    // values ;)
     private static void requireNonNull(final Object obj, final String message) {
         if (obj == null) {
             throw new IllegalArgumentException(message);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/ThreadContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/ThreadContext.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.spi.CleanableThreadContextMap;
 import org.apache.logging.log4j.spi.DefaultThreadContextMap;
@@ -51,7 +50,8 @@ public final class ThreadContext {
     /**
      * An empty read-only ThreadContextStack.
      */
-    private static class EmptyThreadContextStack extends AbstractCollection<String> implements ThreadContextStack {
+    private static class EmptyThreadContextStack extends AbstractCollection<String>
+            implements ThreadContextStack {
 
         private static final long serialVersionUID = 1L;
 
@@ -257,7 +257,7 @@ public final class ThreadContext {
      * @since 2.13.0
      */
     public static void putIfNull(final String key, final String value) {
-        if(!contextMap.containsKey(key)) {
+        if (!contextMap.containsKey(key)) {
             contextMap.put(key, value);
         }
     }
@@ -277,7 +277,7 @@ public final class ThreadContext {
         } else if (contextMap instanceof DefaultThreadContextMap) {
             ((DefaultThreadContextMap) contextMap).putAll(m);
         } else {
-            for (final Map.Entry<String, String> entry: m.entrySet()) {
+            for (final Map.Entry<String, String> entry : m.entrySet()) {
                 contextMap.put(entry.getKey(), entry.getValue());
             }
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.internal;
 
 import java.util.Arrays;
-
 import org.apache.logging.log4j.BridgeAware;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogBuilder;
@@ -201,40 +200,81 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     }
 
     @Override
-    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+    public void log(
+            String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
         if (isValid() && isEnabled(message, p0, p1, p2, p3, p4, p5)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5));
         }
     }
 
     @Override
-    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+    public void log(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6) {
         if (isValid() && isEnabled(message, p0, p1, p2, p3, p4, p5, p6)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6));
         }
     }
 
     @Override
-    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    public void log(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7) {
         if (isValid() && isEnabled(message, p0, p1, p2, p3, p4, p5, p6, p7)) {
-            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7));
+            logMessage(
+                    logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7));
         }
     }
 
     @Override
-    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8) {
+    public void log(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8) {
         if (isValid() && isEnabled(message, p0, p1, p2, p3, p4, p5, p6, p7, p8)) {
-            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8));
+            logMessage(
+                    logger.getMessageFactory()
+                            .newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8));
         }
     }
 
     @Override
-    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9) {
+    public void log(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9) {
         if (isValid() && isEnabled(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)) {
-            logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9));
+            logMessage(
+                    logger.getMessageFactory()
+                            .newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9));
         }
     }
 
@@ -255,12 +295,14 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
 
     private boolean isValid() {
         if (!inUse) {
-            LOGGER.warn("Attempt to reuse LogBuilder was ignored. {}",
+            LOGGER.warn(
+                    "Attempt to reuse LogBuilder was ignored. {}",
                     StackLocatorUtil.getCallerClass(2));
-            return false ;
+            return false;
         }
         if (this.threadId != Thread.currentThread().getId()) {
-            LOGGER.warn("LogBuilder can only be used on the owning thread. {}",
+            LOGGER.warn(
+                    "LogBuilder can only be used on the owning thread. {}",
                     StackLocatorUtil.getCallerClass(2));
             return false;
         }
@@ -295,58 +337,105 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     }
 
     protected boolean isEnabled(String message, Object p0) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, throwable)
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, throwable)
                 : logger.isEnabled(level, marker, message, p0);
     }
 
     protected boolean isEnabled(String message, Object p0, Object p1) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, throwable)
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1);
     }
 
     protected boolean isEnabled(String message, Object p0, Object p1, Object p2) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, throwable)
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, p2, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2);
     }
 
     protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, throwable)
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3);
     }
 
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, throwable)
+    protected boolean isEnabled(
+            String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4);
     }
 
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, throwable)
+    protected boolean isEnabled(
+            String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+    protected boolean isEnabled(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
             Object p6) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, throwable)
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6, Object p7) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, throwable)
+    protected boolean isEnabled(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7) {
+        return throwable != null
+                ? logger.isEnabled(
+                        level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6, Object p7, Object p8) {
+    protected boolean isEnabled(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8) {
         return throwable != null
-                ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, throwable)
+                ? logger.isEnabled(
+                        level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6, Object p7, Object p8, Object p9) {
+    protected boolean isEnabled(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9) {
         return throwable != null
-                ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, throwable)
+                ? logger.isEnabled(
+                        level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/AbstractMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/AbstractMessageFactory.java
@@ -66,7 +66,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
      */
     @Override
     public Message newMessage(final String message, final Object p0) {
-        return newMessage(message, new Object[] { p0 });
+        return newMessage(message, new Object[] {p0});
     }
 
     /**
@@ -74,75 +74,127 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1) {
-        return newMessage(message, new Object[] { p0, p1 });
+        return newMessage(message, new Object[] {p0, p1});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2) {
-        return newMessage(message, new Object[] { p0, p1, p2 });
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2) {
+        return newMessage(message, new Object[] {p0, p1, p2});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3 });
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
+        return newMessage(message, new Object[] {p0, p1, p2, p3});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4 });
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
+        return newMessage(message, new Object[] {p0, p1, p2, p3, p4});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5 });
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
+        return newMessage(message, new Object[] {p0, p1, p2, p3, p4, p5});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5, p6 });
+        return newMessage(message, new Object[] {p0, p1, p2, p3, p4, p5, p6});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5, p6, p7 });
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
+        return newMessage(message, new Object[] {p0, p1, p2, p3, p4, p5, p6, p7});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8 });
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
+        return newMessage(message, new Object[] {p0, p1, p2, p3, p4, p5, p6, p7, p8});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9 });
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
+        return newMessage(message, new Object[] {p0, p1, p2, p3, p4, p5, p6, p7, p8, p9});
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/AsynchronouslyFormattable.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/AsynchronouslyFormattable.java
@@ -55,6 +55,5 @@ import java.lang.annotation.Target;
  */
 @Documented // This annotation is part of the public API of annotated elements.
 @Target(ElementType.TYPE) // Only applies to types.
-@Retention(RetentionPolicy.RUNTIME) //Needs to be reflectively discoverable runtime.
-public @interface AsynchronouslyFormattable {
-}
+@Retention(RetentionPolicy.RUNTIME) // Needs to be reflectively discoverable runtime.
+public @interface AsynchronouslyFormattable {}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/BasicThreadInformation.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/BasicThreadInformation.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.message;
 
-import org.apache.logging.log4j.util.StringBuilders;
-
 import static org.apache.logging.log4j.util.Chars.LF;
 import static org.apache.logging.log4j.util.Chars.SPACE;
+
+import org.apache.logging.log4j.util.StringBuilders;
 
 /**
  * Generates information about the current Thread. Used internally by ThreadDumpMessage.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/Clearable.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/Clearable.java
@@ -29,5 +29,4 @@ interface Clearable {
      * Resets the object to a clean state.
      */
     void clear();
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.io.Serializable;
-
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.StringBuilders;
@@ -127,17 +126,18 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
         }
     }
 
-    private static final class SimpleEntryMessage extends AbstractFlowMessage implements EntryMessage {
+    private static final class SimpleEntryMessage extends AbstractFlowMessage
+            implements EntryMessage {
 
         private static final long serialVersionUID = 1L;
 
         SimpleEntryMessage(final String entryText, final Message message) {
             super(entryText, message);
         }
-
     }
 
-    private static final class SimpleExitMessage extends AbstractFlowMessage implements ExitMessage {
+    private static final class SimpleExitMessage extends AbstractFlowMessage
+            implements ExitMessage {
 
         private static final long serialVersionUID = 1L;
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessage.java
@@ -49,7 +49,7 @@ public class FormattedMessage implements Message {
      * @since 2.6
      */
     public FormattedMessage(final Locale locale, final String messagePattern, final Object arg) {
-        this(locale, messagePattern, new Object[] { arg }, null);
+        this(locale, messagePattern, new Object[] {arg}, null);
     }
 
     /**
@@ -60,8 +60,12 @@ public class FormattedMessage implements Message {
      * @param arg2 The second parameter.
      * @since 2.6
      */
-    public FormattedMessage(final Locale locale, final String messagePattern, final Object arg1, final Object arg2) {
-        this(locale, messagePattern, new Object[] { arg1, arg2 });
+    public FormattedMessage(
+            final Locale locale,
+            final String messagePattern,
+            final Object arg1,
+            final Object arg2) {
+        this(locale, messagePattern, new Object[] {arg1, arg2});
     }
 
     /**
@@ -71,7 +75,8 @@ public class FormattedMessage implements Message {
      * @param arguments The parameter.
      * @since 2.6
      */
-    public FormattedMessage(final Locale locale, final String messagePattern, final Object... arguments) {
+    public FormattedMessage(
+            final Locale locale, final String messagePattern, final Object... arguments) {
         this(locale, messagePattern, arguments, null);
     }
 
@@ -83,7 +88,11 @@ public class FormattedMessage implements Message {
      * @param throwable The throwable
      * @since 2.6
      */
-    public FormattedMessage(final Locale locale, final String messagePattern, final Object[] arguments, final Throwable throwable) {
+    public FormattedMessage(
+            final Locale locale,
+            final String messagePattern,
+            final Object[] arguments,
+            final Throwable throwable) {
         this.locale = locale;
         this.messagePattern = messagePattern;
         this.argArray = arguments;
@@ -96,7 +105,7 @@ public class FormattedMessage implements Message {
      * @param arg The parameter.
      */
     public FormattedMessage(final String messagePattern, final Object arg) {
-        this(messagePattern, new Object[] { arg }, null);
+        this(messagePattern, new Object[] {arg}, null);
     }
 
     /**
@@ -106,7 +115,7 @@ public class FormattedMessage implements Message {
      * @param arg2 The second parameter.
      */
     public FormattedMessage(final String messagePattern, final Object arg1, final Object arg2) {
-        this(messagePattern, new Object[] { arg1, arg2 });
+        this(messagePattern, new Object[] {arg1, arg2});
     }
 
     /**
@@ -124,13 +133,13 @@ public class FormattedMessage implements Message {
      * @param arguments The parameter.
      * @param throwable The throwable
      */
-    public FormattedMessage(final String messagePattern, final Object[] arguments, final Throwable throwable) {
+    public FormattedMessage(
+            final String messagePattern, final Object[] arguments, final Throwable throwable) {
         this.locale = Locale.getDefault(Locale.Category.FORMAT);
         this.messagePattern = messagePattern;
         this.argArray = arguments;
         this.throwable = throwable;
     }
-
 
     @Override
     public boolean equals(final Object o) {
@@ -143,7 +152,9 @@ public class FormattedMessage implements Message {
 
         final FormattedMessage that = (FormattedMessage) o;
 
-        if (messagePattern != null ? !messagePattern.equals(that.messagePattern) : that.messagePattern != null) {
+        if (messagePattern != null
+                ? !messagePattern.equals(that.messagePattern)
+                : that.messagePattern != null) {
             return false;
         }
         if (!Arrays.equals(stringArgs, that.stringArgs)) {
@@ -196,7 +207,8 @@ public class FormattedMessage implements Message {
      * @param aThrowable The throwable
      * @return The message that performs formatting.
      */
-    protected Message getMessage(final String msgPattern, final Object[] args, final Throwable aThrowable) {
+    protected Message getMessage(
+            final String msgPattern, final Object[] args, final Throwable aThrowable) {
         // Check for valid `{ ArgumentIndex [, FormatType [, FormatStyle]] }` format specifiers
         try {
             final MessageFormat format = new MessageFormat(msgPattern);
@@ -239,7 +251,6 @@ public class FormattedMessage implements Message {
         }
         return message.getThrowable();
     }
-
 
     @Override
     public int hashCode() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessageFactory.java
@@ -34,8 +34,7 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
     /**
      * Constructs a message factory with default flow strings.
      */
-    public FormattedMessageFactory() {
-    }
+    public FormattedMessageFactory() {}
 
     /**
      * Creates {@link StringFormattedMessage} instances.
@@ -71,7 +70,8 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2) {
         return new FormattedMessage(message, p0, p1, p2);
     }
 
@@ -79,7 +79,12 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         return new FormattedMessage(message, p0, p1, p2, p3);
     }
 
@@ -87,7 +92,13 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         return new FormattedMessage(message, p0, p1, p2, p3, p4);
     }
 
@@ -95,7 +106,14 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return new FormattedMessage(message, p0, p1, p2, p3, p4, p5);
     }
 
@@ -103,7 +121,14 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         return new FormattedMessage(message, p0, p1, p2, p3, p4, p5, p6);
     }
@@ -112,8 +137,16 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return new FormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
@@ -121,8 +154,17 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return new FormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
@@ -130,8 +172,18 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return new FormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessage.java
@@ -22,7 +22,6 @@ import java.io.ObjectOutputStream;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
-
 import org.apache.logging.log4j.status.StatusLogger;
 
 /**
@@ -67,11 +66,16 @@ public class LocalizedMessage implements Message, LoggerNameAwareMessage {
         this(baseName, (Locale) null, key, arguments);
     }
 
-    public LocalizedMessage(final ResourceBundle bundle, final String key, final Object[] arguments) {
+    public LocalizedMessage(
+            final ResourceBundle bundle, final String key, final Object[] arguments) {
         this(bundle, (Locale) null, key, arguments);
     }
 
-    public LocalizedMessage(final String baseName, final Locale locale, final String key, final Object[] arguments) {
+    public LocalizedMessage(
+            final String baseName,
+            final Locale locale,
+            final String key,
+            final Object[] arguments) {
         this.key = key;
         this.argArray = arguments;
         this.throwable = null;
@@ -80,7 +84,10 @@ public class LocalizedMessage implements Message, LoggerNameAwareMessage {
         this.locale = locale;
     }
 
-    public LocalizedMessage(final ResourceBundle bundle, final Locale locale, final String key,
+    public LocalizedMessage(
+            final ResourceBundle bundle,
+            final Locale locale,
+            final String key,
             final Object[] arguments) {
         this.key = key;
         this.argArray = arguments;
@@ -113,11 +120,13 @@ public class LocalizedMessage implements Message, LoggerNameAwareMessage {
         this(bundle, (Locale) null, key, new Object[] {arg});
     }
 
-    public LocalizedMessage(final String baseName, final Locale locale, final String key, final Object arg) {
+    public LocalizedMessage(
+            final String baseName, final Locale locale, final String key, final Object arg) {
         this(baseName, locale, key, new Object[] {arg});
     }
 
-    public LocalizedMessage(final ResourceBundle bundle, final Locale locale, final String key, final Object arg) {
+    public LocalizedMessage(
+            final ResourceBundle bundle, final Locale locale, final String key, final Object arg) {
         this(bundle, locale, key, new Object[] {arg});
     }
 
@@ -129,25 +138,36 @@ public class LocalizedMessage implements Message, LoggerNameAwareMessage {
         this((ResourceBundle) null, (Locale) null, messagePattern, new Object[] {arg1, arg2});
     }
 
-    public LocalizedMessage(final String baseName, final String key, final Object arg1, final Object arg2) {
+    public LocalizedMessage(
+            final String baseName, final String key, final Object arg1, final Object arg2) {
         this(baseName, (Locale) null, key, new Object[] {arg1, arg2});
     }
 
-    public LocalizedMessage(final ResourceBundle bundle, final String key, final Object arg1, final Object arg2) {
+    public LocalizedMessage(
+            final ResourceBundle bundle, final String key, final Object arg1, final Object arg2) {
         this(bundle, (Locale) null, key, new Object[] {arg1, arg2});
     }
 
-    public LocalizedMessage(final String baseName, final Locale locale, final String key, final Object arg1,
+    public LocalizedMessage(
+            final String baseName,
+            final Locale locale,
+            final String key,
+            final Object arg1,
             final Object arg2) {
         this(baseName, locale, key, new Object[] {arg1, arg2});
     }
 
-    public LocalizedMessage(final ResourceBundle bundle, final Locale locale, final String key, final Object arg1,
+    public LocalizedMessage(
+            final ResourceBundle bundle,
+            final Locale locale,
+            final String key,
+            final Object arg1,
             final Object arg2) {
         this(bundle, locale, key, new Object[] {arg1, arg2});
     }
 
-    public LocalizedMessage(final Locale locale, final String key, final Object arg1, final Object arg2) {
+    public LocalizedMessage(
+            final Locale locale, final String key, final Object arg1, final Object arg2) {
         this((ResourceBundle) null, locale, key, new Object[] {arg1, arg2});
     }
 
@@ -190,7 +210,8 @@ public class LocalizedMessage implements Message, LoggerNameAwareMessage {
             }
         }
         final String myKey = getFormat();
-        final String msgPattern = (bundle == null || !bundle.containsKey(myKey)) ? myKey : bundle.getString(myKey);
+        final String msgPattern =
+                (bundle == null || !bundle.containsKey(myKey)) ? myKey : bundle.getString(myKey);
         final Object[] array = argArray == null ? stringArgs : argArray;
         final FormattedMessage msg = new FormattedMessage(msgPattern, array);
         formattedMessage = msg.getFormattedMessage();
@@ -225,8 +246,8 @@ public class LocalizedMessage implements Message, LoggerNameAwareMessage {
      *            based on all or part of the package name. If false the key is expected to be the exact bundle id.
      * @return The ResourceBundle.
      */
-    protected ResourceBundle getResourceBundle(final String rbBaseName, final Locale resourceBundleLocale,
-            final boolean loop) {
+    protected ResourceBundle getResourceBundle(
+            final String rbBaseName, final Locale resourceBundleLocale, final boolean loop) {
         ResourceBundle rb = null;
 
         if (rbBaseName == null) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessageFactory.java
@@ -34,7 +34,7 @@ public class LocalizedMessageFactory extends AbstractMessageFactory {
     private static final long serialVersionUID = -1996295808703146741L;
 
     // FIXME: cannot use ResourceBundle name for serialization until Java 8
-    private transient final ResourceBundle resourceBundle;
+    private final transient ResourceBundle resourceBundle;
     private final String baseName;
 
     public LocalizedMessageFactory(final ResourceBundle resourceBundle) {
@@ -71,7 +71,7 @@ public class LocalizedMessageFactory extends AbstractMessageFactory {
     @Override
     public Message newMessage(final String key) {
         if (resourceBundle == null) {
-            return new LocalizedMessage(baseName,  key);
+            return new LocalizedMessage(baseName, key);
         }
         return new LocalizedMessage(resourceBundle, key);
     }
@@ -92,5 +92,4 @@ public class LocalizedMessageFactory extends AbstractMessageFactory {
         }
         return new LocalizedMessage(resourceBundle, key, params);
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
@@ -20,7 +20,6 @@ import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
-
 import org.apache.logging.log4j.util.BiConsumer;
 import org.apache.logging.log4j.util.Chars;
 import org.apache.logging.log4j.util.EnglishEnums;
@@ -50,7 +49,8 @@ import org.apache.logging.log4j.util.TriConsumer;
  */
 @PerformanceSensitive("allocation")
 @AsynchronouslyFormattable
-public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStringBuilderFormattable {
+public class MapMessage<M extends MapMessage<M, V>, V>
+        implements MultiFormatStringBuilderFormattable {
 
     private static final long serialVersionUID = -5031471831131487120L;
 
@@ -82,11 +82,15 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
          * @return a MapFormat
          */
         public static MapFormat lookupIgnoreCase(final String format) {
-            return XML.name().equalsIgnoreCase(format) ? XML //
-                    : JSON.name().equalsIgnoreCase(format) ? JSON //
-                    : JAVA.name().equalsIgnoreCase(format) ? JAVA //
-                    : JAVA_UNQUOTED.name().equalsIgnoreCase(format) ? JAVA_UNQUOTED //
-                    : null;
+            return XML.name().equalsIgnoreCase(format)
+                    ? XML //
+                    : JSON.name().equalsIgnoreCase(format)
+                            ? JSON //
+                            : JAVA.name().equalsIgnoreCase(format)
+                                    ? JAVA //
+                                    : JAVA_UNQUOTED.name().equalsIgnoreCase(format)
+                                            ? JAVA_UNQUOTED //
+                                            : null;
         }
 
         /**
@@ -160,7 +164,8 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     public Map<String, V> getData() {
         final TreeMap<String, V> result = new TreeMap<>(); // returned map must be sorted
         for (int i = 0; i < data.size(); i++) {
-            // The Eclipse compiler does not need the typecast to V, but the Oracle compiler sure does.
+            // The Eclipse compiler does not need the typecast to V, but the Oracle compiler sure
+            // does.
             result.put(data.getKeyAt(i), (V) data.getValueAt(i));
         }
         return Collections.unmodifiableMap(result);
@@ -254,7 +259,8 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      */
     public String asString(final String format) {
         try {
-            return format(EnglishEnums.valueOf(MapFormat.class, format), new StringBuilder()).toString();
+            return format(EnglishEnums.valueOf(MapFormat.class, format), new StringBuilder())
+                    .toString();
         } catch (final IllegalArgumentException ex) {
             return asString();
         }
@@ -322,24 +328,28 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
             appendMap(sb);
         } else {
             switch (format) {
-                case XML : {
-                    asXml(sb);
-                    break;
-                }
-                case JSON : {
-                    asJson(sb);
-                    break;
-                }
-                case JAVA : {
-                    asJava(sb);
-                    break;
-                }
+                case XML:
+                    {
+                        asXml(sb);
+                        break;
+                    }
+                case JSON:
+                    {
+                        asJson(sb);
+                        break;
+                    }
+                case JAVA:
+                    {
+                        asJava(sb);
+                        break;
+                    }
                 case JAVA_UNQUOTED:
                     asJavaUnquoted(sb);
                     break;
-                default : {
-                    appendMap(sb);
-                }
+                default:
+                    {
+                        appendMap(sb);
+                    }
             }
         }
         return sb;
@@ -353,9 +363,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     public void asXml(final StringBuilder sb) {
         sb.append("<Map>\n");
         for (int i = 0; i < data.size(); i++) {
-            sb.append("  <Entry key=\"")
-                    .append(data.getKeyAt(i))
-                    .append("\">");
+            sb.append("  <Entry key=\"").append(data.getKeyAt(i)).append("\">");
             final int size = sb.length();
             ParameterFormatter.recursiveDeepToString(data.getValueAt(i), sb);
             StringBuilders.escapeXml(sb, size);
@@ -642,7 +650,6 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
         return (M) this;
     }
 
-
     /**
      * Adds an item to the data Map.
      * @param candidateKey The name of the data item.
@@ -745,5 +752,4 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
         put(key, value);
         return (M) this;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessageJsonFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessageJsonFormatter.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.logging.log4j.util.IndexedStringMap;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
@@ -45,7 +44,8 @@ import org.apache.logging.log4j.util.StringBuilders;
  * It supports nesting up to a maximum depth of 8, which is set by
  * <tt>log4j2.mapMessage.jsonFormatter.maxDepth</tt> property.
  */
-enum MapMessageJsonFormatter {;
+enum MapMessageJsonFormatter {
+    ;
 
     public static final int MAX_DEPTH = readMaxDepth();
 
@@ -64,9 +64,9 @@ enum MapMessageJsonFormatter {;
     private static final char COLON = ':';
 
     private static int readMaxDepth() {
-        final int maxDepth = PropertiesUtil
-                .getProperties()
-                .getIntegerProperty("log4j2.mapMessage.jsonFormatter.maxDepth", 8);
+        final int maxDepth =
+                PropertiesUtil.getProperties()
+                        .getIntegerProperty("log4j2.mapMessage.jsonFormatter.maxDepth", 8);
         if (maxDepth < 0) {
             throw new IllegalArgumentException(
                     "was expecting a positive maxDepth, found: " + maxDepth);
@@ -78,10 +78,7 @@ enum MapMessageJsonFormatter {;
         format(sb, object, 0);
     }
 
-    private static void format(
-            final StringBuilder sb,
-            final Object object,
-            final int depth) {
+    private static void format(final StringBuilder sb, final Object object, final int depth) {
 
         if (depth >= MAX_DEPTH) {
             throw new IllegalArgumentException("maxDepth has been exceeded");
@@ -162,13 +159,10 @@ enum MapMessageJsonFormatter {;
         else {
             formatString(sb, object);
         }
-
     }
 
     private static void formatIndexedStringMap(
-            final StringBuilder sb,
-            final IndexedStringMap map,
-            final int depth) {
+            final StringBuilder sb, final IndexedStringMap map, final int depth) {
         sb.append(LCURLY);
         final int nextDepth = depth + 1;
         for (int entryIndex = 0; entryIndex < map.size(); entryIndex++) {
@@ -188,36 +182,33 @@ enum MapMessageJsonFormatter {;
     }
 
     private static void formatMap(
-            final StringBuilder sb,
-            final Map<Object, Object> map,
-            final int depth) {
+            final StringBuilder sb, final Map<Object, Object> map, final int depth) {
         sb.append(LCURLY);
         final int nextDepth = depth + 1;
         final boolean[] firstEntry = {true};
-        map.forEach((final Object key, final Object value) -> {
-            if (key == null) {
-                throw new IllegalArgumentException("null keys are not allowed");
-            }
-            if (firstEntry[0]) {
-                firstEntry[0] = false;
-            } else {
-                sb.append(COMMA);
-            }
-            sb.append(DQUOTE);
-            final String keyString = String.valueOf(key);
-            final int keyStartIndex = sb.length();
-            sb.append(keyString);
-            StringBuilders.escapeJson(sb, keyStartIndex);
-            sb.append(DQUOTE).append(COLON);
-            format(sb, value, nextDepth);
-        });
+        map.forEach(
+                (final Object key, final Object value) -> {
+                    if (key == null) {
+                        throw new IllegalArgumentException("null keys are not allowed");
+                    }
+                    if (firstEntry[0]) {
+                        firstEntry[0] = false;
+                    } else {
+                        sb.append(COMMA);
+                    }
+                    sb.append(DQUOTE);
+                    final String keyString = String.valueOf(key);
+                    final int keyStartIndex = sb.length();
+                    sb.append(keyString);
+                    StringBuilders.escapeJson(sb, keyStartIndex);
+                    sb.append(DQUOTE).append(COLON);
+                    format(sb, value, nextDepth);
+                });
         sb.append(RCURLY);
     }
 
     private static void formatList(
-            final StringBuilder sb,
-            final List<Object> items,
-            final int depth) {
+            final StringBuilder sb, final List<Object> items, final int depth) {
         sb.append(LBRACE);
         final int nextDepth = depth + 1;
         for (int itemIndex = 0; itemIndex < items.size(); itemIndex++) {
@@ -231,20 +222,19 @@ enum MapMessageJsonFormatter {;
     }
 
     private static void formatCollection(
-            final StringBuilder sb,
-            final Collection<Object> items,
-            final int depth) {
+            final StringBuilder sb, final Collection<Object> items, final int depth) {
         sb.append(LBRACE);
         final int nextDepth = depth + 1;
         final boolean[] firstItem = {true};
-        items.forEach((final Object item) -> {
-            if (firstItem[0]) {
-                firstItem[0] = false;
-            } else {
-                sb.append(COMMA);
-            }
-            format(sb, item, nextDepth);
-        });
+        items.forEach(
+                (final Object item) -> {
+                    if (firstItem[0]) {
+                        firstItem[0] = false;
+                    } else {
+                        sb.append(COMMA);
+                    }
+                    format(sb, item, nextDepth);
+                });
         sb.append(RBRACE);
     }
 
@@ -258,10 +248,10 @@ enum MapMessageJsonFormatter {;
         } else if (number instanceof Float) {
             final float floatNumber = (float) number;
             sb.append(floatNumber);
-        } else if (number instanceof Byte ||
-                number instanceof Short ||
-                number instanceof Integer ||
-                number instanceof Long) {
+        } else if (number instanceof Byte
+                || number instanceof Short
+                || number instanceof Integer
+                || number instanceof Long) {
             final long longNumber = number.longValue();
             sb.append(longNumber);
         } else {
@@ -280,8 +270,7 @@ enum MapMessageJsonFormatter {;
     }
 
     private static void formatFormattable(
-            final StringBuilder sb,
-            final StringBuilderFormattable formattable) {
+            final StringBuilder sb, final StringBuilderFormattable formattable) {
         sb.append(DQUOTE);
         final int startIndex = sb.length();
         formattable.formatTo(sb);
@@ -377,9 +366,7 @@ enum MapMessageJsonFormatter {;
         sb.append(RBRACE);
     }
 
-    private static void formatDoubleArray(
-            final StringBuilder sb,
-            final double[] items) {
+    private static void formatDoubleArray(final StringBuilder sb, final double[] items) {
         sb.append(LBRACE);
         for (int itemIndex = 0; itemIndex < items.length; itemIndex++) {
             if (itemIndex > 0) {
@@ -392,9 +379,7 @@ enum MapMessageJsonFormatter {;
     }
 
     private static void formatObjectArray(
-            final StringBuilder sb,
-            final Object[] items,
-            final int depth) {
+            final StringBuilder sb, final Object[] items, final int depth) {
         sb.append(LBRACE);
         final int nextDepth = depth + 1;
         for (int itemIndex = 0; itemIndex < items.length; itemIndex++) {
@@ -415,5 +400,4 @@ enum MapMessageJsonFormatter {;
         StringBuilders.escapeJson(sb, startIndex);
         sb.append(DQUOTE);
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/Message.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/Message.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.io.Serializable;
-
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
 /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageCollectionMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageCollectionMessage.java
@@ -20,7 +20,4 @@ package org.apache.logging.log4j.message;
  * A Message that is a collection of Messages.
  * @param <T> The Message type.
  */
-public interface MessageCollectionMessage<T> extends Message, Iterable<T> {
-
-
-}
+public interface MessageCollectionMessage<T> extends Message, Iterable<T> {}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFactory2.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFactory2.java
@@ -104,7 +104,8 @@ public interface MessageFactory2 extends MessageFactory {
      * @return a new message
      * @see ParameterizedMessageFactory
      */
-    Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+    Message newMessage(
+            String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
 
     /**
      * Creates a new parameterized message.
@@ -120,7 +121,15 @@ public interface MessageFactory2 extends MessageFactory {
      * @return a new message
      * @see ParameterizedMessageFactory
      */
-    Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
+    Message newMessage(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6);
 
     /**
      * Creates a new parameterized message.
@@ -137,7 +146,15 @@ public interface MessageFactory2 extends MessageFactory {
      * @return a new message
      * @see ParameterizedMessageFactory
      */
-    Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    Message newMessage(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -156,8 +173,17 @@ public interface MessageFactory2 extends MessageFactory {
      * @return a new message
      * @see ParameterizedMessageFactory
      */
-    Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    Message newMessage(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Creates a new parameterized message.
@@ -176,6 +202,16 @@ public interface MessageFactory2 extends MessageFactory {
      * @return a new message
      * @see ParameterizedMessageFactory
      */
-    Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    Message newMessage(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFormatMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFormatMessage.java
@@ -23,7 +23,6 @@ import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.IllegalFormatException;
 import java.util.Locale;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
 
@@ -56,7 +55,8 @@ public class MessageFormatMessage implements Message {
      * @param parameters The objects to format
      * @since 2.6
      */
-    public MessageFormatMessage(final Locale locale, final String messagePattern, final Object... parameters) {
+    public MessageFormatMessage(
+            final Locale locale, final String messagePattern, final Object... parameters) {
         this.locale = locale;
         this.messagePattern = messagePattern;
         this.parameters = parameters;
@@ -130,7 +130,9 @@ public class MessageFormatMessage implements Message {
 
         final MessageFormatMessage that = (MessageFormatMessage) o;
 
-        if (messagePattern != null ? !messagePattern.equals(that.messagePattern) : that.messagePattern != null) {
+        if (messagePattern != null
+                ? !messagePattern.equals(that.messagePattern)
+                : that.messagePattern != null) {
             return false;
         }
         return Arrays.equals(serializedParameters, that.serializedParameters);
@@ -139,10 +141,13 @@ public class MessageFormatMessage implements Message {
     @Override
     public int hashCode() {
         int result = messagePattern != null ? messagePattern.hashCode() : 0;
-        result = HASHVAL * result + (serializedParameters != null ? Arrays.hashCode(serializedParameters) : 0);
+        result =
+                HASHVAL * result
+                        + (serializedParameters != null
+                                ? Arrays.hashCode(serializedParameters)
+                                : 0);
         return result;
     }
-
 
     @Override
     public String toString() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFormatMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFormatMessageFactory.java
@@ -32,8 +32,7 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
     /**
      * Constructs a message factory with default flow strings.
      */
-    public MessageFormatMessageFactory() {
-    }
+    public MessageFormatMessageFactory() {}
 
     /**
      * Creates {@link org.apache.logging.log4j.message.StringFormattedMessage} instances.
@@ -68,7 +67,8 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2) {
         return new MessageFormatMessage(message, p0, p1, p2);
     }
 
@@ -76,7 +76,12 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         return new MessageFormatMessage(message, p0, p1, p2, p3);
     }
 
@@ -84,7 +89,13 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         return new MessageFormatMessage(message, p0, p1, p2, p3, p4);
     }
 
@@ -92,7 +103,14 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5);
     }
 
@@ -100,7 +118,14 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5, p6);
     }
@@ -109,8 +134,16 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
@@ -118,8 +151,17 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
@@ -127,8 +169,18 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectArrayMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectArrayMessage.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Arrays;
-
 import org.apache.logging.log4j.util.Constants;
 
 /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectMessage.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.StringBuilders;
 import org.apache.logging.log4j.util.internal.SerializationUtil;
@@ -126,8 +125,8 @@ public class ObjectMessage implements Message, StringBuilderFormattable {
 
     private void writeObject(final ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
-        SerializationUtil.writeWrappedObject(obj instanceof Serializable ? (Serializable) obj : String.valueOf(obj),
-                out);
+        SerializationUtil.writeWrappedObject(
+                obj instanceof Serializable ? (Serializable) obj : String.valueOf(obj), out);
     }
 
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterConsumer.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterConsumer.java
@@ -38,5 +38,4 @@ public interface ParameterConsumer<S> {
      * @param state the state data
      */
     void accept(Object parameter, int parameterIndex, S state);
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -20,7 +20,6 @@ import java.io.Serializable;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-
 import org.apache.logging.log4j.util.StringBuilders;
 
 /**
@@ -31,6 +30,7 @@ final class ParameterFormatter {
      * Prefix for recursion.
      */
     static final String RECURSION_PREFIX = "[...";
+
     /**
      * Suffix for recursion.
      */
@@ -40,14 +40,17 @@ final class ParameterFormatter {
      * Prefix for errors.
      */
     static final String ERROR_PREFIX = "[!!!";
+
     /**
      * Separator for errors.
      */
     static final String ERROR_SEPARATOR = "=>";
+
     /**
      * Separator for error messages.
      */
     static final String ERROR_MSG_SEPARATOR = ":";
+
     /**
      * Suffix for errors.
      */
@@ -57,8 +60,9 @@ final class ParameterFormatter {
     private static final char DELIM_STOP = '}';
     private static final char ESCAPE_CHAR = '\\';
 
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
-            .withZone(ZoneId.systemDefault());
+    private static final DateTimeFormatter DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+                    .withZone(ZoneId.systemDefault());
 
     private ParameterFormatter() {}
 
@@ -111,9 +115,7 @@ final class ParameterFormatter {
      * @param analysis an object to store the results
      */
     static void analyzePattern(
-            final String pattern,
-            final int argCount,
-            final MessagePatternAnalysis analysis) {
+            final String pattern, final int argCount, final MessagePatternAnalysis analysis) {
 
         // Short-circuit if there is nothing interesting
         final int l;
@@ -147,7 +149,6 @@ final class ParameterFormatter {
                 }
             }
         }
-
     }
 
     /**
@@ -192,16 +193,18 @@ final class ParameterFormatter {
 
             // Extend the index buffer, if necessary
             else if (placeholderCount >= placeholderCharIndices.length) {
-                final int newLength = argCount > 0
-                        ? argCount
-                        : Math.addExact(placeholderCharIndices.length, PLACEHOLDER_CHAR_INDEX_BUFFER_SIZE_INCREMENT);
+                final int newLength =
+                        argCount > 0
+                                ? argCount
+                                : Math.addExact(
+                                        placeholderCharIndices.length,
+                                        PLACEHOLDER_CHAR_INDEX_BUFFER_SIZE_INCREMENT);
                 final int[] newPlaceholderCharIndices = new int[newLength];
-                System.arraycopy(placeholderCharIndices, 0, newPlaceholderCharIndices, 0, placeholderCount);
+                System.arraycopy(
+                        placeholderCharIndices, 0, newPlaceholderCharIndices, 0, placeholderCount);
                 placeholderCharIndices = newPlaceholderCharIndices;
             }
-
         }
-
     }
 
     /**
@@ -233,11 +236,10 @@ final class ParameterFormatter {
 
         // Fail if there are insufficient arguments
         if (analysis.placeholderCount > args.length) {
-            final String message = String.format(
-                    "found %d argument placeholders, but provided %d for pattern `%s`",
-                    analysis.placeholderCount,
-                    args.length,
-                    pattern);
+            final String message =
+                    String.format(
+                            "found %d argument placeholders, but provided %d for pattern `%s`",
+                            analysis.placeholderCount, args.length, pattern);
             throw new IllegalArgumentException(message);
         }
 
@@ -250,7 +252,6 @@ final class ParameterFormatter {
         else {
             formatMessageContainingNoEscapes(buffer, pattern, args, argCount, analysis);
         }
-
     }
 
     static void formatMessageContainingNoEscapes(
@@ -272,7 +273,6 @@ final class ParameterFormatter {
 
         // Format the last trailing text
         buffer.append(pattern, precedingTextStartIndex, pattern.length());
-
     }
 
     static void formatMessageContainingEscapes(
@@ -287,14 +287,15 @@ final class ParameterFormatter {
         final int argLimit = Math.min(analysis.placeholderCount, argCount);
         for (int argIndex = 0; argIndex < argLimit; argIndex++) {
             final int placeholderCharIndex = analysis.placeholderCharIndices[argIndex];
-            copyMessagePatternContainingEscapes(buffer, pattern, precedingTextStartIndex, placeholderCharIndex);
+            copyMessagePatternContainingEscapes(
+                    buffer, pattern, precedingTextStartIndex, placeholderCharIndex);
             recursiveDeepToString(args[argIndex], buffer);
             precedingTextStartIndex = placeholderCharIndex + 2;
         }
 
         // Format the last trailing text
-        copyMessagePatternContainingEscapes(buffer, pattern, precedingTextStartIndex, pattern.length());
-
+        copyMessagePatternContainingEscapes(
+                buffer, pattern, precedingTextStartIndex, pattern.length());
     }
 
     private static void copyMessagePatternContainingEscapes(
@@ -430,7 +431,8 @@ final class ParameterFormatter {
      * @param str    the {@code StringBuilder} that {@code o} will be appended to
      * @param dejaVu a set of container objects directly or transitively containing {@code o}
      */
-    private static void recursiveDeepToString(final Object o, final StringBuilder str, final Set<Object> dejaVu) {
+    private static void recursiveDeepToString(
+            final Object o, final StringBuilder str, final Set<Object> dejaVu) {
         if (appendSpecialTypes(o, str)) {
             return;
         }
@@ -461,9 +463,7 @@ final class ParameterFormatter {
     }
 
     private static void appendPotentiallyRecursiveValue(
-            final Object o,
-            final StringBuilder str,
-            final Set<Object> dejaVu) {
+            final Object o, final StringBuilder str, final Set<Object> dejaVu) {
         final Class<?> oClass = o.getClass();
         if (oClass.isArray()) {
             appendArray(o, str, dejaVu, oClass);
@@ -525,9 +525,7 @@ final class ParameterFormatter {
      * Specialized handler for {@link Map}s.
      */
     private static void appendMap(
-            final Object o,
-            final StringBuilder str,
-            final Set<Object> dejaVu) {
+            final Object o, final StringBuilder str, final Set<Object> dejaVu) {
         final Set<Object> effectiveDejaVu = getOrCreateDejaVu(dejaVu);
         final boolean seen = !effectiveDejaVu.add(o);
         if (seen) {
@@ -557,9 +555,7 @@ final class ParameterFormatter {
      * Specialized handler for {@link Collection}s.
      */
     private static void appendCollection(
-            final Object o,
-            final StringBuilder str,
-            final Set<Object> dejaVu) {
+            final Object o, final StringBuilder str, final Set<Object> dejaVu) {
         final Set<Object> effectiveDejaVu = getOrCreateDejaVu(dejaVu);
         final boolean seen = !effectiveDejaVu.add(o);
         if (seen) {
@@ -582,9 +578,7 @@ final class ParameterFormatter {
     }
 
     private static Set<Object> getOrCreateDejaVu(final Set<Object> dejaVu) {
-        return dejaVu == null
-                ? createDejaVu()
-                : dejaVu;
+        return dejaVu == null ? createDejaVu() : dejaVu;
     }
 
     private static Set<Object> createDejaVu() {
@@ -606,7 +600,8 @@ final class ParameterFormatter {
         }
     }
 
-    private static void handleErrorInObjectToString(final Object o, final StringBuilder str, final Throwable t) {
+    private static void handleErrorInObjectToString(
+            final Object o, final StringBuilder str, final Throwable t) {
         str.append(ERROR_PREFIX);
         str.append(identityToString(o));
         str.append(ERROR_SEPARATOR);
@@ -646,5 +641,4 @@ final class ParameterFormatter {
         }
         return obj.getClass().getName() + '@' + Integer.toHexString(System.identityHashCode(obj));
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterVisitable.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterVisitable.java
@@ -42,5 +42,4 @@ public interface ParameterVisitable {
      * @since 2.11
      */
     <S> void forEachParameter(ParameterConsumer<S> action, S state);
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
@@ -16,20 +16,19 @@
  */
 package org.apache.logging.log4j.message;
 
+import static org.apache.logging.log4j.message.ParameterFormatter.analyzePattern;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
-
 import org.apache.logging.log4j.message.ParameterFormatter.MessagePatternAnalysis;
 import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.StringBuilders;
 import org.apache.logging.log4j.util.internal.SerializationUtil;
-
-import static org.apache.logging.log4j.message.ParameterFormatter.analyzePattern;
 
 /**
  * A {@link Message} accepting argument placeholders in the formatting pattern.
@@ -83,15 +82,17 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
 
     private static final long serialVersionUID = -665975803997290697L;
 
-    private static final ThreadLocal<StringBuilder> STRING_BUILDER_HOLDER = Constants.ENABLE_THREADLOCALS
-            ? ThreadLocal.withInitial(() -> new StringBuilder(Constants.MAX_REUSABLE_MESSAGE_SIZE))
-            : null;
+    private static final ThreadLocal<StringBuilder> STRING_BUILDER_HOLDER =
+            Constants.ENABLE_THREADLOCALS
+                    ? ThreadLocal.withInitial(
+                            () -> new StringBuilder(Constants.MAX_REUSABLE_MESSAGE_SIZE))
+                    : null;
 
     private final String pattern;
 
     private transient Object[] args;
 
-    private transient final Throwable throwable;
+    private final transient Throwable throwable;
 
     private final MessagePatternAnalysis patternAnalysis;
 
@@ -113,7 +114,8 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      * @deprecated Use {@link #ParameterizedMessage(String, Object[], Throwable)} instead
      */
     @Deprecated
-    public ParameterizedMessage(final String pattern, final String[] args, final Throwable throwable) {
+    public ParameterizedMessage(
+            final String pattern, final String[] args, final Throwable throwable) {
         this(pattern, Arrays.stream(args).toArray(Object[]::new), throwable);
     }
 
@@ -131,7 +133,8 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      * @param args arguments to be formatted
      * @param throwable a {@link Throwable}
      */
-    public ParameterizedMessage(final String pattern, final Object[] args, final Throwable throwable) {
+    public ParameterizedMessage(
+            final String pattern, final Object[] args, final Throwable throwable) {
         this.args = args;
         this.pattern = pattern;
         this.patternAnalysis = analyzePattern(pattern, args != null ? args.length : 0);
@@ -139,9 +142,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
     }
 
     private static Throwable determineThrowable(
-            final Throwable throwable,
-            final Object[] args,
-            final MessagePatternAnalysis analysis) {
+            final Throwable throwable, final Object[] args, final MessagePatternAnalysis analysis) {
 
         // Short-circuit if an explicit `Throwable` is provided
         if (throwable != null) {
@@ -158,7 +159,6 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
 
         // No `Throwable`s available
         return null;
-
     }
 
     /**
@@ -184,7 +184,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      * @param arg an argument
      */
     public ParameterizedMessage(final String pattern, final Object arg) {
-        this(pattern, new Object[]{arg});
+        this(pattern, new Object[] {arg});
     }
 
     /**
@@ -198,7 +198,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      * @param arg1 the second argument
      */
     public ParameterizedMessage(final String pattern, final Object arg0, final Object arg1) {
-        this(pattern, new Object[]{arg0, arg1});
+        this(pattern, new Object[] {arg0, arg1});
     }
 
     /**
@@ -355,16 +355,24 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
 
     @Override
     public String toString() {
-        return "ParameterizedMessage[messagePattern=" + pattern + ", stringArgs=" +
-                Arrays.toString(args) + ", throwable=" + throwable + ']';
+        return "ParameterizedMessage[messagePattern="
+                + pattern
+                + ", stringArgs="
+                + Arrays.toString(args)
+                + ", throwable="
+                + throwable
+                + ']';
     }
 
     private void writeObject(final ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
         out.writeInt(args.length);
         for (int i = 0; i < args.length; i++) {
-            SerializationUtil.writeWrappedObject(args[i] instanceof Serializable ? (Serializable) args[i] :
-                    String.valueOf(args[i]), out);
+            SerializationUtil.writeWrappedObject(
+                    args[i] instanceof Serializable
+                            ? (Serializable) args[i]
+                            : String.valueOf(args[i]),
+                    out);
         }
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessageFactory.java
@@ -47,8 +47,7 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
     /**
      * Constructs a message factory.
      */
-    public ParameterizedMessageFactory() {
-    }
+    public ParameterizedMessageFactory() {}
 
     /**
      * Creates {@link ParameterizedMessage} instances.
@@ -84,7 +83,8 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2) {
         return new ParameterizedMessage(message, p0, p1, p2);
     }
 
@@ -92,7 +92,12 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         return new ParameterizedMessage(message, p0, p1, p2, p3);
     }
 
@@ -100,7 +105,13 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         return new ParameterizedMessage(message, p0, p1, p2, p3, p4);
     }
 
@@ -108,7 +119,14 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5);
     }
 
@@ -116,7 +134,14 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5, p6);
     }
@@ -125,8 +150,16 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
@@ -134,8 +167,17 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
@@ -143,8 +185,18 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedNoReferenceMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedNoReferenceMessageFactory.java
@@ -81,13 +81,13 @@ public final class ParameterizedNoReferenceMessageFactory extends AbstractMessag
     /**
      * Constructs a message factory with default flow strings.
      */
-    public ParameterizedNoReferenceMessageFactory() {
-    }
+    public ParameterizedNoReferenceMessageFactory() {}
 
     /**
      * Instance of ParameterizedStatusMessageFactory.
      */
-    public static final ParameterizedNoReferenceMessageFactory INSTANCE = new ParameterizedNoReferenceMessageFactory();
+    public static final ParameterizedNoReferenceMessageFactory INSTANCE =
+            new ParameterizedNoReferenceMessageFactory();
 
     /**
      * Creates {@link SimpleMessage} instances containing the formatted parameterized message string.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.io.Serializable;
-
 import org.apache.logging.log4j.util.PerformanceSensitive;
 
 /**
@@ -38,15 +37,17 @@ public final class ReusableMessageFactory implements MessageFactory2, Serializab
     public static final ReusableMessageFactory INSTANCE = new ReusableMessageFactory();
 
     private static final long serialVersionUID = 1L;
-    private transient final ThreadLocal<ReusableParameterizedMessage> threadLocalParameterized = new ThreadLocal<>();
-    private transient final ThreadLocal<ReusableSimpleMessage> threadLocalSimpleMessage = new ThreadLocal<>();
-    private transient final ThreadLocal<ReusableObjectMessage> threadLocalObjectMessage = new ThreadLocal<>();
+    private final transient ThreadLocal<ReusableParameterizedMessage> threadLocalParameterized =
+            new ThreadLocal<>();
+    private final transient ThreadLocal<ReusableSimpleMessage> threadLocalSimpleMessage =
+            new ThreadLocal<>();
+    private final transient ThreadLocal<ReusableObjectMessage> threadLocalObjectMessage =
+            new ThreadLocal<>();
 
     /**
      * Constructs a message factory.
      */
-    public ReusableMessageFactory() {
-    }
+    public ReusableMessageFactory() {}
 
     private ReusableParameterizedMessage getParameterized() {
         ReusableParameterizedMessage result = threadLocalParameterized.get();
@@ -120,49 +121,99 @@ public final class ReusableMessageFactory implements MessageFactory2, Serializab
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2) {
         return getParameterized().set(message, p0, p1, p2);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         return getParameterized().set(message, p0, p1, p2, p3);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         return getParameterized().set(message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -180,7 +231,6 @@ public final class ReusableMessageFactory implements MessageFactory2, Serializab
         result.set(message);
         return result;
     }
-
 
     /**
      * Creates {@link ReusableObjectMessage} instances.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.util.Arrays;
-
 import org.apache.logging.log4j.message.ParameterFormatter.MessagePatternAnalysis;
 import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.PerformanceSensitive;
@@ -31,7 +30,8 @@ import org.apache.logging.log4j.util.StringBuilders;
  * @since 2.6
  */
 @PerformanceSensitive("allocation")
-public class ReusableParameterizedMessage implements ReusableMessage, ParameterVisitable, Clearable {
+public class ReusableParameterizedMessage
+        implements ReusableMessage, ParameterVisitable, Clearable {
 
     private static final int MIN_BUILDER_SIZE = 512;
     private static final int MAX_PARAMS = 10;
@@ -44,13 +44,13 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
     private transient Object[] varargs;
     private transient Object[] params = new Object[MAX_PARAMS];
     private transient Throwable throwable;
-    transient boolean reserved = false; // LOG4J2-1583 prevent scrambled logs with nested logging calls
+    transient boolean reserved =
+            false; // LOG4J2-1583 prevent scrambled logs with nested logging calls
 
     /**
      * Creates a reusable message.
      */
-    public ReusableParameterizedMessage() {
-    }
+    public ReusableParameterizedMessage() {}
 
     private Object[] getTrimmedParams() {
         return varargs == null ? Arrays.copyOf(params, argCount) : varargs;
@@ -84,10 +84,14 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         } else {
             // The returned array will be reused by the caller in future swapParameter() calls.
             // Therefore we want to avoid returning arrays with less than 10 elements.
-            // If the vararg array is less than 10 params we just copy its content into the specified array
-            // and return it. This helps the caller to retain a reusable array of at least 10 elements.
-            // NOTE: LOG4J2-1688 unearthed the use case that an application array (not a varargs array) is passed
-            // as the argument array. This array should not be modified, so it cannot be passed to the caller
+            // If the vararg array is less than 10 params we just copy its content into the
+            // specified array
+            // and return it. This helps the caller to retain a reusable array of at least 10
+            // elements.
+            // NOTE: LOG4J2-1688 unearthed the use case that an application array (not a varargs
+            // array) is passed
+            // as the argument array. This array should not be modified, so it cannot be passed to
+            // the caller
             // who will at some point null out the elements in the array).
             if (argCount <= emptyReplacement.length) {
                 result = emptyReplacement;
@@ -127,7 +131,8 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         this.throwable = determineThrowable(args, argCount, patternAnalysis.placeholderCount);
     }
 
-    private static Throwable determineThrowable(final Object[] args, final int argCount, final int placeholderCount) {
+    private static Throwable determineThrowable(
+            final Object[] args, final int argCount, final int placeholderCount) {
         if (placeholderCount < argCount) {
             final Object lastArg = args[argCount - 1];
             if (lastArg instanceof Throwable) {
@@ -149,14 +154,16 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1) {
+    ReusableParameterizedMessage set(
+            final String messagePattern, final Object p0, final Object p1) {
         params[0] = p0;
         params[1] = p1;
         init(messagePattern, 2, params);
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2) {
+    ReusableParameterizedMessage set(
+            final String messagePattern, final Object p0, final Object p1, final Object p2) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
@@ -164,7 +171,12 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3) {
+    ReusableParameterizedMessage set(
+            final String messagePattern,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
@@ -173,7 +185,13 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    ReusableParameterizedMessage set(
+            final String messagePattern,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
@@ -183,7 +201,14 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    ReusableParameterizedMessage set(
+            final String messagePattern,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
@@ -194,7 +219,14 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    ReusableParameterizedMessage set(
+            final String messagePattern,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         params[0] = p0;
         params[1] = p1;
@@ -207,8 +239,16 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    ReusableParameterizedMessage set(
+            final String messagePattern,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
@@ -221,8 +261,17 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    ReusableParameterizedMessage set(
+            final String messagePattern,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
@@ -236,8 +285,18 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    ReusableParameterizedMessage set(
+            final String messagePattern,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
@@ -313,7 +372,8 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
 
     @Override
     public void formatTo(final StringBuilder builder) {
-        ParameterFormatter.formatMessage(builder, messagePattern, getParams(), argCount, patternAnalysis);
+        ParameterFormatter.formatMessage(
+                builder, messagePattern, getParams(), argCount, patternAnalysis);
     }
 
     /**
@@ -328,8 +388,13 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
 
     @Override
     public String toString() {
-        return "ReusableParameterizedMessage[messagePattern=" + getFormat() + ", stringArgs=" +
-                Arrays.toString(getParameters()) + ", throwable=" + getThrowable() + ']';
+        return "ReusableParameterizedMessage[messagePattern="
+                + getFormat()
+                + ", stringArgs="
+                + Arrays.toString(getParameters())
+                + ", throwable="
+                + getThrowable()
+                + ']';
     }
 
     @Override
@@ -342,7 +407,9 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         throwable = null;
         // Cut down on the memory usage after an analysis with an excessive argument count
         final int placeholderCharIndicesMaxLength = 16;
-        if (patternAnalysis.placeholderCharIndices != null && patternAnalysis.placeholderCharIndices.length > placeholderCharIndicesMaxLength) {
+        if (patternAnalysis.placeholderCharIndices != null
+                && patternAnalysis.placeholderCharIndices.length
+                        > placeholderCharIndicesMaxLength) {
             patternAnalysis.placeholderCharIndices = new int[placeholderCharIndicesMaxLength];
         }
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
@@ -24,7 +24,8 @@ import org.apache.logging.log4j.util.PerformanceSensitive;
  * @since 2.6
  */
 @PerformanceSensitive("allocation")
-public class ReusableSimpleMessage implements ReusableMessage, CharSequence, ParameterVisitable, Clearable {
+public class ReusableSimpleMessage
+        implements ReusableMessage, CharSequence, ParameterVisitable, Clearable {
     private static final long serialVersionUID = -9199974506498249809L;
     private CharSequence charSequence;
 
@@ -81,8 +82,7 @@ public class ReusableSimpleMessage implements ReusableMessage, CharSequence, Par
     }
 
     @Override
-    public <S> void forEachParameter(final ParameterConsumer<S> action, final S state) {
-    }
+    public <S> void forEachParameter(final ParameterConsumer<S> action, final S state) {}
 
     @Override
     public Message memento() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessage.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.message;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
 /**
@@ -62,12 +61,12 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
      */
     @Override
     public String getFormattedMessage() {
-        return message = message == null ? String.valueOf(charSequence) : message ;
+        return message = message == null ? String.valueOf(charSequence) : message;
     }
 
     @Override
     public void formatTo(final StringBuilder buffer) {
-    buffer.append(message != null ? message : charSequence);
+        buffer.append(message != null ? message : charSequence);
     }
 
     /**
@@ -99,7 +98,9 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
 
         final SimpleMessage that = (SimpleMessage) o;
 
-        return !(charSequence != null ? !charSequence.equals(that.charSequence) : that.charSequence != null);
+        return !(charSequence != null
+                ? !charSequence.equals(that.charSequence)
+                : that.charSequence != null);
     }
 
     @Override
@@ -122,7 +123,6 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
         return null;
     }
 
-
     // CharSequence impl
 
     @Override
@@ -139,7 +139,6 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
     public CharSequence subSequence(final int start, final int end) {
         return charSequence.subSequence(start, end);
     }
-
 
     private void writeObject(final ObjectOutputStream out) throws IOException {
         getFormattedMessage(); // initialize the message:String field

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessageFactory.java
@@ -44,6 +44,7 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * Instance of StringFormatterMessageFactory.
      */
     public static final SimpleMessageFactory INSTANCE = new SimpleMessageFactory();
+
     private static final long serialVersionUID = 4418995198790088516L;
 
     /**
@@ -82,7 +83,8 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2) {
         return new SimpleMessage(message);
     }
 
@@ -90,7 +92,12 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         return new SimpleMessage(message);
     }
 
@@ -98,7 +105,13 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         return new SimpleMessage(message);
     }
 
@@ -106,7 +119,14 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return new SimpleMessage(message);
     }
 
@@ -114,7 +134,14 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         return new SimpleMessage(message);
     }
@@ -123,8 +150,16 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return new SimpleMessage(message);
     }
 
@@ -132,8 +167,17 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return new SimpleMessage(message);
     }
 
@@ -141,8 +185,18 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return new SimpleMessage(message);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormattedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormattedMessage.java
@@ -22,7 +22,6 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.IllegalFormatException;
 import java.util.Locale;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
 
@@ -52,19 +51,22 @@ public class StringFormattedMessage implements Message {
     private transient Throwable throwable;
     private final Locale locale;
 
-   /**
-    * Constructs a message.
-    *
-    * @param locale the locale for this message format
-    * @param messagePattern the pattern for this message format
-    * @param arguments The objects to format
-    * @since 2.6
-    */
-    public StringFormattedMessage(final Locale locale, final String messagePattern, final Object... arguments) {
+    /**
+     * Constructs a message.
+     *
+     * @param locale the locale for this message format
+     * @param messagePattern the pattern for this message format
+     * @param arguments The objects to format
+     * @since 2.6
+     */
+    public StringFormattedMessage(
+            final Locale locale, final String messagePattern, final Object... arguments) {
         this.locale = locale;
         this.messagePattern = messagePattern;
         this.argArray = arguments;
-        if (arguments != null && arguments.length > 0 && arguments[arguments.length - 1] instanceof Throwable) {
+        if (arguments != null
+                && arguments.length > 0
+                && arguments[arguments.length - 1] instanceof Throwable) {
             this.throwable = (Throwable) arguments[arguments.length - 1];
         }
     }
@@ -137,7 +139,9 @@ public class StringFormattedMessage implements Message {
 
         final StringFormattedMessage that = (StringFormattedMessage) o;
 
-        if (messagePattern != null ? !messagePattern.equals(that.messagePattern) : that.messagePattern != null) {
+        if (messagePattern != null
+                ? !messagePattern.equals(that.messagePattern)
+                : that.messagePattern != null) {
             return false;
         }
 
@@ -150,7 +154,6 @@ public class StringFormattedMessage implements Message {
         result = HASHVAL * result + (stringArgs != null ? Arrays.hashCode(stringArgs) : 0);
         return result;
     }
-
 
     @Override
     public String toString() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormatterMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormatterMessageFactory.java
@@ -40,14 +40,15 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
     /**
      * Instance of StringFormatterMessageFactory.
      */
-    public static final StringFormatterMessageFactory INSTANCE = new StringFormatterMessageFactory();
+    public static final StringFormatterMessageFactory INSTANCE =
+            new StringFormatterMessageFactory();
+
     private static final long serialVersionUID = -1626332412176965642L;
 
     /**
      * Constructs a message factory with default flow strings.
      */
-    public StringFormatterMessageFactory() {
-    }
+    public StringFormatterMessageFactory() {}
 
     /**
      * Creates {@link StringFormattedMessage} instances.
@@ -83,7 +84,8 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2) {
         return new StringFormattedMessage(message, p0, p1, p2);
     }
 
@@ -91,7 +93,12 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         return new StringFormattedMessage(message, p0, p1, p2, p3);
     }
 
@@ -99,7 +106,13 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         return new StringFormattedMessage(message, p0, p1, p2, p3, p4);
     }
 
@@ -107,7 +120,14 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return new StringFormattedMessage(message, p0, p1, p2, p3, p4, p5);
     }
 
@@ -115,7 +135,14 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         return new StringFormattedMessage(message, p0, p1, p2, p3, p4, p5, p6);
     }
@@ -124,8 +151,16 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return new StringFormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
@@ -133,8 +168,17 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return new StringFormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
@@ -142,8 +186,18 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return new StringFormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StringMapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StringMapMessage.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.util.Map;
-
 import org.apache.logging.log4j.util.PerformanceSensitive;
 
 /**
@@ -34,8 +33,7 @@ public class StringMapMessage extends MapMessage<StringMapMessage, String> {
     /**
      * Constructs a new instance.
      */
-    public StringMapMessage() {
-    }
+    public StringMapMessage() {}
 
     /**
      * Constructs a new instance.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataCollectionMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataCollectionMessage.java
@@ -19,14 +19,13 @@ package org.apache.logging.log4j.message;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
 /**
  * A collection of StructuredDataMessages.
  */
-public class StructuredDataCollectionMessage implements StringBuilderFormattable,
-        MessageCollectionMessage<StructuredDataMessage> {
+public class StructuredDataCollectionMessage
+        implements StringBuilderFormattable, MessageCollectionMessage<StructuredDataMessage> {
     private static final long serialVersionUID = 5725337076388822924L;
 
     private final List<StructuredDataMessage> structuredDataMessageList;
@@ -82,9 +81,9 @@ public class StructuredDataCollectionMessage implements StringBuilderFormattable
         final Object[] objects = new Object[count];
         int index = 0;
         for (final Object[] objs : objectList) {
-           for (final Object obj : objs) {
-               objects[index++] = obj;
-           }
+            for (final Object obj : objs) {
+                objects[index++] = obj;
+            }
         }
         return objects;
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.io.Serializable;
-
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.Strings;
 
@@ -29,20 +28,23 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
     /**
      * RFC 5424 Time Quality.
      */
-    public static final StructuredDataId TIME_QUALITY = new StructuredDataId("timeQuality", null, new String[] {
-            "tzKnown", "isSynced", "syncAccuracy"});
+    public static final StructuredDataId TIME_QUALITY =
+            new StructuredDataId(
+                    "timeQuality", null, new String[] {"tzKnown", "isSynced", "syncAccuracy"});
 
     /**
      * RFC 5424 Origin.
      */
-    public static final StructuredDataId ORIGIN = new StructuredDataId("origin", null, new String[] {"ip",
-            "enterpriseId", "software", "swVersion"});
+    public static final StructuredDataId ORIGIN =
+            new StructuredDataId(
+                    "origin", null, new String[] {"ip", "enterpriseId", "software", "swVersion"});
 
     /**
      * RFC 5424 Meta.
      */
-    public static final StructuredDataId META = new StructuredDataId("meta", null, new String[] {"sequenceId",
-            "sysUpTime", "language"});
+    public static final StructuredDataId META =
+            new StructuredDataId(
+                    "meta", null, new String[] {"sequenceId", "sysUpTime", "language"});
 
     /**
      * Reserved enterprise number.
@@ -96,15 +98,18 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @param maxLength The maximum length of the id's name.
      * @since 2.9
      */
-    public StructuredDataId(final String name, final String[] required, final String[] optional, int maxLength) {
+    public StructuredDataId(
+            final String name, final String[] required, final String[] optional, int maxLength) {
         int index = -1;
         if (name != null) {
             if (maxLength <= 0) {
                 maxLength = MAX_LENGTH;
             }
             if (name.length() > maxLength) {
-                throw new IllegalArgumentException(String.format("Length of id %s exceeds maximum of %d characters",
-                        name, maxLength));
+                throw new IllegalArgumentException(
+                        String.format(
+                                "Length of id %s exceeds maximum of %d characters",
+                                name, maxLength));
             }
             index = name.indexOf(AT_SIGN);
         }
@@ -128,8 +133,11 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @param required The list of keys that are required for this id.
      * @param optional The list of keys that are optional for this id.
      */
-    public StructuredDataId(final String name, final String enterpriseNumber, final String[] required,
-                            final String[] optional) {
+    public StructuredDataId(
+            final String name,
+            final String enterpriseNumber,
+            final String[] required,
+            final String[] optional) {
         this(name, enterpriseNumber, required, optional, MAX_LENGTH);
     }
 
@@ -143,8 +151,11 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @deprecated Use {@link #StructuredDataId(String, String, String[], String[])} instead.
      */
     @Deprecated
-    public StructuredDataId(final String name, final int enterpriseNumber, final String[] required,
-                            final String[] optional) {
+    public StructuredDataId(
+            final String name,
+            final int enterpriseNumber,
+            final String[] required,
+            final String[] optional) {
         this(name, String.valueOf(enterpriseNumber), required, optional, MAX_LENGTH);
     }
 
@@ -158,13 +169,18 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @param maxLength The maximum length of the StructuredData Id key.
      * @since 2.9
      */
-    public StructuredDataId(final String name, final String enterpriseNumber, final String[] required,
-                            final String[] optional, final int maxLength) {
+    public StructuredDataId(
+            final String name,
+            final String enterpriseNumber,
+            final String[] required,
+            final String[] optional,
+            final int maxLength) {
         if (name == null) {
             throw new IllegalArgumentException("No structured id name was supplied");
         }
         if (name.contains(AT_SIGN)) {
-            throw new IllegalArgumentException("Structured id name cannot contain an " + Strings.quote(AT_SIGN));
+            throw new IllegalArgumentException(
+                    "Structured id name cannot contain an " + Strings.quote(AT_SIGN));
         }
         if (RESERVED.equals(enterpriseNumber)) {
             throw new IllegalArgumentException("No enterprise number was supplied");
@@ -173,7 +189,8 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
         this.enterpriseNumber = enterpriseNumber;
         final String id = name + AT_SIGN + enterpriseNumber;
         if (maxLength > 0 && id.length() > maxLength) {
-            throw new IllegalArgumentException("Length of id exceeds maximum of " + maxLength + " characters: " + id);
+            throw new IllegalArgumentException(
+                    "Length of id exceeds maximum of " + maxLength + " characters: " + id);
         }
         this.required = required;
         this.optional = optional;
@@ -191,8 +208,12 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @deprecated Use {@link #StructuredDataId(String, String, String[], String[], int)} instead.
      */
     @Deprecated
-    public StructuredDataId(final String name, final int enterpriseNumber, final String[] required,
-            final String[] optional, final int maxLength) {
+    public StructuredDataId(
+            final String name,
+            final int enterpriseNumber,
+            final String[] required,
+            final String[] optional,
+            final int maxLength) {
         this(name, String.valueOf(enterpriseNumber), required, optional, maxLength);
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.util.Map;
-
 import org.apache.logging.log4j.util.EnglishEnums;
 import org.apache.logging.log4j.util.StringBuilders;
 
@@ -76,7 +75,8 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param maxLength The maximum length of keys;
      * @since 2.9
      */
-    public StructuredDataMessage(final String id, final String msg, final String type, final int maxLength) {
+    public StructuredDataMessage(
+            final String id, final String msg, final String type, final int maxLength) {
         this.id = new StructuredDataId(id, null, null, maxLength);
         this.message = msg;
         this.type = type;
@@ -91,8 +91,8 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param type The message type.
      * @param data The StructuredData map.
      */
-    public StructuredDataMessage(final String id, final String msg, final String type,
-                                 final Map<String, String> data) {
+    public StructuredDataMessage(
+            final String id, final String msg, final String type, final Map<String, String> data) {
         this(id, msg, type, data, MAX_LENGTH);
     }
 
@@ -106,8 +106,12 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param maxLength The maximum length of keys;
      * @since 2.9
      */
-    public StructuredDataMessage(final String id, final String msg, final String type,
-                                 final Map<String, String> data, final int maxLength) {
+    public StructuredDataMessage(
+            final String id,
+            final String msg,
+            final String type,
+            final Map<String, String> data,
+            final int maxLength) {
         super(data);
         this.id = new StructuredDataId(id, null, null, maxLength);
         this.message = msg;
@@ -133,7 +137,8 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param maxLength The maximum length of keys;
      * @since 2.9
      */
-    public StructuredDataMessage(final StructuredDataId id, final String msg, final String type, final int maxLength) {
+    public StructuredDataMessage(
+            final StructuredDataId id, final String msg, final String type, final int maxLength) {
         this.id = id;
         this.message = msg;
         this.type = type;
@@ -148,8 +153,11 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param type The message type.
      * @param data The StructuredData map.
      */
-    public StructuredDataMessage(final StructuredDataId id, final String msg, final String type,
-                                 final Map<String, String> data) {
+    public StructuredDataMessage(
+            final StructuredDataId id,
+            final String msg,
+            final String type,
+            final Map<String, String> data) {
         this(id, msg, type, data, MAX_LENGTH);
     }
 
@@ -163,15 +171,18 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param maxLength The maximum length of keys;
      * @since 2.9
      */
-    public StructuredDataMessage(final StructuredDataId id, final String msg, final String type,
-                                 final Map<String, String> data, final int maxLength) {
+    public StructuredDataMessage(
+            final StructuredDataId id,
+            final String msg,
+            final String type,
+            final Map<String, String> data,
+            final int maxLength) {
         super(data);
         this.id = id;
         this.message = msg;
         this.type = type;
         this.maxLength = maxLength;
     }
-
 
     /**
      * Constructor based on a StructuredDataMessage.
@@ -241,7 +252,8 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
 
     protected void setType(final String type) {
         if (type.length() > MAX_LENGTH) {
-            throw new IllegalArgumentException("structured data type exceeds maximum length of 32 characters: " + type);
+            throw new IllegalArgumentException(
+                    "structured data type exceeds maximum length of 32 characters: " + type);
         }
         this.type = type;
     }
@@ -285,7 +297,6 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param format The format identifier. Ignored in this implementation.
      * @return The formatted String.
      */
-
     @Override
     public String asString(final String format) {
         try {
@@ -319,7 +330,8 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      *                         will be used.
      * @param sb The StringBuilder to append the formatted message to.
      */
-    public final void asString(final Format format, final StructuredDataId structuredDataId, final StringBuilder sb) {
+    public final void asString(
+            final Format format, final StructuredDataId structuredDataId, final StringBuilder sb) {
         final boolean full = Format.FULL.equals(format);
         if (full) {
             final String myType = getType();
@@ -342,7 +354,8 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
             return;
         }
         sb.append('[');
-        StringBuilders.appendValue(sb, sdId); // avoids toString if implements StringBuilderFormattable
+        StringBuilders.appendValue(
+                sb, sdId); // avoids toString if implements StringBuilderFormattable
         sb.append(' ');
         appendMap(sb);
         sb.append(']');
@@ -404,7 +417,6 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
     public String toString() {
         return asString(null, null);
     }
-
 
     @Override
     public StructuredDataMessage newInstance(final Map<String, String> map) {
@@ -523,16 +535,19 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
 
     protected void validateKey(final String key) {
         if (maxLength > 0 && key.length() > maxLength) {
-            throw new IllegalArgumentException("Structured data keys are limited to " + maxLength +
-                    " characters. key: " + key);
+            throw new IllegalArgumentException(
+                    "Structured data keys are limited to "
+                            + maxLength
+                            + " characters. key: "
+                            + key);
         }
         for (int i = 0; i < key.length(); i++) {
             final char c = key.charAt(i);
             if (c < '!' || c > '~' || c == '=' || c == ']' || c == '"') {
-                throw new IllegalArgumentException("Structured data keys must contain printable US ASCII characters" +
-                        "and may not contain a space, =, ], or \"");
+                throw new IllegalArgumentException(
+                        "Structured data keys must contain printable US ASCII characters"
+                                + "and may not contain a space, =, ], or \"");
             }
         }
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadDumpMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadDumpMessage.java
@@ -16,28 +16,30 @@
  */
 package org.apache.logging.log4j.message;
 
+import static org.apache.logging.log4j.util.Chars.LF;
+
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
-
-import aQute.bnd.annotation.Cardinality;
-import aQute.bnd.annotation.Resolution;
-import aQute.bnd.annotation.spi.ServiceConsumer;
 import org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
 import org.apache.logging.log4j.util.ServiceLoaderUtil;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.Strings;
 
-import static org.apache.logging.log4j.util.Chars.LF;
-
 /**
  * Captures information about all running Threads.
  */
 @AsynchronouslyFormattable
-@ServiceConsumer(value = ThreadInfoFactory.class, resolution = Resolution.OPTIONAL, cardinality = Cardinality.SINGLE)
+@ServiceConsumer(
+        value = ThreadInfoFactory.class,
+        resolution = Resolution.OPTIONAL,
+        cardinality = Cardinality.SINGLE)
 public class ThreadDumpMessage implements Message, StringBuilderFormattable {
     private static final long serialVersionUID = -1103400781608841088L;
     private static ThreadInfoFactory FACTORY;
@@ -68,7 +70,8 @@ public class ThreadDumpMessage implements Message, StringBuilderFormattable {
     }
 
     private static ThreadInfoFactory initFactory() {
-        return ServiceLoaderUtil.loadServices(ThreadInfoFactory.class, MethodHandles.lookup(), false)
+        return ServiceLoaderUtil.loadServices(
+                        ThreadInfoFactory.class, MethodHandles.lookup(), false)
                 .findFirst()
                 .orElseGet(BasicThreadInfoFactory::new);
     }
@@ -125,7 +128,7 @@ public class ThreadDumpMessage implements Message, StringBuilderFormattable {
         return null;
     }
 
-        /**
+    /**
      * Creates a ThreadDumpMessageProxy that can be serialized.
      * @return a ThreadDumpMessageProxy.
      */
@@ -133,8 +136,7 @@ public class ThreadDumpMessage implements Message, StringBuilderFormattable {
         return new ThreadDumpMessageProxy(this);
     }
 
-    private void readObject(final ObjectInputStream stream)
-        throws InvalidObjectException {
+    private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
         throw new InvalidObjectException("Proxy required");
     }
 
@@ -178,8 +180,7 @@ public class ThreadDumpMessage implements Message, StringBuilderFormattable {
         @Override
         public Map<ThreadInformation, StackTraceElement[]> createThreadInfo() {
             final Map<Thread, StackTraceElement[]> map = Thread.getAllStackTraces();
-            final Map<ThreadInformation, StackTraceElement[]> threads =
-                new HashMap<>(map.size());
+            final Map<ThreadInformation, StackTraceElement[]> threads = new HashMap<>(map.size());
             for (final Map.Entry<Thread, StackTraceElement[]> entry : map.entrySet()) {
                 threads.put(new BasicThreadInformation(entry.getKey()), entry.getValue());
             }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadInformation.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadInformation.java
@@ -33,5 +33,4 @@ public interface ThreadInformation {
      * @param trace The stack trace element array to format.
      */
     void printStack(StringBuilder sb, StackTraceElement[] trace);
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLogger.java
@@ -21,7 +21,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.ThreadContext;
@@ -58,12 +57,20 @@ public class SimpleLogger extends AbstractLogger {
 
     private final String logName;
 
-    public SimpleLogger(final String name, final Level defaultLevel, final boolean showLogName,
-            final boolean showShortLogName, final boolean showDateTime, final boolean showContextMap,
-            final String dateTimeFormat, final MessageFactory messageFactory, final PropertiesUtil props,
+    public SimpleLogger(
+            final String name,
+            final Level defaultLevel,
+            final boolean showLogName,
+            final boolean showShortLogName,
+            final boolean showDateTime,
+            final boolean showContextMap,
+            final String dateTimeFormat,
+            final MessageFactory messageFactory,
+            final PropertiesUtil props,
             final PrintStream stream) {
         super(name, messageFactory);
-        final String lvl = props.getStringProperty(SimpleLoggerContext.SYSTEM_PREFIX + name + ".level");
+        final String lvl =
+                props.getStringProperty(SimpleLoggerContext.SYSTEM_PREFIX + name + ".level");
         this.level = Level.toLevel(lvl, defaultLevel);
         if (showShortLogName) {
             final int index = name.lastIndexOf(".");
@@ -101,17 +108,20 @@ public class SimpleLogger extends AbstractLogger {
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final Message msg, final Throwable t) {
+    public boolean isEnabled(
+            final Level testLevel, final Marker marker, final Message msg, final Throwable t) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final CharSequence msg, final Throwable t) {
+    public boolean isEnabled(
+            final Level testLevel, final Marker marker, final CharSequence msg, final Throwable t) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final Object msg, final Throwable t) {
+    public boolean isEnabled(
+            final Level testLevel, final Marker marker, final Object msg, final Throwable t) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
@@ -121,85 +131,155 @@ public class SimpleLogger extends AbstractLogger {
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String msg, final Object... p1) {
+    public boolean isEnabled(
+            final Level testLevel, final Marker marker, final String msg, final Object... p1) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0) {
+    public boolean isEnabled(
+            final Level testLevel, final Marker marker, final String message, final Object p0) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
             final Object p1) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2) {
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3) {
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
             final Object p7) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8) {
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String msg, final Throwable t) {
+    public boolean isEnabled(
+            final Level testLevel, final Marker marker, final String msg, final Throwable t) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public void logMessage(final String fqcn, final Level mgsLevel, final Marker marker, final Message msg,
+    public void logMessage(
+            final String fqcn,
+            final Level mgsLevel,
+            final Marker marker,
+            final Message msg,
             final Throwable throwable) {
         final StringBuilder sb = new StringBuilder();
         // Append date-time if so configured
@@ -230,7 +310,9 @@ public class SimpleLogger extends AbstractLogger {
         }
         final Object[] params = msg.getParameters();
         Throwable t;
-        if (throwable == null && params != null && params.length > 0
+        if (throwable == null
+                && params != null
+                && params.length > 0
                 && params[params.length - 1] instanceof Throwable) {
             t = (Throwable) params[params.length - 1];
         } else {
@@ -252,5 +334,4 @@ public class SimpleLogger extends AbstractLogger {
     public void setStream(final PrintStream stream) {
         this.stream = stream;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContext.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.simple;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.spi.AbstractLogger;
@@ -85,8 +84,12 @@ public class SimpleLoggerContext implements LoggerContext {
         final String lvl = props.getStringProperty(SYSTEM_PREFIX + "level");
         defaultLevel = Level.toLevel(lvl, Level.ERROR);
 
-        dateTimeFormat = showDateTime ? props.getStringProperty(SimpleLoggerContext.SYSTEM_PREFIX + "dateTimeFormat",
-                DEFAULT_DATE_TIME_FORMAT) : null;
+        dateTimeFormat =
+                showDateTime
+                        ? props.getStringProperty(
+                                SimpleLoggerContext.SYSTEM_PREFIX + "dateTimeFormat",
+                                DEFAULT_DATE_TIME_FORMAT)
+                        : null;
 
         final String fileName = props.getStringProperty(SYSTEM_PREFIX + "logFile", SYSTEM_ERR);
         PrintStream ps;
@@ -122,8 +125,18 @@ public class SimpleLoggerContext implements LoggerContext {
             AbstractLogger.checkMessageFactory(extendedLogger, messageFactory);
             return extendedLogger;
         }
-        final SimpleLogger simpleLogger = new SimpleLogger(name, defaultLevel, showLogName, showShortName, showDateTime,
-                showContextMap, dateTimeFormat, messageFactory, props, stream);
+        final SimpleLogger simpleLogger =
+                new SimpleLogger(
+                        name,
+                        defaultLevel,
+                        showLogName,
+                        showShortName,
+                        showDateTime,
+                        showContextMap,
+                        dateTimeFormat,
+                        messageFactory,
+                        props,
+                        stream);
         loggerRegistry.putIfAbsent(name, messageFactory, simpleLogger);
         return loggerRegistry.getLogger(name, messageFactory);
     }
@@ -145,7 +158,8 @@ public class SimpleLoggerContext implements LoggerContext {
     }
 
     @Override
-    public boolean hasLogger(final String name, final Class<? extends MessageFactory> messageFactoryClass) {
+    public boolean hasLogger(
+            final String name, final Class<? extends MessageFactory> messageFactoryClass) {
         return false;
     }
 
@@ -153,5 +167,4 @@ public class SimpleLoggerContext implements LoggerContext {
     public boolean hasLogger(final String name, final MessageFactory messageFactory) {
         return false;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContextFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContextFactory.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.simple;
 
 import java.net.URI;
-
 import org.apache.logging.log4j.spi.LoggerContext;
 import org.apache.logging.log4j.spi.LoggerContextFactory;
 
@@ -32,13 +31,22 @@ public class SimpleLoggerContextFactory implements LoggerContextFactory {
     public static final SimpleLoggerContextFactory INSTANCE = new SimpleLoggerContextFactory();
 
     @Override
-    public LoggerContext getContext(final String fqcn, final ClassLoader loader, final Object externalContext, final boolean currentContext) {
+    public LoggerContext getContext(
+            final String fqcn,
+            final ClassLoader loader,
+            final Object externalContext,
+            final boolean currentContext) {
         return SimpleLoggerContext.INSTANCE;
     }
 
     @Override
-    public LoggerContext getContext(final String fqcn, final ClassLoader loader, final Object externalContext, final boolean currentContext,
-        final URI configLocation, final String name) {
+    public LoggerContext getContext(
+            final String fqcn,
+            final ClassLoader loader,
+            final Object externalContext,
+            final boolean currentContext,
+            final URI configLocation,
+            final String name) {
         return SimpleLoggerContext.INSTANCE;
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.spi;
 
 import java.io.Serializable;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogBuilder;
 import org.apache.logging.log4j.LoggingException;
@@ -49,7 +48,8 @@ import org.apache.logging.log4j.util.Supplier;
 public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLogger, Serializable {
     // Implementation note: many methods in this class are tuned for performance. MODIFY WITH CARE!
     // Specifically, try to keep the hot methods to 35 bytecodes or less:
-    // this is within the MaxInlineSize threshold on Java 7 and Java 8 Hotspot and makes these methods
+    // this is within the MaxInlineSize threshold on Java 7 and Java 8 Hotspot and makes these
+    // methods
     // candidates for immediate inlining instead of waiting until they are designated "hot enough".
 
     /**
@@ -60,12 +60,14 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     /**
      * Marker for method entry tracing.
      */
-    public static final Marker ENTRY_MARKER = MarkerManager.getMarker("ENTER").setParents(FLOW_MARKER);
+    public static final Marker ENTRY_MARKER =
+            MarkerManager.getMarker("ENTER").setParents(FLOW_MARKER);
 
     /**
      * Marker for method exit tracing.
      */
-    public static final Marker EXIT_MARKER = MarkerManager.getMarker("EXIT").setParents(FLOW_MARKER);
+    public static final Marker EXIT_MARKER =
+            MarkerManager.getMarker("EXIT").setParents(FLOW_MARKER);
 
     /**
      * Marker for exception tracing.
@@ -75,25 +77,30 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     /**
      * Marker for throwing exceptions.
      */
-    public static final Marker THROWING_MARKER = MarkerManager.getMarker("THROWING").setParents(EXCEPTION_MARKER);
+    public static final Marker THROWING_MARKER =
+            MarkerManager.getMarker("THROWING").setParents(EXCEPTION_MARKER);
 
     /**
      * Marker for catching exceptions.
      */
-    public static final Marker CATCHING_MARKER = MarkerManager.getMarker("CATCHING").setParents(EXCEPTION_MARKER);
+    public static final Marker CATCHING_MARKER =
+            MarkerManager.getMarker("CATCHING").setParents(EXCEPTION_MARKER);
 
     /**
      * The default MessageFactory class.
      */
     public static final Class<? extends MessageFactory> DEFAULT_MESSAGE_FACTORY_CLASS =
-            createClassForProperty("log4j2.messageFactory", ReusableMessageFactory.class,
+            createClassForProperty(
+                    "log4j2.messageFactory",
+                    ReusableMessageFactory.class,
                     ParameterizedMessageFactory.class);
 
     /**
      * The default FlowMessageFactory class.
      */
     public static final Class<? extends FlowMessageFactory> DEFAULT_FLOW_MESSAGE_FACTORY_CLASS =
-            createFlowClassForProperty("log4j2.flowMessageFactory", DefaultFlowMessageFactory.class);
+            createFlowClassForProperty(
+                    "log4j2.flowMessageFactory", DefaultFlowMessageFactory.class);
 
     private static final long serialVersionUID = 2L;
 
@@ -104,8 +111,10 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     protected final String name;
     private final MessageFactory2 messageFactory;
     private final FlowMessageFactory flowMessageFactory;
-    private static final ThreadLocal<int[]> recursionDepthHolder = new ThreadLocal<>(); // LOG4J2-1518, LOG4J2-2031
-    private static final ThreadLocal<DefaultLogBuilder> logBuilder = ThreadLocal.withInitial(DefaultLogBuilder::new);
+    private static final ThreadLocal<int[]> recursionDepthHolder =
+            new ThreadLocal<>(); // LOG4J2-1518, LOG4J2-2031
+    private static final ThreadLocal<DefaultLogBuilder> logBuilder =
+            ThreadLocal.withInitial(DefaultLogBuilder::new);
 
     /**
      * Creates a new logger named after this class (or subclass).
@@ -134,7 +143,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      */
     public AbstractLogger(final String name, final MessageFactory messageFactory) {
         this.name = name;
-        this.messageFactory = messageFactory == null ? createDefaultMessageFactory() : narrow(messageFactory);
+        this.messageFactory =
+                messageFactory == null ? createDefaultMessageFactory() : narrow(messageFactory);
         this.flowMessageFactory = createDefaultFlowMessageFactory();
     }
 
@@ -146,21 +156,28 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param logger The logger to check
      * @param messageFactory The message factory to check.
      */
-    public static void checkMessageFactory(final ExtendedLogger logger, final MessageFactory messageFactory) {
+    public static void checkMessageFactory(
+            final ExtendedLogger logger, final MessageFactory messageFactory) {
         final String name = logger.getName();
         final MessageFactory loggerMessageFactory = logger.getMessageFactory();
         if (messageFactory != null && !loggerMessageFactory.equals(messageFactory)) {
-            StatusLogger.getLogger().warn(
-                    "The Logger {} was created with the message factory {} and is now requested with the "
-                            + "message factory {}, which may create log events with unexpected formatting.", name,
-                    loggerMessageFactory, messageFactory);
-        } else if (messageFactory == null && !loggerMessageFactory.getClass().equals(DEFAULT_MESSAGE_FACTORY_CLASS)) {
-            StatusLogger
-                    .getLogger()
-                    .warn("The Logger {} was created with the message factory {} and is now requested with a null "
-                            + "message factory (defaults to {}), which may create log events with unexpected "
-                            + "formatting.",
-                            name, loggerMessageFactory, DEFAULT_MESSAGE_FACTORY_CLASS.getName());
+            StatusLogger.getLogger()
+                    .warn(
+                            "The Logger {} was created with the message factory {} and is now requested with the "
+                                    + "message factory {}, which may create log events with unexpected formatting.",
+                            name,
+                            loggerMessageFactory,
+                            messageFactory);
+        } else if (messageFactory == null
+                && !loggerMessageFactory.getClass().equals(DEFAULT_MESSAGE_FACTORY_CLASS)) {
+            StatusLogger.getLogger()
+                    .warn(
+                            "The Logger {} was created with the message factory {} and is now requested with a null "
+                                    + "message factory (defaults to {}), which may create log events with unexpected "
+                                    + "formatting.",
+                            name,
+                            loggerMessageFactory,
+                            DEFAULT_MESSAGE_FACTORY_CLASS.getName());
         }
     }
 
@@ -193,23 +210,30 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         return messageFactory.newMessage(CATCHING);
     }
 
-    private static Class<? extends MessageFactory> createClassForProperty(final String property,
+    private static Class<? extends MessageFactory> createClassForProperty(
+            final String property,
             final Class<ReusableMessageFactory> reusableParameterizedMessageFactoryClass,
             final Class<ParameterizedMessageFactory> parameterizedMessageFactoryClass) {
         try {
-            final String fallback = Constants.ENABLE_THREADLOCALS ? reusableParameterizedMessageFactoryClass.getName()
-                    : parameterizedMessageFactoryClass.getName();
-            final String clsName = PropertiesUtil.getProperties().getStringProperty(property, fallback);
+            final String fallback =
+                    Constants.ENABLE_THREADLOCALS
+                            ? reusableParameterizedMessageFactoryClass.getName()
+                            : parameterizedMessageFactoryClass.getName();
+            final String clsName =
+                    PropertiesUtil.getProperties().getStringProperty(property, fallback);
             return LoaderUtil.loadClass(clsName).asSubclass(MessageFactory.class);
         } catch (final Throwable throwable) {
             return parameterizedMessageFactoryClass;
         }
     }
 
-    private static Class<? extends FlowMessageFactory> createFlowClassForProperty(final String property,
+    private static Class<? extends FlowMessageFactory> createFlowClassForProperty(
+            final String property,
             final Class<DefaultFlowMessageFactory> defaultFlowMessageFactoryClass) {
         try {
-            final String clsName = PropertiesUtil.getProperties().getStringProperty(property, defaultFlowMessageFactoryClass.getName());
+            final String clsName =
+                    PropertiesUtil.getProperties()
+                            .getStringProperty(property, defaultFlowMessageFactoryClass.getName());
             return LoaderUtil.loadClass(clsName).asSubclass(FlowMessageFactory.class);
         } catch (final Throwable throwable) {
             return defaultFlowMessageFactoryClass;
@@ -252,7 +276,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void debug(final Marker marker, final Message message) {
-        logIfEnabled(FQCN, Level.DEBUG, marker, message, message != null ? message.getThrowable() : null);
+        logIfEnabled(
+                FQCN,
+                Level.DEBUG,
+                marker,
+                message,
+                message != null ? message.getThrowable() : null);
     }
 
     @Override
@@ -287,7 +316,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void debug(final Message message) {
-        logIfEnabled(FQCN, Level.DEBUG, null, message, message != null ? message.getThrowable() : null);
+        logIfEnabled(
+                FQCN, Level.DEBUG, null, message, message != null ? message.getThrowable() : null);
     }
 
     @Override
@@ -346,12 +376,14 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
+    public void debug(
+            final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, paramSuppliers);
     }
 
     @Override
-    public void debug(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
+    public void debug(
+            final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.DEBUG, marker, messageSupplier, throwable);
     }
 
@@ -366,7 +398,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void debug(final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
+    public void debug(
+            final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.DEBUG, marker, messageSupplier, throwable);
     }
 
@@ -391,53 +424,110 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2);
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4) {
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5) {
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -457,46 +547,93 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public void debug(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+    public void debug(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void debug(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void debug(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
+    public void debug(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
             final Object p7) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8) {
+    public void debug(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public void debug(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -507,11 +644,18 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param format Format String for the parameters.
      * @param paramSuppliers The Suppliers of the parameters.
      */
-    protected EntryMessage enter(final String fqcn, final String format, final Supplier<?>... paramSuppliers) {
+    protected EntryMessage enter(
+            final String fqcn, final String format, final Supplier<?>... paramSuppliers) {
         EntryMessage entryMsg = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER,
-                    entryMsg = flowMessageFactory.newEntryMessage(format, LambdaUtil.getAll(paramSuppliers)), null);
+            logMessageSafely(
+                    fqcn,
+                    Level.TRACE,
+                    ENTRY_MARKER,
+                    entryMsg =
+                            flowMessageFactory.newEntryMessage(
+                                    format, LambdaUtil.getAll(paramSuppliers)),
+                    null);
         }
         return entryMsg;
     }
@@ -524,10 +668,16 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param paramSuppliers The parameters to the method.
      */
     @Deprecated
-    protected EntryMessage enter(final String fqcn, final String format, final MessageSupplier... paramSuppliers) {
+    protected EntryMessage enter(
+            final String fqcn, final String format, final MessageSupplier... paramSuppliers) {
         EntryMessage entryMsg = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg = entryMsg(format, paramSuppliers), null);
+            logMessageSafely(
+                    fqcn,
+                    Level.TRACE,
+                    ENTRY_MARKER,
+                    entryMsg = entryMsg(format, paramSuppliers),
+                    null);
         }
         return entryMsg;
     }
@@ -542,7 +692,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     protected EntryMessage enter(final String fqcn, final String format, final Object... params) {
         EntryMessage entryMsg = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg = flowMessageFactory.newEntryMessage(format, params), null);
+            logMessageSafely(
+                    fqcn,
+                    Level.TRACE,
+                    ENTRY_MARKER,
+                    entryMsg = flowMessageFactory.newEntryMessage(format, params),
+                    null);
         }
         return entryMsg;
     }
@@ -557,8 +712,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     protected EntryMessage enter(final String fqcn, final MessageSupplier messageSupplier) {
         EntryMessage message = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, message = flowMessageFactory.newEntryMessage(
-                    messageSupplier.get()), null);
+            logMessageSafely(
+                    fqcn,
+                    Level.TRACE,
+                    ENTRY_MARKER,
+                    message = flowMessageFactory.newEntryMessage(messageSupplier.get()),
+                    null);
         }
         return message;
     }
@@ -575,7 +734,11 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     protected EntryMessage enter(final String fqcn, final Message message) {
         EntryMessage flowMessage = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, flowMessage = flowMessageFactory.newEntryMessage(message),
+            logMessageSafely(
+                    fqcn,
+                    Level.TRACE,
+                    ENTRY_MARKER,
+                    flowMessage = flowMessageFactory.newEntryMessage(message),
                     null);
         }
         return flowMessage;
@@ -601,7 +764,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     protected void entry(final String fqcn, final Object... params) {
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
             if (params == null) {
-                logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg(null, (Supplier<?>[]) null), null);
+                logMessageSafely(
+                        fqcn,
+                        Level.TRACE,
+                        ENTRY_MARKER,
+                        entryMsg(null, (Supplier<?>[]) null),
+                        null);
             } else {
                 logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg(null, params), null);
             }
@@ -627,7 +795,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void error(final Marker marker, final Message message) {
-        logIfEnabled(FQCN, Level.ERROR, marker, message, message != null ? message.getThrowable() : null);
+        logIfEnabled(
+                FQCN,
+                Level.ERROR,
+                marker,
+                message,
+                message != null ? message.getThrowable() : null);
     }
 
     @Override
@@ -672,7 +845,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void error(final Message message) {
-        logIfEnabled(FQCN, Level.ERROR, null, message, message != null ? message.getThrowable() : null);
+        logIfEnabled(
+                FQCN, Level.ERROR, null, message, message != null ? message.getThrowable() : null);
     }
 
     @Override
@@ -731,12 +905,14 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
+    public void error(
+            final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, paramSuppliers);
     }
 
     @Override
-    public void error(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
+    public void error(
+            final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.ERROR, marker, messageSupplier, throwable);
     }
 
@@ -751,7 +927,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void error(final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
+    public void error(
+            final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.ERROR, marker, messageSupplier, throwable);
     }
 
@@ -776,53 +953,110 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2);
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4) {
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5) {
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -842,43 +1076,93 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void error(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public void error(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void error(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+    public void error(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void error(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void error(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void error(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void error(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void error(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void error(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void error(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public void error(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void error(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void error(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -904,7 +1188,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      */
     protected <R> R exit(final String fqcn, final R result) {
         if (isEnabled(Level.TRACE, EXIT_MARKER, (CharSequence) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(null, result), null);
+            logMessageSafely(
+                    fqcn,
+                    Level.TRACE,
+                    EXIT_MARKER,
+                    flowMessageFactory.newExitMessage(null, result),
+                    null);
         }
         return result;
     }
@@ -919,7 +1208,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      */
     protected <R> R exit(final String fqcn, final String format, final R result) {
         if (isEnabled(Level.TRACE, EXIT_MARKER, (CharSequence) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(format, result), null);
+            logMessageSafely(
+                    fqcn,
+                    Level.TRACE,
+                    EXIT_MARKER,
+                    flowMessageFactory.newExitMessage(format, result),
+                    null);
         }
         return result;
     }
@@ -930,7 +1224,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void fatal(final Marker marker, final Message message) {
-        logIfEnabled(FQCN, Level.FATAL, marker, message, message != null ? message.getThrowable() : null);
+        logIfEnabled(
+                FQCN,
+                Level.FATAL,
+                marker,
+                message,
+                message != null ? message.getThrowable() : null);
     }
 
     @Override
@@ -975,7 +1274,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void fatal(final Message message) {
-        logIfEnabled(FQCN, Level.FATAL, null, message, message != null ? message.getThrowable() : null);
+        logIfEnabled(
+                FQCN, Level.FATAL, null, message, message != null ? message.getThrowable() : null);
     }
 
     @Override
@@ -1034,12 +1334,14 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
+    public void fatal(
+            final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, paramSuppliers);
     }
 
     @Override
-    public void fatal(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
+    public void fatal(
+            final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.FATAL, marker, messageSupplier, throwable);
     }
 
@@ -1054,7 +1356,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void fatal(final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
+    public void fatal(
+            final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.FATAL, marker, messageSupplier, throwable);
     }
 
@@ -1079,51 +1382,110 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2);
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4) {
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5) {
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6) {
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -1143,44 +1505,93 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void fatal(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public void fatal(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void fatal(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+    public void fatal(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void fatal(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void fatal(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void fatal(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void fatal(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void fatal(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void fatal(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void fatal(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public void fatal(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void fatal(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public void fatal(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -1202,7 +1613,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void info(final Marker marker, final Message message) {
-        logIfEnabled(FQCN, Level.INFO, marker, message, message != null ? message.getThrowable() : null);
+        logIfEnabled(
+                FQCN, Level.INFO, marker, message, message != null ? message.getThrowable() : null);
     }
 
     @Override
@@ -1247,7 +1659,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void info(final Message message) {
-        logIfEnabled(FQCN, Level.INFO, null, message, message != null ? message.getThrowable() : null);
+        logIfEnabled(
+                FQCN, Level.INFO, null, message, message != null ? message.getThrowable() : null);
     }
 
     @Override
@@ -1306,12 +1719,14 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
+    public void info(
+            final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.INFO, marker, message, paramSuppliers);
     }
 
     @Override
-    public void info(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
+    public void info(
+            final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.INFO, marker, messageSupplier, throwable);
     }
 
@@ -1326,7 +1741,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void info(final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
+    public void info(
+            final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.INFO, marker, messageSupplier, throwable);
     }
 
@@ -1351,51 +1767,110 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2);
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4) {
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5) {
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6) {
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -1415,46 +1890,93 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void info(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public void info(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void info(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+    public void info(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void info(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void info(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void info(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void info(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void info(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
+    public void info(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
             final Object p7) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void info(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8) {
+    public void info(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void info(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public void info(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -1534,7 +2056,11 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final Message message, final Throwable throwable) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final Message message,
+            final Throwable throwable) {
         logIfEnabled(FQCN, level, marker, message, throwable);
     }
 
@@ -1544,7 +2070,11 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final CharSequence message, final Throwable throwable) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final CharSequence message,
+            final Throwable throwable) {
         if (isEnabled(level, marker, message, throwable)) {
             logMessage(FQCN, level, marker, message, throwable);
         }
@@ -1556,7 +2086,11 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final Object message, final Throwable throwable) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final Object message,
+            final Throwable throwable) {
         if (isEnabled(level, marker, message, throwable)) {
             logMessage(FQCN, level, marker, message, throwable);
         }
@@ -1568,12 +2102,17 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object... params) {
+    public void log(
+            final Level level, final Marker marker, final String message, final Object... params) {
         logIfEnabled(FQCN, level, marker, message, params);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Throwable throwable) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Throwable throwable) {
         logIfEnabled(FQCN, level, marker, message, throwable);
     }
 
@@ -1628,7 +2167,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final Supplier<?> messageSupplier, final Throwable throwable) {
+    public void log(
+            final Level level, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, level, null, messageSupplier, throwable);
     }
 
@@ -1638,12 +2178,20 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, level, marker, message, paramSuppliers);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final Supplier<?> messageSupplier,
+            final Throwable throwable) {
         logIfEnabled(FQCN, level, marker, messageSupplier, throwable);
     }
 
@@ -1658,7 +2206,11 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final MessageSupplier messageSupplier,
+            final Throwable throwable) {
         logIfEnabled(FQCN, level, marker, messageSupplier, throwable);
     }
 
@@ -1668,7 +2220,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final MessageSupplier messageSupplier, final Throwable throwable) {
+    public void log(
+            final Level level, final MessageSupplier messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, level, null, messageSupplier, throwable);
     }
 
@@ -1678,58 +2231,128 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1) {
         logIfEnabled(FQCN, level, marker, message, p0, p1);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
             final Object p2) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3, final Object p4) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3, final Object p4, final Object p5) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3, final Object p4, final Object p5, final Object p6) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -1744,53 +2367,119 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2) {
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2);
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final Message message,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Message message,
             final Throwable throwable) {
         if (isEnabled(level, marker, message, throwable)) {
             logMessageSafely(fqcn, level, marker, message, throwable);
@@ -1798,31 +2487,11 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker,
-            final MessageSupplier messageSupplier, final Throwable throwable) {
-        if (isEnabled(level, marker, messageSupplier, throwable)) {
-            logMessage(fqcn, level, marker, messageSupplier, throwable);
-        }
-    }
-
-    @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final Object message,
-            final Throwable throwable) {
-        if (isEnabled(level, marker, message, throwable)) {
-            logMessage(fqcn, level, marker, message, throwable);
-        }
-    }
-
-    @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final CharSequence message,
-            final Throwable throwable) {
-        if (isEnabled(level, marker, message, throwable)) {
-            logMessage(fqcn, level, marker, message, throwable);
-        }
-    }
-
-    @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final Supplier<?> messageSupplier,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final MessageSupplier messageSupplier,
             final Throwable throwable) {
         if (isEnabled(level, marker, messageSupplier, throwable)) {
             logMessage(fqcn, level, marker, messageSupplier, throwable);
@@ -1830,14 +2499,55 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Object message,
+            final Throwable throwable) {
+        if (isEnabled(level, marker, message, throwable)) {
+            logMessage(fqcn, level, marker, message, throwable);
+        }
+    }
+
+    @Override
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final CharSequence message,
+            final Throwable throwable) {
+        if (isEnabled(level, marker, message, throwable)) {
+            logMessage(fqcn, level, marker, message, throwable);
+        }
+    }
+
+    @Override
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Supplier<?> messageSupplier,
+            final Throwable throwable) {
+        if (isEnabled(level, marker, messageSupplier, throwable)) {
+            logMessage(fqcn, level, marker, messageSupplier, throwable);
+        }
+    }
+
+    @Override
+    public void logIfEnabled(
+            final String fqcn, final Level level, final Marker marker, final String message) {
         if (isEnabled(level, marker, message)) {
             logMessage(fqcn, level, marker, message);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
             final Supplier<?>... paramSuppliers) {
         if (isEnabled(level, marker, message)) {
             logMessage(fqcn, level, marker, message, paramSuppliers);
@@ -1845,7 +2555,11 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
             final Object... params) {
         if (isEnabled(level, marker, message, params)) {
             logMessage(fqcn, level, marker, message, params);
@@ -1853,7 +2567,11 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
             final Object p0) {
         if (isEnabled(level, marker, message, p0)) {
             logMessage(fqcn, level, marker, message, p0);
@@ -1861,48 +2579,92 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1) {
         if (isEnabled(level, marker, message, p0, p1)) {
             logMessage(fqcn, level, marker, message, p0, p1);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         if (isEnabled(level, marker, message, p0, p1, p2)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3, p4)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3, p4);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3, p4, p5);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3, p4, p5, p6);
@@ -1910,157 +2672,308 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
             final Throwable throwable) {
         if (isEnabled(level, marker, message, throwable)) {
             logMessage(fqcn, level, marker, message, throwable);
         }
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final CharSequence message,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final CharSequence message,
             final Throwable throwable) {
         logMessageSafely(fqcn, level, marker, messageFactory.newMessage(message), throwable);
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final Object message,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Object message,
             final Throwable throwable) {
         logMessageSafely(fqcn, level, marker, messageFactory.newMessage(message), throwable);
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker,
-            final MessageSupplier messageSupplier, final Throwable throwable) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final MessageSupplier messageSupplier,
+            final Throwable throwable) {
         final Message message = LambdaUtil.get(messageSupplier);
-        final Throwable effectiveThrowable = (throwable == null && message != null)
-                ? message.getThrowable()
-                : throwable;
+        final Throwable effectiveThrowable =
+                (throwable == null && message != null) ? message.getThrowable() : throwable;
         logMessageSafely(fqcn, level, marker, message, effectiveThrowable);
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final Supplier<?> messageSupplier,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Supplier<?> messageSupplier,
             final Throwable throwable) {
         final Message message = LambdaUtil.getMessage(messageSupplier, messageFactory);
-        final Throwable effectiveThrowable = (throwable == null && message != null)
-                ? message.getThrowable()
-                : throwable;
+        final Throwable effectiveThrowable =
+                (throwable == null && message != null) ? message.getThrowable() : throwable;
         logMessageSafely(fqcn, level, marker, message, effectiveThrowable);
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
             final Throwable throwable) {
         logMessageSafely(fqcn, level, marker, messageFactory.newMessage(message), throwable);
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message) {
+    protected void logMessage(
+            final String fqcn, final Level level, final Marker marker, final String message) {
         final Message msg = messageFactory.newMessage(message);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
             final Object... params) {
         final Message msg = messageFactory.newMessage(message, params);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
             final Object p0) {
         final Message msg = messageFactory.newMessage(message, p0);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1) {
         final Message msg = messageFactory.newMessage(message, p0, p1);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3, p4);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3, p4, p5);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3, p4, p5, p6);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
-        final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
+        final Message msg =
+                messageFactory.newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
             final Supplier<?>... paramSuppliers) {
         final Message msg = messageFactory.newMessage(message, LambdaUtil.getAll(paramSuppliers));
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
     @Override
-    public void logMessage(final Level level, final Marker marker, final String fqcn, final StackTraceElement location,
-        final Message message, final Throwable throwable) {
+    public void logMessage(
+            final Level level,
+            final Marker marker,
+            final String fqcn,
+            final StackTraceElement location,
+            final Message message,
+            final Throwable throwable) {
         try {
             incrementRecursionDepth();
             log(level, marker, fqcn, location, message, throwable);
@@ -2072,13 +2985,19 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         }
     }
 
-    protected void log(final Level level, final Marker marker, final String fqcn, final StackTraceElement location,
-        final Message message, final Throwable throwable) {
+    protected void log(
+            final Level level,
+            final Marker marker,
+            final String fqcn,
+            final StackTraceElement location,
+            final Message message,
+            final Throwable throwable) {
         logMessage(fqcn, level, marker, message, throwable);
     }
 
     @Override
-    public void printf(final Level level, final Marker marker, final String format, final Object... params) {
+    public void printf(
+            final Level level, final Marker marker, final String format, final Object... params) {
         if (isEnabled(level, marker, format, params)) {
             final Message message = new StringFormattedMessage(format, params);
             logMessageSafely(FQCN, level, marker, message, message.getThrowable());
@@ -2096,12 +3015,17 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     @PerformanceSensitive
     // NOTE: This is a hot method. Current implementation compiles to 30 bytes of byte code.
     // This is within the 35 byte MaxInlineSize threshold. Modify with care!
-    private void logMessageSafely(final String fqcn, final Level level, final Marker marker, final Message message,
+    private void logMessageSafely(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Message message,
             final Throwable throwable) {
         try {
             logMessageTrackRecursion(fqcn, level, marker, message, throwable);
         } finally {
-            // LOG4J2-1583 prevent scrambled logs when logging calls are nested (logging in toString())
+            // LOG4J2-1583 prevent scrambled logs when logging calls are nested (logging in
+            // toString())
             ReusableMessageFactory.release(message);
         }
     }
@@ -2109,11 +3033,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     @PerformanceSensitive
     // NOTE: This is a hot method. Current implementation compiles to 33 bytes of byte code.
     // This is within the 35 byte MaxInlineSize threshold. Modify with care!
-    private void logMessageTrackRecursion(final String fqcn,
-                                          final Level level,
-                                          final Marker marker,
-                                          final Message message,
-                                          final Throwable throwable) {
+    private void logMessageTrackRecursion(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Message message,
+            final Throwable throwable) {
         try {
             incrementRecursionDepth(); // LOG4J2-1518, LOG4J2-2031
             tryLogMessage(fqcn, getLocation(fqcn), level, marker, message, throwable);
@@ -2155,16 +3080,18 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     @PerformanceSensitive
     // NOTE: This is a hot method. Current implementation compiles to 26 bytes of byte code.
     // This is within the 35 byte MaxInlineSize threshold. Modify with care!
-    private void tryLogMessage(final String fqcn,
-                               final StackTraceElement location,
-                               final Level level,
-                               final Marker marker,
-                               final Message message,
-                               final Throwable throwable) {
+    private void tryLogMessage(
+            final String fqcn,
+            final StackTraceElement location,
+            final Level level,
+            final Marker marker,
+            final Message message,
+            final Throwable throwable) {
         try {
             log(level, marker, fqcn, location, message, throwable);
         } catch (final Throwable t) {
-            // LOG4J2-1990 Log4j2 suppresses all exceptions that occur once application called the logger
+            // LOG4J2-1990 Log4j2 suppresses all exceptions that occur once application called the
+            // logger
             handleLogMessageException(t, fqcn, message);
         }
     }
@@ -2178,16 +3105,19 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     // LOG4J2-1990 Log4j2 suppresses all exceptions that occur once application called the logger
     // TODO Configuration setting to propagate exceptions back to the caller *if requested*
-    private void handleLogMessageException(final Throwable throwable, final String fqcn, final Message message) {
+    private void handleLogMessageException(
+            final Throwable throwable, final String fqcn, final Message message) {
         if (throwable instanceof LoggingException) {
             throw (LoggingException) throwable;
         }
-        StatusLogger.getLogger().warn("{} caught {} logging {}: {}",
-                fqcn,
-                throwable.getClass().getName(),
-                message.getClass().getSimpleName(),
-                message.getFormat(),
-                throwable);
+        StatusLogger.getLogger()
+                .warn(
+                        "{} caught {} logging {}: {}",
+                        fqcn,
+                        throwable.getClass().getName(),
+                        message.getClass().getSimpleName(),
+                        message.getFormat(),
+                        throwable);
     }
 
     @Override
@@ -2209,7 +3139,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param throwable The Throwable.
      * @return the Throwable.
      */
-    protected <T extends Throwable> T throwing(final String fqcn, final Level level, final T throwable) {
+    protected <T extends Throwable> T throwing(
+            final String fqcn, final Level level, final T throwable) {
         if (isEnabled(level, THROWING_MARKER, (Object) null, null)) {
             logMessageSafely(fqcn, level, THROWING_MARKER, throwingMsg(throwable), throwable);
         }
@@ -2222,7 +3153,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void trace(final Marker marker, final Message message) {
-        logIfEnabled(FQCN, Level.TRACE, marker, message, message != null ? message.getThrowable() : null);
+        logIfEnabled(
+                FQCN,
+                Level.TRACE,
+                marker,
+                message,
+                message != null ? message.getThrowable() : null);
     }
 
     @Override
@@ -2267,7 +3203,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void trace(final Message message) {
-        logIfEnabled(FQCN, Level.TRACE, null, message, message != null ? message.getThrowable() : null);
+        logIfEnabled(
+                FQCN, Level.TRACE, null, message, message != null ? message.getThrowable() : null);
     }
 
     @Override
@@ -2326,12 +3263,14 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
+    public void trace(
+            final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, paramSuppliers);
     }
 
     @Override
-    public void trace(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
+    public void trace(
+            final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.TRACE, marker, messageSupplier, throwable);
     }
 
@@ -2346,7 +3285,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void trace(final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
+    public void trace(
+            final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.TRACE, marker, messageSupplier, throwable);
     }
 
@@ -2371,51 +3311,110 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2);
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4) {
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5) {
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6) {
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -2435,43 +3434,93 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void trace(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public void trace(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void trace(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+    public void trace(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void trace(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void trace(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void trace(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void trace(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void trace(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void trace(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void trace(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public void trace(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void trace(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void trace(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -2517,33 +3566,52 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void traceExit(final EntryMessage message) {
-        // If the message is null, traceEnter returned null because flow logging was disabled, we can optimize out calling isEnabled().
+        // If the message is null, traceEnter returned null because flow logging was disabled, we
+        // can optimize out calling isEnabled().
         if (message != null && isEnabled(Level.TRACE, EXIT_MARKER, message, null)) {
-            logMessageSafely(FQCN, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(message), null);
+            logMessageSafely(
+                    FQCN,
+                    Level.TRACE,
+                    EXIT_MARKER,
+                    flowMessageFactory.newExitMessage(message),
+                    null);
         }
     }
 
     @Override
     public <R> R traceExit(final EntryMessage message, final R result) {
-        // If the message is null, traceEnter returned null because flow logging was disabled, we can optimize out calling isEnabled().
+        // If the message is null, traceEnter returned null because flow logging was disabled, we
+        // can optimize out calling isEnabled().
         if (message != null && isEnabled(Level.TRACE, EXIT_MARKER, message, null)) {
-            logMessageSafely(FQCN, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(result, message), null);
+            logMessageSafely(
+                    FQCN,
+                    Level.TRACE,
+                    EXIT_MARKER,
+                    flowMessageFactory.newExitMessage(result, message),
+                    null);
         }
         return result;
     }
 
     @Override
     public <R> R traceExit(final Message message, final R result) {
-        // If the message is null, traceEnter returned null because flow logging was disabled, we can optimize out calling isEnabled().
+        // If the message is null, traceEnter returned null because flow logging was disabled, we
+        // can optimize out calling isEnabled().
         if (message != null && isEnabled(Level.TRACE, EXIT_MARKER, message, null)) {
-            logMessageSafely(FQCN, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(result, message), null);
+            logMessageSafely(
+                    FQCN,
+                    Level.TRACE,
+                    EXIT_MARKER,
+                    flowMessageFactory.newExitMessage(result, message),
+                    null);
         }
         return result;
     }
 
     @Override
     public void warn(final Marker marker, final Message message) {
-        logIfEnabled(FQCN, Level.WARN, marker, message, message != null ? message.getThrowable() : null);
+        logIfEnabled(
+                FQCN, Level.WARN, marker, message, message != null ? message.getThrowable() : null);
     }
 
     @Override
@@ -2588,7 +3656,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void warn(final Message message) {
-        logIfEnabled(FQCN, Level.WARN, null, message, message != null ? message.getThrowable() : null);
+        logIfEnabled(
+                FQCN, Level.WARN, null, message, message != null ? message.getThrowable() : null);
     }
 
     @Override
@@ -2647,12 +3716,14 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
+    public void warn(
+            final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.WARN, marker, message, paramSuppliers);
     }
 
     @Override
-    public void warn(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
+    public void warn(
+            final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.WARN, marker, messageSupplier, throwable);
     }
 
@@ -2667,7 +3738,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void warn(final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
+    public void warn(
+            final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.WARN, marker, messageSupplier, throwable);
     }
 
@@ -2692,50 +3764,110 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2) {
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2);
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4) {
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5) {
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6) {
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -2755,44 +3887,93 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void warn(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public void warn(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void warn(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+    public void warn(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void warn(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void warn(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void warn(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void warn(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void warn(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void warn(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void warn(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public void warn(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void warn(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public void warn(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -2897,5 +4078,4 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         }
         return new DefaultLogBuilder(this, level);
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLoggerAdapter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLoggerAdapter.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.util.LoaderUtil;
 
@@ -33,14 +32,16 @@ import org.apache.logging.log4j.util.LoaderUtil;
  * @param <L> the Logger class to adapt
  * @since 2.1
  */
-public abstract class AbstractLoggerAdapter<L> implements LoggerAdapter<L>, LoggerContextShutdownAware {
+public abstract class AbstractLoggerAdapter<L>
+        implements LoggerAdapter<L>, LoggerContextShutdownAware {
 
     /**
      * A map to store loggers for their given LoggerContexts.
      */
-    protected final Map<LoggerContext, ConcurrentMap<String, L>> registry = new ConcurrentHashMap<>();
+    protected final Map<LoggerContext, ConcurrentMap<String, L>> registry =
+            new ConcurrentHashMap<>();
 
-    private final ReadWriteLock lock = new ReentrantReadWriteLock (true);
+    private final ReadWriteLock lock = new ReentrantReadWriteLock(true);
 
     @Override
     public L getLogger(final String name) {
@@ -67,29 +68,29 @@ public abstract class AbstractLoggerAdapter<L> implements LoggerAdapter<L>, Logg
      */
     public ConcurrentMap<String, L> getLoggersInContext(final LoggerContext context) {
         ConcurrentMap<String, L> loggers;
-        lock.readLock ().lock ();
+        lock.readLock().lock();
         try {
-            loggers = registry.get (context);
+            loggers = registry.get(context);
         } finally {
-            lock.readLock ().unlock ();
+            lock.readLock().unlock();
         }
 
         if (loggers != null) {
             return loggers;
         }
-        lock.writeLock ().lock ();
+        lock.writeLock().lock();
         try {
-            loggers = registry.get (context);
+            loggers = registry.get(context);
             if (loggers == null) {
-                loggers = new ConcurrentHashMap<> ();
-                registry.put (context, loggers);
+                loggers = new ConcurrentHashMap<>();
+                registry.put(context, loggers);
                 if (context instanceof LoggerContextShutdownEnabled) {
                     ((LoggerContextShutdownEnabled) context).addShutdownListener(this);
                 }
             }
             return loggers;
         } finally {
-            lock.writeLock ().unlock ();
+            lock.writeLock().unlock();
         }
     }
 
@@ -139,11 +140,11 @@ public abstract class AbstractLoggerAdapter<L> implements LoggerAdapter<L>, Logg
 
     @Override
     public void close() {
-        lock.writeLock ().lock ();
+        lock.writeLock().lock();
         try {
             registry.clear();
         } finally {
-            lock.writeLock ().unlock ();
+            lock.writeLock().unlock();
         }
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/CleanableThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/CleanableThreadContextMap.java
@@ -30,10 +30,9 @@ public interface CleanableThreadContextMap extends ThreadContextMap2 {
      *
      * <p>If the current thread does not have a context map it is
      * created as a side effect.</p>
-
+     *
      * @param keys The keys.
      * @since 2.8
      */
     void removeAll(final Iterable<String> keys);
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/CopyOnWrite.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/CopyOnWrite.java
@@ -22,5 +22,4 @@ package org.apache.logging.log4j.spi;
  * @see ReadOnlyThreadContextMap#getReadOnlyContextData()
  * @since 2.7
  */
-public interface CopyOnWrite {
-}
+public interface CopyOnWrite {}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/CopyOnWriteSortedArrayThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/CopyOnWriteSortedArrayThreadContextMap.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
@@ -35,7 +34,8 @@ import org.apache.logging.log4j.util.StringMap;
  *
  * @since 2.7
  */
-class CopyOnWriteSortedArrayThreadContextMap implements ReadOnlyThreadContextMap, ObjectThreadContextMap, CopyOnWrite {
+class CopyOnWriteSortedArrayThreadContextMap
+        implements ReadOnlyThreadContextMap, ObjectThreadContextMap, CopyOnWrite {
 
     /**
      * Property name ({@value} ) for selecting {@code InheritableThreadLocal} (value "true") or plain
@@ -51,7 +51,8 @@ class CopyOnWriteSortedArrayThreadContextMap implements ReadOnlyThreadContextMap
     /**
      * System property name that can be used to control the data structure's initial capacity.
      */
-    protected static final String PROPERTY_NAME_INITIAL_CAPACITY = "log4j2.ThreadContext.initial.capacity";
+    protected static final String PROPERTY_NAME_INITIAL_CAPACITY =
+            "log4j2.ThreadContext.initial.capacity";
 
     private static final StringMap EMPTY_CONTEXT_DATA = new SortedArrayStringMap(1);
 
@@ -64,7 +65,9 @@ class CopyOnWriteSortedArrayThreadContextMap implements ReadOnlyThreadContextMap
      */
     static void init() {
         final PropertiesUtil properties = PropertiesUtil.getProperties();
-        initialCapacity = properties.getIntegerProperty(PROPERTY_NAME_INITIAL_CAPACITY, DEFAULT_INITIAL_CAPACITY);
+        initialCapacity =
+                properties.getIntegerProperty(
+                        PROPERTY_NAME_INITIAL_CAPACITY, DEFAULT_INITIAL_CAPACITY);
         inheritableMap = properties.getBooleanProperty(INHERITABLE_MAP);
     }
 
@@ -79,7 +82,8 @@ class CopyOnWriteSortedArrayThreadContextMap implements ReadOnlyThreadContextMap
         this.localMap = createThreadLocalMap();
     }
 
-    // LOG4J2-479: by default, use a plain ThreadLocal, only use InheritableThreadLocal if configured.
+    // LOG4J2-479: by default, use a plain ThreadLocal, only use InheritableThreadLocal if
+    // configured.
     // (This method is package protected for JUnit tests.)
     private ThreadLocal<StringMap> createThreadLocalMap() {
         if (inheritableMap) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/DefaultThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/DefaultThreadContextMap.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
 import org.apache.logging.log4j.util.BiConsumer;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
@@ -50,7 +49,8 @@ public class DefaultThreadContextMap implements ThreadContextMap, ReadOnlyString
         init();
     }
 
-    // LOG4J2-479: by default, use a plain ThreadLocal, only use InheritableThreadLocal if configured.
+    // LOG4J2-479: by default, use a plain ThreadLocal, only use InheritableThreadLocal if
+    // configured.
     // (This method is package protected for JUnit tests.)
     static ThreadLocal<Map<String, String>> createThreadLocalMap(final boolean isMapEnabled) {
         if (inheritableMap) {
@@ -58,7 +58,7 @@ public class DefaultThreadContextMap implements ThreadContextMap, ReadOnlyString
                 @Override
                 protected Map<String, String> childValue(final Map<String, String> parentValue) {
                     return parentValue != null && isMapEnabled //
-                    ? Collections.unmodifiableMap(new HashMap<>(parentValue)) //
+                            ? Collections.unmodifiableMap(new HashMap<>(parentValue)) //
                             : null;
                 }
             };
@@ -153,10 +153,10 @@ public class DefaultThreadContextMap implements ThreadContextMap, ReadOnlyString
             return;
         }
         for (final Map.Entry<String, String> entry : map.entrySet()) {
-            //BiConsumer should be able to handle values of any type V. In our case the values are of type String.
+            // BiConsumer should be able to handle values of any type V. In our case the values are
+            // of type String.
             @SuppressWarnings("unchecked")
-            final
-            V value = (V) entry.getValue();
+            final V value = (V) entry.getValue();
             action.accept(entry.getKey(), value);
         }
     }
@@ -168,10 +168,10 @@ public class DefaultThreadContextMap implements ThreadContextMap, ReadOnlyString
             return;
         }
         for (final Map.Entry<String, String> entry : map.entrySet()) {
-            //TriConsumer should be able to handle values of any type V. In our case the values are of type String.
+            // TriConsumer should be able to handle values of any type V. In our case the values are
+            // of type String.
             @SuppressWarnings("unchecked")
-            final
-            V value = (V) entry.getValue();
+            final V value = (V) entry.getValue();
             action.accept(entry.getKey(), value, state);
         }
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/DefaultThreadContextStack.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/DefaultThreadContextStack.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-
 import org.apache.logging.log4j.ThreadContext.ContextStack;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.StringBuilders;
@@ -46,7 +45,8 @@ public class DefaultThreadContextStack implements ThreadContextStack, StringBuil
 
     private MutableThreadContextStack getNonNullStackCopy() {
         final MutableThreadContextStack values = STACK.get();
-        return (MutableThreadContextStack) (values == null ? new MutableThreadContextStack() : values.copy());
+        return (MutableThreadContextStack)
+                (values == null ? new MutableThreadContextStack() : values.copy());
     }
 
     @Override
@@ -97,7 +97,7 @@ public class DefaultThreadContextStack implements ThreadContextStack, StringBuil
     public boolean containsAll(final Collection<?> objects) {
         if (objects.isEmpty()) { // quick check before accessing the ThreadLocal
             return true; // looks counter-intuitive, but see
-                         // j.u.AbstractCollection
+            // j.u.AbstractCollection
         }
         final MutableThreadContextStack values = STACK.get();
         return values != null && values.containsAll(objects);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLogger.java
@@ -142,7 +142,8 @@ public interface ExtendedLogger extends Logger {
      * @param p3 the message parameters
      * @return True if logging is enabled, false otherwise.
      */
-    boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3);
+    boolean isEnabled(
+            Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3);
 
     /**
      * Tests if logging is enabled.
@@ -157,7 +158,14 @@ public interface ExtendedLogger extends Logger {
      * @param p4 the message parameters
      * @return True if logging is enabled, false otherwise.
      */
-    boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
+    boolean isEnabled(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
             Object p4);
 
     /**
@@ -174,8 +182,16 @@ public interface ExtendedLogger extends Logger {
      * @param p5 the message parameters
      * @return True if logging is enabled, false otherwise.
      */
-    boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
-            Object p4, Object p5);
+    boolean isEnabled(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5);
 
     /**
      * Determines if logging is enabled.
@@ -192,8 +208,17 @@ public interface ExtendedLogger extends Logger {
      * @param p6 the message parameters
      * @return True if logging is enabled, false otherwise.
      */
-    boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
-            Object p4, Object p5, Object p6);
+    boolean isEnabled(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6);
 
     /**
      * Tests if logging is enabled.
@@ -211,8 +236,18 @@ public interface ExtendedLogger extends Logger {
      * @param p7 the message parameters
      * @return True if logging is enabled, false otherwise.
      */
-    boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
-            Object p4, Object p5, Object p6, Object p7);
+    boolean isEnabled(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7);
 
     /**
      * Tests if logging is enabled.
@@ -231,8 +266,19 @@ public interface ExtendedLogger extends Logger {
      * @param p8 the message parameters
      * @return True if logging is enabled, false otherwise.
      */
-    boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
-            Object p4, Object p5, Object p6, Object p7, Object p8);
+    boolean isEnabled(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Tests if logging is enabled.
@@ -252,8 +298,20 @@ public interface ExtendedLogger extends Logger {
      * @param p9 the message parameters
      * @return True if logging is enabled, false otherwise.
      */
-    boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
-            Object p4, Object p5, Object p6, Object p7, Object p8, Object p9);
+    boolean isEnabled(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message if the specified level is active.
@@ -349,7 +407,8 @@ public interface ExtendedLogger extends Logger {
      * @param p0 the message parameters
      * @param p1 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1);
+    void logIfEnabled(
+            String fqcn, Level level, Marker marker, String message, Object p0, Object p1);
 
     /**
      * Logs a message if the specified level is active.
@@ -363,7 +422,14 @@ public interface ExtendedLogger extends Logger {
      * @param p1 the message parameters
      * @param p2 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2);
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2);
 
     /**
      * Logs a message if the specified level is active.
@@ -378,7 +444,14 @@ public interface ExtendedLogger extends Logger {
      * @param p2 the message parameters
      * @param p3 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
             Object p3);
 
     /**
@@ -395,8 +468,16 @@ public interface ExtendedLogger extends Logger {
      * @param p3 the message parameters
      * @param p4 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
-            Object p3, Object p4);
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4);
 
     /**
      * Logs a message if the specified level is active.
@@ -413,8 +494,17 @@ public interface ExtendedLogger extends Logger {
      * @param p4 the message parameters
      * @param p5 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
-            Object p3, Object p4, Object p5);
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5);
 
     /**
      * Logs a message if the specified level is active.
@@ -432,8 +522,18 @@ public interface ExtendedLogger extends Logger {
      * @param p5 the message parameters
      * @param p6 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
-            Object p3, Object p4, Object p5, Object p6);
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6);
 
     /**
      * Logs a message if the specified level is active.
@@ -452,8 +552,19 @@ public interface ExtendedLogger extends Logger {
      * @param p6 the message parameters
      * @param p7 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
-            Object p3, Object p4, Object p5, Object p6, Object p7);
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7);
 
     /**
      * Logs a message if the specified level is active.
@@ -473,8 +584,20 @@ public interface ExtendedLogger extends Logger {
      * @param p7 the message parameters
      * @param p8 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
-            Object p3, Object p4, Object p5, Object p6, Object p7, Object p8);
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message if the specified level is active.
@@ -495,8 +618,21 @@ public interface ExtendedLogger extends Logger {
      * @param p8 the message parameters
      * @param p9 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
-            Object p3, Object p4, Object p5, Object p6, Object p7, Object p8, Object p9);
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message at the specified level. It is the responsibility of the caller to ensure the specified
@@ -521,7 +657,8 @@ public interface ExtendedLogger extends Logger {
      * @param msgSupplier A function, which when called, produces the desired log message.
      * @param t the exception to log, including its stack trace.
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, MessageSupplier msgSupplier, Throwable t);
+    void logIfEnabled(
+            String fqcn, Level level, Marker marker, MessageSupplier msgSupplier, Throwable t);
 
     /**
      * Logs a message whose parameters are only to be constructed if the specified level is active.
@@ -533,7 +670,8 @@ public interface ExtendedLogger extends Logger {
      * @param message The message format.
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Supplier<?>... paramSuppliers);
+    void logIfEnabled(
+            String fqcn, Level level, Marker marker, String message, Supplier<?>... paramSuppliers);
 
     /**
      * Logs a message which is only to be constructed if the specified level is active.
@@ -545,6 +683,6 @@ public interface ExtendedLogger extends Logger {
      * @param msgSupplier A function, which when called, produces the desired log message.
      * @param t the exception to log, including its stack trace.
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, Supplier<?> msgSupplier, Throwable t);
-
+    void logIfEnabled(
+            String fqcn, Level level, Marker marker, Supplier<?> msgSupplier, Throwable t);
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLoggerWrapper.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLoggerWrapper.java
@@ -41,7 +41,8 @@ public class ExtendedLoggerWrapper extends AbstractLogger {
      * @param name The name of the Logger.
      * @param messageFactory TODO
      */
-    public ExtendedLoggerWrapper(final ExtendedLogger logger, final String name, final MessageFactory messageFactory) {
+    public ExtendedLoggerWrapper(
+            final ExtendedLogger logger, final String name, final MessageFactory messageFactory) {
         super(name, messageFactory);
         this.logger = logger;
     }
@@ -61,7 +62,8 @@ public class ExtendedLoggerWrapper extends AbstractLogger {
      * @return true if the event would be logged for the Level, Marker, Message and Throwable, false otherwise.
      */
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final Message message, final Throwable t) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final Message message, final Throwable t) {
         return logger.isEnabled(level, marker, message, t);
     }
 
@@ -75,7 +77,8 @@ public class ExtendedLoggerWrapper extends AbstractLogger {
      * @return true if the event would be logged for the Level, Marker, Object and Throwable, false otherwise.
      */
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final CharSequence message, final Throwable t) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final CharSequence message, final Throwable t) {
         return logger.isEnabled(level, marker, message, t);
     }
 
@@ -89,7 +92,8 @@ public class ExtendedLoggerWrapper extends AbstractLogger {
      * @return true if the event would be logged for the Level, Marker, Object and Throwable, false otherwise.
      */
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final Object message, final Throwable t) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final Object message, final Throwable t) {
         return logger.isEnabled(level, marker, message, t);
     }
 
@@ -116,75 +120,140 @@ public class ExtendedLoggerWrapper extends AbstractLogger {
      * @return true if the event would be logged for the Level, Marker, message and parameter.
      */
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object... params) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final String message, final Object... params) {
         return logger.isEnabled(level, marker, message, params);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final String message, final Object p0) {
         return logger.isEnabled(level, marker, message, p0);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
             final Object p1) {
         return logger.isEnabled(level, marker, message, p0, p1);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         return logger.isEnabled(level, marker, message, p0, p1, p2);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
             final Object p7) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -198,7 +267,8 @@ public class ExtendedLoggerWrapper extends AbstractLogger {
      * @return true if the event would be logged for the Level, Marker, message and Throwable, false otherwise.
      */
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Throwable t) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final String message, final Throwable t) {
         return logger.isEnabled(level, marker, message, t);
     }
 
@@ -213,11 +283,16 @@ public class ExtendedLoggerWrapper extends AbstractLogger {
      * @param t A Throwable or null.
      */
     @Override
-    public void logMessage(final String fqcn, final Level level, final Marker marker, final Message message,
+    public void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Message message,
             final Throwable t) {
         if (logger instanceof LocationAwareLogger && requiresLocation()) {
-            ((LocationAwareLogger) logger).logMessage(level, marker, fqcn, StackLocatorUtil.calcLocation(fqcn),
-                message, t);
+            ((LocationAwareLogger) logger)
+                    .logMessage(
+                            level, marker, fqcn, StackLocatorUtil.calcLocation(fqcn), message, t);
         } else {
             logger.logMessage(fqcn, level, marker, message, t);
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/GarbageFreeSortedArrayThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/GarbageFreeSortedArrayThreadContextMap.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
@@ -35,7 +34,8 @@ import org.apache.logging.log4j.util.StringMap;
  * </p>
  * @since 2.7
  */
-class GarbageFreeSortedArrayThreadContextMap implements ReadOnlyThreadContextMap, ObjectThreadContextMap  {
+class GarbageFreeSortedArrayThreadContextMap
+        implements ReadOnlyThreadContextMap, ObjectThreadContextMap {
 
     /**
      * Property name ({@value} ) for selecting {@code InheritableThreadLocal} (value "true") or plain
@@ -51,7 +51,8 @@ class GarbageFreeSortedArrayThreadContextMap implements ReadOnlyThreadContextMap
     /**
      * System property name that can be used to control the data structure's initial capacity.
      */
-    protected static final String PROPERTY_NAME_INITIAL_CAPACITY = "log4j2.ThreadContext.initial.capacity";
+    protected static final String PROPERTY_NAME_INITIAL_CAPACITY =
+            "log4j2.ThreadContext.initial.capacity";
 
     protected final ThreadLocal<StringMap> localMap;
 
@@ -64,7 +65,9 @@ class GarbageFreeSortedArrayThreadContextMap implements ReadOnlyThreadContextMap
      */
     static void init() {
         final PropertiesUtil properties = PropertiesUtil.getProperties();
-        initialCapacity = properties.getIntegerProperty(PROPERTY_NAME_INITIAL_CAPACITY, DEFAULT_INITIAL_CAPACITY);
+        initialCapacity =
+                properties.getIntegerProperty(
+                        PROPERTY_NAME_INITIAL_CAPACITY, DEFAULT_INITIAL_CAPACITY);
         inheritableMap = properties.getBooleanProperty(INHERITABLE_MAP);
     }
 
@@ -76,7 +79,8 @@ class GarbageFreeSortedArrayThreadContextMap implements ReadOnlyThreadContextMap
         this.localMap = createThreadLocalMap();
     }
 
-    // LOG4J2-479: by default, use a plain ThreadLocal, only use InheritableThreadLocal if configured.
+    // LOG4J2-479: by default, use a plain ThreadLocal, only use InheritableThreadLocal if
+    // configured.
     // (This method is package protected for JUnit tests.)
     private ThreadLocal<StringMap> createThreadLocalMap() {
         if (inheritableMap) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LocationAwareLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LocationAwareLogger.java
@@ -24,6 +24,11 @@ import org.apache.logging.log4j.message.Message;
  * Logger that accepts the location of the caller.
  */
 public interface LocationAwareLogger {
-    void logMessage(final Level level, final Marker marker, final String fqcn, final StackTraceElement location,
-        final Message message, final Throwable throwable);
+    void logMessage(
+            final Level level,
+            final Marker marker,
+            final String fqcn,
+            final StackTraceElement location,
+            final Message message,
+            final Throwable throwable);
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContext.java
@@ -46,7 +46,6 @@ public interface LoggerContext {
         return getLogger(canonicalName != null ? canonicalName : cls.getName());
     }
 
-
     /**
      * Gets an ExtendedLogger using the fully qualified name of the Class as the Logger name.
      * @param cls The Class whose name should be used as the Logger name.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextFactory.java
@@ -32,7 +32,8 @@ public interface LoggerContextFactory {
      * @param allContexts if true all LoggerContexts that can be located will be shutdown.
      * @since 2.13.0
      */
-    default void shutdown(String fqcn, ClassLoader loader, boolean currentContext, boolean allContexts) {
+    default void shutdown(
+            String fqcn, ClassLoader loader, boolean currentContext, boolean allContexts) {
         if (hasContext(fqcn, loader, currentContext)) {
             final LoggerContext ctx = getContext(fqcn, loader, null, currentContext);
             if (ctx instanceof Terminable) {
@@ -64,7 +65,8 @@ public interface LoggerContextFactory {
      * @param externalContext An external context (such as a ServletContext) to be associated with the LoggerContext.
      * @return The LoggerContext.
      */
-    LoggerContext getContext(String fqcn, ClassLoader loader, Object externalContext, boolean currentContext);
+    LoggerContext getContext(
+            String fqcn, ClassLoader loader, Object externalContext, boolean currentContext);
 
     /**
      * Creates a {@link LoggerContext}.
@@ -78,8 +80,13 @@ public interface LoggerContextFactory {
      * @param name The name of the context or null.
      * @return The LoggerContext.
      */
-    LoggerContext getContext(String fqcn, ClassLoader loader, Object externalContext, boolean currentContext,
-                             URI configLocation, String name);
+    LoggerContext getContext(
+            String fqcn,
+            ClassLoader loader,
+            Object externalContext,
+            boolean currentContext,
+            URI configLocation,
+            String name);
 
     /**
      * Removes knowledge of a LoggerContext.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextKey.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextKey.java
@@ -32,15 +32,19 @@ public class LoggerContextKey {
     }
 
     public static String create(final String name, final MessageFactory messageFactory) {
-        final Class<? extends MessageFactory> messageFactoryClass = messageFactory != null ? messageFactory.getClass()
-                : AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS;
+        final Class<? extends MessageFactory> messageFactoryClass =
+                messageFactory != null
+                        ? messageFactory.getClass()
+                        : AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS;
         return create(name, messageFactoryClass);
     }
 
-    public static String create(final String name, final Class<? extends MessageFactory> messageFactoryClass) {
-        final Class<? extends MessageFactory> mfClass = messageFactoryClass != null ? messageFactoryClass
-                : AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS;
+    public static String create(
+            final String name, final Class<? extends MessageFactory> messageFactoryClass) {
+        final Class<? extends MessageFactory> mfClass =
+                messageFactoryClass != null
+                        ? messageFactoryClass
+                        : AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS;
         return name + "." + mfClass.getName();
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextShutdownEnabled.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextShutdownEnabled.java
@@ -25,5 +25,5 @@ public interface LoggerContextShutdownEnabled {
 
     void addShutdownListener(LoggerContextShutdownAware listener);
 
-     List<LoggerContextShutdownAware> getListeners();
+    List<LoggerContextShutdownAware> getListeners();
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerRegistry.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerRegistry.java
@@ -23,14 +23,14 @@ import java.util.Objects;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
 import org.apache.logging.log4j.message.MessageFactory;
 
 /**
  * Convenience class to be used by {@code LoggerContext} implementations.
  */
 public class LoggerRegistry<T extends ExtendedLogger> {
-    private static final String DEFAULT_FACTORY_KEY = AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS.getName();
+    private static final String DEFAULT_FACTORY_KEY =
+            AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS.getName();
     private final MapFactory<T> factory;
     private final Map<String, Map<String, T>> map;
 
@@ -97,7 +97,8 @@ public class LoggerRegistry<T extends ExtendedLogger> {
         this.map = factory.createOuterMap();
     }
 
-    private static String factoryClassKey(final Class<? extends MessageFactory> messageFactoryClass) {
+    private static String factoryClassKey(
+            final Class<? extends MessageFactory> messageFactoryClass) {
         return messageFactoryClass == null ? DEFAULT_FACTORY_KEY : messageFactoryClass.getName();
     }
 
@@ -172,11 +173,13 @@ public class LoggerRegistry<T extends ExtendedLogger> {
      * @return true if the Logger exists, false otherwise.
      * @since 2.5
      */
-    public boolean hasLogger(final String name, final Class<? extends MessageFactory> messageFactoryClass) {
+    public boolean hasLogger(
+            final String name, final Class<? extends MessageFactory> messageFactoryClass) {
         return getOrCreateInnerMap(factoryClassKey(messageFactoryClass)).containsKey(name);
     }
 
-    public void putIfAbsent(final String name, final MessageFactory messageFactory, final T logger) {
+    public void putIfAbsent(
+            final String name, final MessageFactory messageFactory, final T logger) {
         factory.putIfAbsent(getOrCreateInnerMap(factoryKey(messageFactory)), name, logger);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/MessageFactory2Adapter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/MessageFactory2Adapter.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.spi;
 
 import java.util.Objects;
-
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.message.MessageFactory2;
@@ -55,49 +54,99 @@ public class MessageFactory2Adapter implements MessageFactory2 {
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2) {
         return wrapped.newMessage(message, p0, p1, p2);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         return wrapped.newMessage(message, p0, p1, p2, p3);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         return wrapped.newMessage(message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return wrapped.newMessage(message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         return wrapped.newMessage(message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return wrapped.newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return wrapped.newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return wrapped.newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/MutableThreadContextStack.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/MutableThreadContextStack.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-
 import org.apache.logging.log4j.ThreadContext.ContextStack;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
@@ -36,6 +35,7 @@ public class MutableThreadContextStack implements ThreadContextStack, StringBuil
      * The underlying list (never null).
      */
     private final List<String> list;
+
     private boolean frozen;
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/NoOpThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/NoOpThreadContextMap.java
@@ -27,8 +27,7 @@ import java.util.Map;
  */
 public class NoOpThreadContextMap implements ThreadContextMap {
     @Override
-    public void clear() {
-    }
+    public void clear() {}
 
     @Override
     public boolean containsKey(final String key) {
@@ -56,10 +55,8 @@ public class NoOpThreadContextMap implements ThreadContextMap {
     }
 
     @Override
-    public void put(final String key, final String value) {
-    }
+    public void put(final String key, final String value) {}
 
     @Override
-    public void remove(final String key) {
-    }
+    public void remove(final String key) {}
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ObjectThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ObjectThreadContextMap.java
@@ -50,5 +50,4 @@ public interface ObjectThreadContextMap extends CleanableThreadContextMap {
      * @param values the map of key-value pairs to add
      */
     <V> void putAllValues(Map<String, V> values);
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/Provider.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/Provider.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.spi;
 import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.util.Properties;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
 
@@ -33,10 +32,12 @@ public class Provider {
      * Property name to set for a Log4j 2 provider to specify the priority of this implementation.
      */
     public static final String FACTORY_PRIORITY = "FactoryPriority";
+
     /**
      * Property name to set to the implementation of {@link org.apache.logging.log4j.spi.ThreadContextMap}.
      */
     public static final String THREAD_CONTEXT_MAP = "ThreadContextMap";
+
     /**
      * Property name to set to the implementation of {@link org.apache.logging.log4j.spi.LoggerContextFactory}.
      */
@@ -66,15 +67,18 @@ public class Provider {
         versions = null;
     }
 
-    public Provider(final Integer priority, final String versions,
-                    final Class<? extends LoggerContextFactory> loggerContextFactoryClass) {
+    public Provider(
+            final Integer priority,
+            final String versions,
+            final Class<? extends LoggerContextFactory> loggerContextFactoryClass) {
         this(priority, versions, loggerContextFactoryClass, null);
     }
 
-
-    public Provider(final Integer priority, final String versions,
-                    final Class<? extends LoggerContextFactory> loggerContextFactoryClass,
-                    final Class<? extends ThreadContextMap> threadContextMapClass) {
+    public Provider(
+            final Integer priority,
+            final String versions,
+            final Class<? extends LoggerContextFactory> loggerContextFactoryClass,
+            final Class<? extends ThreadContextMap> threadContextMapClass) {
         this.url = null;
         this.classLoader = null;
         this.priority = priority;
@@ -176,7 +180,11 @@ public class Provider {
                 return clazz.asSubclass(ThreadContextMap.class);
             }
         } catch (final Exception e) {
-            LOGGER.error("Unable to create class {} specified in {}", threadContextMap, url.toString(), e);
+            LOGGER.error(
+                    "Unable to create class {} specified in {}",
+                    threadContextMap,
+                    url.toString(),
+                    e);
         }
         return null;
     }
@@ -233,10 +241,14 @@ public class Provider {
         if (priority != null ? !priority.equals(provider.priority) : provider.priority != null) {
             return false;
         }
-        if (className != null ? !className.equals(provider.className) : provider.className != null) {
+        if (className != null
+                ? !className.equals(provider.className)
+                : provider.className != null) {
             return false;
         }
-        if (loggerContextFactoryClass != null ? !loggerContextFactoryClass.equals(provider.loggerContextFactoryClass) : provider.loggerContextFactoryClass != null) {
+        if (loggerContextFactoryClass != null
+                ? !loggerContextFactoryClass.equals(provider.loggerContextFactoryClass)
+                : provider.loggerContextFactoryClass != null) {
             return false;
         }
         return versions != null ? versions.equals(provider.versions) : provider.versions == null;
@@ -246,7 +258,11 @@ public class Provider {
     public int hashCode() {
         int result = priority != null ? priority.hashCode() : 0;
         result = 31 * result + (className != null ? className.hashCode() : 0);
-        result = 31 * result + (loggerContextFactoryClass != null ? loggerContextFactoryClass.hashCode() : 0);
+        result =
+                31 * result
+                        + (loggerContextFactoryClass != null
+                                ? loggerContextFactoryClass.hashCode()
+                                : 0);
         result = 31 * result + (versions != null ? versions.hashCode() : 0);
         return result;
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ReadOnlyThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ReadOnlyThreadContextMap.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.spi;
 
 import java.util.Map;
-
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.util.StringMap;
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMap.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.spi;
 
 import java.util.Map;
-
 import org.apache.logging.log4j.ThreadContext;
 
 /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMap2.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMap2.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.spi;
 
 import java.util.Map;
-
 import org.apache.logging.log4j.util.StringMap;
 
 /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMapFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMapFactory.java
@@ -78,8 +78,7 @@ public final class ThreadContextMapFactory {
         GcFreeThreadContextKey = properties.getBooleanProperty(GC_FREE_THREAD_CONTEXT_KEY);
     }
 
-    private ThreadContextMapFactory() {
-    }
+    private ThreadContextMapFactory() {}
 
     public static ThreadContextMap createThreadContextMap() {
         final ClassLoader cl = ProviderUtil.findClassLoader();
@@ -91,12 +90,18 @@ public final class ThreadContextMapFactory {
                     result = (ThreadContextMap) clazz.newInstance();
                 }
             } catch (final ClassNotFoundException cnfe) {
-                LOGGER.error("Unable to locate configured ThreadContextMap {}", ThreadContextMapName);
+                LOGGER.error(
+                        "Unable to locate configured ThreadContextMap {}", ThreadContextMapName);
             } catch (final Exception ex) {
-                LOGGER.error("Unable to create configured ThreadContextMap {}", ThreadContextMapName, ex);
+                LOGGER.error(
+                        "Unable to create configured ThreadContextMap {}",
+                        ThreadContextMapName,
+                        ex);
             }
         }
-        if (result == null && ProviderUtil.hasProviders() && LogManager.getFactory() != null) { //LOG4J2-1658
+        if (result == null
+                && ProviderUtil.hasProviders()
+                && LogManager.getFactory() != null) { // LOG4J2-1658
             final String factoryClassName = LogManager.getFactory().getClass().getName();
             for (final Provider provider : ProviderUtil.getProviders()) {
                 if (factoryClassName.equals(provider.getClassName())) {
@@ -106,8 +111,10 @@ public final class ThreadContextMapFactory {
                             result = clazz.newInstance();
                             break;
                         } catch (final Exception e) {
-                            LOGGER.error("Unable to locate or load configured ThreadContextMap {}",
-                                    provider.getThreadContextMap(), e);
+                            LOGGER.error(
+                                    "Unable to locate or load configured ThreadContextMap {}",
+                                    provider.getThreadContextMap(),
+                                    e);
                             result = createDefaultThreadContextMap();
                         }
                     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/SimpleLoggerFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/SimpleLoggerFactory.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.status;
 
 import java.io.PrintStream;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.simple.SimpleLogger;
@@ -41,7 +40,8 @@ final class SimpleLoggerFactory {
             final Level level,
             final MessageFactory messageFactory,
             final PrintStream stream) {
-        final String dateFormat = StatusLogger.PROPS.getStringProperty(StatusLogger.STATUS_DATE_FORMAT);
+        final String dateFormat =
+                StatusLogger.PROPS.getStringProperty(StatusLogger.STATUS_DATE_FORMAT);
         final boolean dateFormatProvided = Strings.isNotBlank(dateFormat);
         return new SimpleLogger(
                 name,
@@ -55,5 +55,4 @@ final class SimpleLoggerFactory {
                 StatusLogger.PROPS,
                 stream);
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.status;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Objects;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedNoReferenceMessageFactory;
@@ -63,18 +62,16 @@ public class StatusConsoleListener implements StatusListener {
     }
 
     StatusConsoleListener(
-            final Level level,
-            final PrintStream stream,
-            final SimpleLoggerFactory loggerFactory) {
+            final Level level, final PrintStream stream, final SimpleLoggerFactory loggerFactory) {
         this.level = Objects.requireNonNull(level, "level");
         this.stream = Objects.requireNonNull(stream, "stream");
-        this.logger = Objects
-                .requireNonNull(loggerFactory, "loggerFactory")
-                .createSimpleLogger(
-                        "StatusConsoleListener",
-                        level,
-                        ParameterizedNoReferenceMessageFactory.INSTANCE,
-                        stream);
+        this.logger =
+                Objects.requireNonNull(loggerFactory, "loggerFactory")
+                        .createSimpleLogger(
+                                "StatusConsoleListener",
+                                level,
+                                ParameterizedNoReferenceMessageFactory.INSTANCE,
+                                stream);
     }
 
     /**
@@ -103,7 +100,8 @@ public class StatusConsoleListener implements StatusListener {
         final boolean filtered = filtered(data);
         if (!filtered) {
             logger
-                    // Logging using _only_ the following 4 fields set by `StatusLogger#logMessage()`:
+                    // Logging using _only_ the following 4 fields set by
+                    // `StatusLogger#logMessage()`:
                     .atLevel(data.getLevel())
                     .withThrowable(data.getThrowable())
                     .withLocation(data.getStackTraceElement())
@@ -139,5 +137,4 @@ public class StatusConsoleListener implements StatusListener {
             this.stream.close();
         }
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
@@ -16,16 +16,15 @@
  */
 package org.apache.logging.log4j.status;
 
+import static org.apache.logging.log4j.util.Chars.SPACE;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.message.Message;
-
-import static org.apache.logging.log4j.util.Chars.SPACE;
 
 /**
  * The Status data.
@@ -50,7 +49,11 @@ public class StatusData implements Serializable {
      * @param t The Error or Exception that occurred.
      * @param threadName The thread name
      */
-    public StatusData(final StackTraceElement caller, final Level level, final Message msg, final Throwable t,
+    public StatusData(
+            final StackTraceElement caller,
+            final Level level,
+            final Message msg,
+            final Throwable t,
             final String threadName) {
         this.timestamp = System.currentTimeMillis();
         this.caller = caller;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusListener.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusListener.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.status;
 
 import java.io.Closeable;
 import java.util.EventListener;
-
 import org.apache.logging.log4j.Level;
 
 /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -28,7 +28,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.message.Message;
@@ -78,17 +77,18 @@ public final class StatusLogger extends AbstractLogger {
 
     private static final int MAX_ENTRIES = PROPS.getIntegerProperty(MAX_STATUS_ENTRIES, 200);
 
-    private static final String DEFAULT_STATUS_LEVEL = PROPS.getStringProperty(DEFAULT_STATUS_LISTENER_LEVEL);
+    private static final String DEFAULT_STATUS_LEVEL =
+            PROPS.getStringProperty(DEFAULT_STATUS_LISTENER_LEVEL);
 
-    static final boolean DEBUG_ENABLED = PropertiesUtil
-            .getProperties()
-            .getBooleanProperty(Constants.LOG4J2_DEBUG, false, true);
+    static final boolean DEBUG_ENABLED =
+            PropertiesUtil.getProperties().getBooleanProperty(Constants.LOG4J2_DEBUG, false, true);
 
     // LOG4J2-1176: normal parameterized message remembers param object, causing memory leaks.
-    private static final StatusLogger STATUS_LOGGER = new StatusLogger(
-            StatusLogger.class.getName(),
-            ParameterizedNoReferenceMessageFactory.INSTANCE,
-            SimpleLoggerFactory.getInstance());
+    private static final StatusLogger STATUS_LOGGER =
+            new StatusLogger(
+                    StatusLogger.class.getName(),
+                    ParameterizedNoReferenceMessageFactory.INSTANCE,
+                    SimpleLoggerFactory.getInstance());
 
     private final SimpleLogger logger;
 
@@ -140,7 +140,9 @@ public final class StatusLogger extends AbstractLogger {
             final SimpleLoggerFactory loggerFactory) {
         super(name, messageFactory);
         final Level loggerLevel = DEBUG_ENABLED ? Level.TRACE : Level.ERROR;
-        this.logger = loggerFactory.createSimpleLogger("StatusLogger", loggerLevel, messageFactory, System.err);
+        this.logger =
+                loggerFactory.createSimpleLogger(
+                        "StatusLogger", loggerLevel, messageFactory, System.err);
         this.listenersLevel = Level.toLevel(DEFAULT_STATUS_LEVEL, Level.WARN).intLevel();
     }
 
@@ -279,7 +281,11 @@ public final class StatusLogger extends AbstractLogger {
      * @param t A Throwable or null.
      */
     @Override
-    public void logMessage(final String fqcn, final Level level, final Marker marker, final Message msg,
+    public void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Message msg,
             final Throwable t) {
         StackTraceElement element = null;
         if (fqcn != null) {
@@ -304,7 +310,8 @@ public final class StatusLogger extends AbstractLogger {
         }
     }
 
-    private StackTraceElement getStackTraceElement(final String fqcn, final StackTraceElement[] stackTrace) {
+    private StackTraceElement getStackTraceElement(
+            final String fqcn, final StackTraceElement[] stackTrace) {
         if (fqcn == null) {
             return null;
         }
@@ -324,7 +331,8 @@ public final class StatusLogger extends AbstractLogger {
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Throwable t) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final String message, final Throwable t) {
         return isEnabled(level, marker);
     }
 
@@ -334,90 +342,158 @@ public final class StatusLogger extends AbstractLogger {
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object... params) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final String message, final Object... params) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final String message, final Object p0) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
             final Object p1) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
             final Object p7) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final CharSequence message, final Throwable t) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final CharSequence message, final Throwable t) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final Object message, final Throwable t) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final Object message, final Throwable t) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final Message message, final Throwable t) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final Message message, final Throwable t) {
         return isEnabled(level, marker);
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Activator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Activator.java
@@ -20,7 +20,6 @@ import java.net.URL;
 import java.security.Permission;
 import java.util.Collection;
 import java.util.List;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.spi.LoggerContextFactory;
 import org.apache.logging.log4j.spi.Provider;
@@ -54,7 +53,8 @@ public class Activator implements BundleActivator, SynchronousBundleListener {
 
     private static final Logger LOGGER = StatusLogger.getLogger();
 
-    // until we have at least one Provider, we'll lock ProviderUtil which locks LogManager.<clinit> by extension.
+    // until we have at least one Provider, we'll lock ProviderUtil which locks LogManager.<clinit>
+    // by extension.
     // this variable needs to be reset once the lock has been released
     private boolean lockingProviderUtil;
 
@@ -70,43 +70,53 @@ public class Activator implements BundleActivator, SynchronousBundleListener {
         }
         try {
             checkPermission(new AdminPermission(bundle, AdminPermission.RESOURCE));
-            checkPermission(new AdaptPermission(BundleWiring.class.getName(), bundle, AdaptPermission.ADAPT));
+            checkPermission(
+                    new AdaptPermission(
+                            BundleWiring.class.getName(), bundle, AdaptPermission.ADAPT));
             final BundleContext bundleContext = bundle.getBundleContext();
             if (bundleContext == null) {
-                LOGGER.debug("Bundle {} has no context (state={}), skipping loading provider", bundle.getSymbolicName(), toStateString(bundle.getState()));
+                LOGGER.debug(
+                        "Bundle {} has no context (state={}), skipping loading provider",
+                        bundle.getSymbolicName(),
+                        toStateString(bundle.getState()));
             } else {
                 loadProvider(bundleContext, bundle.adapt(BundleWiring.class));
             }
         } catch (final SecurityException e) {
-            LOGGER.debug("Cannot access bundle [{}] contents. Ignoring.", bundle.getSymbolicName(), e);
+            LOGGER.debug(
+                    "Cannot access bundle [{}] contents. Ignoring.", bundle.getSymbolicName(), e);
         } catch (final Exception e) {
-            LOGGER.warn("Problem checking bundle {} for Log4j 2 provider.", bundle.getSymbolicName(), e);
+            LOGGER.warn(
+                    "Problem checking bundle {} for Log4j 2 provider.",
+                    bundle.getSymbolicName(),
+                    e);
         }
     }
 
     private String toStateString(final int state) {
         switch (state) {
-        case Bundle.UNINSTALLED:
-            return "UNINSTALLED";
-        case Bundle.INSTALLED:
-            return "INSTALLED";
-        case Bundle.RESOLVED:
-            return "RESOLVED";
-        case Bundle.STARTING:
-            return "STARTING";
-        case Bundle.STOPPING:
-            return "STOPPING";
-        case Bundle.ACTIVE:
-            return "ACTIVE";
-        default:
-            return Integer.toString(state);
+            case Bundle.UNINSTALLED:
+                return "UNINSTALLED";
+            case Bundle.INSTALLED:
+                return "INSTALLED";
+            case Bundle.RESOLVED:
+                return "RESOLVED";
+            case Bundle.STARTING:
+                return "STARTING";
+            case Bundle.STOPPING:
+                return "STOPPING";
+            case Bundle.ACTIVE:
+                return "ACTIVE";
+            default:
+                return Integer.toString(state);
         }
     }
 
     private void loadProvider(final BundleContext bundleContext, final BundleWiring bundleWiring) {
         final String filter = "(APIVersion>=2.6.0)";
         try {
-            final Collection<ServiceReference<Provider>> serviceReferences = bundleContext.getServiceReferences(Provider.class, filter);
+            final Collection<ServiceReference<Provider>> serviceReferences =
+                    bundleContext.getServiceReferences(Provider.class, filter);
             Provider maxProvider = null;
             for (final ServiceReference<Provider> serviceReference : serviceReferences) {
                 final Provider provider = bundleContext.getService(serviceReference);
@@ -131,7 +141,8 @@ public class Activator implements BundleActivator, SynchronousBundleListener {
         ProviderUtil.STARTUP_LOCK.lock();
         lockingProviderUtil = true;
         final BundleWiring self = bundleContext.getBundle().adapt(BundleWiring.class);
-        final List<BundleWire> required = self.getRequiredWires(LoggerContextFactory.class.getName());
+        final List<BundleWire> required =
+                self.getRequiredWires(LoggerContextFactory.class.getName());
         for (final BundleWire wire : required) {
             loadProvider(bundleContext, wire.getProviderWiring());
         }
@@ -168,5 +179,4 @@ public class Activator implements BundleActivator, SynchronousBundleListener {
                 break;
         }
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.util;
 
 import java.lang.reflect.Method;
-
 import org.apache.logging.log4j.LoggingException;
 
 /**
@@ -46,14 +45,13 @@ public final class Base64Util {
         }
     }
 
-    private Base64Util() {
-    }
+    private Base64Util() {}
 
     public static String encode(final String str) {
         if (str == null) {
             return null;
         }
-        final byte [] data = str.getBytes();
+        final byte[] data = str.getBytes();
         if (encodeMethod != null) {
             try {
                 return (String) encodeMethod.invoke(encoder, data);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Chars.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Chars.java
@@ -83,6 +83,5 @@ public final class Chars {
         return (char) ('a' + digit - 10);
     }
 
-    private Chars() {
-    }
+    private Chars() {}
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
@@ -27,9 +27,12 @@ public final class Constants {
      * "log4j2.is.webapp", or (if this system property is not set) whether the  {@code javax.servlet.Servlet} class
      * is present in the classpath.
      */
-    public static final boolean IS_WEB_APP = PropertiesUtil.getProperties().getBooleanProperty(
-            "log4j2.is.webapp", isClassAvailable("javax.servlet.Servlet")
-                    || isClassAvailable("jakarta.servlet.Servlet"));
+    public static final boolean IS_WEB_APP =
+            PropertiesUtil.getProperties()
+                    .getBooleanProperty(
+                            "log4j2.is.webapp",
+                            isClassAvailable("javax.servlet.Servlet")
+                                    || isClassAvailable("jakarta.servlet.Servlet"));
 
     /**
      * Kill switch for object pooling in ThreadLocals that enables much of the LOG4J2-1270 no-GC behaviour.
@@ -38,8 +41,10 @@ public final class Constants {
      * "log4j2.enable.threadlocals" to "false".
      * </p>
      */
-    public static final boolean ENABLE_THREADLOCALS = !IS_WEB_APP && PropertiesUtil.getProperties().getBooleanProperty(
-            "log4j2.enable.threadlocals", true);
+    public static final boolean ENABLE_THREADLOCALS =
+            !IS_WEB_APP
+                    && PropertiesUtil.getProperties()
+                            .getBooleanProperty("log4j2.enable.threadlocals", true);
 
     /**
      * Java major version.
@@ -55,7 +60,8 @@ public final class Constants {
      * </p>
      * @since 2.9
      */
-    public static final int MAX_REUSABLE_MESSAGE_SIZE = size("log4j.maxReusableMsgSize", (128 * 2 + 2) * 2 + 2);
+    public static final int MAX_REUSABLE_MESSAGE_SIZE =
+            size("log4j.maxReusableMsgSize", (128 * 2 + 2) * 2 + 2);
 
     /**
      * Name of the system property that will turn on TRACE level internal log4j2 status logging.
@@ -99,8 +105,7 @@ public final class Constants {
     /**
      * Prevent class instantiation.
      */
-    private Constants() {
-    }
+    private Constants() {}
 
     private static int getMajorVersion() {
         return getMajorVersion(System.getProperty("java.version"));

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/EnglishEnums.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/EnglishEnums.java
@@ -16,7 +16,6 @@
  */
 package org.apache.logging.log4j.util;
 
-
 import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
@@ -32,8 +31,7 @@ import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
  */
 public final class EnglishEnums {
 
-    private EnglishEnums() {
-    }
+    private EnglishEnums() {}
 
     /**
      * Returns the Result for the given string.
@@ -64,8 +62,8 @@ public final class EnglishEnums {
      * @param <T> The type of the enum.
      * @return an enum value or {@code defaultValue} if {@code name} is null.
      */
-    public static <T extends Enum<T>> T valueOf(final Class<T> enumType, final String name, final T defaultValue) {
+    public static <T extends Enum<T>> T valueOf(
+            final Class<T> enumType, final String name, final T defaultValue) {
         return name == null ? defaultValue : Enum.valueOf(enumType, toRootUpperCase(name));
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/EnvironmentPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/EnvironmentPropertySource.java
@@ -16,11 +16,10 @@
  */
 package org.apache.logging.log4j.util;
 
-import java.util.Collection;
-import java.util.Map;
-
 import aQute.bnd.annotation.Resolution;
 import aQute.bnd.annotation.spi.ServiceProvider;
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * PropertySource implementation that uses environment variables as a source.
@@ -45,7 +44,9 @@ public class EnvironmentPropertySource implements PropertySource {
     private void logException(final SecurityException e) {
         // There is no status logger yet.
         LowLevelLogUtil.logException(
-                "The system environment variables are not available to Log4j due to security restrictions: " + e, e);
+                "The system environment variables are not available to Log4j due to security restrictions: "
+                        + e,
+                e);
     }
 
     @Override
@@ -108,5 +109,4 @@ public class EnvironmentPropertySource implements PropertySource {
             return PropertySource.super.containsProperty(key);
         }
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/FilteredObjectInputStream.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/FilteredObjectInputStream.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.util;
 
+import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_JAVA_CLASSES;
+import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_JAVA_PACKAGES;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InvalidObjectException;
@@ -23,9 +26,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
 import java.util.Collection;
 import java.util.Collections;
-
-import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_JAVA_CLASSES;
-import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_JAVA_PACKAGES;
 
 /**
  * Extends {@link ObjectInputStream} to only allow some built-in Log4j classes and caller-specified classes to be
@@ -47,12 +47,13 @@ public class FilteredObjectInputStream extends ObjectInputStream {
     }
 
     public FilteredObjectInputStream(final Collection<String> allowedExtraClasses)
-        throws IOException, SecurityException {
+            throws IOException, SecurityException {
         this.allowedExtraClasses = allowedExtraClasses;
     }
 
-    public FilteredObjectInputStream(final InputStream inputStream, final Collection<String> allowedExtraClasses)
-        throws IOException {
+    public FilteredObjectInputStream(
+            final InputStream inputStream, final Collection<String> allowedExtraClasses)
+            throws IOException {
         super(inputStream);
         this.allowedExtraClasses = allowedExtraClasses;
     }
@@ -62,7 +63,8 @@ public class FilteredObjectInputStream extends ObjectInputStream {
     }
 
     @Override
-    protected Class<?> resolveClass(final ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+    protected Class<?> resolveClass(final ObjectStreamClass desc)
+            throws IOException, ClassNotFoundException {
         final String name = desc.getName();
         if (!(isAllowedByDefault(name) || allowedExtraClasses.contains(name))) {
             throw new InvalidObjectException("Class is not allowed for deserialization: " + name);
@@ -82,5 +84,4 @@ public class FilteredObjectInputStream extends ObjectInputStream {
         }
         return false;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LambdaUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LambdaUtil.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.util;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MessageFactory;
 
-
 /**
  * Utility class for lambda support.
  */
@@ -27,8 +26,7 @@ public final class LambdaUtil {
     /**
      * Private constructor: this class is not intended to be instantiated.
      */
-    private LambdaUtil() {
-    }
+    private LambdaUtil() {}
 
     /**
      * Converts an array of lambda expressions into an array of their evaluation results.
@@ -83,7 +81,8 @@ public final class LambdaUtil {
      * @return the Message resulting from evaluating the lambda expression or the Message created by the factory for
      * supplied values that are not of type Message
      */
-    public static Message getMessage(final Supplier<?> supplier, final MessageFactory messageFactory) {
+    public static Message getMessage(
+            final Supplier<?> supplier, final MessageFactory messageFactory) {
         if (supplier == null) {
             return null;
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
@@ -47,13 +47,15 @@ public final class LoaderUtil {
 
     private static final SecurityManager SECURITY_MANAGER = System.getSecurityManager();
 
-    // this variable must be lazily loaded; otherwise, we get a nice circular class loading problem where LoaderUtil
+    // this variable must be lazily loaded; otherwise, we get a nice circular class loading problem
+    // where LoaderUtil
     // wants to use PropertiesUtil, but then PropertiesUtil wants to use LoaderUtil.
     private static Boolean ignoreTCCL;
 
     private static final boolean GET_CLASS_LOADER_DISABLED;
 
-    private static final PrivilegedAction<ClassLoader> TCCL_GETTER = new ThreadContextClassLoaderGetter();
+    private static final PrivilegedAction<ClassLoader> TCCL_GETTER =
+            new ThreadContextClassLoaderGetter();
 
     static {
         if (SECURITY_MANAGER != null) {
@@ -70,8 +72,7 @@ public final class LoaderUtil {
         }
     }
 
-    private LoaderUtil() {
-    }
+    private LoaderUtil() {}
 
     /**
      * Gets the current Thread ClassLoader. Returns the system ClassLoader if the TCCL is {@code null}. If the system
@@ -87,7 +88,9 @@ public final class LoaderUtil {
             // however, if this is null, there's really no option left at this point
             return LoaderUtil.class.getClassLoader();
         }
-        return SECURITY_MANAGER == null ? TCCL_GETTER.run() : AccessController.doPrivileged(TCCL_GETTER);
+        return SECURITY_MANAGER == null
+                ? TCCL_GETTER.run()
+                : AccessController.doPrivileged(TCCL_GETTER);
     }
 
     /**
@@ -101,7 +104,9 @@ public final class LoaderUtil {
                 return cl;
             }
             final ClassLoader ccl = LoaderUtil.class.getClassLoader();
-            return ccl == null && !GET_CLASS_LOADER_DISABLED ? ClassLoader.getSystemClassLoader() : ccl;
+            return ccl == null && !GET_CLASS_LOADER_DISABLED
+                    ? ClassLoader.getSystemClassLoader()
+                    : ccl;
         }
     }
 
@@ -119,7 +124,8 @@ public final class LoaderUtil {
         } catch (final ClassNotFoundException | LinkageError e) {
             return false;
         } catch (final Throwable e) {
-            LowLevelLogUtil.logException("Unknown error checking for existence of class: " + className, e);
+            LowLevelLogUtil.logException(
+                    "Unknown error checking for existence of class: " + className, e);
             return false;
         }
     }
@@ -163,7 +169,8 @@ public final class LoaderUtil {
         try {
             return clazz.getConstructor().newInstance();
         } catch (final NoSuchMethodException ignored) {
-            // FIXME: looking at the code for Class.newInstance(), this seems to do the same thing as above
+            // FIXME: looking at the code for Class.newInstance(), this seems to do the same thing
+            // as above
             return clazz.newInstance();
         }
     }
@@ -180,8 +187,11 @@ public final class LoaderUtil {
      * @since 2.1
      */
     @SuppressWarnings("unchecked")
-    public static <T> T newInstanceOf(final String className) throws ClassNotFoundException, IllegalAccessException,
-            InstantiationException, InvocationTargetException {
+    public static <T> T newInstanceOf(final String className)
+            throws ClassNotFoundException,
+                    IllegalAccessException,
+                    InstantiationException,
+                    InvocationTargetException {
         return newInstanceOf((Class<T>) loadClass(className));
     }
 
@@ -200,8 +210,10 @@ public final class LoaderUtil {
      * @since 2.1
      */
     public static <T> T newCheckedInstanceOf(final String className, final Class<T> clazz)
-            throws ClassNotFoundException, InvocationTargetException, InstantiationException,
-            IllegalAccessException {
+            throws ClassNotFoundException,
+                    InvocationTargetException,
+                    InstantiationException,
+                    IllegalAccessException {
         return clazz.cast(newInstanceOf(className));
     }
 
@@ -219,9 +231,12 @@ public final class LoaderUtil {
      * @throws ClassCastException        if the constructed object isn't type compatible with {@code T}
      * @since 2.5
      */
-    public static <T> T newCheckedInstanceOfProperty(final String propertyName, final Class<T> clazz)
-        throws ClassNotFoundException, InvocationTargetException, InstantiationException,
-        IllegalAccessException {
+    public static <T> T newCheckedInstanceOfProperty(
+            final String propertyName, final Class<T> clazz)
+            throws ClassNotFoundException,
+                    InvocationTargetException,
+                    InstantiationException,
+                    IllegalAccessException {
         final String className = PropertiesUtil.getProperties().getStringProperty(propertyName);
         if (className == null) {
             return null;
@@ -232,7 +247,8 @@ public final class LoaderUtil {
     private static boolean isIgnoreTccl() {
         // we need to lazily initialize this, but concurrent access is not an issue
         if (ignoreTCCL == null) {
-            final String ignoreTccl = PropertiesUtil.getProperties().getStringProperty(IGNORE_TCCL_PROPERTY, null);
+            final String ignoreTccl =
+                    PropertiesUtil.getProperties().getStringProperty(IGNORE_TCCL_PROPERTY, null);
             ignoreTCCL = ignoreTccl != null && !"false".equalsIgnoreCase(ignoreTccl.trim());
         }
         return ignoreTCCL;
@@ -261,9 +277,10 @@ public final class LoaderUtil {
     static Collection<UrlResource> findUrlResources(final String resource, final boolean useTccl) {
         // @formatter:off
         final ClassLoader[] candidates = {
-                useTccl ? getThreadContextClassLoader() : null,
-                LoaderUtil.class.getClassLoader(),
-                GET_CLASS_LOADER_DISABLED ? null : ClassLoader.getSystemClassLoader()};
+            useTccl ? getThreadContextClassLoader() : null,
+            LoaderUtil.class.getClassLoader(),
+            GET_CLASS_LOADER_DISABLED ? null : ClassLoader.getSystemClassLoader()
+        };
         // @formatter:on
         final Collection<UrlResource> resources = new LinkedHashSet<>();
         for (final ClassLoader cl : candidates) {
@@ -312,7 +329,9 @@ public final class LoaderUtil {
 
             final UrlResource that = (UrlResource) o;
 
-            if (classLoader != null ? !classLoader.equals(that.classLoader) : that.classLoader != null) {
+            if (classLoader != null
+                    ? !classLoader.equals(that.classLoader)
+                    : that.classLoader != null) {
                 return false;
             }
             if (url != null ? !url.equals(that.url) : that.url != null) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LowLevelLogUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LowLevelLogUtil.java
@@ -73,6 +73,5 @@ final class LowLevelLogUtil {
         LowLevelLogUtil.writer = new PrintWriter(Objects.requireNonNull(writer), true);
     }
 
-    private LowLevelLogUtil() {
-    }
+    private LowLevelLogUtil() {}
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/MultiFormatStringBuilderFormattable.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/MultiFormatStringBuilderFormattable.java
@@ -26,7 +26,8 @@ import org.apache.logging.log4j.message.MultiformatMessage;
  *
  * @since 2.10
  */
-public interface MultiFormatStringBuilderFormattable extends MultiformatMessage, StringBuilderFormattable {
+public interface MultiFormatStringBuilderFormattable
+        extends MultiformatMessage, StringBuilderFormattable {
 
     /**
      * Writes a text representation of this object into the specified {@code StringBuilder}, ideally without allocating
@@ -37,5 +38,4 @@ public interface MultiFormatStringBuilderFormattable extends MultiformatMessage,
      * @param buffer the StringBuilder to write into
      */
     void formatTo(String[] formats, StringBuilder buffer);
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/OsgiServiceLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/OsgiServiceLocator.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.util;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.util.Objects;
 import java.util.stream.Stream;
-
 import org.apache.logging.log4j.status.StatusLogger;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -35,9 +34,9 @@ public class OsgiServiceLocator {
              * OSGI classes of any version can still be present even if Log4j2 does not run in
              * an OSGI container, hence we check if this class is in a bundle.
              */
-            final Class< ? > clazz = Class.forName("org.osgi.framework.FrameworkUtil");
-            return clazz.getMethod("getBundle", Class.class)
-                    .invoke(null, OsgiServiceLocator.class) != null;
+            final Class<?> clazz = Class.forName("org.osgi.framework.FrameworkUtil");
+            return clazz.getMethod("getBundle", Class.class).invoke(null, OsgiServiceLocator.class)
+                    != null;
         } catch (final ClassNotFoundException | NoSuchMethodException | LinkageError e) {
             return false;
         } catch (final Throwable e) {
@@ -54,23 +53,34 @@ public class OsgiServiceLocator {
         return loadServices(serviceType, lookup, true);
     }
 
-    public static <T> Stream<T> loadServices(final Class<T> serviceType, final Lookup lookup, final boolean verbose) {
+    public static <T> Stream<T> loadServices(
+            final Class<T> serviceType, final Lookup lookup, final boolean verbose) {
         final Class<?> lookupClass = Objects.requireNonNull(lookup, "lookup").lookupClass();
-        final Bundle bundle = FrameworkUtil.getBundle(Objects.requireNonNull(lookupClass, "lookupClass"));
+        final Bundle bundle =
+                FrameworkUtil.getBundle(Objects.requireNonNull(lookupClass, "lookupClass"));
         if (bundle != null) {
             final BundleContext ctx = bundle.getBundleContext();
             if (ctx == null) {
                 if (verbose) {
-                    StatusLogger.getLogger().error(
-                            "Unable to load OSGI services: The bundle has no valid BundleContext for serviceType = {}, lookup = {}, lookupClass = {}, bundle = {}",
-                            serviceType, lookup, lookupClass, bundle);
+                    StatusLogger.getLogger()
+                            .error(
+                                    "Unable to load OSGI services: The bundle has no valid BundleContext for serviceType = {}, lookup = {}, lookupClass = {}, bundle = {}",
+                                    serviceType,
+                                    lookup,
+                                    lookupClass,
+                                    bundle);
                 }
             } else {
                 try {
-                    return ctx.getServiceReferences(serviceType, null).stream().map(ctx::getService);
+                    return ctx.getServiceReferences(serviceType, null).stream()
+                            .map(ctx::getService);
                 } catch (Throwable e) {
                     if (verbose) {
-                        StatusLogger.getLogger().error("Unable to load OSGI services for service {}", serviceType, e);
+                        StatusLogger.getLogger()
+                                .error(
+                                        "Unable to load OSGI services for service {}",
+                                        serviceType,
+                                        e);
                     }
                 }
             }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PerformanceSensitive.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PerformanceSensitive.java
@@ -29,7 +29,9 @@ import java.lang.annotation.RetentionPolicy;
  */
 // Not @Documented: Do not (yet) make this annotation part of the public API of annotated elements.
 // No @Target: No restrictions yet on what code elements may be annotated or not.
-@Retention(RetentionPolicy.CLASS) // Currently no need to reflectively discover this annotation at runtime.
+@Retention(
+        RetentionPolicy
+                .CLASS) // Currently no need to reflectively discover this annotation at runtime.
 public @interface PerformanceSensitive {
     /** Description of why this is written the way it is. */
     String[] value() default "";

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PrivateSecurityManagerStackTraceUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PrivateSecurityManagerStackTraceUtil.java
@@ -61,7 +61,8 @@ final class PrivateSecurityManagerStackTraceUtil {
      *
      * @return the execution stack.
      */
-    // benchmarks show that using the SecurityManager is much faster than looping through getCallerClass(int)
+    // benchmarks show that using the SecurityManager is much faster than looping through
+    // getCallerClass(int)
     static Deque<Class<?>> getCurrentStackTrace() {
         final Class<?>[] array = SECURITY_MANAGER.getClassContext();
         final Deque<Class<?>> classes = new ArrayDeque<>(array.length);
@@ -75,6 +76,5 @@ final class PrivateSecurityManagerStackTraceUtil {
         protected Class<?>[] getClassContext() {
             return super.getClassContext();
         }
-
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProcessIdUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProcessIdUtil.java
@@ -29,19 +29,25 @@ public class ProcessIdUtil {
 
     public static String getProcessId() {
         try {
-            // LOG4J2-2126 use reflection to improve compatibility with Android Platform which does not support JMX extensions
-            final Class<?> managementFactoryClass = Class.forName("java.lang.management.ManagementFactory");
-            final Method getRuntimeMXBean = managementFactoryClass.getDeclaredMethod("getRuntimeMXBean");
+            // LOG4J2-2126 use reflection to improve compatibility with Android Platform which does
+            // not support JMX extensions
+            final Class<?> managementFactoryClass =
+                    Class.forName("java.lang.management.ManagementFactory");
+            final Method getRuntimeMXBean =
+                    managementFactoryClass.getDeclaredMethod("getRuntimeMXBean");
             final Class<?> runtimeMXBeanClass = Class.forName("java.lang.management.RuntimeMXBean");
             final Method getName = runtimeMXBeanClass.getDeclaredMethod("getName");
 
             final Object runtimeMXBean = getRuntimeMXBean.invoke(null);
             final String name = (String) getName.invoke(runtimeMXBean);
-            //String name = ManagementFactory.getRuntimeMXBean().getName(); //JMX not allowed on Android
+            // String name = ManagementFactory.getRuntimeMXBean().getName(); //JMX not allowed on
+            // Android
             return name.split("@")[0]; // likely works on most platforms
         } catch (final Exception ex) {
             try {
-                return new File("/proc/self").getCanonicalFile().getName(); // try a Linux-specific way
+                return new File("/proc/self")
+                        .getCanonicalFile()
+                        .getName(); // try a Linux-specific way
             } catch (final IOException ignoredUseDefault) {
                 // Ignore exception.
             }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
@@ -75,5 +75,4 @@ public class PropertiesPropertySource implements PropertySource {
     public boolean containsProperty(final String key) {
         return getProperty(key) != null;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.util;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
@@ -35,10 +38,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 
-import aQute.bnd.annotation.Cardinality;
-import aQute.bnd.annotation.Resolution;
-import aQute.bnd.annotation.spi.ServiceConsumer;
-
 /**
  * <em>Consider this class private.</em>
  * <p>
@@ -52,12 +51,16 @@ import aQute.bnd.annotation.spi.ServiceConsumer;
  *
  * @see PropertySource
  */
-@ServiceConsumer(value = PropertySource.class, resolution = Resolution.OPTIONAL, cardinality = Cardinality.MULTIPLE)
+@ServiceConsumer(
+        value = PropertySource.class,
+        resolution = Resolution.OPTIONAL,
+        cardinality = Cardinality.MULTIPLE)
 public final class PropertiesUtil {
 
     private static final String LOG4J_PROPERTIES_FILE_NAME = "log4j2.component.properties";
     private static final String LOG4J_SYSTEM_PROPERTIES_FILE_NAME = "log4j2.system.properties";
-    private static final PropertiesUtil LOG4J_PROPERTIES = new PropertiesUtil(LOG4J_PROPERTIES_FILE_NAME, false);
+    private static final PropertiesUtil LOG4J_PROPERTIES =
+            new PropertiesUtil(LOG4J_PROPERTIES_FILE_NAME, false);
 
     private final Environment environment;
 
@@ -178,11 +181,14 @@ public final class PropertiesUtil {
      * @param defaultValueIfPresent the default value to use if the property is defined but not assigned
      * @return the boolean value of the property or {@code defaultValue} if undefined.
      */
-    public boolean getBooleanProperty(final String name, final boolean defaultValueIfAbsent,
-                                      final boolean defaultValueIfPresent) {
+    public boolean getBooleanProperty(
+            final String name,
+            final boolean defaultValueIfAbsent,
+            final boolean defaultValueIfPresent) {
         final String prop = getStringProperty(name);
-        return prop == null ? defaultValueIfAbsent
-            : prop.isEmpty() ? defaultValueIfPresent : "true".equalsIgnoreCase(prop);
+        return prop == null
+                ? defaultValueIfAbsent
+                : prop.isEmpty() ? defaultValueIfPresent : "true".equalsIgnoreCase(prop);
     }
 
     /**
@@ -194,7 +200,8 @@ public final class PropertiesUtil {
      * @return The value or null if it is not found.
      * @since 2.13.0
      */
-    public Boolean getBooleanProperty(final String[] prefixes, final String key, final Supplier<Boolean> supplier) {
+    public Boolean getBooleanProperty(
+            final String[] prefixes, final String key, final Supplier<Boolean> supplier) {
         for (String prefix : prefixes) {
             if (hasProperty(prefix + key)) {
                 return getBooleanProperty(prefix + key);
@@ -236,8 +243,14 @@ public final class PropertiesUtil {
                 return Charset.forName(mapped);
             }
         }
-        LowLevelLogUtil.log("Unable to get Charset '" + charsetName + "' for property '" + name + "', using default "
-            + defaultValue + " and continuing.");
+        LowLevelLogUtil.log(
+                "Unable to get Charset '"
+                        + charsetName
+                        + "' for property '"
+                        + name
+                        + "', using default "
+                        + defaultValue
+                        + " and continuing.");
         return defaultValue;
     }
 
@@ -288,7 +301,8 @@ public final class PropertiesUtil {
      * @return The value or null if it is not found.
      * @since 2.13.0
      */
-    public Integer getIntegerProperty(final String[] prefixes, final String key, final Supplier<Integer> supplier) {
+    public Integer getIntegerProperty(
+            final String[] prefixes, final String key, final Supplier<Integer> supplier) {
         for (String prefix : prefixes) {
             if (hasProperty(prefix + key)) {
                 return getIntegerProperty(prefix + key, 0);
@@ -324,7 +338,8 @@ public final class PropertiesUtil {
      * @return The value or null if it is not found.
      * @since 2.13.0
      */
-    public Long getLongProperty(final String[] prefixes, final String key, final Supplier<Long> supplier) {
+    public Long getLongProperty(
+            final String[] prefixes, final String key, final Supplier<Long> supplier) {
         for (String prefix : prefixes) {
             if (hasProperty(prefix + key)) {
                 return getLongProperty(prefix + key, 0);
@@ -358,7 +373,8 @@ public final class PropertiesUtil {
      * @return The value or null if it is not found.
      * @since 2.13.0
      */
-    public Duration getDurationProperty(final String[] prefixes, final String key, final Supplier<Duration> supplier) {
+    public Duration getDurationProperty(
+            final String[] prefixes, final String key, final Supplier<Duration> supplier) {
         for (String prefix : prefixes) {
             if (hasProperty(prefix + key)) {
                 return getDurationProperty(prefix + key, null);
@@ -376,7 +392,8 @@ public final class PropertiesUtil {
      * @return The value or null if it is not found.
      * @since 2.13.0
      */
-    public String getStringProperty(final String[] prefixes, final String key, final Supplier<String> supplier) {
+    public String getStringProperty(
+            final String[] prefixes, final String key, final Supplier<String> supplier) {
         for (String prefix : prefixes) {
             final String result = getStringProperty(prefix + key);
             if (result != null) {
@@ -447,27 +464,33 @@ public final class PropertiesUtil {
      */
     private static final class Environment {
 
-        private final Set<PropertySource> sources = new ConcurrentSkipListSet<>(new PropertySource.Comparator());
+        private final Set<PropertySource> sources =
+                new ConcurrentSkipListSet<>(new PropertySource.Comparator());
+
         /**
          * Maps a key to its value or the value of its normalization in the lowest priority source that contains it.
          */
         private final Map<String, String> literal = new ConcurrentHashMap<>();
+
         private final Map<List<CharSequence>, String> tokenized = new ConcurrentHashMap<>();
 
         private Environment(final PropertySource propertySource) {
-            final PropertyFilePropertySource sysProps = new PropertyFilePropertySource(LOG4J_SYSTEM_PROPERTIES_FILE_NAME, false);
+            final PropertyFilePropertySource sysProps =
+                    new PropertyFilePropertySource(LOG4J_SYSTEM_PROPERTIES_FILE_NAME, false);
             try {
-                sysProps.forEach((key, value) -> {
-                    if (System.getProperty(key) == null) {
-                        System.setProperty(key, value);
-                    }
-                });
+                sysProps.forEach(
+                        (key, value) -> {
+                            if (System.getProperty(key) == null) {
+                                System.setProperty(key, value);
+                            }
+                        });
             } catch (SecurityException ex) {
                 // Access to System Properties is restricted so just skip it.
             }
             sources.add(propertySource);
             // We don't log anything on the status logger.
-            ServiceLoaderUtil.loadServices(PropertySource.class, MethodHandles.lookup(), false, false)
+            ServiceLoaderUtil.loadServices(
+                            PropertySource.class, MethodHandles.lookup(), false, false)
                     .forEach(sources::add);
 
             reload();
@@ -486,33 +509,38 @@ public final class PropertiesUtil {
             tokenized.clear();
             // 1. Collects all property keys from enumerable sources.
             final Set<String> keys = new HashSet<>();
-            sources.stream()
-                   .map(PropertySource::getPropertyNames)
-                   .forEach(keys::addAll);
-            // 2. Fills the property caches. Sources with higher priority values don't override the previous ones.
+            sources.stream().map(PropertySource::getPropertyNames).forEach(keys::addAll);
+            // 2. Fills the property caches. Sources with higher priority values don't override the
+            // previous ones.
             keys.stream()
-                .filter(Objects::nonNull)
-                .forEach(key -> {
-                    final List<CharSequence> tokens = PropertySource.Util.tokenize(key);
-                    final boolean hasTokens = !tokens.isEmpty();
-                    sources.forEach(source -> {
-                        if (source.containsProperty(key)) {
-                            final String value = source.getProperty(key);
-                            if (hasTokens) {
-                                tokenized.putIfAbsent(tokens, value);
-                            }
-                        }
-                        if (hasTokens) {
-                            final String normalKey = Objects.toString(source.getNormalForm(tokens), null);
-                            if (normalKey != null && source.containsProperty(normalKey)) {
-                                literal.putIfAbsent(key, source.getProperty(normalKey));
-                            }
-                            else if(source.containsProperty(key)) {
-                                literal.putIfAbsent(key, source.getProperty(key));
-                            }
-                        }
-                    });
-                });
+                    .filter(Objects::nonNull)
+                    .forEach(
+                            key -> {
+                                final List<CharSequence> tokens = PropertySource.Util.tokenize(key);
+                                final boolean hasTokens = !tokens.isEmpty();
+                                sources.forEach(
+                                        source -> {
+                                            if (source.containsProperty(key)) {
+                                                final String value = source.getProperty(key);
+                                                if (hasTokens) {
+                                                    tokenized.putIfAbsent(tokens, value);
+                                                }
+                                            }
+                                            if (hasTokens) {
+                                                final String normalKey =
+                                                        Objects.toString(
+                                                                source.getNormalForm(tokens), null);
+                                                if (normalKey != null
+                                                        && source.containsProperty(normalKey)) {
+                                                    literal.putIfAbsent(
+                                                            key, source.getProperty(normalKey));
+                                                } else if (source.containsProperty(key)) {
+                                                    literal.putIfAbsent(
+                                                            key, source.getProperty(key));
+                                                }
+                                            }
+                                        });
+                            });
         }
 
         private String get(final String key) {
@@ -537,12 +565,17 @@ public final class PropertiesUtil {
 
         private boolean containsKey(final String key) {
             final List<CharSequence> tokens = PropertySource.Util.tokenize(key);
-            return literal.containsKey(key) ||
-                   tokenized.containsKey(tokens) ||
-                   sources.stream().anyMatch(s -> {
-                        final CharSequence normalizedKey = s.getNormalForm(tokens);
-                        return s.containsProperty(key) || normalizedKey != null && s.containsProperty(normalizedKey.toString());
-                   });
+            return literal.containsKey(key)
+                    || tokenized.containsKey(tokens)
+                    || sources.stream()
+                            .anyMatch(
+                                    s -> {
+                                        final CharSequence normalizedKey = s.getNormalForm(tokens);
+                                        return s.containsProperty(key)
+                                                || normalizedKey != null
+                                                        && s.containsProperty(
+                                                                normalizedKey.toString());
+                                    });
         }
     }
 
@@ -561,13 +594,15 @@ public final class PropertiesUtil {
             return subset;
         }
 
-        final String prefixToMatch = prefix.charAt(prefix.length() - 1) != '.' ? prefix + '.' : prefix;
+        final String prefixToMatch =
+                prefix.charAt(prefix.length() - 1) != '.' ? prefix + '.' : prefix;
 
         final List<String> keys = new ArrayList<>();
 
         for (final String key : properties.stringPropertyNames()) {
             if (key.startsWith(prefixToMatch)) {
-                subset.setProperty(key.substring(prefixToMatch.length()), properties.getProperty(key));
+                subset.setProperty(
+                        key.substring(prefixToMatch.length()), properties.getProperty(key));
                 keys.add(key);
             }
         }
@@ -603,8 +638,8 @@ public final class PropertiesUtil {
      * new property maps without the prefix and period in the key
      * @since 2.17.2
      */
-    public static Map<String, Properties> partitionOnCommonPrefixes(final Properties properties,
-            final boolean includeBaseKey) {
+    public static Map<String, Properties> partitionOnCommonPrefixes(
+            final Properties properties, final boolean includeBaseKey) {
         final Map<String, Properties> parts = new ConcurrentHashMap<>();
         for (final String key : properties.stringPropertyNames()) {
             final int idx = key.indexOf('.');
@@ -664,7 +699,9 @@ public final class PropertiesUtil {
                 for (String suffix : timeUnit.descriptions) {
                     if (value.endsWith(suffix)) {
                         temporalUnit = timeUnit.timeUnit;
-                        timeVal = Long.parseLong(value.substring(0, value.length() - suffix.length()));
+                        timeVal =
+                                Long.parseLong(
+                                        value.substring(0, value.length() - suffix.length()));
                     }
                 }
             }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyFilePropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyFilePropertySource.java
@@ -47,5 +47,4 @@ public class PropertyFilePropertySource extends PropertiesPropertySource {
         }
         return props;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.util;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,8 +29,6 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 
 /**
  * A source for global configuration properties.
@@ -50,8 +50,7 @@ public interface PropertySource {
      *
      * @param action action to perform on each key/value pair
      */
-    default void forEach(BiConsumer<String, String> action) {
-    }
+    default void forEach(BiConsumer<String, String> action) {}
 
     /**
      * Returns the list of all property names.
@@ -83,7 +82,6 @@ public interface PropertySource {
         return null;
     }
 
-
     /**
      * For PropertySources that cannot iterate over all the potential properties this provides a direct lookup.
      * @param key The key to search for.
@@ -104,7 +102,9 @@ public interface PropertySource {
 
         @Override
         public int compare(final PropertySource o1, final PropertySource o2) {
-            return Integer.compare(Objects.requireNonNull(o1).getPriority(), Objects.requireNonNull(o2).getPriority());
+            return Integer.compare(
+                    Objects.requireNonNull(o1).getPriority(),
+                    Objects.requireNonNull(o2).getPriority());
         }
     }
 
@@ -114,18 +114,28 @@ public interface PropertySource {
      * @since 2.10.0
      */
     final class Util {
-        private static final Pattern PREFIX_PATTERN = Pattern.compile(
-                // just lookahead for AsyncLogger
-                "(^log4j2?[-._/]?|^org\\.apache\\.logging\\.log4j\\.)|(?=AsyncLogger(Config)?\\.)",
-                Pattern.CASE_INSENSITIVE);
-        private static final Pattern PROPERTY_TOKENIZER = Pattern.compile("([A-Z]*[a-z0-9]+|[A-Z0-9]+)[-._/]?");
-        private static final Map<CharSequence, List<CharSequence>> CACHE = new ConcurrentHashMap<>();
+        private static final Pattern PREFIX_PATTERN =
+                Pattern.compile(
+                        // just lookahead for AsyncLogger
+                        "(^log4j2?[-._/]?|^org\\.apache\\.logging\\.log4j\\.)|(?=AsyncLogger(Config)?\\.)",
+                        Pattern.CASE_INSENSITIVE);
+        private static final Pattern PROPERTY_TOKENIZER =
+                Pattern.compile("([A-Z]*[a-z0-9]+|[A-Z0-9]+)[-._/]?");
+        private static final Map<CharSequence, List<CharSequence>> CACHE =
+                new ConcurrentHashMap<>();
+
         static {
             // Add legacy properties without Log4j prefix
             CACHE.put("disableThreadContext", Arrays.asList("disable", "thread", "context"));
-            CACHE.put("disableThreadContextStack", Arrays.asList("disable", "thread", "context", "stack"));
-            CACHE.put("disableThreadContextMap", Arrays.asList("disable", "thread", "context", "map"));
-            CACHE.put("isThreadContextMapInheritable", Arrays.asList("is", "thread", "context", "map", "inheritable"));
+            CACHE.put(
+                    "disableThreadContextStack",
+                    Arrays.asList("disable", "thread", "context", "stack"));
+            CACHE.put(
+                    "disableThreadContextMap",
+                    Arrays.asList("disable", "thread", "context", "map"));
+            CACHE.put(
+                    "isThreadContextMapInheritable",
+                    Arrays.asList("is", "thread", "context", "map", "inheritable"));
         }
 
         /**
@@ -179,7 +189,6 @@ public interface PropertySource {
             return sb.toString();
         }
 
-        private Util() {
-        }
+        private Util() {}
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderActivator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderActivator.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.util;
 
 import java.util.Hashtable;
-
 import org.apache.logging.log4j.spi.Provider;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -50,5 +49,4 @@ public abstract class ProviderActivator implements BundleActivator {
             providerRegistration.unregister();
         }
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderUtil.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.util;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.URL;
@@ -25,10 +28,6 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-
-import aQute.bnd.annotation.Cardinality;
-import aQute.bnd.annotation.Resolution;
-import aQute.bnd.annotation.spi.ServiceConsumer;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.spi.Provider;
 import org.apache.logging.log4j.status.StatusLogger;
@@ -38,7 +37,10 @@ import org.apache.logging.log4j.status.StatusLogger;
  * container framework, any Log4j Providers not accessible through standard classpath scanning should
  * {@link #loadProvider(java.net.URL, ClassLoader)} a classpath accordingly.
  */
-@ServiceConsumer(value = Provider.class, resolution = Resolution.OPTIONAL, cardinality = Cardinality.MULTIPLE)
+@ServiceConsumer(
+        value = Provider.class,
+        resolution = Resolution.OPTIONAL,
+        cardinality = Cardinality.MULTIPLE)
 public final class ProviderUtil {
 
     /**
@@ -62,7 +64,8 @@ public final class ProviderUtil {
     private static final String[] COMPATIBLE_API_VERSIONS = {"2.6.0"};
     private static final Logger LOGGER = StatusLogger.getLogger();
 
-    // STARTUP_LOCK guards INSTANCE for lazy initialization; this allows the OSGi Activator to pause the startup and
+    // STARTUP_LOCK guards INSTANCE for lazy initialization; this allows the OSGi Activator to pause
+    // the startup and
     // wait for a Provider to be installed. See LOG4J2-373
     private static volatile ProviderUtil instance;
 
@@ -71,7 +74,8 @@ public final class ProviderUtil {
                 .filter(provider -> validVersion(provider.getVersions()))
                 .forEach(PROVIDERS::add);
 
-        for (final LoaderUtil.UrlResource resource : LoaderUtil.findUrlResources(PROVIDER_RESOURCE, false)) {
+        for (final LoaderUtil.UrlResource resource :
+                LoaderUtil.findUrlResources(PROVIDER_RESOURCE, false)) {
             loadProvider(resource.getUrl(), resource.getClassLoader());
         }
     }
@@ -106,7 +110,8 @@ public final class ProviderUtil {
      * @param classLoader null can be used to mark the bootstrap class loader.
      */
     protected static void loadProviders(final ClassLoader classLoader) {
-        ServiceLoaderUtil.loadClassloaderServices(Provider.class, MethodHandles.lookup(), classLoader, true)
+        ServiceLoaderUtil.loadClassloaderServices(
+                        Provider.class, MethodHandles.lookup(), classLoader, true)
                 .filter(provider -> validVersion(provider.getVersions()))
                 .forEach(PROVIDERS::add);
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
@@ -24,7 +24,6 @@ import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
 import org.apache.logging.log4j.util.internal.SerializationUtil;
 
 /**
@@ -56,15 +55,18 @@ public class SortedArrayStringMap implements IndexedStringMap {
      * The default initial capacity.
      */
     private static final int DEFAULT_INITIAL_CAPACITY = 4;
+
     private static final long serialVersionUID = -5748905872274478116L;
     private static final int HASHVAL = 31;
 
-    private static final TriConsumer<String, Object, StringMap> PUT_ALL = (key, value, contextData) -> contextData.putValue(key, value);
+    private static final TriConsumer<String, Object, StringMap> PUT_ALL =
+            (key, value, contextData) -> contextData.putValue(key, value);
 
     /**
      * An empty array instance to share when the table is not inflated.
      */
     private static final String[] EMPTY = Strings.EMPTY_ARRAY;
+
     private static final String FROZEN = "Frozen collection cannot be modified";
 
     private transient String[] keys = EMPTY;
@@ -82,6 +84,7 @@ public class SortedArrayStringMap implements IndexedStringMap {
     // If table == EMPTY_TABLE then this is the initial capacity at which the
     // table will be created when inflated.
     private int threshold;
+
     private boolean immutable;
     private transient boolean iterating;
 
@@ -91,7 +94,8 @@ public class SortedArrayStringMap implements IndexedStringMap {
 
     public SortedArrayStringMap(final int initialCapacity) {
         if (initialCapacity < 0) {
-            throw new IllegalArgumentException("Initial capacity must be at least zero but was " + initialCapacity);
+            throw new IllegalArgumentException(
+                    "Initial capacity must be at least zero but was " + initialCapacity);
         }
         threshold = ceilingNextPowerOfTwo(initialCapacity == 0 ? 1 : initialCapacity);
     }
@@ -480,8 +484,8 @@ public class SortedArrayStringMap implements IndexedStringMap {
         if (size > 0) {
             for (int i = 0; i < size; i++) {
                 s.writeObject(keys[i]);
-                SerializationUtil.writeWrappedObject((values[i] instanceof Serializable) ? (Serializable) values[i] : null,
-                        s);
+                SerializationUtil.writeWrappedObject(
+                        (values[i] instanceof Serializable) ? (Serializable) values[i] : null, s);
             }
         }
     }
@@ -503,7 +507,8 @@ public class SortedArrayStringMap implements IndexedStringMap {
      * Reconstitute the {@code SortedArrayStringMap} instance from a stream (i.e.,
      * deserialize it).
      */
-    private void readObject(final java.io.ObjectInputStream s)  throws IOException, ClassNotFoundException {
+    private void readObject(final java.io.ObjectInputStream s)
+            throws IOException, ClassNotFoundException {
         SerializationUtil.assertFiltered(s);
         // Read in the threshold (ignored), and any hidden stuff
         s.defaultReadObject();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -63,7 +63,8 @@ public final class StackLocator {
         int java7u25CompensationOffset = 0;
         try {
             final Class<?> sunReflectionClass = LoaderUtil.loadClass("sun.reflect.Reflection");
-            getCallerClassMethod = sunReflectionClass.getDeclaredMethod("getCallerClass", int.class);
+            getCallerClassMethod =
+                    sunReflectionClass.getDeclaredMethod("getCallerClass", int.class);
             Object o = getCallerClassMethod.invoke(null, 0);
             getCallerClassMethod.invoke(null, 0);
             if (o == null || o != sunReflectionClass) {
@@ -103,14 +104,14 @@ public final class StackLocator {
         return INSTANCE;
     }
 
-    private StackLocator() {
-    }
+    private StackLocator() {}
 
     // TODO: return Object.class instead of null (though it will have a null ClassLoader)
     // (MS) I believe this would work without any modifications elsewhere, but I could be wrong
 
     @PerformanceSensitive
-    public Class<?> getCallerClass(final Class<?> sentinelClass, final Predicate<Class<?>> callerPredicate) {
+    public Class<?> getCallerClass(
+            final Class<?> sentinelClass, final Predicate<Class<?>> callerPredicate) {
         if (sentinelClass == null) {
             throw new IllegalArgumentException("sentinelClass cannot be null");
         }
@@ -153,7 +154,8 @@ public final class StackLocator {
         if (GET_CALLER_CLASS_METHOD == null) {
             return DEFAULT_CALLER_CLASS;
         }
-        // note that we need to add 1 to the depth value to compensate for this method, but not for the Method.invoke
+        // note that we need to add 1 to the depth value to compensate for this method, but not for
+        // the Method.invoke
         // since Reflection.getCallerClass ignores the call to Method.invoke()
         try {
             return (Class<?>) GET_CALLER_CLASS_METHOD.invoke(null, depth + 1 + JDK_7U25_OFFSET);
@@ -202,7 +204,8 @@ public final class StackLocator {
     // migrated from ThrowableProxy
     @PerformanceSensitive
     public Deque<Class<?>> getCurrentStackTrace() {
-        // benchmarks show that using the SecurityManager is much faster than looping through getCallerClass(int)
+        // benchmarks show that using the SecurityManager is much faster than looping through
+        // getCallerClass(int)
         if (PrivateSecurityManagerStackTraceUtil.isEnabled()) {
             return PrivateSecurityManagerStackTraceUtil.getCurrentStackTrace();
         }
@@ -219,7 +222,8 @@ public final class StackLocator {
         if (fqcnOfLogger == null) {
             return null;
         }
-        // LOG4J2-1029 new Throwable().getStackTrace is faster than Thread.currentThread().getStackTrace().
+        // LOG4J2-1029 new Throwable().getStackTrace is faster than
+        // Thread.currentThread().getStackTrace().
         final StackTraceElement[] stackTrace = new Throwable().getStackTrace();
         boolean found = false;
         for (int i = 0; i < stackTrace.length; i++) {
@@ -236,8 +240,10 @@ public final class StackLocator {
     }
 
     public StackTraceElement getStackTraceElement(final int depth) {
-        // (MS) I tested the difference between using Throwable.getStackTrace() and Thread.getStackTrace(), and
-        // the version using Throwable was surprisingly faster! at least on Java 1.8. See ReflectionBenchmark.
+        // (MS) I tested the difference between using Throwable.getStackTrace() and
+        // Thread.getStackTrace(), and
+        // the version using Throwable was surprisingly faster! at least on Java 1.8. See
+        // ReflectionBenchmark.
         int i = 0;
         for (final StackTraceElement element : new Throwable().getStackTrace()) {
             if (isValid(element)) {
@@ -265,7 +271,8 @@ public final class StackLocator {
         // Method.invoke
         // InvocationHandler.invoke
         // Constructor.newInstance
-        if (cn.startsWith("java.lang.reflect.") && (mn.equals("invoke") || mn.equals("newInstance"))) {
+        if (cn.startsWith("java.lang.reflect.")
+                && (mn.equals("invoke") || mn.equals("newInstance"))) {
             return false;
         }
         // ignore use of Java 1.9+ reflection classes

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.util;
 import java.util.Deque;
 import java.util.NoSuchElementException;
 import java.util.function.Predicate;
-
 import org.apache.logging.log4j.status.StatusLogger;
 
 /**
@@ -33,8 +32,7 @@ public final class StackLocatorUtil {
         stackLocator = StackLocator.getInstance();
     }
 
-    private StackLocatorUtil() {
-    }
+    private StackLocatorUtil() {}
 
     // TODO: return Object.class instead of null (though it will have a null ClassLoader)
     // (MS) I believe this would work without any modifications elsewhere, but I could be wrong
@@ -100,7 +98,8 @@ public final class StackLocatorUtil {
      * @return the first matching class after <code>sentinelClass</code> is found.
      */
     @PerformanceSensitive
-    public static Class<?> getCallerClass(final Class<?> sentinelClass, final Predicate<Class<?>> callerPredicate) {
+    public static Class<?> getCallerClass(
+            final Class<?> sentinelClass, final Predicate<Class<?>> callerPredicate) {
         return stackLocator.getCallerClass(sentinelClass, callerPredicate);
     }
 
@@ -122,7 +121,8 @@ public final class StackLocatorUtil {
         } catch (NoSuchElementException ex) {
             if (!errorLogged) {
                 errorLogged = true;
-                StatusLogger.getLogger().warn("Unable to locate stack trace element for {}", fqcnOfLogger, ex);
+                StatusLogger.getLogger()
+                        .warn("Unable to locate stack trace element for {}", fqcnOfLogger, ex);
             }
             return null;
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.util;
 
-import java.util.Map.Entry;
-
 import static java.lang.Character.toLowerCase;
+
+import java.util.Map.Entry;
 
 /**
  * <em>Consider this class private.</em>
@@ -32,21 +32,20 @@ public final class StringBuilders {
         Class<?> clazz;
         try {
             clazz = Class.forName("java.sql.Time");
-        } catch(ClassNotFoundException ex) {
+        } catch (ClassNotFoundException ex) {
             clazz = null;
         }
         timeClass = clazz;
 
         try {
             clazz = Class.forName("java.sql.Date");
-        } catch(ClassNotFoundException ex) {
+        } catch (ClassNotFoundException ex) {
             clazz = null;
         }
         dateClass = clazz;
     }
 
-    private StringBuilders() {
-    }
+    private StringBuilders() {}
 
     /**
      * Appends in the following format: double quoted value.
@@ -66,7 +65,8 @@ public final class StringBuilders {
      * @param entry a map entry
      * @return {@code key="value"}
      */
-    public static StringBuilder appendKeyDqValue(final StringBuilder sb, final Entry<String, String> entry) {
+    public static StringBuilder appendKeyDqValue(
+            final StringBuilder sb, final Entry<String, String> entry) {
         return appendKeyDqValue(sb, entry.getKey(), entry.getValue());
     }
 
@@ -78,8 +78,13 @@ public final class StringBuilders {
      * @param value a value
      * @return the specified StringBuilder
      */
-    public static StringBuilder appendKeyDqValue(final StringBuilder sb, final String key, final Object value) {
-        return sb.append(key).append(Chars.EQ).append(Chars.DQUOTE).append(value).append(Chars.DQUOTE);
+    public static StringBuilder appendKeyDqValue(
+            final StringBuilder sb, final String key, final Object value) {
+        return sb.append(key)
+                .append(Chars.EQ)
+                .append(Chars.DQUOTE)
+                .append(value)
+                .append(Chars.DQUOTE);
     }
 
     /**
@@ -102,7 +107,9 @@ public final class StringBuilders {
             ((StringBuilderFormattable) obj).formatTo(stringBuilder);
         } else if (obj instanceof CharSequence) {
             stringBuilder.append((CharSequence) obj);
-        } else if (obj instanceof Integer) { // LOG4J2-1437 unbox auto-boxed primitives to avoid calling toString()
+        } else if (obj
+                instanceof
+                Integer) { // LOG4J2-1437 unbox auto-boxed primitives to avoid calling toString()
             stringBuilder.append(((Integer) obj).intValue());
         } else if (obj instanceof Long) {
             stringBuilder.append(((Long) obj).longValue());
@@ -127,8 +134,8 @@ public final class StringBuilders {
     }
 
     /*
-        Check to see if obj is an instance of java.sql.Time without requiring the java.sql module.
-     */
+       Check to see if obj is an instance of java.sql.Time without requiring the java.sql module.
+    */
     private static boolean isTime(final Object obj) {
         return timeClass != null && timeClass.isAssignableFrom(obj.getClass());
     }
@@ -152,8 +159,13 @@ public final class StringBuilders {
      * @param rightLength length of the section in the right CharSequence
      * @return true if equal, false otherwise
      */
-    public static boolean equals(final CharSequence left, final int leftOffset, final int leftLength,
-                                    final CharSequence right, final int rightOffset, final int rightLength) {
+    public static boolean equals(
+            final CharSequence left,
+            final int leftOffset,
+            final int leftLength,
+            final CharSequence right,
+            final int rightOffset,
+            final int rightLength) {
         if (leftLength == rightLength) {
             for (int i = 0; i < rightLength; i++) {
                 if (left.charAt(i + leftOffset) != right.charAt(i + rightOffset)) {
@@ -177,11 +189,17 @@ public final class StringBuilders {
      * @param rightLength length of the section in the right CharSequence
      * @return true if equal ignoring case, false otherwise
      */
-    public static boolean equalsIgnoreCase(final CharSequence left, final int leftOffset, final int leftLength,
-                                              final CharSequence right, final int rightOffset, final int rightLength) {
+    public static boolean equalsIgnoreCase(
+            final CharSequence left,
+            final int leftOffset,
+            final int leftLength,
+            final CharSequence right,
+            final int rightOffset,
+            final int rightLength) {
         if (leftLength == rightLength) {
             for (int i = 0; i < rightLength; i++) {
-                if (toLowerCase(left.charAt(i + leftOffset)) != toLowerCase(right.charAt(i + rightOffset))) {
+                if (toLowerCase(left.charAt(i + leftOffset))
+                        != toLowerCase(right.charAt(i + rightOffset))) {
                     return false;
                 }
             }
@@ -275,7 +293,8 @@ public final class StringBuilders {
         }
     }
 
-    private static int escapeAndDecrement(final StringBuilder toAppendTo, int lastPos, final char c) {
+    private static int escapeAndDecrement(
+            final StringBuilder toAppendTo, int lastPos, final char c) {
         toAppendTo.setCharAt(lastPos--, c);
         toAppendTo.setCharAt(lastPos--, '\\');
         return lastPos;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -27,12 +27,14 @@ import java.util.Objects;
  */
 public final class Strings {
 
-    private static final ThreadLocal<StringBuilder> tempStr = ThreadLocal.withInitial(StringBuilder::new);
+    private static final ThreadLocal<StringBuilder> tempStr =
+            ThreadLocal.withInitial(StringBuilder::new);
 
     /**
      * The empty string.
      */
     public static final String EMPTY = "";
+
     private static final String COMMA_DELIMITED_RE = "\\s*,\\s*";
 
     /**
@@ -44,8 +46,8 @@ public final class Strings {
      * OS-dependent line separator, defaults to {@code "\n"} if the system property {@code ""line.separator"} cannot be
      * read.
      */
-    public static final String LINE_SEPARATOR = SystemPropertiesPropertySource.getSystemProperty("line.separator",
-            "\n");
+    public static final String LINE_SEPARATOR =
+            SystemPropertiesPropertySource.getSystemProperty("line.separator", "\n");
 
     /**
      * Returns a double quoted string.
@@ -346,5 +348,4 @@ public final class Strings {
             sb.setLength(0);
         }
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/SystemPropertiesPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/SystemPropertiesPropertySource.java
@@ -16,12 +16,11 @@
  */
 package org.apache.logging.log4j.util;
 
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceProvider;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Properties;
-
-import aQute.bnd.annotation.Resolution;
-import aQute.bnd.annotation.spi.ServiceProvider;
 
 /**
  * PropertySource backed by the current system properties. Other than having a
@@ -107,5 +106,4 @@ public class SystemPropertiesPropertySource implements PropertySource {
     public boolean containsProperty(final String key) {
         return getProperty(key) != null;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Timer.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Timer.java
@@ -24,33 +24,36 @@ import java.text.DecimalFormat;
  * so long as all the timer methods are called on the same thread in which it was started. Calling start on
  * multiple threads will cause the times to be aggregated.
  */
-public class Timer implements Serializable, StringBuilderFormattable
-{
+public class Timer implements Serializable, StringBuilderFormattable {
     private static final long serialVersionUID = 9175191792439630013L;
 
-    private final String name;        // The timer's name
+    private final String name; // The timer's name
+
     public enum Status {
-        Started, Stopped, Paused
+        Started,
+        Stopped,
+        Paused
     }
+
     private Status status; // The timer's status
-    private long elapsedTime;         // The elapsed time
+    private long elapsedTime; // The elapsed time
     private final int iterations;
     private static long NANO_PER_SECOND = 1000000000L;
     private static long NANO_PER_MINUTE = NANO_PER_SECOND * 60;
     private static long NANO_PER_HOUR = NANO_PER_MINUTE * 60;
-    private ThreadLocal<Long> startTime = new ThreadLocal<Long>() {
-            @Override protected Long initialValue() {
-                return 0L;
-            }
-    };
-
+    private ThreadLocal<Long> startTime =
+            new ThreadLocal<Long>() {
+                @Override
+                protected Long initialValue() {
+                    return 0L;
+                }
+            };
 
     /**
      * Constructor.
      * @param name the timer name.
      */
-    public Timer(final String name)
-    {
+    public Timer(final String name) {
         this(name, 0);
     }
 
@@ -59,8 +62,7 @@ public class Timer implements Serializable, StringBuilderFormattable
      *
      * @param name the timer name.
      */
-    public Timer(final String name, final int iterations)
-    {
+    public Timer(final String name, final int iterations) {
         this.name = name;
         status = Status.Stopped;
         this.iterations = (iterations > 0) ? iterations : 0;
@@ -69,8 +71,7 @@ public class Timer implements Serializable, StringBuilderFormattable
     /**
      * Start the timer.
      */
-    public synchronized void start()
-    {
+    public synchronized void start() {
         startTime.set(System.nanoTime());
         elapsedTime = 0;
         status = Status.Started;
@@ -87,8 +88,7 @@ public class Timer implements Serializable, StringBuilderFormattable
     /**
      * Stop the timer.
      */
-    public synchronized String stop()
-    {
+    public synchronized String stop() {
         elapsedTime += System.nanoTime() - startTime.get();
         startTime.set(0L);
         status = Status.Stopped;
@@ -98,8 +98,7 @@ public class Timer implements Serializable, StringBuilderFormattable
     /**
      * Pause the timer.
      */
-    public synchronized void pause()
-    {
+    public synchronized void pause() {
         elapsedTime += System.nanoTime() - startTime.get();
         startTime.set(0L);
         status = Status.Paused;
@@ -108,8 +107,7 @@ public class Timer implements Serializable, StringBuilderFormattable
     /**
      * Resume the timer.
      */
-    public synchronized void resume()
-    {
+    public synchronized void resume() {
         startTime.set(System.nanoTime());
         status = Status.Started;
     }
@@ -118,8 +116,7 @@ public class Timer implements Serializable, StringBuilderFormattable
      * Accessor for the name.
      * @return the timer's name.
      */
-    public String getName()
-    {
+    public String getName() {
         return name;
     }
 
@@ -128,8 +125,7 @@ public class Timer implements Serializable, StringBuilderFormattable
      *
      * @return the elapsed time.
      */
-    public long getElapsedTime()
-    {
+    public long getElapsedTime() {
         return elapsedTime / 1000000;
     }
 
@@ -138,8 +134,7 @@ public class Timer implements Serializable, StringBuilderFormattable
      *
      * @return the elapsed time.
      */
-    public long getElapsedNanoTime()
-    {
+    public long getElapsedNanoTime() {
         return elapsedTime;
     }
 
@@ -148,8 +143,7 @@ public class Timer implements Serializable, StringBuilderFormattable
      * Resume).
      * @return the string representing the last operation performed.
      */
-    public Status getStatus()
-    {
+    public Status getStatus() {
         return status;
     }
 
@@ -157,8 +151,7 @@ public class Timer implements Serializable, StringBuilderFormattable
      * Returns the String representation of the timer based upon its current state
      */
     @Override
-    public String toString()
-    {
+    public String toString() {
         final StringBuilder result = new StringBuilder();
         formatTo(result);
         return result.toString();
@@ -278,5 +271,4 @@ public class Timer implements Serializable, StringBuilderFormattable
         result = 29 * result + (int) (elapsedTime ^ (elapsedTime >>> 32));
         return result;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
@@ -50,7 +50,8 @@ public class Unbox {
     private static final Logger LOGGER = StatusLogger.getLogger();
     private static final int BITS_PER_INT = 32;
     private static final int RINGBUFFER_MIN_SIZE = 32;
-    private static final int RINGBUFFER_SIZE = calculateRingBufferSize("log4j.unbox.ringbuffer.size");
+    private static final int RINGBUFFER_SIZE =
+            calculateRingBufferSize("log4j.unbox.ringbuffer.size");
     private static final int MASK = RINGBUFFER_SIZE - 1;
 
     /**
@@ -99,6 +100,7 @@ public class Unbox {
     private static class State {
         private final StringBuilder[] ringBuffer = new StringBuilder[RINGBUFFER_SIZE];
         private int current;
+
         State() {
             for (int i = 0; i < ringBuffer.length; i++) {
                 ringBuffer[i] = new StringBuilder(21);
@@ -120,6 +122,7 @@ public class Unbox {
             return false;
         }
     }
+
     private static ThreadLocal<State> threadLocalState = new ThreadLocal<>();
     private static WebSafeState webSafeState = new WebSafeState();
 
@@ -128,18 +131,25 @@ public class Unbox {
     }
 
     private static int calculateRingBufferSize(final String propertyName) {
-        final String userPreferredRBSize = PropertiesUtil.getProperties().getStringProperty(propertyName,
-                String.valueOf(RINGBUFFER_MIN_SIZE));
+        final String userPreferredRBSize =
+                PropertiesUtil.getProperties()
+                        .getStringProperty(propertyName, String.valueOf(RINGBUFFER_MIN_SIZE));
         try {
             int size = Integer.parseInt(userPreferredRBSize.trim());
             if (size < RINGBUFFER_MIN_SIZE) {
                 size = RINGBUFFER_MIN_SIZE;
-                LOGGER.warn("Invalid {} {}, using minimum size {}.", propertyName, userPreferredRBSize,
+                LOGGER.warn(
+                        "Invalid {} {}, using minimum size {}.",
+                        propertyName,
+                        userPreferredRBSize,
                         RINGBUFFER_MIN_SIZE);
             }
             return ceilingNextPowerOfTwo(size);
         } catch (final Exception ex) {
-            LOGGER.warn("Invalid {} {}, using default size {}.", propertyName, userPreferredRBSize,
+            LOGGER.warn(
+                    "Invalid {} {}, using default size {}.",
+                    propertyName,
+                    userPreferredRBSize,
                     RINGBUFFER_MIN_SIZE);
             return RINGBUFFER_MIN_SIZE;
         }
@@ -263,7 +273,9 @@ public class Unbox {
     }
 
     private static StringBuilder getSB() {
-        return Constants.ENABLE_THREADLOCALS ? getState().getStringBuilder() : webSafeState.getStringBuilder();
+        return Constants.ENABLE_THREADLOCALS
+                ? getState().getStringBuilder()
+                : webSafeState.getStringBuilder();
     }
 
     /** For testing. */

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.util.internal;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -28,8 +29,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.FilteredObjectInputStream;
 
@@ -38,7 +37,8 @@ import org.apache.logging.log4j.util.FilteredObjectInputStream;
  */
 public final class SerializationUtil {
 
-    private static final String DEFAULT_FILTER_CLASS= "org.apache.logging.log4j.util.internal.DefaultObjectInputFilter";
+    private static final String DEFAULT_FILTER_CLASS =
+            "org.apache.logging.log4j.util.internal.DefaultObjectInputFilter";
     private static final Method setObjectInputFilter;
     private static final Method getObjectInputFilter;
     private static final Method newObjectInputFilter;
@@ -60,7 +60,8 @@ public final class SerializationUtil {
                 final Class<?> clazz = Class.forName(DEFAULT_FILTER_CLASS);
                 methods = clazz.getMethods();
                 for (final Method method : methods) {
-                    if (method.getName().equals("newInstance") && Modifier.isStatic(method.getModifiers())) {
+                    if (method.getName().equals("newInstance")
+                            && Modifier.isStatic(method.getModifiers())) {
                         newMethod = method;
                         break;
                     }
@@ -74,25 +75,26 @@ public final class SerializationUtil {
         getObjectInputFilter = getMethod;
     }
 
-    public static final List<String> REQUIRED_JAVA_CLASSES = Arrays.asList(
-            "java.math.BigDecimal",
-            "java.math.BigInteger",
-            // for Message delegate
-            "java.rmi.MarshalledObject",
-            "[B",
-            // for MessagePatternAnalysis
-            "[I"
-    );
+    public static final List<String> REQUIRED_JAVA_CLASSES =
+            Arrays.asList(
+                    "java.math.BigDecimal",
+                    "java.math.BigInteger",
+                    // for Message delegate
+                    "java.rmi.MarshalledObject",
+                    "[B",
+                    // for MessagePatternAnalysis
+                    "[I");
 
-    public static final List<String> REQUIRED_JAVA_PACKAGES = Arrays.asList(
-            "java.lang.",
-            "java.time",
-            "java.util.",
-            "org.apache.logging.log4j.",
-            "[Lorg.apache.logging.log4j."
-    );
+    public static final List<String> REQUIRED_JAVA_PACKAGES =
+            Arrays.asList(
+                    "java.lang.",
+                    "java.time",
+                    "java.util.",
+                    "org.apache.logging.log4j.",
+                    "[Lorg.apache.logging.log4j.");
 
-    public static void writeWrappedObject(final Serializable obj, final ObjectOutputStream out) throws IOException {
+    public static void writeWrappedObject(final Serializable obj, final ObjectOutputStream out)
+            throws IOException {
         final ByteArrayOutputStream bout = new ByteArrayOutputStream();
         try (final ObjectOutputStream oos = new ObjectOutputStream(bout)) {
             oos.writeObject(obj);
@@ -103,7 +105,8 @@ public final class SerializationUtil {
 
     @SuppressFBWarnings(
             value = "OBJECT_DESERIALIZATION",
-            justification = "Object deserialization uses either Java 9 native filter or our custom filter to limit the kinds of classes deserialized.")
+            justification =
+                    "Object deserialization uses either Java 9 native filter or our custom filter to limit the kinds of classes deserialized.")
     public static Object readWrappedObject(final ObjectInputStream in)
             throws IOException, ClassNotFoundException {
         assertFiltered(in);
@@ -111,7 +114,9 @@ public final class SerializationUtil {
         final ByteArrayInputStream bin = new ByteArrayInputStream(data);
         final ObjectInputStream ois;
         if (in instanceof FilteredObjectInputStream) {
-            ois = new FilteredObjectInputStream(bin, ((FilteredObjectInputStream) in).getAllowedClasses());
+            ois =
+                    new FilteredObjectInputStream(
+                            bin, ((FilteredObjectInputStream) in).getAllowedClasses());
         } else {
             try {
                 final Object obj = getObjectInputFilter.invoke(in);
@@ -134,7 +139,8 @@ public final class SerializationUtil {
 
     public static void assertFiltered(final java.io.ObjectInputStream stream) {
         if (!(stream instanceof FilteredObjectInputStream) && setObjectInputFilter == null) {
-            throw new IllegalArgumentException("readObject requires a FilteredObjectInputStream or an ObjectInputStream that accepts an ObjectInputFilter");
+            throw new IllegalArgumentException(
+                    "readObject requires a FilteredObjectInputStream or an ObjectInputStream that accepts an ObjectInputFilter");
         }
     }
 


### PR DESCRIPTION
This PR evaluates the effect of the following Spotless configuration on `log4j-api`:
```xml
<java>
  <googleJavaFormat>
    <formatJavadoc>false</formatJavadoc>
    <style>AOSP</style>
    <version>1.18.1</version>
  </googleJavaFormat>
</java>
```

The `log4j-api` source code is about 33k LOCs.