### PR TITLE
Evaluate Palantir Java Format

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/CloseableThreadContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/CloseableThreadContext.java
@@ -36,8 +36,7 @@ import java.util.Map;
  */
 public class CloseableThreadContext {
 
-    private CloseableThreadContext() {
-    }
+    private CloseableThreadContext() {}
 
     /**
      * Pushes new diagnostic context information on to the Thread Context Stack. The information will be popped off when
@@ -105,8 +104,7 @@ public class CloseableThreadContext {
         private int pushCount = 0;
         private final Map<String, String> originalValues = new HashMap<>();
 
-        private Instance() {
-        }
+        private Instance() {}
 
         /**
          * Pushes new diagnostic context information on to the Thread Context Stack.
@@ -205,7 +203,9 @@ public class CloseableThreadContext {
         }
 
         private void closeMap() {
-            for (final Iterator<Map.Entry<String, String>> it = originalValues.entrySet().iterator(); it.hasNext();) {
+            for (final Iterator<Map.Entry<String, String>> it =
+                            originalValues.entrySet().iterator();
+                    it.hasNext(); ) {
                 final Map.Entry<String, String> entry = it.next();
                 final String key = entry.getKey();
                 final String originalValue = entry.getValue();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
@@ -16,15 +16,14 @@
  */
 package org.apache.logging.log4j;
 
+import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
+
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
 import org.apache.logging.log4j.spi.StandardLevel;
 import org.apache.logging.log4j.util.Strings;
-
-import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
  * Levels used for identifying the severity of an event. Levels are organized from most specific to least:
@@ -218,6 +217,7 @@ public final class Level implements Comparable<Level>, Serializable {
     public Level clone() throws CloneNotSupportedException {
         throw new CloneNotSupportedException();
     }
+
     // CHECKSTYLE:ON
 
     @Override

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
@@ -19,14 +19,13 @@ package org.apache.logging.log4j;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.Supplier;
 
-
 /**
  * Interface for constructing log events before logging them. Instances of LogBuilders should only be created
  * by calling one of the Logger methods that return a LogBuilder.
  */
 public interface LogBuilder {
     /** NOOP Logbuilder */
-    LogBuilder NOOP = new LogBuilder() { };
+    LogBuilder NOOP = new LogBuilder() {};
 
     /**
      * Includes a Marker in the log event. Interface default method does nothing.
@@ -68,15 +67,13 @@ public interface LogBuilder {
      * Causes all the data collected to be logged along with the message. Interface default method does nothing.
      * @param message The message to log.
      */
-    default void log(CharSequence message) {
-    }
+    default void log(CharSequence message) {}
 
     /**
      * Causes all the data collected to be logged along with the message. Interface default method does nothing.
      * @param message The message to log.
      */
-    default void log(String message) {
-    }
+    default void log(String message) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -86,8 +83,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object... params) {
-    }
+    default void log(String message, Object... params) {}
 
     /**
      * Causes all the data collected to be logged along with the message and parameters.
@@ -95,22 +91,19 @@ public interface LogBuilder {
      * @param message The message.
      * @param params Parameters to the message.
      */
-    default void log(String message, Supplier<?>... params) {
-    }
+    default void log(String message, Supplier<?>... params) {}
 
     /**
      * Causes all the data collected to be logged along with the message. Interface default method does nothing.
      * @param message The message to log.
      */
-    default void log(Message message) {
-    }
+    default void log(Message message) {}
 
     /**
      * Causes all the data collected to be logged along with the message. Interface default method does nothing.
      * @param messageSupplier The supplier of the message to log.
      */
-    default void log(Supplier<Message> messageSupplier) {
-    }
+    default void log(Supplier<Message> messageSupplier) {}
 
     /**
      * Causes all the data collected to be logged along with the message.
@@ -127,8 +120,7 @@ public interface LogBuilder {
      * Causes all the data collected to be logged along with the message. Interface default method does nothing.
      * @param message The message to log.
      */
-    default void log(Object message) {
-    }
+    default void log(Object message) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -138,8 +130,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0) {
-    }
+    default void log(String message, Object p0) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -150,8 +141,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1) {
-    }
+    default void log(String message, Object p0, Object p1) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -163,8 +153,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2) {
-    }
+    default void log(String message, Object p0, Object p1, Object p2) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -177,8 +166,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3) {
-    }
+    default void log(String message, Object p0, Object p1, Object p2, Object p3) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -192,8 +180,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
-    }
+    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -208,8 +195,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
-    }
+    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {}
 
     /**
      * Logs a message with parameters.
@@ -225,8 +211,7 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
-    }
+    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -243,9 +228,8 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7) {
-    }
+    default void log(
+            String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -263,9 +247,17 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8) {
-    }
+    default void log(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8) {}
 
     /**
      * Logs a message with parameters. Interface default method does nothing.
@@ -284,13 +276,21 @@ public interface LogBuilder {
      *
      * @see org.apache.logging.log4j.util.Unbox
      */
-    default void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9) {
-    }
+    default void log(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9) {}
 
     /**
      * Causes all the data collected to be logged. Default implementatoin does nothing.
      */
-    default void log() {
-    }
+    default void log() {}
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
@@ -20,7 +20,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
-
 import org.apache.logging.log4j.internal.LogManagerStatus;
 import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.message.StringFormatterMessageFactory;
@@ -85,7 +84,8 @@ public class LogManager {
 
         if (factory == null) {
             final SortedMap<Integer, LoggerContextFactory> factories = new TreeMap<>();
-            // note that the following initial call to ProviderUtil may block until a Provider has been installed when
+            // note that the following initial call to ProviderUtil may block until a Provider has
+            // been installed when
             // running in an OSGi environment
             if (ProviderUtil.hasProviders()) {
                 for (final Provider provider : ProviderUtil.getProviders()) {
@@ -94,8 +94,11 @@ public class LogManager {
                         try {
                             factories.put(provider.getPriority(), factoryClass.newInstance());
                         } catch (final Exception e) {
-                            LOGGER.error("Unable to create class {} specified in provider URL {}",
-                                    factoryClass.getName(), provider.getUrl(), e);
+                            LOGGER.error(
+                                    "Unable to create class {} specified in provider URL {}",
+                                    factoryClass.getName(),
+                                    provider.getUrl(),
+                                    e);
                         }
                     }
                 }
@@ -109,13 +112,13 @@ public class LogManager {
                 } else {
                     final StringBuilder sb = new StringBuilder("Multiple logging implementations found: \n");
                     for (final Map.Entry<Integer, LoggerContextFactory> entry : factories.entrySet()) {
-                        sb.append("Factory: ").append(entry.getValue().getClass().getName());
+                        sb.append("Factory: ")
+                                .append(entry.getValue().getClass().getName());
                         sb.append(", Weighting: ").append(entry.getKey()).append('\n');
                     }
                     factory = factories.get(factories.lastKey());
                     sb.append("Using factory: ").append(factory.getClass().getName());
                     LOGGER.warn(sb.toString());
-
                 }
             } else {
                 LOGGER.error("Log4j2 could not find a logging implementation. "
@@ -129,8 +132,7 @@ public class LogManager {
     /**
      * Prevents instantiation
      */
-    protected LogManager() {
-    }
+    protected LogManager() {}
 
     /**
      * Detects if a Logger with the specified name exists. This is a convenience method for porting from version 1.
@@ -212,8 +214,8 @@ public class LogManager {
      * @param externalContext An external context (such as a ServletContext) to be associated with the LoggerContext.
      * @return a LoggerContext.
      */
-    public static LoggerContext getContext(final ClassLoader loader, final boolean currentContext,
-            final Object externalContext) {
+    public static LoggerContext getContext(
+            final ClassLoader loader, final boolean currentContext, final Object externalContext) {
         try {
             return factory.getContext(FQCN, loader, externalContext, currentContext);
         } catch (final IllegalStateException ex) {
@@ -234,14 +236,14 @@ public class LogManager {
      * @param configLocation The URI for the configuration to use.
      * @return a LoggerContext.
      */
-    public static LoggerContext getContext(final ClassLoader loader, final boolean currentContext,
-            final URI configLocation) {
+    public static LoggerContext getContext(
+            final ClassLoader loader, final boolean currentContext, final URI configLocation) {
         try {
             return factory.getContext(FQCN, loader, null, currentContext, configLocation, null);
         } catch (final IllegalStateException ex) {
             LOGGER.warn(ex.getMessage() + " Using SimpleLogger");
-            return SimpleLoggerContextFactory.INSTANCE.getContext(FQCN, loader, null, currentContext, configLocation,
-                    null);
+            return SimpleLoggerContextFactory.INSTANCE.getContext(
+                    FQCN, loader, null, currentContext, configLocation, null);
         }
     }
 
@@ -258,14 +260,17 @@ public class LogManager {
      * @param configLocation The URI for the configuration to use.
      * @return a LoggerContext.
      */
-    public static LoggerContext getContext(final ClassLoader loader, final boolean currentContext,
-            final Object externalContext, final URI configLocation) {
+    public static LoggerContext getContext(
+            final ClassLoader loader,
+            final boolean currentContext,
+            final Object externalContext,
+            final URI configLocation) {
         try {
             return factory.getContext(FQCN, loader, externalContext, currentContext, configLocation, null);
         } catch (final IllegalStateException ex) {
             LOGGER.warn(ex.getMessage() + " Using SimpleLogger");
-            return SimpleLoggerContextFactory.INSTANCE.getContext(FQCN, loader, externalContext, currentContext,
-                    configLocation, null);
+            return SimpleLoggerContextFactory.INSTANCE.getContext(
+                    FQCN, loader, externalContext, currentContext, configLocation, null);
         }
     }
 
@@ -283,14 +288,18 @@ public class LogManager {
      * @param name The LoggerContext name.
      * @return a LoggerContext.
      */
-    public static LoggerContext getContext(final ClassLoader loader, final boolean currentContext,
-            final Object externalContext, final URI configLocation, final String name) {
+    public static LoggerContext getContext(
+            final ClassLoader loader,
+            final boolean currentContext,
+            final Object externalContext,
+            final URI configLocation,
+            final String name) {
         try {
             return factory.getContext(FQCN, loader, externalContext, currentContext, configLocation, name);
         } catch (final IllegalStateException ex) {
             LOGGER.warn(ex.getMessage() + " Using SimpleLogger");
-            return SimpleLoggerContextFactory.INSTANCE.getContext(FQCN, loader, externalContext, currentContext,
-                    configLocation, name);
+            return SimpleLoggerContextFactory.INSTANCE.getContext(
+                    FQCN, loader, externalContext, currentContext, configLocation, name);
         }
     }
 
@@ -325,8 +334,8 @@ public class LogManager {
      *            be returned. If true then only a single LoggerContext will be returned.
      * @return a LoggerContext.
      */
-    protected static LoggerContext getContext(final String fqcn, final ClassLoader loader,
-            final boolean currentContext) {
+    protected static LoggerContext getContext(
+            final String fqcn, final ClassLoader loader, final boolean currentContext) {
         try {
             return factory.getContext(fqcn, loader, null, currentContext);
         } catch (final IllegalStateException ex) {
@@ -334,7 +343,6 @@ public class LogManager {
             return SimpleLoggerContextFactory.INSTANCE.getContext(fqcn, loader, null, currentContext);
         }
     }
-
 
     /**
      * Returns a LoggerContext
@@ -350,8 +358,12 @@ public class LogManager {
      * @param name The LoggerContext name.
      * @return a LoggerContext.
      */
-    protected static LoggerContext getContext(final String fqcn, final ClassLoader loader,
-                                          final boolean currentContext, final URI configLocation, final String name) {
+    protected static LoggerContext getContext(
+            final String fqcn,
+            final ClassLoader loader,
+            final boolean currentContext,
+            final URI configLocation,
+            final String name) {
         try {
             return factory.getContext(fqcn, loader, null, currentContext, configLocation, name);
         } catch (final IllegalStateException ex) {
@@ -411,7 +423,6 @@ public class LogManager {
     public static void shutdown(final boolean currentContext, final boolean allContexts) {
         factory.shutdown(FQCN, null, currentContext, allContexts);
     }
-
 
     /**
      * Shutdown the logging system if the logging system supports it.
@@ -497,8 +508,8 @@ public class LogManager {
      * @see StringFormatterMessageFactory
      */
     public static Logger getFormatterLogger(final Class<?> clazz) {
-        return getLogger(clazz != null ? clazz : StackLocatorUtil.getCallerClass(2),
-                StringFormatterMessageFactory.INSTANCE);
+        return getLogger(
+                clazz != null ? clazz : StackLocatorUtil.getCallerClass(2), StringFormatterMessageFactory.INSTANCE);
     }
 
     /**
@@ -529,7 +540,8 @@ public class LogManager {
      * @see StringFormatterMessageFactory
      */
     public static Logger getFormatterLogger(final Object value) {
-        return getLogger(value != null ? value.getClass() : StackLocatorUtil.getCallerClass(2),
+        return getLogger(
+                value != null ? value.getClass() : StackLocatorUtil.getCallerClass(2),
                 StringFormatterMessageFactory.INSTANCE);
     }
 
@@ -560,8 +572,9 @@ public class LogManager {
      * @see StringFormatterMessageFactory
      */
     public static Logger getFormatterLogger(final String name) {
-        return name == null ? getFormatterLogger(StackLocatorUtil.getCallerClass(2)) : getLogger(name,
-                StringFormatterMessageFactory.INSTANCE);
+        return name == null
+                ? getFormatterLogger(StackLocatorUtil.getCallerClass(2))
+                : getLogger(name, StringFormatterMessageFactory.INSTANCE);
     }
 
     private static Class<?> callerClass(final Class<?> clazz) {
@@ -676,8 +689,9 @@ public class LogManager {
      * @throws UnsupportedOperationException if {@code name} is {@code null} and the calling class cannot be determined.
      */
     public static Logger getLogger(final String name, final MessageFactory messageFactory) {
-        return name != null ? getContext(false).getLogger(name, messageFactory) : getLogger(
-                StackLocatorUtil.getCallerClass(2), messageFactory);
+        return name != null
+                ? getContext(false).getLogger(name, messageFactory)
+                : getLogger(StackLocatorUtil.getCallerClass(2), messageFactory);
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -439,8 +439,8 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6);
+    void debug(
+            Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
 
     /**
      * Logs a message with parameters at debug level.
@@ -456,7 +456,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void debug(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -474,8 +483,18 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void debug(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at debug level.
@@ -493,8 +512,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void debug(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at debug level.
@@ -602,7 +632,16 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void debug(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -620,8 +659,18 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void debug(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs entry to a method. Used when the method in question has no parameters or when the parameters should not be
@@ -995,8 +1044,8 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6);
+    void error(
+            Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
 
     /**
      * Logs a message with parameters at error level.
@@ -1012,7 +1061,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void error(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -1030,8 +1088,18 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void error(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at error level.
@@ -1049,8 +1117,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void error(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at error level.
@@ -1158,7 +1237,16 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void error(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -1176,8 +1264,18 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void error(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs exit from a method. Used for methods that do not return anything.
@@ -1543,8 +1641,8 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6);
+    void fatal(
+            Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
 
     /**
      * Logs a message with parameters at fatal level.
@@ -1560,7 +1658,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void fatal(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -1578,8 +1685,18 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void fatal(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at fatal level.
@@ -1597,8 +1714,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void fatal(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at fatal level.
@@ -1706,7 +1834,16 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void fatal(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -1724,8 +1861,18 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void fatal(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Gets the Level associated with the Logger.
@@ -2104,8 +2251,8 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6);
+    void info(
+            Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
 
     /**
      * Logs a message with parameters at info level.
@@ -2121,7 +2268,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void info(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -2139,8 +2295,18 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void info(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at info level.
@@ -2158,8 +2324,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void info(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at info level.
@@ -2267,7 +2444,16 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void info(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -2285,8 +2471,18 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void info(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Checks whether this Logger is enabled for the {@link Level#DEBUG DEBUG} Level.
@@ -2762,7 +2958,16 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      */
-    void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
+    void log(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5);
 
     /**
      * Logs a message with parameters at the specified level.
@@ -2778,7 +2983,16 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+    void log(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
             Object p6);
 
     /**
@@ -2796,7 +3010,17 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void log(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -2815,8 +3039,19 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void log(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at the specified level.
@@ -2835,8 +3070,20 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void log(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at the specified level.
@@ -2936,7 +3183,17 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
+    void log(
+            Level level,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7);
 
     /**
      * Logs a message with parameters at the specified level.
@@ -2953,7 +3210,17 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void log(
+            Level level,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -2972,8 +3239,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void log(
+            Level level,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a formatted message using the specified format string and arguments.
@@ -3370,8 +3648,8 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6);
+    void trace(
+            Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
 
     /**
      * Logs a message with parameters at trace level.
@@ -3387,7 +3665,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void trace(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -3405,8 +3692,18 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void trace(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at trace level.
@@ -3424,8 +3721,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void trace(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at trace level.
@@ -3533,7 +3841,16 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void trace(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -3551,8 +3868,18 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void trace(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs entry to a method. Used when the method in question has no parameters or when the parameters should not be
@@ -4079,8 +4406,8 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      */
-    void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6);
+    void warn(
+            Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
 
     /**
      * Logs a message with parameters at warn level.
@@ -4096,7 +4423,16 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      */
-    void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+    void warn(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
             Object p7);
 
     /**
@@ -4114,8 +4450,18 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    void warn(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message with parameters at warn level.
@@ -4133,8 +4479,19 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    void warn(
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message with parameters at warn level.
@@ -4242,7 +4599,16 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      */
-    void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+    void warn(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
             Object p8);
 
     /**
@@ -4260,8 +4626,18 @@ public interface Logger {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      */
-    void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
-            Object p8, Object p9);
+    void warn(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a Message.
@@ -4274,8 +4650,8 @@ public interface Logger {
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @since 2.13.0
      */
-    default void logMessage(Level level, Marker marker, String fqcn, StackTraceElement location, Message message,
-        Throwable throwable) {
+    default void logMessage(
+            Level level, Marker marker, String fqcn, StackTraceElement location, Message message, Throwable throwable) {
         // noop
     }
 
@@ -4351,5 +4727,4 @@ public interface Logger {
     default LogBuilder atLevel(Level level) {
         return LogBuilder.NOOP;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/MarkerManager.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/MarkerManager.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j;
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
 import org.apache.logging.log4j.util.PerformanceSensitive;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
@@ -135,7 +134,8 @@ public final class MarkerManager {
          * @throws IllegalArgumentException if the argument is {@code null}
          */
         public Log4jMarker(final String name) {
-            // we can't store null references in a ConcurrentHashMap as it is, not to mention that a null Marker
+            // we can't store null references in a ConcurrentHashMap as it is, not to mention that a
+            // null Marker
             // name seems rather pointless. To get an "anonymous" Marker, just use an empty string.
             requireNonNull(name, "Marker name cannot be null.");
             this.name = name;
@@ -147,7 +147,8 @@ public final class MarkerManager {
         @Override
         public synchronized Marker addParents(final Marker... parentMarkers) {
             requireNonNull(parentMarkers, "A parent marker must be specified");
-            // It is not strictly necessary to copy the variable here but it should perform better than
+            // It is not strictly necessary to copy the variable here but it should perform better
+            // than
             // Accessing a volatile variable multiple times.
             final Marker[] localParents = this.parents;
             // Don't add a parent that is already in the hierarchy.
@@ -309,8 +310,8 @@ public final class MarkerManager {
             if (parent == marker) {
                 return true;
             }
-            final Marker[] localParents = parent instanceof Log4jMarker ? ((Log4jMarker) parent).parents : parent
-                    .getParents();
+            final Marker[] localParents =
+                    parent instanceof Log4jMarker ? ((Log4jMarker) parent).parents : parent.getParents();
             if (localParents != null) {
                 final int localParentsLength = localParents.length;
                 if (localParentsLength == 1) {
@@ -335,7 +336,8 @@ public final class MarkerManager {
          */
         @PerformanceSensitive("allocation")
         private static boolean contains(final Marker parent, final Marker... localParents) {
-            // performance tests showed a normal for loop is slightly faster than a for-each loop on some platforms
+            // performance tests showed a normal for loop is slightly faster than a for-each loop on
+            // some platforms
             // noinspection ForLoopReplaceableByForEach
             for (int i = 0, localParentsLength = localParents.length; i < localParentsLength; i++) {
                 final Marker marker = localParents[i];
@@ -365,7 +367,8 @@ public final class MarkerManager {
 
         @Override
         public String toString() {
-            // FIXME: might want to use an initial capacity; the default is 16 (or str.length() + 16)
+            // FIXME: might want to use an initial capacity; the default is 16 (or str.length() +
+            // 16)
             final StringBuilder sb = new StringBuilder();
             formatTo(sb);
             return sb.toString();
@@ -401,7 +404,8 @@ public final class MarkerManager {
         }
     }
 
-    // this method wouldn't be necessary if Marker methods threw an NPE instead of an IAE for null values ;)
+    // this method wouldn't be necessary if Marker methods threw an NPE instead of an IAE for null
+    // values ;)
     private static void requireNonNull(final Object obj, final String message) {
         if (obj == null) {
             throw new IllegalArgumentException(message);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/ThreadContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/ThreadContext.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.spi.CleanableThreadContextMap;
 import org.apache.logging.log4j.spi.DefaultThreadContextMap;
@@ -257,7 +256,7 @@ public final class ThreadContext {
      * @since 2.13.0
      */
     public static void putIfNull(final String key, final String value) {
-        if(!contextMap.containsKey(key)) {
+        if (!contextMap.containsKey(key)) {
             contextMap.put(key, value);
         }
     }
@@ -277,7 +276,7 @@ public final class ThreadContext {
         } else if (contextMap instanceof DefaultThreadContextMap) {
             ((DefaultThreadContextMap) contextMap).putAll(m);
         } else {
-            for (final Map.Entry<String, String> entry: m.entrySet()) {
+            for (final Map.Entry<String, String> entry : m.entrySet()) {
                 contextMap.put(entry.getKey(), entry.getValue());
             }
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.internal;
 
 import java.util.Arrays;
-
 import org.apache.logging.log4j.BridgeAware;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogBuilder;
@@ -215,24 +214,43 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     }
 
     @Override
-    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7) {
+    public void log(
+            String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {
         if (isValid() && isEnabled(message, p0, p1, p2, p3, p4, p5, p6, p7)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7));
         }
     }
 
     @Override
-    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8) {
+    public void log(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8) {
         if (isValid() && isEnabled(message, p0, p1, p2, p3, p4, p5, p6, p7, p8)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8));
         }
     }
 
     @Override
-    public void log(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9) {
+    public void log(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9) {
         if (isValid() && isEnabled(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)) {
             logMessage(logger.getMessageFactory().newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9));
         }
@@ -255,13 +273,11 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
 
     private boolean isValid() {
         if (!inUse) {
-            LOGGER.warn("Attempt to reuse LogBuilder was ignored. {}",
-                    StackLocatorUtil.getCallerClass(2));
-            return false ;
+            LOGGER.warn("Attempt to reuse LogBuilder was ignored. {}", StackLocatorUtil.getCallerClass(2));
+            return false;
         }
         if (this.threadId != Thread.currentThread().getId()) {
-            LOGGER.warn("LogBuilder can only be used on the owning thread. {}",
-                    StackLocatorUtil.getCallerClass(2));
+            LOGGER.warn("LogBuilder can only be used on the owning thread. {}", StackLocatorUtil.getCallerClass(2));
             return false;
         }
         return true;
@@ -295,56 +311,83 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     }
 
     protected boolean isEnabled(String message, Object p0) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, throwable)
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, throwable)
                 : logger.isEnabled(level, marker, message, p0);
     }
 
     protected boolean isEnabled(String message, Object p0, Object p1) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, throwable)
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1);
     }
 
     protected boolean isEnabled(String message, Object p0, Object p1, Object p2) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, throwable)
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, p2, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2);
     }
 
     protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, throwable)
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3);
     }
 
     protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, throwable)
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4);
     }
 
     protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, throwable)
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, throwable)
+    protected boolean isEnabled(
+            String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6, Object p7) {
-        return throwable != null ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, throwable)
+    protected boolean isEnabled(
+            String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {
+        return throwable != null
+                ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6, Object p7, Object p8) {
+    protected boolean isEnabled(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8) {
         return throwable != null
                 ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
-    protected boolean isEnabled(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
-            Object p6, Object p7, Object p8, Object p9) {
+    protected boolean isEnabled(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9) {
         return throwable != null
                 ? logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, throwable)
                 : logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/AbstractMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/AbstractMessageFactory.java
@@ -66,7 +66,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
      */
     @Override
     public Message newMessage(final String message, final Object p0) {
-        return newMessage(message, new Object[] { p0 });
+        return newMessage(message, new Object[] {p0});
     }
 
     /**
@@ -74,7 +74,7 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1) {
-        return newMessage(message, new Object[] { p0, p1 });
+        return newMessage(message, new Object[] {p0, p1});
     }
 
     /**
@@ -82,67 +82,109 @@ public abstract class AbstractMessageFactory implements MessageFactory2, Seriali
      */
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2) {
-        return newMessage(message, new Object[] { p0, p1, p2 });
+        return newMessage(message, new Object[] {p0, p1, p2});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3 });
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+        return newMessage(message, new Object[] {p0, p1, p2, p3});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4 });
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+        return newMessage(message, new Object[] {p0, p1, p2, p3, p4});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5 });
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
+        return newMessage(message, new Object[] {p0, p1, p2, p3, p4, p5});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5, p6 });
+        return newMessage(message, new Object[] {p0, p1, p2, p3, p4, p5, p6});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5, p6, p7 });
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
+        return newMessage(message, new Object[] {p0, p1, p2, p3, p4, p5, p6, p7});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8 });
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
+        return newMessage(message, new Object[] {p0, p1, p2, p3, p4, p5, p6, p7, p8});
     }
 
     /**
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
-        return newMessage(message, new Object[] { p0, p1, p2, p3, p4, p5, p6, p7, p8, p9 });
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
+        return newMessage(message, new Object[] {p0, p1, p2, p3, p4, p5, p6, p7, p8, p9});
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/AsynchronouslyFormattable.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/AsynchronouslyFormattable.java
@@ -55,6 +55,5 @@ import java.lang.annotation.Target;
  */
 @Documented // This annotation is part of the public API of annotated elements.
 @Target(ElementType.TYPE) // Only applies to types.
-@Retention(RetentionPolicy.RUNTIME) //Needs to be reflectively discoverable runtime.
-public @interface AsynchronouslyFormattable {
-}
+@Retention(RetentionPolicy.RUNTIME) // Needs to be reflectively discoverable runtime.
+public @interface AsynchronouslyFormattable {}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/BasicThreadInformation.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/BasicThreadInformation.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.log4j.message;
 
-import org.apache.logging.log4j.util.StringBuilders;
-
 import static org.apache.logging.log4j.util.Chars.LF;
 import static org.apache.logging.log4j.util.Chars.SPACE;
+
+import org.apache.logging.log4j.util.StringBuilders;
 
 /**
  * Generates information about the current Thread. Used internally by ThreadDumpMessage.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/Clearable.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/Clearable.java
@@ -29,5 +29,4 @@ interface Clearable {
      * Resets the object to a clean state.
      */
     void clear();
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.io.Serializable;
-
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.StringBuilders;
@@ -134,7 +133,6 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
         SimpleEntryMessage(final String entryText, final Message message) {
             super(entryText, message);
         }
-
     }
 
     private static final class SimpleExitMessage extends AbstractFlowMessage implements ExitMessage {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessage.java
@@ -49,7 +49,7 @@ public class FormattedMessage implements Message {
      * @since 2.6
      */
     public FormattedMessage(final Locale locale, final String messagePattern, final Object arg) {
-        this(locale, messagePattern, new Object[] { arg }, null);
+        this(locale, messagePattern, new Object[] {arg}, null);
     }
 
     /**
@@ -61,7 +61,7 @@ public class FormattedMessage implements Message {
      * @since 2.6
      */
     public FormattedMessage(final Locale locale, final String messagePattern, final Object arg1, final Object arg2) {
-        this(locale, messagePattern, new Object[] { arg1, arg2 });
+        this(locale, messagePattern, new Object[] {arg1, arg2});
     }
 
     /**
@@ -83,7 +83,8 @@ public class FormattedMessage implements Message {
      * @param throwable The throwable
      * @since 2.6
      */
-    public FormattedMessage(final Locale locale, final String messagePattern, final Object[] arguments, final Throwable throwable) {
+    public FormattedMessage(
+            final Locale locale, final String messagePattern, final Object[] arguments, final Throwable throwable) {
         this.locale = locale;
         this.messagePattern = messagePattern;
         this.argArray = arguments;
@@ -96,7 +97,7 @@ public class FormattedMessage implements Message {
      * @param arg The parameter.
      */
     public FormattedMessage(final String messagePattern, final Object arg) {
-        this(messagePattern, new Object[] { arg }, null);
+        this(messagePattern, new Object[] {arg}, null);
     }
 
     /**
@@ -106,7 +107,7 @@ public class FormattedMessage implements Message {
      * @param arg2 The second parameter.
      */
     public FormattedMessage(final String messagePattern, final Object arg1, final Object arg2) {
-        this(messagePattern, new Object[] { arg1, arg2 });
+        this(messagePattern, new Object[] {arg1, arg2});
     }
 
     /**
@@ -130,7 +131,6 @@ public class FormattedMessage implements Message {
         this.argArray = arguments;
         this.throwable = throwable;
     }
-
 
     @Override
     public boolean equals(final Object o) {
@@ -209,8 +209,7 @@ public class FormattedMessage implements Message {
         }
         // Check for non-escaped `{}` format specifiers
         // This case also includes patterns without any `java.util.Formatter` specifiers
-        if (ParameterFormatter.analyzePattern(msgPattern, 1).placeholderCount > 0
-                || msgPattern.indexOf('%') == -1) {
+        if (ParameterFormatter.analyzePattern(msgPattern, 1).placeholderCount > 0 || msgPattern.indexOf('%') == -1) {
             return new ParameterizedMessage(msgPattern, args, aThrowable);
         }
         // Interpret as `java.util.Formatter` format
@@ -239,7 +238,6 @@ public class FormattedMessage implements Message {
         }
         return message.getThrowable();
     }
-
 
     @Override
     public int hashCode() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessageFactory.java
@@ -34,8 +34,7 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
     /**
      * Constructs a message factory with default flow strings.
      */
-    public FormattedMessageFactory() {
-    }
+    public FormattedMessageFactory() {}
 
     /**
      * Creates {@link StringFormattedMessage} instances.
@@ -79,7 +78,8 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
         return new FormattedMessage(message, p0, p1, p2, p3);
     }
 
@@ -87,7 +87,8 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         return new FormattedMessage(message, p0, p1, p2, p3, p4);
     }
 
@@ -95,7 +96,14 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return new FormattedMessage(message, p0, p1, p2, p3, p4, p5);
     }
 
@@ -103,7 +111,14 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         return new FormattedMessage(message, p0, p1, p2, p3, p4, p5, p6);
     }
@@ -112,8 +127,16 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return new FormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
@@ -121,8 +144,17 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return new FormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
@@ -130,8 +162,18 @@ public class FormattedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return new FormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessage.java
@@ -22,7 +22,6 @@ import java.io.ObjectOutputStream;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
-
 import org.apache.logging.log4j.status.StatusLogger;
 
 /**
@@ -80,8 +79,8 @@ public class LocalizedMessage implements Message, LoggerNameAwareMessage {
         this.locale = locale;
     }
 
-    public LocalizedMessage(final ResourceBundle bundle, final Locale locale, final String key,
-            final Object[] arguments) {
+    public LocalizedMessage(
+            final ResourceBundle bundle, final Locale locale, final String key, final Object[] arguments) {
         this.key = key;
         this.argArray = arguments;
         this.throwable = null;
@@ -137,13 +136,13 @@ public class LocalizedMessage implements Message, LoggerNameAwareMessage {
         this(bundle, (Locale) null, key, new Object[] {arg1, arg2});
     }
 
-    public LocalizedMessage(final String baseName, final Locale locale, final String key, final Object arg1,
-            final Object arg2) {
+    public LocalizedMessage(
+            final String baseName, final Locale locale, final String key, final Object arg1, final Object arg2) {
         this(baseName, locale, key, new Object[] {arg1, arg2});
     }
 
-    public LocalizedMessage(final ResourceBundle bundle, final Locale locale, final String key, final Object arg1,
-            final Object arg2) {
+    public LocalizedMessage(
+            final ResourceBundle bundle, final Locale locale, final String key, final Object arg1, final Object arg2) {
         this(bundle, locale, key, new Object[] {arg1, arg2});
     }
 
@@ -225,8 +224,8 @@ public class LocalizedMessage implements Message, LoggerNameAwareMessage {
      *            based on all or part of the package name. If false the key is expected to be the exact bundle id.
      * @return The ResourceBundle.
      */
-    protected ResourceBundle getResourceBundle(final String rbBaseName, final Locale resourceBundleLocale,
-            final boolean loop) {
+    protected ResourceBundle getResourceBundle(
+            final String rbBaseName, final Locale resourceBundleLocale, final boolean loop) {
         ResourceBundle rb = null;
 
         if (rbBaseName == null) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/LocalizedMessageFactory.java
@@ -34,7 +34,7 @@ public class LocalizedMessageFactory extends AbstractMessageFactory {
     private static final long serialVersionUID = -1996295808703146741L;
 
     // FIXME: cannot use ResourceBundle name for serialization until Java 8
-    private transient final ResourceBundle resourceBundle;
+    private final transient ResourceBundle resourceBundle;
     private final String baseName;
 
     public LocalizedMessageFactory(final ResourceBundle resourceBundle) {
@@ -71,7 +71,7 @@ public class LocalizedMessageFactory extends AbstractMessageFactory {
     @Override
     public Message newMessage(final String key) {
         if (resourceBundle == null) {
-            return new LocalizedMessage(baseName,  key);
+            return new LocalizedMessage(baseName, key);
         }
         return new LocalizedMessage(resourceBundle, key);
     }
@@ -92,5 +92,4 @@ public class LocalizedMessageFactory extends AbstractMessageFactory {
         }
         return new LocalizedMessage(resourceBundle, key, params);
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
@@ -20,7 +20,6 @@ import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.Map;
 import java.util.TreeMap;
-
 import org.apache.logging.log4j.util.BiConsumer;
 import org.apache.logging.log4j.util.Chars;
 import org.apache.logging.log4j.util.EnglishEnums;
@@ -82,11 +81,15 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
          * @return a MapFormat
          */
         public static MapFormat lookupIgnoreCase(final String format) {
-            return XML.name().equalsIgnoreCase(format) ? XML //
-                    : JSON.name().equalsIgnoreCase(format) ? JSON //
-                    : JAVA.name().equalsIgnoreCase(format) ? JAVA //
-                    : JAVA_UNQUOTED.name().equalsIgnoreCase(format) ? JAVA_UNQUOTED //
-                    : null;
+            return XML.name().equalsIgnoreCase(format)
+                    ? XML //
+                    : JSON.name().equalsIgnoreCase(format)
+                            ? JSON //
+                            : JAVA.name().equalsIgnoreCase(format)
+                                    ? JAVA //
+                                    : JAVA_UNQUOTED.name().equalsIgnoreCase(format)
+                                            ? JAVA_UNQUOTED //
+                                            : null;
         }
 
         /**
@@ -160,7 +163,8 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     public Map<String, V> getData() {
         final TreeMap<String, V> result = new TreeMap<>(); // returned map must be sorted
         for (int i = 0; i < data.size(); i++) {
-            // The Eclipse compiler does not need the typecast to V, but the Oracle compiler sure does.
+            // The Eclipse compiler does not need the typecast to V, but the Oracle compiler sure
+            // does.
             result.put(data.getKeyAt(i), (V) data.getValueAt(i));
         }
         return Collections.unmodifiableMap(result);
@@ -254,7 +258,8 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      */
     public String asString(final String format) {
         try {
-            return format(EnglishEnums.valueOf(MapFormat.class, format), new StringBuilder()).toString();
+            return format(EnglishEnums.valueOf(MapFormat.class, format), new StringBuilder())
+                    .toString();
         } catch (final IllegalArgumentException ex) {
             return asString();
         }
@@ -322,22 +327,22 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
             appendMap(sb);
         } else {
             switch (format) {
-                case XML : {
+                case XML: {
                     asXml(sb);
                     break;
                 }
-                case JSON : {
+                case JSON: {
                     asJson(sb);
                     break;
                 }
-                case JAVA : {
+                case JAVA: {
                     asJava(sb);
                     break;
                 }
                 case JAVA_UNQUOTED:
                     asJavaUnquoted(sb);
                     break;
-                default : {
+                default: {
                     appendMap(sb);
                 }
             }
@@ -353,9 +358,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     public void asXml(final StringBuilder sb) {
         sb.append("<Map>\n");
         for (int i = 0; i < data.size(); i++) {
-            sb.append("  <Entry key=\"")
-                    .append(data.getKeyAt(i))
-                    .append("\">");
+            sb.append("  <Entry key=\"").append(data.getKeyAt(i)).append("\">");
             final int size = sb.length();
             ParameterFormatter.recursiveDeepToString(data.getValueAt(i), sb);
             StringBuilders.escapeXml(sb, size);
@@ -642,7 +645,6 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
         return (M) this;
     }
 
-
     /**
      * Adds an item to the data Map.
      * @param candidateKey The name of the data item.
@@ -745,5 +747,4 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
         put(key, value);
         return (M) this;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessageJsonFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessageJsonFormatter.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.logging.log4j.util.IndexedStringMap;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
@@ -45,7 +44,8 @@ import org.apache.logging.log4j.util.StringBuilders;
  * It supports nesting up to a maximum depth of 8, which is set by
  * <tt>log4j2.mapMessage.jsonFormatter.maxDepth</tt> property.
  */
-enum MapMessageJsonFormatter {;
+enum MapMessageJsonFormatter {
+    ;
 
     public static final int MAX_DEPTH = readMaxDepth();
 
@@ -64,12 +64,10 @@ enum MapMessageJsonFormatter {;
     private static final char COLON = ':';
 
     private static int readMaxDepth() {
-        final int maxDepth = PropertiesUtil
-                .getProperties()
-                .getIntegerProperty("log4j2.mapMessage.jsonFormatter.maxDepth", 8);
+        final int maxDepth =
+                PropertiesUtil.getProperties().getIntegerProperty("log4j2.mapMessage.jsonFormatter.maxDepth", 8);
         if (maxDepth < 0) {
-            throw new IllegalArgumentException(
-                    "was expecting a positive maxDepth, found: " + maxDepth);
+            throw new IllegalArgumentException("was expecting a positive maxDepth, found: " + maxDepth);
         }
         return maxDepth;
     }
@@ -78,10 +76,7 @@ enum MapMessageJsonFormatter {;
         format(sb, object, 0);
     }
 
-    private static void format(
-            final StringBuilder sb,
-            final Object object,
-            final int depth) {
+    private static void format(final StringBuilder sb, final Object object, final int depth) {
 
         if (depth >= MAX_DEPTH) {
             throw new IllegalArgumentException("maxDepth has been exceeded");
@@ -162,13 +157,9 @@ enum MapMessageJsonFormatter {;
         else {
             formatString(sb, object);
         }
-
     }
 
-    private static void formatIndexedStringMap(
-            final StringBuilder sb,
-            final IndexedStringMap map,
-            final int depth) {
+    private static void formatIndexedStringMap(final StringBuilder sb, final IndexedStringMap map, final int depth) {
         sb.append(LCURLY);
         final int nextDepth = depth + 1;
         for (int entryIndex = 0; entryIndex < map.size(); entryIndex++) {
@@ -187,10 +178,7 @@ enum MapMessageJsonFormatter {;
         sb.append(RCURLY);
     }
 
-    private static void formatMap(
-            final StringBuilder sb,
-            final Map<Object, Object> map,
-            final int depth) {
+    private static void formatMap(final StringBuilder sb, final Map<Object, Object> map, final int depth) {
         sb.append(LCURLY);
         final int nextDepth = depth + 1;
         final boolean[] firstEntry = {true};
@@ -214,10 +202,7 @@ enum MapMessageJsonFormatter {;
         sb.append(RCURLY);
     }
 
-    private static void formatList(
-            final StringBuilder sb,
-            final List<Object> items,
-            final int depth) {
+    private static void formatList(final StringBuilder sb, final List<Object> items, final int depth) {
         sb.append(LBRACE);
         final int nextDepth = depth + 1;
         for (int itemIndex = 0; itemIndex < items.size(); itemIndex++) {
@@ -230,10 +215,7 @@ enum MapMessageJsonFormatter {;
         sb.append(RBRACE);
     }
 
-    private static void formatCollection(
-            final StringBuilder sb,
-            final Collection<Object> items,
-            final int depth) {
+    private static void formatCollection(final StringBuilder sb, final Collection<Object> items, final int depth) {
         sb.append(LBRACE);
         final int nextDepth = depth + 1;
         final boolean[] firstItem = {true};
@@ -258,10 +240,10 @@ enum MapMessageJsonFormatter {;
         } else if (number instanceof Float) {
             final float floatNumber = (float) number;
             sb.append(floatNumber);
-        } else if (number instanceof Byte ||
-                number instanceof Short ||
-                number instanceof Integer ||
-                number instanceof Long) {
+        } else if (number instanceof Byte
+                || number instanceof Short
+                || number instanceof Integer
+                || number instanceof Long) {
             final long longNumber = number.longValue();
             sb.append(longNumber);
         } else {
@@ -279,9 +261,7 @@ enum MapMessageJsonFormatter {;
         sb.append(booleanValue);
     }
 
-    private static void formatFormattable(
-            final StringBuilder sb,
-            final StringBuilderFormattable formattable) {
+    private static void formatFormattable(final StringBuilder sb, final StringBuilderFormattable formattable) {
         sb.append(DQUOTE);
         final int startIndex = sb.length();
         formattable.formatTo(sb);
@@ -377,9 +357,7 @@ enum MapMessageJsonFormatter {;
         sb.append(RBRACE);
     }
 
-    private static void formatDoubleArray(
-            final StringBuilder sb,
-            final double[] items) {
+    private static void formatDoubleArray(final StringBuilder sb, final double[] items) {
         sb.append(LBRACE);
         for (int itemIndex = 0; itemIndex < items.length; itemIndex++) {
             if (itemIndex > 0) {
@@ -391,10 +369,7 @@ enum MapMessageJsonFormatter {;
         sb.append(RBRACE);
     }
 
-    private static void formatObjectArray(
-            final StringBuilder sb,
-            final Object[] items,
-            final int depth) {
+    private static void formatObjectArray(final StringBuilder sb, final Object[] items, final int depth) {
         sb.append(LBRACE);
         final int nextDepth = depth + 1;
         for (int itemIndex = 0; itemIndex < items.length; itemIndex++) {
@@ -415,5 +390,4 @@ enum MapMessageJsonFormatter {;
         StringBuilders.escapeJson(sb, startIndex);
         sb.append(DQUOTE);
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/Message.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/Message.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.io.Serializable;
-
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
 /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageCollectionMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageCollectionMessage.java
@@ -20,7 +20,4 @@ package org.apache.logging.log4j.message;
  * A Message that is a collection of Messages.
  * @param <T> The Message type.
  */
-public interface MessageCollectionMessage<T> extends Message, Iterable<T> {
-
-
-}
+public interface MessageCollectionMessage<T> extends Message, Iterable<T> {}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFactory2.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFactory2.java
@@ -137,8 +137,8 @@ public interface MessageFactory2 extends MessageFactory {
      * @return a new message
      * @see ParameterizedMessageFactory
      */
-    Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7);
+    Message newMessage(
+            String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
 
     /**
      * Creates a new parameterized message.
@@ -156,8 +156,17 @@ public interface MessageFactory2 extends MessageFactory {
      * @return a new message
      * @see ParameterizedMessageFactory
      */
-    Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8);
+    Message newMessage(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Creates a new parameterized message.
@@ -176,6 +185,16 @@ public interface MessageFactory2 extends MessageFactory {
      * @return a new message
      * @see ParameterizedMessageFactory
      */
-    Message newMessage(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
-            Object p7, Object p8, Object p9);
+    Message newMessage(
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFormatMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFormatMessage.java
@@ -23,7 +23,6 @@ import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.IllegalFormatException;
 import java.util.Locale;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
 
@@ -142,7 +141,6 @@ public class MessageFormatMessage implements Message {
         result = HASHVAL * result + (serializedParameters != null ? Arrays.hashCode(serializedParameters) : 0);
         return result;
     }
-
 
     @Override
     public String toString() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFormatMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFormatMessageFactory.java
@@ -32,8 +32,7 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
     /**
      * Constructs a message factory with default flow strings.
      */
-    public MessageFormatMessageFactory() {
-    }
+    public MessageFormatMessageFactory() {}
 
     /**
      * Creates {@link org.apache.logging.log4j.message.StringFormattedMessage} instances.
@@ -76,7 +75,8 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
         return new MessageFormatMessage(message, p0, p1, p2, p3);
     }
 
@@ -84,7 +84,8 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         return new MessageFormatMessage(message, p0, p1, p2, p3, p4);
     }
 
@@ -92,7 +93,14 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5);
     }
 
@@ -100,7 +108,14 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5, p6);
     }
@@ -109,8 +124,16 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
@@ -118,8 +141,17 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
@@ -127,8 +159,18 @@ public class MessageFormatMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return new MessageFormatMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectArrayMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectArrayMessage.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Arrays;
-
 import org.apache.logging.log4j.util.Constants;
 
 /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectMessage.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.StringBuilders;
 import org.apache.logging.log4j.util.internal.SerializationUtil;
@@ -126,8 +125,8 @@ public class ObjectMessage implements Message, StringBuilderFormattable {
 
     private void writeObject(final ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
-        SerializationUtil.writeWrappedObject(obj instanceof Serializable ? (Serializable) obj : String.valueOf(obj),
-                out);
+        SerializationUtil.writeWrappedObject(
+                obj instanceof Serializable ? (Serializable) obj : String.valueOf(obj), out);
     }
 
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterConsumer.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterConsumer.java
@@ -38,5 +38,4 @@ public interface ParameterConsumer<S> {
      * @param state the state data
      */
     void accept(Object parameter, int parameterIndex, S state);
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -20,7 +20,6 @@ import java.io.Serializable;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-
 import org.apache.logging.log4j.util.StringBuilders;
 
 /**
@@ -31,6 +30,7 @@ final class ParameterFormatter {
      * Prefix for recursion.
      */
     static final String RECURSION_PREFIX = "[...";
+
     /**
      * Suffix for recursion.
      */
@@ -40,14 +40,17 @@ final class ParameterFormatter {
      * Prefix for errors.
      */
     static final String ERROR_PREFIX = "[!!!";
+
     /**
      * Separator for errors.
      */
     static final String ERROR_SEPARATOR = "=>";
+
     /**
      * Separator for error messages.
      */
     static final String ERROR_MSG_SEPARATOR = ":";
+
     /**
      * Suffix for errors.
      */
@@ -57,8 +60,8 @@ final class ParameterFormatter {
     private static final char DELIM_STOP = '}';
     private static final char ESCAPE_CHAR = '\\';
 
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
-            .withZone(ZoneId.systemDefault());
+    private static final DateTimeFormatter DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").withZone(ZoneId.systemDefault());
 
     private ParameterFormatter() {}
 
@@ -110,10 +113,7 @@ final class ParameterFormatter {
      * A negative value indicates no limit.
      * @param analysis an object to store the results
      */
-    static void analyzePattern(
-            final String pattern,
-            final int argCount,
-            final MessagePatternAnalysis analysis) {
+    static void analyzePattern(final String pattern, final int argCount, final MessagePatternAnalysis analysis) {
 
         // Short-circuit if there is nothing interesting
         final int l;
@@ -147,7 +147,6 @@ final class ParameterFormatter {
                 }
             }
         }
-
     }
 
     /**
@@ -199,9 +198,7 @@ final class ParameterFormatter {
                 System.arraycopy(placeholderCharIndices, 0, newPlaceholderCharIndices, 0, placeholderCount);
                 placeholderCharIndices = newPlaceholderCharIndices;
             }
-
         }
-
     }
 
     /**
@@ -235,9 +232,7 @@ final class ParameterFormatter {
         if (analysis.placeholderCount > args.length) {
             final String message = String.format(
                     "found %d argument placeholders, but provided %d for pattern `%s`",
-                    analysis.placeholderCount,
-                    args.length,
-                    pattern);
+                    analysis.placeholderCount, args.length, pattern);
             throw new IllegalArgumentException(message);
         }
 
@@ -250,7 +245,6 @@ final class ParameterFormatter {
         else {
             formatMessageContainingNoEscapes(buffer, pattern, args, argCount, analysis);
         }
-
     }
 
     static void formatMessageContainingNoEscapes(
@@ -272,7 +266,6 @@ final class ParameterFormatter {
 
         // Format the last trailing text
         buffer.append(pattern, precedingTextStartIndex, pattern.length());
-
     }
 
     static void formatMessageContainingEscapes(
@@ -294,14 +287,10 @@ final class ParameterFormatter {
 
         // Format the last trailing text
         copyMessagePatternContainingEscapes(buffer, pattern, precedingTextStartIndex, pattern.length());
-
     }
 
     private static void copyMessagePatternContainingEscapes(
-            final StringBuilder buffer,
-            final String pattern,
-            final int startIndex,
-            final int endIndex) {
+            final StringBuilder buffer, final String pattern, final int startIndex, final int endIndex) {
         boolean escaped = false;
         int i = startIndex;
         for (; i < endIndex; i++) {
@@ -461,9 +450,7 @@ final class ParameterFormatter {
     }
 
     private static void appendPotentiallyRecursiveValue(
-            final Object o,
-            final StringBuilder str,
-            final Set<Object> dejaVu) {
+            final Object o, final StringBuilder str, final Set<Object> dejaVu) {
         final Class<?> oClass = o.getClass();
         if (oClass.isArray()) {
             appendArray(o, str, dejaVu, oClass);
@@ -477,10 +464,7 @@ final class ParameterFormatter {
     }
 
     private static void appendArray(
-            final Object o,
-            final StringBuilder str,
-            final Set<Object> dejaVu,
-            final Class<?> oClass) {
+            final Object o, final StringBuilder str, final Set<Object> dejaVu, final Class<?> oClass) {
         if (oClass == byte[].class) {
             str.append(Arrays.toString((byte[]) o));
         } else if (oClass == short[].class) {
@@ -524,10 +508,7 @@ final class ParameterFormatter {
     /**
      * Specialized handler for {@link Map}s.
      */
-    private static void appendMap(
-            final Object o,
-            final StringBuilder str,
-            final Set<Object> dejaVu) {
+    private static void appendMap(final Object o, final StringBuilder str, final Set<Object> dejaVu) {
         final Set<Object> effectiveDejaVu = getOrCreateDejaVu(dejaVu);
         final boolean seen = !effectiveDejaVu.add(o);
         if (seen) {
@@ -556,10 +537,7 @@ final class ParameterFormatter {
     /**
      * Specialized handler for {@link Collection}s.
      */
-    private static void appendCollection(
-            final Object o,
-            final StringBuilder str,
-            final Set<Object> dejaVu) {
+    private static void appendCollection(final Object o, final StringBuilder str, final Set<Object> dejaVu) {
         final Set<Object> effectiveDejaVu = getOrCreateDejaVu(dejaVu);
         final boolean seen = !effectiveDejaVu.add(o);
         if (seen) {
@@ -582,9 +560,7 @@ final class ParameterFormatter {
     }
 
     private static Set<Object> getOrCreateDejaVu(final Set<Object> dejaVu) {
-        return dejaVu == null
-                ? createDejaVu()
-                : dejaVu;
+        return dejaVu == null ? createDejaVu() : dejaVu;
     }
 
     private static Set<Object> createDejaVu() {
@@ -646,5 +622,4 @@ final class ParameterFormatter {
         }
         return obj.getClass().getName() + '@' + Integer.toHexString(System.identityHashCode(obj));
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterVisitable.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterVisitable.java
@@ -42,5 +42,4 @@ public interface ParameterVisitable {
      * @since 2.11
      */
     <S> void forEachParameter(ParameterConsumer<S> action, S state);
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
@@ -16,20 +16,19 @@
  */
 package org.apache.logging.log4j.message;
 
+import static org.apache.logging.log4j.message.ParameterFormatter.analyzePattern;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
-
 import org.apache.logging.log4j.message.ParameterFormatter.MessagePatternAnalysis;
 import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.StringBuilders;
 import org.apache.logging.log4j.util.internal.SerializationUtil;
-
-import static org.apache.logging.log4j.message.ParameterFormatter.analyzePattern;
 
 /**
  * A {@link Message} accepting argument placeholders in the formatting pattern.
@@ -91,7 +90,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
 
     private transient Object[] args;
 
-    private transient final Throwable throwable;
+    private final transient Throwable throwable;
 
     private final MessagePatternAnalysis patternAnalysis;
 
@@ -139,9 +138,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
     }
 
     private static Throwable determineThrowable(
-            final Throwable throwable,
-            final Object[] args,
-            final MessagePatternAnalysis analysis) {
+            final Throwable throwable, final Object[] args, final MessagePatternAnalysis analysis) {
 
         // Short-circuit if an explicit `Throwable` is provided
         if (throwable != null) {
@@ -158,7 +155,6 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
 
         // No `Throwable`s available
         return null;
-
     }
 
     /**
@@ -184,7 +180,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      * @param arg an argument
      */
     public ParameterizedMessage(final String pattern, final Object arg) {
-        this(pattern, new Object[]{arg});
+        this(pattern, new Object[] {arg});
     }
 
     /**
@@ -198,7 +194,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      * @param arg1 the second argument
      */
     public ParameterizedMessage(final String pattern, final Object arg0, final Object arg1) {
-        this(pattern, new Object[]{arg0, arg1});
+        this(pattern, new Object[] {arg0, arg1});
     }
 
     /**
@@ -355,16 +351,21 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
 
     @Override
     public String toString() {
-        return "ParameterizedMessage[messagePattern=" + pattern + ", stringArgs=" +
-                Arrays.toString(args) + ", throwable=" + throwable + ']';
+        return "ParameterizedMessage[messagePattern="
+                + pattern
+                + ", stringArgs="
+                + Arrays.toString(args)
+                + ", throwable="
+                + throwable
+                + ']';
     }
 
     private void writeObject(final ObjectOutputStream out) throws IOException {
         out.defaultWriteObject();
         out.writeInt(args.length);
         for (int i = 0; i < args.length; i++) {
-            SerializationUtil.writeWrappedObject(args[i] instanceof Serializable ? (Serializable) args[i] :
-                    String.valueOf(args[i]), out);
+            SerializationUtil.writeWrappedObject(
+                    args[i] instanceof Serializable ? (Serializable) args[i] : String.valueOf(args[i]), out);
         }
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessageFactory.java
@@ -47,8 +47,7 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
     /**
      * Constructs a message factory.
      */
-    public ParameterizedMessageFactory() {
-    }
+    public ParameterizedMessageFactory() {}
 
     /**
      * Creates {@link ParameterizedMessage} instances.
@@ -92,7 +91,8 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
         return new ParameterizedMessage(message, p0, p1, p2, p3);
     }
 
@@ -100,7 +100,8 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         return new ParameterizedMessage(message, p0, p1, p2, p3, p4);
     }
 
@@ -108,7 +109,14 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5);
     }
 
@@ -116,7 +124,14 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5, p6);
     }
@@ -125,8 +140,16 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
@@ -134,8 +157,17 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
@@ -143,8 +175,18 @@ public final class ParameterizedMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return new ParameterizedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedNoReferenceMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedNoReferenceMessageFactory.java
@@ -81,8 +81,7 @@ public final class ParameterizedNoReferenceMessageFactory extends AbstractMessag
     /**
      * Constructs a message factory with default flow strings.
      */
-    public ParameterizedNoReferenceMessageFactory() {
-    }
+    public ParameterizedNoReferenceMessageFactory() {}
 
     /**
      * Instance of ParameterizedStatusMessageFactory.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.io.Serializable;
-
 import org.apache.logging.log4j.util.PerformanceSensitive;
 
 /**
@@ -38,15 +37,14 @@ public final class ReusableMessageFactory implements MessageFactory2, Serializab
     public static final ReusableMessageFactory INSTANCE = new ReusableMessageFactory();
 
     private static final long serialVersionUID = 1L;
-    private transient final ThreadLocal<ReusableParameterizedMessage> threadLocalParameterized = new ThreadLocal<>();
-    private transient final ThreadLocal<ReusableSimpleMessage> threadLocalSimpleMessage = new ThreadLocal<>();
-    private transient final ThreadLocal<ReusableObjectMessage> threadLocalObjectMessage = new ThreadLocal<>();
+    private final transient ThreadLocal<ReusableParameterizedMessage> threadLocalParameterized = new ThreadLocal<>();
+    private final transient ThreadLocal<ReusableSimpleMessage> threadLocalSimpleMessage = new ThreadLocal<>();
+    private final transient ThreadLocal<ReusableObjectMessage> threadLocalObjectMessage = new ThreadLocal<>();
 
     /**
      * Constructs a message factory.
      */
-    public ReusableMessageFactory() {
-    }
+    public ReusableMessageFactory() {}
 
     private ReusableParameterizedMessage getParameterized() {
         ReusableParameterizedMessage result = threadLocalParameterized.get();
@@ -125,44 +123,84 @@ public final class ReusableMessageFactory implements MessageFactory2, Serializab
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
         return getParameterized().set(message, p0, p1, p2, p3);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         return getParameterized().set(message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -180,7 +218,6 @@ public final class ReusableMessageFactory implements MessageFactory2, Serializab
         result.set(message);
         return result;
     }
-
 
     /**
      * Creates {@link ReusableObjectMessage} instances.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.util.Arrays;
-
 import org.apache.logging.log4j.message.ParameterFormatter.MessagePatternAnalysis;
 import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.PerformanceSensitive;
@@ -49,8 +48,7 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
     /**
      * Creates a reusable message.
      */
-    public ReusableParameterizedMessage() {
-    }
+    public ReusableParameterizedMessage() {}
 
     private Object[] getTrimmedParams() {
         return varargs == null ? Arrays.copyOf(params, argCount) : varargs;
@@ -84,10 +82,14 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         } else {
             // The returned array will be reused by the caller in future swapParameter() calls.
             // Therefore we want to avoid returning arrays with less than 10 elements.
-            // If the vararg array is less than 10 params we just copy its content into the specified array
-            // and return it. This helps the caller to retain a reusable array of at least 10 elements.
-            // NOTE: LOG4J2-1688 unearthed the use case that an application array (not a varargs array) is passed
-            // as the argument array. This array should not be modified, so it cannot be passed to the caller
+            // If the vararg array is less than 10 params we just copy its content into the
+            // specified array
+            // and return it. This helps the caller to retain a reusable array of at least 10
+            // elements.
+            // NOTE: LOG4J2-1688 unearthed the use case that an application array (not a varargs
+            // array) is passed
+            // as the argument array. This array should not be modified, so it cannot be passed to
+            // the caller
             // who will at some point null out the elements in the array).
             if (argCount <= emptyReplacement.length) {
                 result = emptyReplacement;
@@ -164,7 +166,8 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3) {
+    ReusableParameterizedMessage set(
+            final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
@@ -173,7 +176,13 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    ReusableParameterizedMessage set(
+            final String messagePattern,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
@@ -183,7 +192,14 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    ReusableParameterizedMessage set(
+            final String messagePattern,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
@@ -194,7 +210,14 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    ReusableParameterizedMessage set(
+            final String messagePattern,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         params[0] = p0;
         params[1] = p1;
@@ -207,8 +230,16 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    ReusableParameterizedMessage set(
+            final String messagePattern,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
@@ -221,8 +252,17 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    ReusableParameterizedMessage set(
+            final String messagePattern,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
@@ -236,8 +276,18 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
-    ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    ReusableParameterizedMessage set(
+            final String messagePattern,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         params[0] = p0;
         params[1] = p1;
         params[2] = p2;
@@ -328,8 +378,13 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
 
     @Override
     public String toString() {
-        return "ReusableParameterizedMessage[messagePattern=" + getFormat() + ", stringArgs=" +
-                Arrays.toString(getParameters()) + ", throwable=" + getThrowable() + ']';
+        return "ReusableParameterizedMessage[messagePattern="
+                + getFormat()
+                + ", stringArgs="
+                + Arrays.toString(getParameters())
+                + ", throwable="
+                + getThrowable()
+                + ']';
     }
 
     @Override
@@ -342,7 +397,8 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         throwable = null;
         // Cut down on the memory usage after an analysis with an excessive argument count
         final int placeholderCharIndicesMaxLength = 16;
-        if (patternAnalysis.placeholderCharIndices != null && patternAnalysis.placeholderCharIndices.length > placeholderCharIndicesMaxLength) {
+        if (patternAnalysis.placeholderCharIndices != null
+                && patternAnalysis.placeholderCharIndices.length > placeholderCharIndicesMaxLength) {
             patternAnalysis.placeholderCharIndices = new int[placeholderCharIndicesMaxLength];
         }
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
@@ -81,8 +81,7 @@ public class ReusableSimpleMessage implements ReusableMessage, CharSequence, Par
     }
 
     @Override
-    public <S> void forEachParameter(final ParameterConsumer<S> action, final S state) {
-    }
+    public <S> void forEachParameter(final ParameterConsumer<S> action, final S state) {}
 
     @Override
     public Message memento() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessage.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.message;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
 /**
@@ -62,12 +61,12 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
      */
     @Override
     public String getFormattedMessage() {
-        return message = message == null ? String.valueOf(charSequence) : message ;
+        return message = message == null ? String.valueOf(charSequence) : message;
     }
 
     @Override
     public void formatTo(final StringBuilder buffer) {
-    buffer.append(message != null ? message : charSequence);
+        buffer.append(message != null ? message : charSequence);
     }
 
     /**
@@ -122,7 +121,6 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
         return null;
     }
 
-
     // CharSequence impl
 
     @Override
@@ -139,7 +137,6 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
     public CharSequence subSequence(final int start, final int end) {
         return charSequence.subSequence(start, end);
     }
-
 
     private void writeObject(final ObjectOutputStream out) throws IOException {
         getFormattedMessage(); // initialize the message:String field

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessageFactory.java
@@ -44,6 +44,7 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * Instance of StringFormatterMessageFactory.
      */
     public static final SimpleMessageFactory INSTANCE = new SimpleMessageFactory();
+
     private static final long serialVersionUID = 4418995198790088516L;
 
     /**
@@ -90,7 +91,8 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
         return new SimpleMessage(message);
     }
 
@@ -98,7 +100,8 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         return new SimpleMessage(message);
     }
 
@@ -106,7 +109,14 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return new SimpleMessage(message);
     }
 
@@ -114,7 +124,14 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         return new SimpleMessage(message);
     }
@@ -123,8 +140,16 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return new SimpleMessage(message);
     }
 
@@ -132,8 +157,17 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return new SimpleMessage(message);
     }
 
@@ -141,8 +175,18 @@ public final class SimpleMessageFactory extends AbstractMessageFactory {
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return new SimpleMessage(message);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormattedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormattedMessage.java
@@ -22,7 +22,6 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.IllegalFormatException;
 import java.util.Locale;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
 
@@ -52,14 +51,14 @@ public class StringFormattedMessage implements Message {
     private transient Throwable throwable;
     private final Locale locale;
 
-   /**
-    * Constructs a message.
-    *
-    * @param locale the locale for this message format
-    * @param messagePattern the pattern for this message format
-    * @param arguments The objects to format
-    * @since 2.6
-    */
+    /**
+     * Constructs a message.
+     *
+     * @param locale the locale for this message format
+     * @param messagePattern the pattern for this message format
+     * @param arguments The objects to format
+     * @since 2.6
+     */
     public StringFormattedMessage(final Locale locale, final String messagePattern, final Object... arguments) {
         this.locale = locale;
         this.messagePattern = messagePattern;
@@ -150,7 +149,6 @@ public class StringFormattedMessage implements Message {
         result = HASHVAL * result + (stringArgs != null ? Arrays.hashCode(stringArgs) : 0);
         return result;
     }
-
 
     @Override
     public String toString() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormatterMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormatterMessageFactory.java
@@ -41,13 +41,13 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * Instance of StringFormatterMessageFactory.
      */
     public static final StringFormatterMessageFactory INSTANCE = new StringFormatterMessageFactory();
+
     private static final long serialVersionUID = -1626332412176965642L;
 
     /**
      * Constructs a message factory with default flow strings.
      */
-    public StringFormatterMessageFactory() {
-    }
+    public StringFormatterMessageFactory() {}
 
     /**
      * Creates {@link StringFormattedMessage} instances.
@@ -91,7 +91,8 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
         return new StringFormattedMessage(message, p0, p1, p2, p3);
     }
 
@@ -99,7 +100,8 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         return new StringFormattedMessage(message, p0, p1, p2, p3, p4);
     }
 
@@ -107,7 +109,14 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return new StringFormattedMessage(message, p0, p1, p2, p3, p4, p5);
     }
 
@@ -115,7 +124,14 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         return new StringFormattedMessage(message, p0, p1, p2, p3, p4, p5, p6);
     }
@@ -124,8 +140,16 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return new StringFormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
@@ -133,8 +157,17 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return new StringFormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
@@ -142,8 +175,18 @@ public final class StringFormatterMessageFactory extends AbstractMessageFactory 
      * @since 2.6.1
      */
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return new StringFormattedMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StringMapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StringMapMessage.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.util.Map;
-
 import org.apache.logging.log4j.util.PerformanceSensitive;
 
 /**
@@ -34,8 +33,7 @@ public class StringMapMessage extends MapMessage<StringMapMessage, String> {
     /**
      * Constructs a new instance.
      */
-    public StringMapMessage() {
-    }
+    public StringMapMessage() {}
 
     /**
      * Constructs a new instance.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataCollectionMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataCollectionMessage.java
@@ -19,14 +19,13 @@ package org.apache.logging.log4j.message;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
 /**
  * A collection of StructuredDataMessages.
  */
-public class StructuredDataCollectionMessage implements StringBuilderFormattable,
-        MessageCollectionMessage<StructuredDataMessage> {
+public class StructuredDataCollectionMessage
+        implements StringBuilderFormattable, MessageCollectionMessage<StructuredDataMessage> {
     private static final long serialVersionUID = 5725337076388822924L;
 
     private final List<StructuredDataMessage> structuredDataMessageList;
@@ -82,9 +81,9 @@ public class StructuredDataCollectionMessage implements StringBuilderFormattable
         final Object[] objects = new Object[count];
         int index = 0;
         for (final Object[] objs : objectList) {
-           for (final Object obj : objs) {
-               objects[index++] = obj;
-           }
+            for (final Object obj : objs) {
+                objects[index++] = obj;
+            }
         }
         return objects;
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.io.Serializable;
-
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.Strings;
 
@@ -29,20 +28,20 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
     /**
      * RFC 5424 Time Quality.
      */
-    public static final StructuredDataId TIME_QUALITY = new StructuredDataId("timeQuality", null, new String[] {
-            "tzKnown", "isSynced", "syncAccuracy"});
+    public static final StructuredDataId TIME_QUALITY =
+            new StructuredDataId("timeQuality", null, new String[] {"tzKnown", "isSynced", "syncAccuracy"});
 
     /**
      * RFC 5424 Origin.
      */
-    public static final StructuredDataId ORIGIN = new StructuredDataId("origin", null, new String[] {"ip",
-            "enterpriseId", "software", "swVersion"});
+    public static final StructuredDataId ORIGIN =
+            new StructuredDataId("origin", null, new String[] {"ip", "enterpriseId", "software", "swVersion"});
 
     /**
      * RFC 5424 Meta.
      */
-    public static final StructuredDataId META = new StructuredDataId("meta", null, new String[] {"sequenceId",
-            "sysUpTime", "language"});
+    public static final StructuredDataId META =
+            new StructuredDataId("meta", null, new String[] {"sequenceId", "sysUpTime", "language"});
 
     /**
      * Reserved enterprise number.
@@ -103,8 +102,8 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
                 maxLength = MAX_LENGTH;
             }
             if (name.length() > maxLength) {
-                throw new IllegalArgumentException(String.format("Length of id %s exceeds maximum of %d characters",
-                        name, maxLength));
+                throw new IllegalArgumentException(
+                        String.format("Length of id %s exceeds maximum of %d characters", name, maxLength));
             }
             index = name.indexOf(AT_SIGN);
         }
@@ -128,8 +127,8 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @param required The list of keys that are required for this id.
      * @param optional The list of keys that are optional for this id.
      */
-    public StructuredDataId(final String name, final String enterpriseNumber, final String[] required,
-                            final String[] optional) {
+    public StructuredDataId(
+            final String name, final String enterpriseNumber, final String[] required, final String[] optional) {
         this(name, enterpriseNumber, required, optional, MAX_LENGTH);
     }
 
@@ -143,8 +142,8 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @deprecated Use {@link #StructuredDataId(String, String, String[], String[])} instead.
      */
     @Deprecated
-    public StructuredDataId(final String name, final int enterpriseNumber, final String[] required,
-                            final String[] optional) {
+    public StructuredDataId(
+            final String name, final int enterpriseNumber, final String[] required, final String[] optional) {
         this(name, String.valueOf(enterpriseNumber), required, optional, MAX_LENGTH);
     }
 
@@ -158,8 +157,12 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @param maxLength The maximum length of the StructuredData Id key.
      * @since 2.9
      */
-    public StructuredDataId(final String name, final String enterpriseNumber, final String[] required,
-                            final String[] optional, final int maxLength) {
+    public StructuredDataId(
+            final String name,
+            final String enterpriseNumber,
+            final String[] required,
+            final String[] optional,
+            final int maxLength) {
         if (name == null) {
             throw new IllegalArgumentException("No structured id name was supplied");
         }
@@ -191,8 +194,12 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @deprecated Use {@link #StructuredDataId(String, String, String[], String[], int)} instead.
      */
     @Deprecated
-    public StructuredDataId(final String name, final int enterpriseNumber, final String[] required,
-            final String[] optional, final int maxLength) {
+    public StructuredDataId(
+            final String name,
+            final int enterpriseNumber,
+            final String[] required,
+            final String[] optional,
+            final int maxLength) {
         this(name, String.valueOf(enterpriseNumber), required, optional, maxLength);
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.message;
 
 import java.util.Map;
-
 import org.apache.logging.log4j.util.EnglishEnums;
 import org.apache.logging.log4j.util.StringBuilders;
 
@@ -91,8 +90,7 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param type The message type.
      * @param data The StructuredData map.
      */
-    public StructuredDataMessage(final String id, final String msg, final String type,
-                                 final Map<String, String> data) {
+    public StructuredDataMessage(final String id, final String msg, final String type, final Map<String, String> data) {
         this(id, msg, type, data, MAX_LENGTH);
     }
 
@@ -106,8 +104,8 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param maxLength The maximum length of keys;
      * @since 2.9
      */
-    public StructuredDataMessage(final String id, final String msg, final String type,
-                                 final Map<String, String> data, final int maxLength) {
+    public StructuredDataMessage(
+            final String id, final String msg, final String type, final Map<String, String> data, final int maxLength) {
         super(data);
         this.id = new StructuredDataId(id, null, null, maxLength);
         this.message = msg;
@@ -148,8 +146,8 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param type The message type.
      * @param data The StructuredData map.
      */
-    public StructuredDataMessage(final StructuredDataId id, final String msg, final String type,
-                                 final Map<String, String> data) {
+    public StructuredDataMessage(
+            final StructuredDataId id, final String msg, final String type, final Map<String, String> data) {
         this(id, msg, type, data, MAX_LENGTH);
     }
 
@@ -163,15 +161,18 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param maxLength The maximum length of keys;
      * @since 2.9
      */
-    public StructuredDataMessage(final StructuredDataId id, final String msg, final String type,
-                                 final Map<String, String> data, final int maxLength) {
+    public StructuredDataMessage(
+            final StructuredDataId id,
+            final String msg,
+            final String type,
+            final Map<String, String> data,
+            final int maxLength) {
         super(data);
         this.id = id;
         this.message = msg;
         this.type = type;
         this.maxLength = maxLength;
     }
-
 
     /**
      * Constructor based on a StructuredDataMessage.
@@ -285,7 +286,6 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param format The format identifier. Ignored in this implementation.
      * @return The formatted String.
      */
-
     @Override
     public String asString(final String format) {
         try {
@@ -405,7 +405,6 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
         return asString(null, null);
     }
 
-
     @Override
     public StructuredDataMessage newInstance(final Map<String, String> map) {
         return new StructuredDataMessage(this, map);
@@ -523,16 +522,15 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
 
     protected void validateKey(final String key) {
         if (maxLength > 0 && key.length() > maxLength) {
-            throw new IllegalArgumentException("Structured data keys are limited to " + maxLength +
-                    " characters. key: " + key);
+            throw new IllegalArgumentException(
+                    "Structured data keys are limited to " + maxLength + " characters. key: " + key);
         }
         for (int i = 0; i < key.length(); i++) {
             final char c = key.charAt(i);
             if (c < '!' || c > '~' || c == '=' || c == ']' || c == '"') {
-                throw new IllegalArgumentException("Structured data keys must contain printable US ASCII characters" +
-                        "and may not contain a space, =, ], or \"");
+                throw new IllegalArgumentException("Structured data keys must contain printable US ASCII characters"
+                        + "and may not contain a space, =, ], or \"");
             }
         }
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadDumpMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadDumpMessage.java
@@ -16,22 +16,21 @@
  */
 package org.apache.logging.log4j.message;
 
+import static org.apache.logging.log4j.util.Chars.LF;
+
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
-
-import aQute.bnd.annotation.Cardinality;
-import aQute.bnd.annotation.Resolution;
-import aQute.bnd.annotation.spi.ServiceConsumer;
 import org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
 import org.apache.logging.log4j.util.ServiceLoaderUtil;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.Strings;
-
-import static org.apache.logging.log4j.util.Chars.LF;
 
 /**
  * Captures information about all running Threads.
@@ -125,7 +124,7 @@ public class ThreadDumpMessage implements Message, StringBuilderFormattable {
         return null;
     }
 
-        /**
+    /**
      * Creates a ThreadDumpMessageProxy that can be serialized.
      * @return a ThreadDumpMessageProxy.
      */
@@ -133,8 +132,7 @@ public class ThreadDumpMessage implements Message, StringBuilderFormattable {
         return new ThreadDumpMessageProxy(this);
     }
 
-    private void readObject(final ObjectInputStream stream)
-        throws InvalidObjectException {
+    private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
         throw new InvalidObjectException("Proxy required");
     }
 
@@ -178,8 +176,7 @@ public class ThreadDumpMessage implements Message, StringBuilderFormattable {
         @Override
         public Map<ThreadInformation, StackTraceElement[]> createThreadInfo() {
             final Map<Thread, StackTraceElement[]> map = Thread.getAllStackTraces();
-            final Map<ThreadInformation, StackTraceElement[]> threads =
-                new HashMap<>(map.size());
+            final Map<ThreadInformation, StackTraceElement[]> threads = new HashMap<>(map.size());
             for (final Map.Entry<Thread, StackTraceElement[]> entry : map.entrySet()) {
                 threads.put(new BasicThreadInformation(entry.getKey()), entry.getValue());
             }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadInformation.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadInformation.java
@@ -33,5 +33,4 @@ public interface ThreadInformation {
      * @param trace The stack trace element array to format.
      */
     void printStack(StringBuilder sb, StackTraceElement[] trace);
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLogger.java
@@ -21,7 +21,6 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Map;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.ThreadContext;
@@ -58,9 +57,16 @@ public class SimpleLogger extends AbstractLogger {
 
     private final String logName;
 
-    public SimpleLogger(final String name, final Level defaultLevel, final boolean showLogName,
-            final boolean showShortLogName, final boolean showDateTime, final boolean showContextMap,
-            final String dateTimeFormat, final MessageFactory messageFactory, final PropertiesUtil props,
+    public SimpleLogger(
+            final String name,
+            final Level defaultLevel,
+            final boolean showLogName,
+            final boolean showShortLogName,
+            final boolean showDateTime,
+            final boolean showContextMap,
+            final String dateTimeFormat,
+            final MessageFactory messageFactory,
+            final PropertiesUtil props,
             final PrintStream stream) {
         super(name, messageFactory);
         final String lvl = props.getStringProperty(SimpleLoggerContext.SYSTEM_PREFIX + name + ".level");
@@ -131,65 +137,124 @@ public class SimpleLogger extends AbstractLogger {
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1) {
+    public boolean isEnabled(
+            final Level testLevel, final Marker marker, final String message, final Object p0, final Object p1) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2) {
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3) {
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
             final Object p7) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8) {
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
     @Override
-    public boolean isEnabled(final Level testLevel, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public boolean isEnabled(
+            final Level testLevel,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return this.level.intLevel() >= testLevel.intLevel();
     }
 
@@ -199,7 +264,11 @@ public class SimpleLogger extends AbstractLogger {
     }
 
     @Override
-    public void logMessage(final String fqcn, final Level mgsLevel, final Marker marker, final Message msg,
+    public void logMessage(
+            final String fqcn,
+            final Level mgsLevel,
+            final Marker marker,
+            final Message msg,
             final Throwable throwable) {
         final StringBuilder sb = new StringBuilder();
         // Append date-time if so configured
@@ -230,7 +299,9 @@ public class SimpleLogger extends AbstractLogger {
         }
         final Object[] params = msg.getParameters();
         Throwable t;
-        if (throwable == null && params != null && params.length > 0
+        if (throwable == null
+                && params != null
+                && params.length > 0
                 && params[params.length - 1] instanceof Throwable) {
             t = (Throwable) params[params.length - 1];
         } else {
@@ -252,5 +323,4 @@ public class SimpleLogger extends AbstractLogger {
     public void setStream(final PrintStream stream) {
         this.stream = stream;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContext.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.simple;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.spi.AbstractLogger;
@@ -85,8 +84,10 @@ public class SimpleLoggerContext implements LoggerContext {
         final String lvl = props.getStringProperty(SYSTEM_PREFIX + "level");
         defaultLevel = Level.toLevel(lvl, Level.ERROR);
 
-        dateTimeFormat = showDateTime ? props.getStringProperty(SimpleLoggerContext.SYSTEM_PREFIX + "dateTimeFormat",
-                DEFAULT_DATE_TIME_FORMAT) : null;
+        dateTimeFormat = showDateTime
+                ? props.getStringProperty(
+                        SimpleLoggerContext.SYSTEM_PREFIX + "dateTimeFormat", DEFAULT_DATE_TIME_FORMAT)
+                : null;
 
         final String fileName = props.getStringProperty(SYSTEM_PREFIX + "logFile", SYSTEM_ERR);
         PrintStream ps;
@@ -122,8 +123,17 @@ public class SimpleLoggerContext implements LoggerContext {
             AbstractLogger.checkMessageFactory(extendedLogger, messageFactory);
             return extendedLogger;
         }
-        final SimpleLogger simpleLogger = new SimpleLogger(name, defaultLevel, showLogName, showShortName, showDateTime,
-                showContextMap, dateTimeFormat, messageFactory, props, stream);
+        final SimpleLogger simpleLogger = new SimpleLogger(
+                name,
+                defaultLevel,
+                showLogName,
+                showShortName,
+                showDateTime,
+                showContextMap,
+                dateTimeFormat,
+                messageFactory,
+                props,
+                stream);
         loggerRegistry.putIfAbsent(name, messageFactory, simpleLogger);
         return loggerRegistry.getLogger(name, messageFactory);
     }
@@ -153,5 +163,4 @@ public class SimpleLoggerContext implements LoggerContext {
     public boolean hasLogger(final String name, final MessageFactory messageFactory) {
         return false;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContextFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContextFactory.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.simple;
 
 import java.net.URI;
-
 import org.apache.logging.log4j.spi.LoggerContext;
 import org.apache.logging.log4j.spi.LoggerContextFactory;
 
@@ -32,13 +31,19 @@ public class SimpleLoggerContextFactory implements LoggerContextFactory {
     public static final SimpleLoggerContextFactory INSTANCE = new SimpleLoggerContextFactory();
 
     @Override
-    public LoggerContext getContext(final String fqcn, final ClassLoader loader, final Object externalContext, final boolean currentContext) {
+    public LoggerContext getContext(
+            final String fqcn, final ClassLoader loader, final Object externalContext, final boolean currentContext) {
         return SimpleLoggerContext.INSTANCE;
     }
 
     @Override
-    public LoggerContext getContext(final String fqcn, final ClassLoader loader, final Object externalContext, final boolean currentContext,
-        final URI configLocation, final String name) {
+    public LoggerContext getContext(
+            final String fqcn,
+            final ClassLoader loader,
+            final Object externalContext,
+            final boolean currentContext,
+            final URI configLocation,
+            final String name) {
         return SimpleLoggerContext.INSTANCE;
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.spi;
 
 import java.io.Serializable;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogBuilder;
 import org.apache.logging.log4j.LoggingException;
@@ -49,7 +48,8 @@ import org.apache.logging.log4j.util.Supplier;
 public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLogger, Serializable {
     // Implementation note: many methods in this class are tuned for performance. MODIFY WITH CARE!
     // Specifically, try to keep the hot methods to 35 bytecodes or less:
-    // this is within the MaxInlineSize threshold on Java 7 and Java 8 Hotspot and makes these methods
+    // this is within the MaxInlineSize threshold on Java 7 and Java 8 Hotspot and makes these
+    // methods
     // candidates for immediate inlining instead of waiting until they are designated "hot enough".
 
     /**
@@ -75,19 +75,20 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     /**
      * Marker for throwing exceptions.
      */
-    public static final Marker THROWING_MARKER = MarkerManager.getMarker("THROWING").setParents(EXCEPTION_MARKER);
+    public static final Marker THROWING_MARKER =
+            MarkerManager.getMarker("THROWING").setParents(EXCEPTION_MARKER);
 
     /**
      * Marker for catching exceptions.
      */
-    public static final Marker CATCHING_MARKER = MarkerManager.getMarker("CATCHING").setParents(EXCEPTION_MARKER);
+    public static final Marker CATCHING_MARKER =
+            MarkerManager.getMarker("CATCHING").setParents(EXCEPTION_MARKER);
 
     /**
      * The default MessageFactory class.
      */
-    public static final Class<? extends MessageFactory> DEFAULT_MESSAGE_FACTORY_CLASS =
-            createClassForProperty("log4j2.messageFactory", ReusableMessageFactory.class,
-                    ParameterizedMessageFactory.class);
+    public static final Class<? extends MessageFactory> DEFAULT_MESSAGE_FACTORY_CLASS = createClassForProperty(
+            "log4j2.messageFactory", ReusableMessageFactory.class, ParameterizedMessageFactory.class);
 
     /**
      * The default FlowMessageFactory class.
@@ -150,17 +151,22 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         final String name = logger.getName();
         final MessageFactory loggerMessageFactory = logger.getMessageFactory();
         if (messageFactory != null && !loggerMessageFactory.equals(messageFactory)) {
-            StatusLogger.getLogger().warn(
-                    "The Logger {} was created with the message factory {} and is now requested with the "
-                            + "message factory {}, which may create log events with unexpected formatting.", name,
-                    loggerMessageFactory, messageFactory);
+            StatusLogger.getLogger()
+                    .warn(
+                            "The Logger {} was created with the message factory {} and is now requested with the "
+                                    + "message factory {}, which may create log events with unexpected formatting.",
+                            name,
+                            loggerMessageFactory,
+                            messageFactory);
         } else if (messageFactory == null && !loggerMessageFactory.getClass().equals(DEFAULT_MESSAGE_FACTORY_CLASS)) {
-            StatusLogger
-                    .getLogger()
-                    .warn("The Logger {} was created with the message factory {} and is now requested with a null "
-                            + "message factory (defaults to {}), which may create log events with unexpected "
-                            + "formatting.",
-                            name, loggerMessageFactory, DEFAULT_MESSAGE_FACTORY_CLASS.getName());
+            StatusLogger.getLogger()
+                    .warn(
+                            "The Logger {} was created with the message factory {} and is now requested with a null "
+                                    + "message factory (defaults to {}), which may create log events with unexpected "
+                                    + "formatting.",
+                            name,
+                            loggerMessageFactory,
+                            DEFAULT_MESSAGE_FACTORY_CLASS.getName());
         }
     }
 
@@ -193,11 +199,13 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         return messageFactory.newMessage(CATCHING);
     }
 
-    private static Class<? extends MessageFactory> createClassForProperty(final String property,
+    private static Class<? extends MessageFactory> createClassForProperty(
+            final String property,
             final Class<ReusableMessageFactory> reusableParameterizedMessageFactoryClass,
             final Class<ParameterizedMessageFactory> parameterizedMessageFactoryClass) {
         try {
-            final String fallback = Constants.ENABLE_THREADLOCALS ? reusableParameterizedMessageFactoryClass.getName()
+            final String fallback = Constants.ENABLE_THREADLOCALS
+                    ? reusableParameterizedMessageFactoryClass.getName()
                     : parameterizedMessageFactoryClass.getName();
             final String clsName = PropertiesUtil.getProperties().getStringProperty(property, fallback);
             return LoaderUtil.loadClass(clsName).asSubclass(MessageFactory.class);
@@ -206,10 +214,11 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         }
     }
 
-    private static Class<? extends FlowMessageFactory> createFlowClassForProperty(final String property,
-            final Class<DefaultFlowMessageFactory> defaultFlowMessageFactoryClass) {
+    private static Class<? extends FlowMessageFactory> createFlowClassForProperty(
+            final String property, final Class<DefaultFlowMessageFactory> defaultFlowMessageFactoryClass) {
         try {
-            final String clsName = PropertiesUtil.getProperties().getStringProperty(property, defaultFlowMessageFactoryClass.getName());
+            final String clsName = PropertiesUtil.getProperties()
+                    .getStringProperty(property, defaultFlowMessageFactoryClass.getName());
             return LoaderUtil.loadClass(clsName).asSubclass(FlowMessageFactory.class);
         } catch (final Throwable throwable) {
             return defaultFlowMessageFactoryClass;
@@ -396,48 +405,100 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4) {
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5) {
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void debug(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void debug(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -462,41 +523,78 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4) {
+    public void debug(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void debug(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void debug(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
+    public void debug(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
             final Object p7) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8) {
+    public void debug(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void debug(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public void debug(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -510,8 +608,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     protected EntryMessage enter(final String fqcn, final String format, final Supplier<?>... paramSuppliers) {
         EntryMessage entryMsg = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER,
-                    entryMsg = flowMessageFactory.newEntryMessage(format, LambdaUtil.getAll(paramSuppliers)), null);
+            logMessageSafely(
+                    fqcn,
+                    Level.TRACE,
+                    ENTRY_MARKER,
+                    entryMsg = flowMessageFactory.newEntryMessage(format, LambdaUtil.getAll(paramSuppliers)),
+                    null);
         }
         return entryMsg;
     }
@@ -542,7 +644,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     protected EntryMessage enter(final String fqcn, final String format, final Object... params) {
         EntryMessage entryMsg = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg = flowMessageFactory.newEntryMessage(format, params), null);
+            logMessageSafely(
+                    fqcn,
+                    Level.TRACE,
+                    ENTRY_MARKER,
+                    entryMsg = flowMessageFactory.newEntryMessage(format, params),
+                    null);
         }
         return entryMsg;
     }
@@ -557,8 +664,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     protected EntryMessage enter(final String fqcn, final MessageSupplier messageSupplier) {
         EntryMessage message = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, message = flowMessageFactory.newEntryMessage(
-                    messageSupplier.get()), null);
+            logMessageSafely(
+                    fqcn,
+                    Level.TRACE,
+                    ENTRY_MARKER,
+                    message = flowMessageFactory.newEntryMessage(messageSupplier.get()),
+                    null);
         }
         return message;
     }
@@ -575,8 +686,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     protected EntryMessage enter(final String fqcn, final Message message) {
         EntryMessage flowMessage = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, flowMessage = flowMessageFactory.newEntryMessage(message),
-                    null);
+            logMessageSafely(
+                    fqcn, Level.TRACE, ENTRY_MARKER, flowMessage = flowMessageFactory.newEntryMessage(message), null);
         }
         return flowMessage;
     }
@@ -781,48 +892,100 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4) {
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5) {
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void error(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void error(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -847,38 +1010,78 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void error(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4) {
+    public void error(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void error(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void error(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void error(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void error(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void error(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void error(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void error(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public void error(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void error(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void error(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -1084,46 +1287,100 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4) {
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5) {
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6) {
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void fatal(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void fatal(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -1148,39 +1405,78 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void fatal(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4) {
+    public void fatal(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void fatal(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void fatal(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void fatal(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void fatal(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void fatal(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void fatal(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void fatal(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public void fatal(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void fatal(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public void fatal(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -1356,46 +1652,100 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4) {
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5) {
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6) {
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void info(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void info(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -1420,41 +1770,78 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void info(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4) {
+    public void info(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void info(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void info(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void info(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void info(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void info(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
+    public void info(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
             final Object p7) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void info(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8) {
+    public void info(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void info(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public void info(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -1643,7 +2030,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
+    public void log(
+            final Level level, final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, level, marker, messageSupplier, throwable);
     }
 
@@ -1658,7 +2046,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
+    public void log(
+            final Level level, final Marker marker, final MessageSupplier messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, level, marker, messageSupplier, throwable);
     }
 
@@ -1683,53 +2072,118 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
             final Object p2) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3, final Object p4) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3, final Object p4, final Object p5) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3, final Object p4, final Object p5, final Object p6) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1,
-            final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -1749,48 +2203,109 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void log(
+            final Level level,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final Message message,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Message message,
             final Throwable throwable) {
         if (isEnabled(level, marker, message, throwable)) {
             logMessageSafely(fqcn, level, marker, message, throwable);
@@ -1798,15 +2313,23 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker,
-            final MessageSupplier messageSupplier, final Throwable throwable) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final MessageSupplier messageSupplier,
+            final Throwable throwable) {
         if (isEnabled(level, marker, messageSupplier, throwable)) {
             logMessage(fqcn, level, marker, messageSupplier, throwable);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final Object message,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Object message,
             final Throwable throwable) {
         if (isEnabled(level, marker, message, throwable)) {
             logMessage(fqcn, level, marker, message, throwable);
@@ -1814,7 +2337,11 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final CharSequence message,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final CharSequence message,
             final Throwable throwable) {
         if (isEnabled(level, marker, message, throwable)) {
             logMessage(fqcn, level, marker, message, throwable);
@@ -1822,7 +2349,11 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final Supplier<?> messageSupplier,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Supplier<?> messageSupplier,
             final Throwable throwable) {
         if (isEnabled(level, marker, messageSupplier, throwable)) {
             logMessage(fqcn, level, marker, messageSupplier, throwable);
@@ -1837,7 +2368,11 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
             final Supplier<?>... paramSuppliers) {
         if (isEnabled(level, marker, message)) {
             logMessage(fqcn, level, marker, message, paramSuppliers);
@@ -1845,64 +2380,108 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object... params) {
+    public void logIfEnabled(
+            final String fqcn, final Level level, final Marker marker, final String message, final Object... params) {
         if (isEnabled(level, marker, message, params)) {
             logMessage(fqcn, level, marker, message, params);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0) {
+    public void logIfEnabled(
+            final String fqcn, final Level level, final Marker marker, final String message, final Object p0) {
         if (isEnabled(level, marker, message, p0)) {
             logMessage(fqcn, level, marker, message, p0);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1) {
         if (isEnabled(level, marker, message, p0, p1)) {
             logMessage(fqcn, level, marker, message, p0, p1);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         if (isEnabled(level, marker, message, p0, p1, p2)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3, p4)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3, p4);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3, p4, p5);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3, p4, p5, p6);
@@ -1910,69 +2489,124 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         if (isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)) {
             logMessage(fqcn, level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
         }
     }
 
     @Override
-    public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
             final Throwable throwable) {
         if (isEnabled(level, marker, message, throwable)) {
             logMessage(fqcn, level, marker, message, throwable);
         }
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final CharSequence message,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final CharSequence message,
             final Throwable throwable) {
         logMessageSafely(fqcn, level, marker, messageFactory.newMessage(message), throwable);
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final Object message,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Object message,
             final Throwable throwable) {
         logMessageSafely(fqcn, level, marker, messageFactory.newMessage(message), throwable);
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker,
-            final MessageSupplier messageSupplier, final Throwable throwable) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final MessageSupplier messageSupplier,
+            final Throwable throwable) {
         final Message message = LambdaUtil.get(messageSupplier);
-        final Throwable effectiveThrowable = (throwable == null && message != null)
-                ? message.getThrowable()
-                : throwable;
+        final Throwable effectiveThrowable =
+                (throwable == null && message != null) ? message.getThrowable() : throwable;
         logMessageSafely(fqcn, level, marker, message, effectiveThrowable);
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final Supplier<?> messageSupplier,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Supplier<?> messageSupplier,
             final Throwable throwable) {
         final Message message = LambdaUtil.getMessage(messageSupplier, messageFactory);
-        final Throwable effectiveThrowable = (throwable == null && message != null)
-                ? message.getThrowable()
-                : throwable;
+        final Throwable effectiveThrowable =
+                (throwable == null && message != null) ? message.getThrowable() : throwable;
         logMessageSafely(fqcn, level, marker, message, effectiveThrowable);
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
             final Throwable throwable) {
         logMessageSafely(fqcn, level, marker, messageFactory.newMessage(message), throwable);
     }
@@ -1982,85 +2616,171 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object... params) {
+    protected void logMessage(
+            final String fqcn, final Level level, final Marker marker, final String message, final Object... params) {
         final Message msg = messageFactory.newMessage(message, params);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0) {
+    protected void logMessage(
+            final String fqcn, final Level level, final Marker marker, final String message, final Object p0) {
         final Message msg = messageFactory.newMessage(message, p0);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1) {
         final Message msg = messageFactory.newMessage(message, p0, p1);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3, p4);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3, p4, p5);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
             final Object p6) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3, p4, p5, p6);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
-            final Object p0, final Object p1, final Object p2, final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         final Message msg = messageFactory.newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
             final Supplier<?>... paramSuppliers) {
         final Message msg = messageFactory.newMessage(message, LambdaUtil.getAll(paramSuppliers));
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
     @Override
-    public void logMessage(final Level level, final Marker marker, final String fqcn, final StackTraceElement location,
-        final Message message, final Throwable throwable) {
+    public void logMessage(
+            final Level level,
+            final Marker marker,
+            final String fqcn,
+            final StackTraceElement location,
+            final Message message,
+            final Throwable throwable) {
         try {
             incrementRecursionDepth();
             log(level, marker, fqcn, location, message, throwable);
@@ -2072,8 +2792,13 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         }
     }
 
-    protected void log(final Level level, final Marker marker, final String fqcn, final StackTraceElement location,
-        final Message message, final Throwable throwable) {
+    protected void log(
+            final Level level,
+            final Marker marker,
+            final String fqcn,
+            final StackTraceElement location,
+            final Message message,
+            final Throwable throwable) {
         logMessage(fqcn, level, marker, message, throwable);
     }
 
@@ -2096,12 +2821,17 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     @PerformanceSensitive
     // NOTE: This is a hot method. Current implementation compiles to 30 bytes of byte code.
     // This is within the 35 byte MaxInlineSize threshold. Modify with care!
-    private void logMessageSafely(final String fqcn, final Level level, final Marker marker, final Message message,
+    private void logMessageSafely(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Message message,
             final Throwable throwable) {
         try {
             logMessageTrackRecursion(fqcn, level, marker, message, throwable);
         } finally {
-            // LOG4J2-1583 prevent scrambled logs when logging calls are nested (logging in toString())
+            // LOG4J2-1583 prevent scrambled logs when logging calls are nested (logging in
+            // toString())
             ReusableMessageFactory.release(message);
         }
     }
@@ -2109,11 +2839,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     @PerformanceSensitive
     // NOTE: This is a hot method. Current implementation compiles to 33 bytes of byte code.
     // This is within the 35 byte MaxInlineSize threshold. Modify with care!
-    private void logMessageTrackRecursion(final String fqcn,
-                                          final Level level,
-                                          final Marker marker,
-                                          final Message message,
-                                          final Throwable throwable) {
+    private void logMessageTrackRecursion(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final Message message,
+            final Throwable throwable) {
         try {
             incrementRecursionDepth(); // LOG4J2-1518, LOG4J2-2031
             tryLogMessage(fqcn, getLocation(fqcn), level, marker, message, throwable);
@@ -2155,16 +2886,18 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     @PerformanceSensitive
     // NOTE: This is a hot method. Current implementation compiles to 26 bytes of byte code.
     // This is within the 35 byte MaxInlineSize threshold. Modify with care!
-    private void tryLogMessage(final String fqcn,
-                               final StackTraceElement location,
-                               final Level level,
-                               final Marker marker,
-                               final Message message,
-                               final Throwable throwable) {
+    private void tryLogMessage(
+            final String fqcn,
+            final StackTraceElement location,
+            final Level level,
+            final Marker marker,
+            final Message message,
+            final Throwable throwable) {
         try {
             log(level, marker, fqcn, location, message, throwable);
         } catch (final Throwable t) {
-            // LOG4J2-1990 Log4j2 suppresses all exceptions that occur once application called the logger
+            // LOG4J2-1990 Log4j2 suppresses all exceptions that occur once application called the
+            // logger
             handleLogMessageException(t, fqcn, message);
         }
     }
@@ -2182,12 +2915,14 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         if (throwable instanceof LoggingException) {
             throw (LoggingException) throwable;
         }
-        StatusLogger.getLogger().warn("{} caught {} logging {}: {}",
-                fqcn,
-                throwable.getClass().getName(),
-                message.getClass().getSimpleName(),
-                message.getFormat(),
-                throwable);
+        StatusLogger.getLogger()
+                .warn(
+                        "{} caught {} logging {}: {}",
+                        fqcn,
+                        throwable.getClass().getName(),
+                        message.getClass().getSimpleName(),
+                        message.getFormat(),
+                        throwable);
     }
 
     @Override
@@ -2376,46 +3111,100 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4) {
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5) {
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6) {
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8) {
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void trace(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void trace(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -2440,38 +3229,78 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void trace(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4) {
+    public void trace(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void trace(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void trace(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void trace(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void trace(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void trace(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void trace(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void trace(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public void trace(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void trace(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void trace(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -2517,7 +3346,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public void traceExit(final EntryMessage message) {
-        // If the message is null, traceEnter returned null because flow logging was disabled, we can optimize out calling isEnabled().
+        // If the message is null, traceEnter returned null because flow logging was disabled, we
+        // can optimize out calling isEnabled().
         if (message != null && isEnabled(Level.TRACE, EXIT_MARKER, message, null)) {
             logMessageSafely(FQCN, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(message), null);
         }
@@ -2525,7 +3355,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public <R> R traceExit(final EntryMessage message, final R result) {
-        // If the message is null, traceEnter returned null because flow logging was disabled, we can optimize out calling isEnabled().
+        // If the message is null, traceEnter returned null because flow logging was disabled, we
+        // can optimize out calling isEnabled().
         if (message != null && isEnabled(Level.TRACE, EXIT_MARKER, message, null)) {
             logMessageSafely(FQCN, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(result, message), null);
         }
@@ -2534,7 +3365,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     @Override
     public <R> R traceExit(final Message message, final R result) {
-        // If the message is null, traceEnter returned null because flow logging was disabled, we can optimize out calling isEnabled().
+        // If the message is null, traceEnter returned null because flow logging was disabled, we
+        // can optimize out calling isEnabled().
         if (message != null && isEnabled(Level.TRACE, EXIT_MARKER, message, null)) {
             logMessageSafely(FQCN, Level.TRACE, EXIT_MARKER, flowMessageFactory.newExitMessage(result, message), null);
         }
@@ -2697,45 +3529,100 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
             final Object p3) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4) {
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5) {
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6) {
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void warn(final Marker marker, final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3, final Object p4, final Object p5,
-            final Object p6, final Object p7, final Object p8, final Object p9) {
+    public void warn(
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -2760,39 +3647,78 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
-    public void warn(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4) {
+    public void warn(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public void warn(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public void warn(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public void warn(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public void warn(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public void warn(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public void warn(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public void warn(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public void warn(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public void warn(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public void warn(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -2897,5 +3823,4 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         }
         return new DefaultLogBuilder(this, level);
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLoggerAdapter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLoggerAdapter.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.util.LoaderUtil;
 
@@ -40,7 +39,7 @@ public abstract class AbstractLoggerAdapter<L> implements LoggerAdapter<L>, Logg
      */
     protected final Map<LoggerContext, ConcurrentMap<String, L>> registry = new ConcurrentHashMap<>();
 
-    private final ReadWriteLock lock = new ReentrantReadWriteLock (true);
+    private final ReadWriteLock lock = new ReentrantReadWriteLock(true);
 
     @Override
     public L getLogger(final String name) {
@@ -67,29 +66,29 @@ public abstract class AbstractLoggerAdapter<L> implements LoggerAdapter<L>, Logg
      */
     public ConcurrentMap<String, L> getLoggersInContext(final LoggerContext context) {
         ConcurrentMap<String, L> loggers;
-        lock.readLock ().lock ();
+        lock.readLock().lock();
         try {
-            loggers = registry.get (context);
+            loggers = registry.get(context);
         } finally {
-            lock.readLock ().unlock ();
+            lock.readLock().unlock();
         }
 
         if (loggers != null) {
             return loggers;
         }
-        lock.writeLock ().lock ();
+        lock.writeLock().lock();
         try {
-            loggers = registry.get (context);
+            loggers = registry.get(context);
             if (loggers == null) {
-                loggers = new ConcurrentHashMap<> ();
-                registry.put (context, loggers);
+                loggers = new ConcurrentHashMap<>();
+                registry.put(context, loggers);
                 if (context instanceof LoggerContextShutdownEnabled) {
                     ((LoggerContextShutdownEnabled) context).addShutdownListener(this);
                 }
             }
             return loggers;
         } finally {
-            lock.writeLock ().unlock ();
+            lock.writeLock().unlock();
         }
     }
 
@@ -139,11 +138,11 @@ public abstract class AbstractLoggerAdapter<L> implements LoggerAdapter<L>, Logg
 
     @Override
     public void close() {
-        lock.writeLock ().lock ();
+        lock.writeLock().lock();
         try {
             registry.clear();
         } finally {
-            lock.writeLock ().unlock ();
+            lock.writeLock().unlock();
         }
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/CleanableThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/CleanableThreadContextMap.java
@@ -30,10 +30,9 @@ public interface CleanableThreadContextMap extends ThreadContextMap2 {
      *
      * <p>If the current thread does not have a context map it is
      * created as a side effect.</p>
-
+     *
      * @param keys The keys.
      * @since 2.8
      */
     void removeAll(final Iterable<String> keys);
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/CopyOnWrite.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/CopyOnWrite.java
@@ -22,5 +22,4 @@ package org.apache.logging.log4j.spi;
  * @see ReadOnlyThreadContextMap#getReadOnlyContextData()
  * @since 2.7
  */
-public interface CopyOnWrite {
-}
+public interface CopyOnWrite {}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/CopyOnWriteSortedArrayThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/CopyOnWriteSortedArrayThreadContextMap.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
@@ -79,7 +78,8 @@ class CopyOnWriteSortedArrayThreadContextMap implements ReadOnlyThreadContextMap
         this.localMap = createThreadLocalMap();
     }
 
-    // LOG4J2-479: by default, use a plain ThreadLocal, only use InheritableThreadLocal if configured.
+    // LOG4J2-479: by default, use a plain ThreadLocal, only use InheritableThreadLocal if
+    // configured.
     // (This method is package protected for JUnit tests.)
     private ThreadLocal<StringMap> createThreadLocalMap() {
         if (inheritableMap) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/DefaultThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/DefaultThreadContextMap.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
 import org.apache.logging.log4j.util.BiConsumer;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
@@ -50,7 +49,8 @@ public class DefaultThreadContextMap implements ThreadContextMap, ReadOnlyString
         init();
     }
 
-    // LOG4J2-479: by default, use a plain ThreadLocal, only use InheritableThreadLocal if configured.
+    // LOG4J2-479: by default, use a plain ThreadLocal, only use InheritableThreadLocal if
+    // configured.
     // (This method is package protected for JUnit tests.)
     static ThreadLocal<Map<String, String>> createThreadLocalMap(final boolean isMapEnabled) {
         if (inheritableMap) {
@@ -58,7 +58,7 @@ public class DefaultThreadContextMap implements ThreadContextMap, ReadOnlyString
                 @Override
                 protected Map<String, String> childValue(final Map<String, String> parentValue) {
                     return parentValue != null && isMapEnabled //
-                    ? Collections.unmodifiableMap(new HashMap<>(parentValue)) //
+                            ? Collections.unmodifiableMap(new HashMap<>(parentValue)) //
                             : null;
                 }
             };
@@ -153,10 +153,10 @@ public class DefaultThreadContextMap implements ThreadContextMap, ReadOnlyString
             return;
         }
         for (final Map.Entry<String, String> entry : map.entrySet()) {
-            //BiConsumer should be able to handle values of any type V. In our case the values are of type String.
+            // BiConsumer should be able to handle values of any type V. In our case the values are
+            // of type String.
             @SuppressWarnings("unchecked")
-            final
-            V value = (V) entry.getValue();
+            final V value = (V) entry.getValue();
             action.accept(entry.getKey(), value);
         }
     }
@@ -168,10 +168,10 @@ public class DefaultThreadContextMap implements ThreadContextMap, ReadOnlyString
             return;
         }
         for (final Map.Entry<String, String> entry : map.entrySet()) {
-            //TriConsumer should be able to handle values of any type V. In our case the values are of type String.
+            // TriConsumer should be able to handle values of any type V. In our case the values are
+            // of type String.
             @SuppressWarnings("unchecked")
-            final
-            V value = (V) entry.getValue();
+            final V value = (V) entry.getValue();
             action.accept(entry.getKey(), value, state);
         }
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/DefaultThreadContextStack.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/DefaultThreadContextStack.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-
 import org.apache.logging.log4j.ThreadContext.ContextStack;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.StringBuilders;
@@ -97,7 +96,7 @@ public class DefaultThreadContextStack implements ThreadContextStack, StringBuil
     public boolean containsAll(final Collection<?> objects) {
         if (objects.isEmpty()) { // quick check before accessing the ThreadLocal
             return true; // looks counter-intuitive, but see
-                         // j.u.AbstractCollection
+            // j.u.AbstractCollection
         }
         final MutableThreadContextStack values = STACK.get();
         return values != null && values.containsAll(objects);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLogger.java
@@ -157,8 +157,8 @@ public interface ExtendedLogger extends Logger {
      * @param p4 the message parameters
      * @return True if logging is enabled, false otherwise.
      */
-    boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
-            Object p4);
+    boolean isEnabled(
+            Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
     /**
      * Tests if logging is enabled.
@@ -174,8 +174,16 @@ public interface ExtendedLogger extends Logger {
      * @param p5 the message parameters
      * @return True if logging is enabled, false otherwise.
      */
-    boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
-            Object p4, Object p5);
+    boolean isEnabled(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5);
 
     /**
      * Determines if logging is enabled.
@@ -192,8 +200,17 @@ public interface ExtendedLogger extends Logger {
      * @param p6 the message parameters
      * @return True if logging is enabled, false otherwise.
      */
-    boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
-            Object p4, Object p5, Object p6);
+    boolean isEnabled(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6);
 
     /**
      * Tests if logging is enabled.
@@ -211,8 +228,18 @@ public interface ExtendedLogger extends Logger {
      * @param p7 the message parameters
      * @return True if logging is enabled, false otherwise.
      */
-    boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
-            Object p4, Object p5, Object p6, Object p7);
+    boolean isEnabled(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7);
 
     /**
      * Tests if logging is enabled.
@@ -231,8 +258,19 @@ public interface ExtendedLogger extends Logger {
      * @param p8 the message parameters
      * @return True if logging is enabled, false otherwise.
      */
-    boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
-            Object p4, Object p5, Object p6, Object p7, Object p8);
+    boolean isEnabled(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Tests if logging is enabled.
@@ -252,8 +290,20 @@ public interface ExtendedLogger extends Logger {
      * @param p9 the message parameters
      * @return True if logging is enabled, false otherwise.
      */
-    boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3,
-            Object p4, Object p5, Object p6, Object p7, Object p8, Object p9);
+    boolean isEnabled(
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message if the specified level is active.
@@ -378,8 +428,8 @@ public interface ExtendedLogger extends Logger {
      * @param p2 the message parameters
      * @param p3 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
-            Object p3);
+    void logIfEnabled(
+            String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3);
 
     /**
      * Logs a message if the specified level is active.
@@ -395,8 +445,16 @@ public interface ExtendedLogger extends Logger {
      * @param p3 the message parameters
      * @param p4 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
-            Object p3, Object p4);
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4);
 
     /**
      * Logs a message if the specified level is active.
@@ -413,8 +471,17 @@ public interface ExtendedLogger extends Logger {
      * @param p4 the message parameters
      * @param p5 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
-            Object p3, Object p4, Object p5);
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5);
 
     /**
      * Logs a message if the specified level is active.
@@ -432,8 +499,18 @@ public interface ExtendedLogger extends Logger {
      * @param p5 the message parameters
      * @param p6 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
-            Object p3, Object p4, Object p5, Object p6);
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6);
 
     /**
      * Logs a message if the specified level is active.
@@ -452,8 +529,19 @@ public interface ExtendedLogger extends Logger {
      * @param p6 the message parameters
      * @param p7 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
-            Object p3, Object p4, Object p5, Object p6, Object p7);
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7);
 
     /**
      * Logs a message if the specified level is active.
@@ -473,8 +561,20 @@ public interface ExtendedLogger extends Logger {
      * @param p7 the message parameters
      * @param p8 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
-            Object p3, Object p4, Object p5, Object p6, Object p7, Object p8);
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8);
 
     /**
      * Logs a message if the specified level is active.
@@ -495,8 +595,21 @@ public interface ExtendedLogger extends Logger {
      * @param p8 the message parameters
      * @param p9 the message parameters
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2,
-            Object p3, Object p4, Object p5, Object p6, Object p7, Object p8, Object p9);
+    void logIfEnabled(
+            String fqcn,
+            Level level,
+            Marker marker,
+            String message,
+            Object p0,
+            Object p1,
+            Object p2,
+            Object p3,
+            Object p4,
+            Object p5,
+            Object p6,
+            Object p7,
+            Object p8,
+            Object p9);
 
     /**
      * Logs a message at the specified level. It is the responsibility of the caller to ensure the specified
@@ -546,5 +659,4 @@ public interface ExtendedLogger extends Logger {
      * @param t the exception to log, including its stack trace.
      */
     void logIfEnabled(String fqcn, Level level, Marker marker, Supplier<?> msgSupplier, Throwable t);
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLoggerWrapper.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLoggerWrapper.java
@@ -126,65 +126,124 @@ public class ExtendedLoggerWrapper extends AbstractLogger {
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final String message, final Object p0, final Object p1) {
         return logger.isEnabled(level, marker, message, p0, p1);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         return logger.isEnabled(level, marker, message, p0, p1, p2);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
             final Object p7) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
@@ -213,11 +272,11 @@ public class ExtendedLoggerWrapper extends AbstractLogger {
      * @param t A Throwable or null.
      */
     @Override
-    public void logMessage(final String fqcn, final Level level, final Marker marker, final Message message,
-            final Throwable t) {
+    public void logMessage(
+            final String fqcn, final Level level, final Marker marker, final Message message, final Throwable t) {
         if (logger instanceof LocationAwareLogger && requiresLocation()) {
-            ((LocationAwareLogger) logger).logMessage(level, marker, fqcn, StackLocatorUtil.calcLocation(fqcn),
-                message, t);
+            ((LocationAwareLogger) logger)
+                    .logMessage(level, marker, fqcn, StackLocatorUtil.calcLocation(fqcn), message, t);
         } else {
             logger.logMessage(fqcn, level, marker, message, t);
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/GarbageFreeSortedArrayThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/GarbageFreeSortedArrayThreadContextMap.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
@@ -35,7 +34,7 @@ import org.apache.logging.log4j.util.StringMap;
  * </p>
  * @since 2.7
  */
-class GarbageFreeSortedArrayThreadContextMap implements ReadOnlyThreadContextMap, ObjectThreadContextMap  {
+class GarbageFreeSortedArrayThreadContextMap implements ReadOnlyThreadContextMap, ObjectThreadContextMap {
 
     /**
      * Property name ({@value} ) for selecting {@code InheritableThreadLocal} (value "true") or plain
@@ -76,7 +75,8 @@ class GarbageFreeSortedArrayThreadContextMap implements ReadOnlyThreadContextMap
         this.localMap = createThreadLocalMap();
     }
 
-    // LOG4J2-479: by default, use a plain ThreadLocal, only use InheritableThreadLocal if configured.
+    // LOG4J2-479: by default, use a plain ThreadLocal, only use InheritableThreadLocal if
+    // configured.
     // (This method is package protected for JUnit tests.)
     private ThreadLocal<StringMap> createThreadLocalMap() {
         if (inheritableMap) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LocationAwareLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LocationAwareLogger.java
@@ -24,6 +24,11 @@ import org.apache.logging.log4j.message.Message;
  * Logger that accepts the location of the caller.
  */
 public interface LocationAwareLogger {
-    void logMessage(final Level level, final Marker marker, final String fqcn, final StackTraceElement location,
-        final Message message, final Throwable throwable);
+    void logMessage(
+            final Level level,
+            final Marker marker,
+            final String fqcn,
+            final StackTraceElement location,
+            final Message message,
+            final Throwable throwable);
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContext.java
@@ -46,7 +46,6 @@ public interface LoggerContext {
         return getLogger(canonicalName != null ? canonicalName : cls.getName());
     }
 
-
     /**
      * Gets an ExtendedLogger using the fully qualified name of the Class as the Logger name.
      * @param cls The Class whose name should be used as the Logger name.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextFactory.java
@@ -78,8 +78,13 @@ public interface LoggerContextFactory {
      * @param name The name of the context or null.
      * @return The LoggerContext.
      */
-    LoggerContext getContext(String fqcn, ClassLoader loader, Object externalContext, boolean currentContext,
-                             URI configLocation, String name);
+    LoggerContext getContext(
+            String fqcn,
+            ClassLoader loader,
+            Object externalContext,
+            boolean currentContext,
+            URI configLocation,
+            String name);
 
     /**
      * Removes knowledge of a LoggerContext.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextKey.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextKey.java
@@ -32,15 +32,14 @@ public class LoggerContextKey {
     }
 
     public static String create(final String name, final MessageFactory messageFactory) {
-        final Class<? extends MessageFactory> messageFactoryClass = messageFactory != null ? messageFactory.getClass()
-                : AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS;
+        final Class<? extends MessageFactory> messageFactoryClass =
+                messageFactory != null ? messageFactory.getClass() : AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS;
         return create(name, messageFactoryClass);
     }
 
     public static String create(final String name, final Class<? extends MessageFactory> messageFactoryClass) {
-        final Class<? extends MessageFactory> mfClass = messageFactoryClass != null ? messageFactoryClass
-                : AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS;
+        final Class<? extends MessageFactory> mfClass =
+                messageFactoryClass != null ? messageFactoryClass : AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS;
         return name + "." + mfClass.getName();
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextShutdownEnabled.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextShutdownEnabled.java
@@ -25,5 +25,5 @@ public interface LoggerContextShutdownEnabled {
 
     void addShutdownListener(LoggerContextShutdownAware listener);
 
-     List<LoggerContextShutdownAware> getListeners();
+    List<LoggerContextShutdownAware> getListeners();
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerRegistry.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerRegistry.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
 import org.apache.logging.log4j.message.MessageFactory;
 
 /**
@@ -102,7 +101,9 @@ public class LoggerRegistry<T extends ExtendedLogger> {
     }
 
     private static String factoryKey(final MessageFactory messageFactory) {
-        return messageFactory == null ? DEFAULT_FACTORY_KEY : messageFactory.getClass().getName();
+        return messageFactory == null
+                ? DEFAULT_FACTORY_KEY
+                : messageFactory.getClass().getName();
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/MessageFactory2Adapter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/MessageFactory2Adapter.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.spi;
 
 import java.util.Objects;
-
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.message.MessageFactory2;
@@ -60,44 +59,84 @@ public class MessageFactory2Adapter implements MessageFactory2 {
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3) {
         return wrapped.newMessage(message, p0, p1, p2, p3);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4) {
+    public Message newMessage(
+            final String message, final Object p0, final Object p1, final Object p2, final Object p3, final Object p4) {
         return wrapped.newMessage(message, p0, p1, p2, p3, p4);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return wrapped.newMessage(message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         return wrapped.newMessage(message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7) {
         return wrapped.newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return wrapped.newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
-    public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
+    public Message newMessage(
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return wrapped.newMessage(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/MutableThreadContextStack.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/MutableThreadContextStack.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-
 import org.apache.logging.log4j.ThreadContext.ContextStack;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
@@ -36,6 +35,7 @@ public class MutableThreadContextStack implements ThreadContextStack, StringBuil
      * The underlying list (never null).
      */
     private final List<String> list;
+
     private boolean frozen;
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/NoOpThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/NoOpThreadContextMap.java
@@ -27,8 +27,7 @@ import java.util.Map;
  */
 public class NoOpThreadContextMap implements ThreadContextMap {
     @Override
-    public void clear() {
-    }
+    public void clear() {}
 
     @Override
     public boolean containsKey(final String key) {
@@ -56,10 +55,8 @@ public class NoOpThreadContextMap implements ThreadContextMap {
     }
 
     @Override
-    public void put(final String key, final String value) {
-    }
+    public void put(final String key, final String value) {}
 
     @Override
-    public void remove(final String key) {
-    }
+    public void remove(final String key) {}
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ObjectThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ObjectThreadContextMap.java
@@ -50,5 +50,4 @@ public interface ObjectThreadContextMap extends CleanableThreadContextMap {
      * @param values the map of key-value pairs to add
      */
     <V> void putAllValues(Map<String, V> values);
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/Provider.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/Provider.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.spi;
 import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.util.Properties;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
 
@@ -33,10 +32,12 @@ public class Provider {
      * Property name to set for a Log4j 2 provider to specify the priority of this implementation.
      */
     public static final String FACTORY_PRIORITY = "FactoryPriority";
+
     /**
      * Property name to set to the implementation of {@link org.apache.logging.log4j.spi.ThreadContextMap}.
      */
     public static final String THREAD_CONTEXT_MAP = "ThreadContextMap";
+
     /**
      * Property name to set to the implementation of {@link org.apache.logging.log4j.spi.LoggerContextFactory}.
      */
@@ -66,15 +67,18 @@ public class Provider {
         versions = null;
     }
 
-    public Provider(final Integer priority, final String versions,
-                    final Class<? extends LoggerContextFactory> loggerContextFactoryClass) {
+    public Provider(
+            final Integer priority,
+            final String versions,
+            final Class<? extends LoggerContextFactory> loggerContextFactoryClass) {
         this(priority, versions, loggerContextFactoryClass, null);
     }
 
-
-    public Provider(final Integer priority, final String versions,
-                    final Class<? extends LoggerContextFactory> loggerContextFactoryClass,
-                    final Class<? extends ThreadContextMap> threadContextMapClass) {
+    public Provider(
+            final Integer priority,
+            final String versions,
+            final Class<? extends LoggerContextFactory> loggerContextFactoryClass,
+            final Class<? extends ThreadContextMap> threadContextMapClass) {
         this.url = null;
         this.classLoader = null;
         this.priority = priority;
@@ -236,7 +240,9 @@ public class Provider {
         if (className != null ? !className.equals(provider.className) : provider.className != null) {
             return false;
         }
-        if (loggerContextFactoryClass != null ? !loggerContextFactoryClass.equals(provider.loggerContextFactoryClass) : provider.loggerContextFactoryClass != null) {
+        if (loggerContextFactoryClass != null
+                ? !loggerContextFactoryClass.equals(provider.loggerContextFactoryClass)
+                : provider.loggerContextFactoryClass != null) {
             return false;
         }
         return versions != null ? versions.equals(provider.versions) : provider.versions == null;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ReadOnlyThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ReadOnlyThreadContextMap.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.spi;
 
 import java.util.Map;
-
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.util.StringMap;
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMap.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.spi;
 
 import java.util.Map;
-
 import org.apache.logging.log4j.ThreadContext;
 
 /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMap2.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMap2.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.spi;
 
 import java.util.Map;
-
 import org.apache.logging.log4j.util.StringMap;
 
 /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMapFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMapFactory.java
@@ -78,8 +78,7 @@ public final class ThreadContextMapFactory {
         GcFreeThreadContextKey = properties.getBooleanProperty(GC_FREE_THREAD_CONTEXT_KEY);
     }
 
-    private ThreadContextMapFactory() {
-    }
+    private ThreadContextMapFactory() {}
 
     public static ThreadContextMap createThreadContextMap() {
         final ClassLoader cl = ProviderUtil.findClassLoader();
@@ -96,7 +95,7 @@ public final class ThreadContextMapFactory {
                 LOGGER.error("Unable to create configured ThreadContextMap {}", ThreadContextMapName, ex);
             }
         }
-        if (result == null && ProviderUtil.hasProviders() && LogManager.getFactory() != null) { //LOG4J2-1658
+        if (result == null && ProviderUtil.hasProviders() && LogManager.getFactory() != null) { // LOG4J2-1658
             final String factoryClassName = LogManager.getFactory().getClass().getName();
             for (final Provider provider : ProviderUtil.getProviders()) {
                 if (factoryClassName.equals(provider.getClassName())) {
@@ -106,8 +105,10 @@ public final class ThreadContextMapFactory {
                             result = clazz.newInstance();
                             break;
                         } catch (final Exception e) {
-                            LOGGER.error("Unable to locate or load configured ThreadContextMap {}",
-                                    provider.getThreadContextMap(), e);
+                            LOGGER.error(
+                                    "Unable to locate or load configured ThreadContextMap {}",
+                                    provider.getThreadContextMap(),
+                                    e);
                             result = createDefaultThreadContextMap();
                         }
                     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/SimpleLoggerFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/SimpleLoggerFactory.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.status;
 
 import java.io.PrintStream;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.message.MessageFactory;
 import org.apache.logging.log4j.simple.SimpleLogger;
@@ -37,10 +36,7 @@ final class SimpleLoggerFactory {
     }
 
     SimpleLogger createSimpleLogger(
-            final String name,
-            final Level level,
-            final MessageFactory messageFactory,
-            final PrintStream stream) {
+            final String name, final Level level, final MessageFactory messageFactory, final PrintStream stream) {
         final String dateFormat = StatusLogger.PROPS.getStringProperty(StatusLogger.STATUS_DATE_FORMAT);
         final boolean dateFormatProvided = Strings.isNotBlank(dateFormat);
         return new SimpleLogger(
@@ -55,5 +51,4 @@ final class SimpleLoggerFactory {
                 StatusLogger.PROPS,
                 stream);
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.status;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Objects;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedNoReferenceMessageFactory;
@@ -62,19 +61,12 @@ public class StatusConsoleListener implements StatusListener {
         this(level, stream, SimpleLoggerFactory.getInstance());
     }
 
-    StatusConsoleListener(
-            final Level level,
-            final PrintStream stream,
-            final SimpleLoggerFactory loggerFactory) {
+    StatusConsoleListener(final Level level, final PrintStream stream, final SimpleLoggerFactory loggerFactory) {
         this.level = Objects.requireNonNull(level, "level");
         this.stream = Objects.requireNonNull(stream, "stream");
-        this.logger = Objects
-                .requireNonNull(loggerFactory, "loggerFactory")
+        this.logger = Objects.requireNonNull(loggerFactory, "loggerFactory")
                 .createSimpleLogger(
-                        "StatusConsoleListener",
-                        level,
-                        ParameterizedNoReferenceMessageFactory.INSTANCE,
-                        stream);
+                        "StatusConsoleListener", level, ParameterizedNoReferenceMessageFactory.INSTANCE, stream);
     }
 
     /**
@@ -103,7 +95,8 @@ public class StatusConsoleListener implements StatusListener {
         final boolean filtered = filtered(data);
         if (!filtered) {
             logger
-                    // Logging using _only_ the following 4 fields set by `StatusLogger#logMessage()`:
+                    // Logging using _only_ the following 4 fields set by
+                    // `StatusLogger#logMessage()`:
                     .atLevel(data.getLevel())
                     .withThrowable(data.getThrowable())
                     .withLocation(data.getStackTraceElement())
@@ -139,5 +132,4 @@ public class StatusConsoleListener implements StatusListener {
             this.stream.close();
         }
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
@@ -16,16 +16,15 @@
  */
 package org.apache.logging.log4j.status;
 
+import static org.apache.logging.log4j.util.Chars.SPACE;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.message.Message;
-
-import static org.apache.logging.log4j.util.Chars.SPACE;
 
 /**
  * The Status data.
@@ -50,7 +49,11 @@ public class StatusData implements Serializable {
      * @param t The Error or Exception that occurred.
      * @param threadName The thread name
      */
-    public StatusData(final StackTraceElement caller, final Level level, final Message msg, final Throwable t,
+    public StatusData(
+            final StackTraceElement caller,
+            final Level level,
+            final Message msg,
+            final Throwable t,
             final String threadName) {
         this.timestamp = System.currentTimeMillis();
         this.caller = caller;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusListener.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusListener.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.status;
 
 import java.io.Closeable;
 import java.util.EventListener;
-
 import org.apache.logging.log4j.Level;
 
 /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -28,7 +28,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.message.Message;
@@ -80,9 +79,8 @@ public final class StatusLogger extends AbstractLogger {
 
     private static final String DEFAULT_STATUS_LEVEL = PROPS.getStringProperty(DEFAULT_STATUS_LISTENER_LEVEL);
 
-    static final boolean DEBUG_ENABLED = PropertiesUtil
-            .getProperties()
-            .getBooleanProperty(Constants.LOG4J2_DEBUG, false, true);
+    static final boolean DEBUG_ENABLED =
+            PropertiesUtil.getProperties().getBooleanProperty(Constants.LOG4J2_DEBUG, false, true);
 
     // LOG4J2-1176: normal parameterized message remembers param object, causing memory leaks.
     private static final StatusLogger STATUS_LOGGER = new StatusLogger(
@@ -135,9 +133,7 @@ public final class StatusLogger extends AbstractLogger {
      * @param messageFactory The message factory.
      */
     private StatusLogger(
-            final String name,
-            final MessageFactory messageFactory,
-            final SimpleLoggerFactory loggerFactory) {
+            final String name, final MessageFactory messageFactory, final SimpleLoggerFactory loggerFactory) {
         super(name, messageFactory);
         final Level loggerLevel = DEBUG_ENABLED ? Level.TRACE : Level.ERROR;
         this.logger = loggerFactory.createSimpleLogger("StatusLogger", loggerLevel, messageFactory, System.err);
@@ -279,8 +275,8 @@ public final class StatusLogger extends AbstractLogger {
      * @param t A Throwable or null.
      */
     @Override
-    public void logMessage(final String fqcn, final Level level, final Marker marker, final Message msg,
-            final Throwable t) {
+    public void logMessage(
+            final String fqcn, final Level level, final Marker marker, final Message msg, final Throwable t) {
         StackTraceElement element = null;
         if (fqcn != null) {
             element = getStackTraceElement(fqcn, Thread.currentThread().getStackTrace());
@@ -344,65 +340,124 @@ public final class StatusLogger extends AbstractLogger {
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1) {
+    public boolean isEnabled(
+            final Level level, final Marker marker, final String message, final Object p0, final Object p1) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
             final Object p4) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
             final Object p7) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8) {
         return isEnabled(level, marker);
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker, final String message, final Object p0,
-            final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6,
-            final Object p7, final Object p8, final Object p9) {
+    public boolean isEnabled(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Object p0,
+            final Object p1,
+            final Object p2,
+            final Object p3,
+            final Object p4,
+            final Object p5,
+            final Object p6,
+            final Object p7,
+            final Object p8,
+            final Object p9) {
         return isEnabled(level, marker);
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Activator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Activator.java
@@ -20,7 +20,6 @@ import java.net.URL;
 import java.security.Permission;
 import java.util.Collection;
 import java.util.List;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.spi.LoggerContextFactory;
 import org.apache.logging.log4j.spi.Provider;
@@ -54,7 +53,8 @@ public class Activator implements BundleActivator, SynchronousBundleListener {
 
     private static final Logger LOGGER = StatusLogger.getLogger();
 
-    // until we have at least one Provider, we'll lock ProviderUtil which locks LogManager.<clinit> by extension.
+    // until we have at least one Provider, we'll lock ProviderUtil which locks LogManager.<clinit>
+    // by extension.
     // this variable needs to be reset once the lock has been released
     private boolean lockingProviderUtil;
 
@@ -73,7 +73,10 @@ public class Activator implements BundleActivator, SynchronousBundleListener {
             checkPermission(new AdaptPermission(BundleWiring.class.getName(), bundle, AdaptPermission.ADAPT));
             final BundleContext bundleContext = bundle.getBundleContext();
             if (bundleContext == null) {
-                LOGGER.debug("Bundle {} has no context (state={}), skipping loading provider", bundle.getSymbolicName(), toStateString(bundle.getState()));
+                LOGGER.debug(
+                        "Bundle {} has no context (state={}), skipping loading provider",
+                        bundle.getSymbolicName(),
+                        toStateString(bundle.getState()));
             } else {
                 loadProvider(bundleContext, bundle.adapt(BundleWiring.class));
             }
@@ -86,27 +89,28 @@ public class Activator implements BundleActivator, SynchronousBundleListener {
 
     private String toStateString(final int state) {
         switch (state) {
-        case Bundle.UNINSTALLED:
-            return "UNINSTALLED";
-        case Bundle.INSTALLED:
-            return "INSTALLED";
-        case Bundle.RESOLVED:
-            return "RESOLVED";
-        case Bundle.STARTING:
-            return "STARTING";
-        case Bundle.STOPPING:
-            return "STOPPING";
-        case Bundle.ACTIVE:
-            return "ACTIVE";
-        default:
-            return Integer.toString(state);
+            case Bundle.UNINSTALLED:
+                return "UNINSTALLED";
+            case Bundle.INSTALLED:
+                return "INSTALLED";
+            case Bundle.RESOLVED:
+                return "RESOLVED";
+            case Bundle.STARTING:
+                return "STARTING";
+            case Bundle.STOPPING:
+                return "STOPPING";
+            case Bundle.ACTIVE:
+                return "ACTIVE";
+            default:
+                return Integer.toString(state);
         }
     }
 
     private void loadProvider(final BundleContext bundleContext, final BundleWiring bundleWiring) {
         final String filter = "(APIVersion>=2.6.0)";
         try {
-            final Collection<ServiceReference<Provider>> serviceReferences = bundleContext.getServiceReferences(Provider.class, filter);
+            final Collection<ServiceReference<Provider>> serviceReferences =
+                    bundleContext.getServiceReferences(Provider.class, filter);
             Provider maxProvider = null;
             for (final ServiceReference<Provider> serviceReference : serviceReferences) {
                 final Provider provider = bundleContext.getService(serviceReference);
@@ -168,5 +172,4 @@ public class Activator implements BundleActivator, SynchronousBundleListener {
                 break;
         }
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.util;
 
 import java.lang.reflect.Method;
-
 import org.apache.logging.log4j.LoggingException;
 
 /**
@@ -46,14 +45,13 @@ public final class Base64Util {
         }
     }
 
-    private Base64Util() {
-    }
+    private Base64Util() {}
 
     public static String encode(final String str) {
         if (str == null) {
             return null;
         }
-        final byte [] data = str.getBytes();
+        final byte[] data = str.getBytes();
         if (encodeMethod != null) {
             try {
                 return (String) encodeMethod.invoke(encoder, data);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Chars.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Chars.java
@@ -83,6 +83,5 @@ public final class Chars {
         return (char) ('a' + digit - 10);
     }
 
-    private Chars() {
-    }
+    private Chars() {}
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
@@ -27,9 +27,10 @@ public final class Constants {
      * "log4j2.is.webapp", or (if this system property is not set) whether the  {@code javax.servlet.Servlet} class
      * is present in the classpath.
      */
-    public static final boolean IS_WEB_APP = PropertiesUtil.getProperties().getBooleanProperty(
-            "log4j2.is.webapp", isClassAvailable("javax.servlet.Servlet")
-                    || isClassAvailable("jakarta.servlet.Servlet"));
+    public static final boolean IS_WEB_APP = PropertiesUtil.getProperties()
+            .getBooleanProperty(
+                    "log4j2.is.webapp",
+                    isClassAvailable("javax.servlet.Servlet") || isClassAvailable("jakarta.servlet.Servlet"));
 
     /**
      * Kill switch for object pooling in ThreadLocals that enables much of the LOG4J2-1270 no-GC behaviour.
@@ -38,8 +39,8 @@ public final class Constants {
      * "log4j2.enable.threadlocals" to "false".
      * </p>
      */
-    public static final boolean ENABLE_THREADLOCALS = !IS_WEB_APP && PropertiesUtil.getProperties().getBooleanProperty(
-            "log4j2.enable.threadlocals", true);
+    public static final boolean ENABLE_THREADLOCALS =
+            !IS_WEB_APP && PropertiesUtil.getProperties().getBooleanProperty("log4j2.enable.threadlocals", true);
 
     /**
      * Java major version.
@@ -99,8 +100,7 @@ public final class Constants {
     /**
      * Prevent class instantiation.
      */
-    private Constants() {
-    }
+    private Constants() {}
 
     private static int getMajorVersion() {
         return getMajorVersion(System.getProperty("java.version"));

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/EnglishEnums.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/EnglishEnums.java
@@ -16,7 +16,6 @@
  */
 package org.apache.logging.log4j.util;
 
-
 import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
 /**
@@ -32,8 +31,7 @@ import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
  */
 public final class EnglishEnums {
 
-    private EnglishEnums() {
-    }
+    private EnglishEnums() {}
 
     /**
      * Returns the Result for the given string.
@@ -67,5 +65,4 @@ public final class EnglishEnums {
     public static <T extends Enum<T>> T valueOf(final Class<T> enumType, final String name, final T defaultValue) {
         return name == null ? defaultValue : Enum.valueOf(enumType, toRootUpperCase(name));
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/EnvironmentPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/EnvironmentPropertySource.java
@@ -16,11 +16,10 @@
  */
 package org.apache.logging.log4j.util;
 
-import java.util.Collection;
-import java.util.Map;
-
 import aQute.bnd.annotation.Resolution;
 import aQute.bnd.annotation.spi.ServiceProvider;
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * PropertySource implementation that uses environment variables as a source.
@@ -108,5 +107,4 @@ public class EnvironmentPropertySource implements PropertySource {
             return PropertySource.super.containsProperty(key);
         }
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/FilteredObjectInputStream.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/FilteredObjectInputStream.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.util;
 
+import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_JAVA_CLASSES;
+import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_JAVA_PACKAGES;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InvalidObjectException;
@@ -23,9 +26,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
 import java.util.Collection;
 import java.util.Collections;
-
-import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_JAVA_CLASSES;
-import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_JAVA_PACKAGES;
 
 /**
  * Extends {@link ObjectInputStream} to only allow some built-in Log4j classes and caller-specified classes to be
@@ -47,12 +47,12 @@ public class FilteredObjectInputStream extends ObjectInputStream {
     }
 
     public FilteredObjectInputStream(final Collection<String> allowedExtraClasses)
-        throws IOException, SecurityException {
+            throws IOException, SecurityException {
         this.allowedExtraClasses = allowedExtraClasses;
     }
 
     public FilteredObjectInputStream(final InputStream inputStream, final Collection<String> allowedExtraClasses)
-        throws IOException {
+            throws IOException {
         super(inputStream);
         this.allowedExtraClasses = allowedExtraClasses;
     }
@@ -82,5 +82,4 @@ public class FilteredObjectInputStream extends ObjectInputStream {
         }
         return false;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LambdaUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LambdaUtil.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.util;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MessageFactory;
 
-
 /**
  * Utility class for lambda support.
  */
@@ -27,8 +26,7 @@ public final class LambdaUtil {
     /**
      * Private constructor: this class is not intended to be instantiated.
      */
-    private LambdaUtil() {
-    }
+    private LambdaUtil() {}
 
     /**
      * Converts an array of lambda expressions into an array of their evaluation results.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
@@ -47,7 +47,8 @@ public final class LoaderUtil {
 
     private static final SecurityManager SECURITY_MANAGER = System.getSecurityManager();
 
-    // this variable must be lazily loaded; otherwise, we get a nice circular class loading problem where LoaderUtil
+    // this variable must be lazily loaded; otherwise, we get a nice circular class loading problem
+    // where LoaderUtil
     // wants to use PropertiesUtil, but then PropertiesUtil wants to use LoaderUtil.
     private static Boolean ignoreTCCL;
 
@@ -70,8 +71,7 @@ public final class LoaderUtil {
         }
     }
 
-    private LoaderUtil() {
-    }
+    private LoaderUtil() {}
 
     /**
      * Gets the current Thread ClassLoader. Returns the system ClassLoader if the TCCL is {@code null}. If the system
@@ -163,7 +163,8 @@ public final class LoaderUtil {
         try {
             return clazz.getConstructor().newInstance();
         } catch (final NoSuchMethodException ignored) {
-            // FIXME: looking at the code for Class.newInstance(), this seems to do the same thing as above
+            // FIXME: looking at the code for Class.newInstance(), this seems to do the same thing
+            // as above
             return clazz.newInstance();
         }
     }
@@ -180,8 +181,8 @@ public final class LoaderUtil {
      * @since 2.1
      */
     @SuppressWarnings("unchecked")
-    public static <T> T newInstanceOf(final String className) throws ClassNotFoundException, IllegalAccessException,
-            InstantiationException, InvocationTargetException {
+    public static <T> T newInstanceOf(final String className)
+            throws ClassNotFoundException, IllegalAccessException, InstantiationException, InvocationTargetException {
         return newInstanceOf((Class<T>) loadClass(className));
     }
 
@@ -200,8 +201,7 @@ public final class LoaderUtil {
      * @since 2.1
      */
     public static <T> T newCheckedInstanceOf(final String className, final Class<T> clazz)
-            throws ClassNotFoundException, InvocationTargetException, InstantiationException,
-            IllegalAccessException {
+            throws ClassNotFoundException, InvocationTargetException, InstantiationException, IllegalAccessException {
         return clazz.cast(newInstanceOf(className));
     }
 
@@ -220,8 +220,7 @@ public final class LoaderUtil {
      * @since 2.5
      */
     public static <T> T newCheckedInstanceOfProperty(final String propertyName, final Class<T> clazz)
-        throws ClassNotFoundException, InvocationTargetException, InstantiationException,
-        IllegalAccessException {
+            throws ClassNotFoundException, InvocationTargetException, InstantiationException, IllegalAccessException {
         final String className = PropertiesUtil.getProperties().getStringProperty(propertyName);
         if (className == null) {
             return null;
@@ -261,9 +260,10 @@ public final class LoaderUtil {
     static Collection<UrlResource> findUrlResources(final String resource, final boolean useTccl) {
         // @formatter:off
         final ClassLoader[] candidates = {
-                useTccl ? getThreadContextClassLoader() : null,
-                LoaderUtil.class.getClassLoader(),
-                GET_CLASS_LOADER_DISABLED ? null : ClassLoader.getSystemClassLoader()};
+            useTccl ? getThreadContextClassLoader() : null,
+            LoaderUtil.class.getClassLoader(),
+            GET_CLASS_LOADER_DISABLED ? null : ClassLoader.getSystemClassLoader()
+        };
         // @formatter:on
         final Collection<UrlResource> resources = new LinkedHashSet<>();
         for (final ClassLoader cl : candidates) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LowLevelLogUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LowLevelLogUtil.java
@@ -73,6 +73,5 @@ final class LowLevelLogUtil {
         LowLevelLogUtil.writer = new PrintWriter(Objects.requireNonNull(writer), true);
     }
 
-    private LowLevelLogUtil() {
-    }
+    private LowLevelLogUtil() {}
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/MultiFormatStringBuilderFormattable.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/MultiFormatStringBuilderFormattable.java
@@ -37,5 +37,4 @@ public interface MultiFormatStringBuilderFormattable extends MultiformatMessage,
      * @param buffer the StringBuilder to write into
      */
     void formatTo(String[] formats, StringBuilder buffer);
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/OsgiServiceLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/OsgiServiceLocator.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.util;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.util.Objects;
 import java.util.stream.Stream;
-
 import org.apache.logging.log4j.status.StatusLogger;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -35,9 +34,8 @@ public class OsgiServiceLocator {
              * OSGI classes of any version can still be present even if Log4j2 does not run in
              * an OSGI container, hence we check if this class is in a bundle.
              */
-            final Class< ? > clazz = Class.forName("org.osgi.framework.FrameworkUtil");
-            return clazz.getMethod("getBundle", Class.class)
-                    .invoke(null, OsgiServiceLocator.class) != null;
+            final Class<?> clazz = Class.forName("org.osgi.framework.FrameworkUtil");
+            return clazz.getMethod("getBundle", Class.class).invoke(null, OsgiServiceLocator.class) != null;
         } catch (final ClassNotFoundException | NoSuchMethodException | LinkageError e) {
             return false;
         } catch (final Throwable e) {
@@ -61,9 +59,13 @@ public class OsgiServiceLocator {
             final BundleContext ctx = bundle.getBundleContext();
             if (ctx == null) {
                 if (verbose) {
-                    StatusLogger.getLogger().error(
-                            "Unable to load OSGI services: The bundle has no valid BundleContext for serviceType = {}, lookup = {}, lookupClass = {}, bundle = {}",
-                            serviceType, lookup, lookupClass, bundle);
+                    StatusLogger.getLogger()
+                            .error(
+                                    "Unable to load OSGI services: The bundle has no valid BundleContext for serviceType = {}, lookup = {}, lookupClass = {}, bundle = {}",
+                                    serviceType,
+                                    lookup,
+                                    lookupClass,
+                                    bundle);
                 }
             } else {
                 try {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PrivateSecurityManagerStackTraceUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PrivateSecurityManagerStackTraceUtil.java
@@ -61,7 +61,8 @@ final class PrivateSecurityManagerStackTraceUtil {
      *
      * @return the execution stack.
      */
-    // benchmarks show that using the SecurityManager is much faster than looping through getCallerClass(int)
+    // benchmarks show that using the SecurityManager is much faster than looping through
+    // getCallerClass(int)
     static Deque<Class<?>> getCurrentStackTrace() {
         final Class<?>[] array = SECURITY_MANAGER.getClassContext();
         final Deque<Class<?>> classes = new ArrayDeque<>(array.length);
@@ -75,6 +76,5 @@ final class PrivateSecurityManagerStackTraceUtil {
         protected Class<?>[] getClassContext() {
             return super.getClassContext();
         }
-
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProcessIdUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProcessIdUtil.java
@@ -29,7 +29,8 @@ public class ProcessIdUtil {
 
     public static String getProcessId() {
         try {
-            // LOG4J2-2126 use reflection to improve compatibility with Android Platform which does not support JMX extensions
+            // LOG4J2-2126 use reflection to improve compatibility with Android Platform which does
+            // not support JMX extensions
             final Class<?> managementFactoryClass = Class.forName("java.lang.management.ManagementFactory");
             final Method getRuntimeMXBean = managementFactoryClass.getDeclaredMethod("getRuntimeMXBean");
             final Class<?> runtimeMXBeanClass = Class.forName("java.lang.management.RuntimeMXBean");
@@ -37,7 +38,8 @@ public class ProcessIdUtil {
 
             final Object runtimeMXBean = getRuntimeMXBean.invoke(null);
             final String name = (String) getName.invoke(runtimeMXBean);
-            //String name = ManagementFactory.getRuntimeMXBean().getName(); //JMX not allowed on Android
+            // String name = ManagementFactory.getRuntimeMXBean().getName(); //JMX not allowed on
+            // Android
             return name.split("@")[0]; // likely works on most platforms
         } catch (final Exception ex) {
             try {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
@@ -75,5 +75,4 @@ public class PropertiesPropertySource implements PropertySource {
     public boolean containsProperty(final String key) {
         return getProperty(key) != null;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.util;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
@@ -34,10 +37,6 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
-
-import aQute.bnd.annotation.Cardinality;
-import aQute.bnd.annotation.Resolution;
-import aQute.bnd.annotation.spi.ServiceConsumer;
 
 /**
  * <em>Consider this class private.</em>
@@ -178,11 +177,12 @@ public final class PropertiesUtil {
      * @param defaultValueIfPresent the default value to use if the property is defined but not assigned
      * @return the boolean value of the property or {@code defaultValue} if undefined.
      */
-    public boolean getBooleanProperty(final String name, final boolean defaultValueIfAbsent,
-                                      final boolean defaultValueIfPresent) {
+    public boolean getBooleanProperty(
+            final String name, final boolean defaultValueIfAbsent, final boolean defaultValueIfPresent) {
         final String prop = getStringProperty(name);
-        return prop == null ? defaultValueIfAbsent
-            : prop.isEmpty() ? defaultValueIfPresent : "true".equalsIgnoreCase(prop);
+        return prop == null
+                ? defaultValueIfAbsent
+                : prop.isEmpty() ? defaultValueIfPresent : "true".equalsIgnoreCase(prop);
     }
 
     /**
@@ -236,8 +236,13 @@ public final class PropertiesUtil {
                 return Charset.forName(mapped);
             }
         }
-        LowLevelLogUtil.log("Unable to get Charset '" + charsetName + "' for property '" + name + "', using default "
-            + defaultValue + " and continuing.");
+        LowLevelLogUtil.log("Unable to get Charset '"
+                + charsetName
+                + "' for property '"
+                + name
+                + "', using default "
+                + defaultValue
+                + " and continuing.");
         return defaultValue;
     }
 
@@ -448,14 +453,17 @@ public final class PropertiesUtil {
     private static final class Environment {
 
         private final Set<PropertySource> sources = new ConcurrentSkipListSet<>(new PropertySource.Comparator());
+
         /**
          * Maps a key to its value or the value of its normalization in the lowest priority source that contains it.
          */
         private final Map<String, String> literal = new ConcurrentHashMap<>();
+
         private final Map<List<CharSequence>, String> tokenized = new ConcurrentHashMap<>();
 
         private Environment(final PropertySource propertySource) {
-            final PropertyFilePropertySource sysProps = new PropertyFilePropertySource(LOG4J_SYSTEM_PROPERTIES_FILE_NAME, false);
+            final PropertyFilePropertySource sysProps =
+                    new PropertyFilePropertySource(LOG4J_SYSTEM_PROPERTIES_FILE_NAME, false);
             try {
                 sysProps.forEach((key, value) -> {
                     if (System.getProperty(key) == null) {
@@ -486,33 +494,29 @@ public final class PropertiesUtil {
             tokenized.clear();
             // 1. Collects all property keys from enumerable sources.
             final Set<String> keys = new HashSet<>();
-            sources.stream()
-                   .map(PropertySource::getPropertyNames)
-                   .forEach(keys::addAll);
-            // 2. Fills the property caches. Sources with higher priority values don't override the previous ones.
-            keys.stream()
-                .filter(Objects::nonNull)
-                .forEach(key -> {
-                    final List<CharSequence> tokens = PropertySource.Util.tokenize(key);
-                    final boolean hasTokens = !tokens.isEmpty();
-                    sources.forEach(source -> {
-                        if (source.containsProperty(key)) {
-                            final String value = source.getProperty(key);
-                            if (hasTokens) {
-                                tokenized.putIfAbsent(tokens, value);
-                            }
-                        }
+            sources.stream().map(PropertySource::getPropertyNames).forEach(keys::addAll);
+            // 2. Fills the property caches. Sources with higher priority values don't override the
+            // previous ones.
+            keys.stream().filter(Objects::nonNull).forEach(key -> {
+                final List<CharSequence> tokens = PropertySource.Util.tokenize(key);
+                final boolean hasTokens = !tokens.isEmpty();
+                sources.forEach(source -> {
+                    if (source.containsProperty(key)) {
+                        final String value = source.getProperty(key);
                         if (hasTokens) {
-                            final String normalKey = Objects.toString(source.getNormalForm(tokens), null);
-                            if (normalKey != null && source.containsProperty(normalKey)) {
-                                literal.putIfAbsent(key, source.getProperty(normalKey));
-                            }
-                            else if(source.containsProperty(key)) {
-                                literal.putIfAbsent(key, source.getProperty(key));
-                            }
+                            tokenized.putIfAbsent(tokens, value);
                         }
-                    });
+                    }
+                    if (hasTokens) {
+                        final String normalKey = Objects.toString(source.getNormalForm(tokens), null);
+                        if (normalKey != null && source.containsProperty(normalKey)) {
+                            literal.putIfAbsent(key, source.getProperty(normalKey));
+                        } else if (source.containsProperty(key)) {
+                            literal.putIfAbsent(key, source.getProperty(key));
+                        }
+                    }
                 });
+            });
         }
 
         private String get(final String key) {
@@ -537,12 +541,13 @@ public final class PropertiesUtil {
 
         private boolean containsKey(final String key) {
             final List<CharSequence> tokens = PropertySource.Util.tokenize(key);
-            return literal.containsKey(key) ||
-                   tokenized.containsKey(tokens) ||
-                   sources.stream().anyMatch(s -> {
+            return literal.containsKey(key)
+                    || tokenized.containsKey(tokens)
+                    || sources.stream().anyMatch(s -> {
                         final CharSequence normalizedKey = s.getNormalForm(tokens);
-                        return s.containsProperty(key) || normalizedKey != null && s.containsProperty(normalizedKey.toString());
-                   });
+                        return s.containsProperty(key)
+                                || normalizedKey != null && s.containsProperty(normalizedKey.toString());
+                    });
         }
     }
 
@@ -603,8 +608,8 @@ public final class PropertiesUtil {
      * new property maps without the prefix and period in the key
      * @since 2.17.2
      */
-    public static Map<String, Properties> partitionOnCommonPrefixes(final Properties properties,
-            final boolean includeBaseKey) {
+    public static Map<String, Properties> partitionOnCommonPrefixes(
+            final Properties properties, final boolean includeBaseKey) {
         final Map<String, Properties> parts = new ConcurrentHashMap<>();
         for (final String key : properties.stringPropertyNames()) {
             final int idx = key.indexOf('.');

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyFilePropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyFilePropertySource.java
@@ -47,5 +47,4 @@ public class PropertyFilePropertySource extends PropertiesPropertySource {
         }
         return props;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.util;
 
+import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,8 +29,6 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.apache.logging.log4j.util.Strings.toRootLowerCase;
 
 /**
  * A source for global configuration properties.
@@ -50,8 +50,7 @@ public interface PropertySource {
      *
      * @param action action to perform on each key/value pair
      */
-    default void forEach(BiConsumer<String, String> action) {
-    }
+    default void forEach(BiConsumer<String, String> action) {}
 
     /**
      * Returns the list of all property names.
@@ -83,7 +82,6 @@ public interface PropertySource {
         return null;
     }
 
-
     /**
      * For PropertySources that cannot iterate over all the potential properties this provides a direct lookup.
      * @param key The key to search for.
@@ -104,7 +102,9 @@ public interface PropertySource {
 
         @Override
         public int compare(final PropertySource o1, final PropertySource o2) {
-            return Integer.compare(Objects.requireNonNull(o1).getPriority(), Objects.requireNonNull(o2).getPriority());
+            return Integer.compare(
+                    Objects.requireNonNull(o1).getPriority(),
+                    Objects.requireNonNull(o2).getPriority());
         }
     }
 
@@ -120,6 +120,7 @@ public interface PropertySource {
                 Pattern.CASE_INSENSITIVE);
         private static final Pattern PROPERTY_TOKENIZER = Pattern.compile("([A-Z]*[a-z0-9]+|[A-Z0-9]+)[-._/]?");
         private static final Map<CharSequence, List<CharSequence>> CACHE = new ConcurrentHashMap<>();
+
         static {
             // Add legacy properties without Log4j prefix
             CACHE.put("disableThreadContext", Arrays.asList("disable", "thread", "context"));
@@ -179,7 +180,6 @@ public interface PropertySource {
             return sb.toString();
         }
 
-        private Util() {
-        }
+        private Util() {}
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderActivator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderActivator.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.util;
 
 import java.util.Hashtable;
-
 import org.apache.logging.log4j.spi.Provider;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
@@ -50,5 +49,4 @@ public abstract class ProviderActivator implements BundleActivator {
             providerRegistration.unregister();
         }
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderUtil.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.util;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.URL;
@@ -25,10 +28,6 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-
-import aQute.bnd.annotation.Cardinality;
-import aQute.bnd.annotation.Resolution;
-import aQute.bnd.annotation.spi.ServiceConsumer;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.spi.Provider;
 import org.apache.logging.log4j.status.StatusLogger;
@@ -62,7 +61,8 @@ public final class ProviderUtil {
     private static final String[] COMPATIBLE_API_VERSIONS = {"2.6.0"};
     private static final Logger LOGGER = StatusLogger.getLogger();
 
-    // STARTUP_LOCK guards INSTANCE for lazy initialization; this allows the OSGi Activator to pause the startup and
+    // STARTUP_LOCK guards INSTANCE for lazy initialization; this allows the OSGi Activator to pause
+    // the startup and
     // wait for a Provider to be installed. See LOG4J2-373
     private static volatile ProviderUtil instance;
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ServiceLoaderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ServiceLoaderUtil.java
@@ -33,7 +33,6 @@ import java.util.Spliterator;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
 
@@ -44,8 +43,7 @@ public final class ServiceLoaderUtil {
 
     private static final int MAX_BROKEN_SERVICES = 8;
 
-    private ServiceLoaderUtil() {
-    }
+    private ServiceLoaderUtil() {}
 
     /**
      * Retrieves the available services from the caller's classloader.
@@ -77,15 +75,15 @@ public final class ServiceLoaderUtil {
         return loadServices(serviceType, lookup, useTccl, true);
     }
 
-    static <T> Stream<T> loadServices(final Class<T> serviceType, final Lookup lookup, final boolean useTccl,
-            final boolean verbose) {
+    static <T> Stream<T> loadServices(
+            final Class<T> serviceType, final Lookup lookup, final boolean useTccl, final boolean verbose) {
         final ClassLoader classLoader = lookup.lookupClass().getClassLoader();
         Stream<T> services = loadClassloaderServices(serviceType, lookup, classLoader, verbose);
         if (useTccl) {
             final ClassLoader contextClassLoader = LoaderUtil.getThreadContextClassLoader();
             if (contextClassLoader != classLoader) {
-                services = Stream.concat(services,
-                        loadClassloaderServices(serviceType, lookup, contextClassLoader, verbose));
+                services = Stream.concat(
+                        services, loadClassloaderServices(serviceType, lookup, contextClassLoader, verbose));
             }
         }
         if (OsgiServiceLocator.isAvailable()) {
@@ -96,33 +94,38 @@ public final class ServiceLoaderUtil {
         return services.filter(service -> classes.add(service.getClass()));
     }
 
-    static <T> Stream<T> loadClassloaderServices(final Class<T> serviceType, final Lookup lookup,
-            final ClassLoader classLoader, final boolean verbose) {
+    static <T> Stream<T> loadClassloaderServices(
+            final Class<T> serviceType, final Lookup lookup, final ClassLoader classLoader, final boolean verbose) {
         return StreamSupport.stream(new ServiceLoaderSpliterator<T>(serviceType, lookup, classLoader, verbose), false);
     }
 
-    static <T> Iterable<T> callServiceLoader(final Lookup lookup, final Class<T> serviceType, final ClassLoader classLoader,
-            final boolean verbose) {
+    static <T> Iterable<T> callServiceLoader(
+            final Lookup lookup, final Class<T> serviceType, final ClassLoader classLoader, final boolean verbose) {
         try {
             // Creates a lambda in the caller's domain that calls `ServiceLoader`
-            final MethodHandle loadHandle = lookup.findStatic(ServiceLoader.class, "load",
+            final MethodHandle loadHandle = lookup.findStatic(
+                    ServiceLoader.class,
+                    "load",
                     MethodType.methodType(ServiceLoader.class, Class.class, ClassLoader.class));
-            final CallSite callSite = LambdaMetafactory.metafactory(lookup,
+            final CallSite callSite = LambdaMetafactory.metafactory(
+                    lookup,
                     "run",
                     MethodType.methodType(PrivilegedAction.class, Class.class, ClassLoader.class),
                     MethodType.methodType(Object.class),
                     loadHandle,
                     MethodType.methodType(ServiceLoader.class));
-            final PrivilegedAction<ServiceLoader<T>> action = (PrivilegedAction<ServiceLoader<T>>) callSite
-                    .getTarget()//
-                    .bindTo(serviceType)
-                    .bindTo(classLoader)
-                    .invoke();
+            final PrivilegedAction<ServiceLoader<T>> action = (PrivilegedAction<ServiceLoader<T>>)
+                    callSite.getTarget() //
+                            .bindTo(serviceType)
+                            .bindTo(classLoader)
+                            .invoke();
             final ServiceLoader<T> serviceLoader;
             if (System.getSecurityManager() == null) {
                 serviceLoader = action.run();
             } else {
-                final MethodHandle privilegedHandle = lookup.findStatic(AccessController.class, "doPrivileged",
+                final MethodHandle privilegedHandle = lookup.findStatic(
+                        AccessController.class,
+                        "doPrivileged",
                         MethodType.methodType(Object.class, PrivilegedAction.class));
                 serviceLoader = (ServiceLoader<T>) privilegedHandle.invoke(action);
             }
@@ -141,9 +144,10 @@ public final class ServiceLoaderUtil {
         private final Logger logger;
         private final String serviceName;
 
-        public ServiceLoaderSpliterator(final Class<S> serviceType, final Lookup lookup, final ClassLoader classLoader,
-                final boolean verbose) {
-            this.serviceIterator = callServiceLoader(lookup, serviceType, classLoader, verbose).iterator();
+        public ServiceLoaderSpliterator(
+                final Class<S> serviceType, final Lookup lookup, final ClassLoader classLoader, final boolean verbose) {
+            this.serviceIterator =
+                    callServiceLoader(lookup, serviceType, classLoader, verbose).iterator();
             this.logger = verbose ? StatusLogger.getLogger() : null;
             this.serviceName = serviceType.toString();
         }
@@ -185,6 +189,5 @@ public final class ServiceLoaderUtil {
         public int characteristics() {
             return NONNULL | IMMUTABLE;
         }
-
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
@@ -24,7 +24,6 @@ import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-
 import org.apache.logging.log4j.util.internal.SerializationUtil;
 
 /**
@@ -56,15 +55,18 @@ public class SortedArrayStringMap implements IndexedStringMap {
      * The default initial capacity.
      */
     private static final int DEFAULT_INITIAL_CAPACITY = 4;
+
     private static final long serialVersionUID = -5748905872274478116L;
     private static final int HASHVAL = 31;
 
-    private static final TriConsumer<String, Object, StringMap> PUT_ALL = (key, value, contextData) -> contextData.putValue(key, value);
+    private static final TriConsumer<String, Object, StringMap> PUT_ALL =
+            (key, value, contextData) -> contextData.putValue(key, value);
 
     /**
      * An empty array instance to share when the table is not inflated.
      */
     private static final String[] EMPTY = Strings.EMPTY_ARRAY;
+
     private static final String FROZEN = "Frozen collection cannot be modified";
 
     private transient String[] keys = EMPTY;
@@ -82,6 +84,7 @@ public class SortedArrayStringMap implements IndexedStringMap {
     // If table == EMPTY_TABLE then this is the initial capacity at which the
     // table will be created when inflated.
     private int threshold;
+
     private boolean immutable;
     private transient boolean iterating;
 
@@ -480,8 +483,8 @@ public class SortedArrayStringMap implements IndexedStringMap {
         if (size > 0) {
             for (int i = 0; i < size; i++) {
                 s.writeObject(keys[i]);
-                SerializationUtil.writeWrappedObject((values[i] instanceof Serializable) ? (Serializable) values[i] : null,
-                        s);
+                SerializationUtil.writeWrappedObject(
+                        (values[i] instanceof Serializable) ? (Serializable) values[i] : null, s);
             }
         }
     }
@@ -503,7 +506,7 @@ public class SortedArrayStringMap implements IndexedStringMap {
      * Reconstitute the {@code SortedArrayStringMap} instance from a stream (i.e.,
      * deserialize it).
      */
-    private void readObject(final java.io.ObjectInputStream s)  throws IOException, ClassNotFoundException {
+    private void readObject(final java.io.ObjectInputStream s) throws IOException, ClassNotFoundException {
         SerializationUtil.assertFiltered(s);
         // Read in the threshold (ignored), and any hidden stuff
         s.defaultReadObject();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -103,8 +103,7 @@ public final class StackLocator {
         return INSTANCE;
     }
 
-    private StackLocator() {
-    }
+    private StackLocator() {}
 
     // TODO: return Object.class instead of null (though it will have a null ClassLoader)
     // (MS) I believe this would work without any modifications elsewhere, but I could be wrong
@@ -153,7 +152,8 @@ public final class StackLocator {
         if (GET_CALLER_CLASS_METHOD == null) {
             return DEFAULT_CALLER_CLASS;
         }
-        // note that we need to add 1 to the depth value to compensate for this method, but not for the Method.invoke
+        // note that we need to add 1 to the depth value to compensate for this method, but not for
+        // the Method.invoke
         // since Reflection.getCallerClass ignores the call to Method.invoke()
         try {
             return (Class<?>) GET_CALLER_CLASS_METHOD.invoke(null, depth + 1 + JDK_7U25_OFFSET);
@@ -202,7 +202,8 @@ public final class StackLocator {
     // migrated from ThrowableProxy
     @PerformanceSensitive
     public Deque<Class<?>> getCurrentStackTrace() {
-        // benchmarks show that using the SecurityManager is much faster than looping through getCallerClass(int)
+        // benchmarks show that using the SecurityManager is much faster than looping through
+        // getCallerClass(int)
         if (PrivateSecurityManagerStackTraceUtil.isEnabled()) {
             return PrivateSecurityManagerStackTraceUtil.getCurrentStackTrace();
         }
@@ -219,7 +220,8 @@ public final class StackLocator {
         if (fqcnOfLogger == null) {
             return null;
         }
-        // LOG4J2-1029 new Throwable().getStackTrace is faster than Thread.currentThread().getStackTrace().
+        // LOG4J2-1029 new Throwable().getStackTrace is faster than
+        // Thread.currentThread().getStackTrace().
         final StackTraceElement[] stackTrace = new Throwable().getStackTrace();
         boolean found = false;
         for (int i = 0; i < stackTrace.length; i++) {
@@ -236,8 +238,10 @@ public final class StackLocator {
     }
 
     public StackTraceElement getStackTraceElement(final int depth) {
-        // (MS) I tested the difference between using Throwable.getStackTrace() and Thread.getStackTrace(), and
-        // the version using Throwable was surprisingly faster! at least on Java 1.8. See ReflectionBenchmark.
+        // (MS) I tested the difference between using Throwable.getStackTrace() and
+        // Thread.getStackTrace(), and
+        // the version using Throwable was surprisingly faster! at least on Java 1.8. See
+        // ReflectionBenchmark.
         int i = 0;
         for (final StackTraceElement element : new Throwable().getStackTrace()) {
             if (isValid(element)) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.util;
 import java.util.Deque;
 import java.util.NoSuchElementException;
 import java.util.function.Predicate;
-
 import org.apache.logging.log4j.status.StatusLogger;
 
 /**
@@ -33,8 +32,7 @@ public final class StackLocatorUtil {
         stackLocator = StackLocator.getInstance();
     }
 
-    private StackLocatorUtil() {
-    }
+    private StackLocatorUtil() {}
 
     // TODO: return Object.class instead of null (though it will have a null ClassLoader)
     // (MS) I believe this would work without any modifications elsewhere, but I could be wrong

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.util;
 
-import java.util.Map.Entry;
-
 import static java.lang.Character.toLowerCase;
+
+import java.util.Map.Entry;
 
 /**
  * <em>Consider this class private.</em>
@@ -32,21 +32,20 @@ public final class StringBuilders {
         Class<?> clazz;
         try {
             clazz = Class.forName("java.sql.Time");
-        } catch(ClassNotFoundException ex) {
+        } catch (ClassNotFoundException ex) {
             clazz = null;
         }
         timeClass = clazz;
 
         try {
             clazz = Class.forName("java.sql.Date");
-        } catch(ClassNotFoundException ex) {
+        } catch (ClassNotFoundException ex) {
             clazz = null;
         }
         dateClass = clazz;
     }
 
-    private StringBuilders() {
-    }
+    private StringBuilders() {}
 
     /**
      * Appends in the following format: double quoted value.
@@ -79,7 +78,11 @@ public final class StringBuilders {
      * @return the specified StringBuilder
      */
     public static StringBuilder appendKeyDqValue(final StringBuilder sb, final String key, final Object value) {
-        return sb.append(key).append(Chars.EQ).append(Chars.DQUOTE).append(value).append(Chars.DQUOTE);
+        return sb.append(key)
+                .append(Chars.EQ)
+                .append(Chars.DQUOTE)
+                .append(value)
+                .append(Chars.DQUOTE);
     }
 
     /**
@@ -127,8 +130,8 @@ public final class StringBuilders {
     }
 
     /*
-        Check to see if obj is an instance of java.sql.Time without requiring the java.sql module.
-     */
+       Check to see if obj is an instance of java.sql.Time without requiring the java.sql module.
+    */
     private static boolean isTime(final Object obj) {
         return timeClass != null && timeClass.isAssignableFrom(obj.getClass());
     }
@@ -152,8 +155,13 @@ public final class StringBuilders {
      * @param rightLength length of the section in the right CharSequence
      * @return true if equal, false otherwise
      */
-    public static boolean equals(final CharSequence left, final int leftOffset, final int leftLength,
-                                    final CharSequence right, final int rightOffset, final int rightLength) {
+    public static boolean equals(
+            final CharSequence left,
+            final int leftOffset,
+            final int leftLength,
+            final CharSequence right,
+            final int rightOffset,
+            final int rightLength) {
         if (leftLength == rightLength) {
             for (int i = 0; i < rightLength; i++) {
                 if (left.charAt(i + leftOffset) != right.charAt(i + rightOffset)) {
@@ -177,8 +185,13 @@ public final class StringBuilders {
      * @param rightLength length of the section in the right CharSequence
      * @return true if equal ignoring case, false otherwise
      */
-    public static boolean equalsIgnoreCase(final CharSequence left, final int leftOffset, final int leftLength,
-                                              final CharSequence right, final int rightOffset, final int rightLength) {
+    public static boolean equalsIgnoreCase(
+            final CharSequence left,
+            final int leftOffset,
+            final int leftLength,
+            final CharSequence right,
+            final int rightOffset,
+            final int rightLength) {
         if (leftLength == rightLength) {
             for (int i = 0; i < rightLength; i++) {
                 if (toLowerCase(left.charAt(i + leftOffset)) != toLowerCase(right.charAt(i + rightOffset))) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -33,6 +33,7 @@ public final class Strings {
      * The empty string.
      */
     public static final String EMPTY = "";
+
     private static final String COMMA_DELIMITED_RE = "\\s*,\\s*";
 
     /**
@@ -44,8 +45,8 @@ public final class Strings {
      * OS-dependent line separator, defaults to {@code "\n"} if the system property {@code ""line.separator"} cannot be
      * read.
      */
-    public static final String LINE_SEPARATOR = SystemPropertiesPropertySource.getSystemProperty("line.separator",
-            "\n");
+    public static final String LINE_SEPARATOR =
+            SystemPropertiesPropertySource.getSystemProperty("line.separator", "\n");
 
     /**
      * Returns a double quoted string.
@@ -346,5 +347,4 @@ public final class Strings {
             sb.setLength(0);
         }
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/SystemPropertiesPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/SystemPropertiesPropertySource.java
@@ -16,12 +16,11 @@
  */
 package org.apache.logging.log4j.util;
 
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceProvider;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Properties;
-
-import aQute.bnd.annotation.Resolution;
-import aQute.bnd.annotation.spi.ServiceProvider;
 
 /**
  * PropertySource backed by the current system properties. Other than having a
@@ -107,5 +106,4 @@ public class SystemPropertiesPropertySource implements PropertySource {
     public boolean containsProperty(final String key) {
         return getProperty(key) != null;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Timer.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Timer.java
@@ -24,33 +24,35 @@ import java.text.DecimalFormat;
  * so long as all the timer methods are called on the same thread in which it was started. Calling start on
  * multiple threads will cause the times to be aggregated.
  */
-public class Timer implements Serializable, StringBuilderFormattable
-{
+public class Timer implements Serializable, StringBuilderFormattable {
     private static final long serialVersionUID = 9175191792439630013L;
 
-    private final String name;        // The timer's name
+    private final String name; // The timer's name
+
     public enum Status {
-        Started, Stopped, Paused
+        Started,
+        Stopped,
+        Paused
     }
+
     private Status status; // The timer's status
-    private long elapsedTime;         // The elapsed time
+    private long elapsedTime; // The elapsed time
     private final int iterations;
     private static long NANO_PER_SECOND = 1000000000L;
     private static long NANO_PER_MINUTE = NANO_PER_SECOND * 60;
     private static long NANO_PER_HOUR = NANO_PER_MINUTE * 60;
     private ThreadLocal<Long> startTime = new ThreadLocal<Long>() {
-            @Override protected Long initialValue() {
-                return 0L;
-            }
+        @Override
+        protected Long initialValue() {
+            return 0L;
+        }
     };
-
 
     /**
      * Constructor.
      * @param name the timer name.
      */
-    public Timer(final String name)
-    {
+    public Timer(final String name) {
         this(name, 0);
     }
 
@@ -59,8 +61,7 @@ public class Timer implements Serializable, StringBuilderFormattable
      *
      * @param name the timer name.
      */
-    public Timer(final String name, final int iterations)
-    {
+    public Timer(final String name, final int iterations) {
         this.name = name;
         status = Status.Stopped;
         this.iterations = (iterations > 0) ? iterations : 0;
@@ -69,8 +70,7 @@ public class Timer implements Serializable, StringBuilderFormattable
     /**
      * Start the timer.
      */
-    public synchronized void start()
-    {
+    public synchronized void start() {
         startTime.set(System.nanoTime());
         elapsedTime = 0;
         status = Status.Started;
@@ -87,8 +87,7 @@ public class Timer implements Serializable, StringBuilderFormattable
     /**
      * Stop the timer.
      */
-    public synchronized String stop()
-    {
+    public synchronized String stop() {
         elapsedTime += System.nanoTime() - startTime.get();
         startTime.set(0L);
         status = Status.Stopped;
@@ -98,8 +97,7 @@ public class Timer implements Serializable, StringBuilderFormattable
     /**
      * Pause the timer.
      */
-    public synchronized void pause()
-    {
+    public synchronized void pause() {
         elapsedTime += System.nanoTime() - startTime.get();
         startTime.set(0L);
         status = Status.Paused;
@@ -108,8 +106,7 @@ public class Timer implements Serializable, StringBuilderFormattable
     /**
      * Resume the timer.
      */
-    public synchronized void resume()
-    {
+    public synchronized void resume() {
         startTime.set(System.nanoTime());
         status = Status.Started;
     }
@@ -118,8 +115,7 @@ public class Timer implements Serializable, StringBuilderFormattable
      * Accessor for the name.
      * @return the timer's name.
      */
-    public String getName()
-    {
+    public String getName() {
         return name;
     }
 
@@ -128,8 +124,7 @@ public class Timer implements Serializable, StringBuilderFormattable
      *
      * @return the elapsed time.
      */
-    public long getElapsedTime()
-    {
+    public long getElapsedTime() {
         return elapsedTime / 1000000;
     }
 
@@ -138,8 +133,7 @@ public class Timer implements Serializable, StringBuilderFormattable
      *
      * @return the elapsed time.
      */
-    public long getElapsedNanoTime()
-    {
+    public long getElapsedNanoTime() {
         return elapsedTime;
     }
 
@@ -148,8 +142,7 @@ public class Timer implements Serializable, StringBuilderFormattable
      * Resume).
      * @return the string representing the last operation performed.
      */
-    public Status getStatus()
-    {
+    public Status getStatus() {
         return status;
     }
 
@@ -157,8 +150,7 @@ public class Timer implements Serializable, StringBuilderFormattable
      * Returns the String representation of the timer based upon its current state
      */
     @Override
-    public String toString()
-    {
+    public String toString() {
         final StringBuilder result = new StringBuilder();
         formatTo(result);
         return result.toString();
@@ -278,5 +270,4 @@ public class Timer implements Serializable, StringBuilderFormattable
         result = 29 * result + (int) (elapsedTime ^ (elapsedTime >>> 32));
         return result;
     }
-
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
@@ -99,6 +99,7 @@ public class Unbox {
     private static class State {
         private final StringBuilder[] ringBuffer = new StringBuilder[RINGBUFFER_SIZE];
         private int current;
+
         State() {
             for (int i = 0; i < ringBuffer.length; i++) {
                 ringBuffer[i] = new StringBuilder(21);
@@ -120,6 +121,7 @@ public class Unbox {
             return false;
         }
     }
+
     private static ThreadLocal<State> threadLocalState = new ThreadLocal<>();
     private static WebSafeState webSafeState = new WebSafeState();
 
@@ -128,19 +130,22 @@ public class Unbox {
     }
 
     private static int calculateRingBufferSize(final String propertyName) {
-        final String userPreferredRBSize = PropertiesUtil.getProperties().getStringProperty(propertyName,
-                String.valueOf(RINGBUFFER_MIN_SIZE));
+        final String userPreferredRBSize =
+                PropertiesUtil.getProperties().getStringProperty(propertyName, String.valueOf(RINGBUFFER_MIN_SIZE));
         try {
             int size = Integer.parseInt(userPreferredRBSize.trim());
             if (size < RINGBUFFER_MIN_SIZE) {
                 size = RINGBUFFER_MIN_SIZE;
-                LOGGER.warn("Invalid {} {}, using minimum size {}.", propertyName, userPreferredRBSize,
+                LOGGER.warn(
+                        "Invalid {} {}, using minimum size {}.",
+                        propertyName,
+                        userPreferredRBSize,
                         RINGBUFFER_MIN_SIZE);
             }
             return ceilingNextPowerOfTwo(size);
         } catch (final Exception ex) {
-            LOGGER.warn("Invalid {} {}, using default size {}.", propertyName, userPreferredRBSize,
-                    RINGBUFFER_MIN_SIZE);
+            LOGGER.warn(
+                    "Invalid {} {}, using default size {}.", propertyName, userPreferredRBSize, RINGBUFFER_MIN_SIZE);
             return RINGBUFFER_MIN_SIZE;
         }
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.util.internal;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -28,8 +29,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.FilteredObjectInputStream;
 
@@ -38,7 +37,8 @@ import org.apache.logging.log4j.util.FilteredObjectInputStream;
  */
 public final class SerializationUtil {
 
-    private static final String DEFAULT_FILTER_CLASS= "org.apache.logging.log4j.util.internal.DefaultObjectInputFilter";
+    private static final String DEFAULT_FILTER_CLASS =
+            "org.apache.logging.log4j.util.internal.DefaultObjectInputFilter";
     private static final Method setObjectInputFilter;
     private static final Method getObjectInputFilter;
     private static final Method newObjectInputFilter;
@@ -81,16 +81,10 @@ public final class SerializationUtil {
             "java.rmi.MarshalledObject",
             "[B",
             // for MessagePatternAnalysis
-            "[I"
-    );
+            "[I");
 
     public static final List<String> REQUIRED_JAVA_PACKAGES = Arrays.asList(
-            "java.lang.",
-            "java.time",
-            "java.util.",
-            "org.apache.logging.log4j.",
-            "[Lorg.apache.logging.log4j."
-    );
+            "java.lang.", "java.time", "java.util.", "org.apache.logging.log4j.", "[Lorg.apache.logging.log4j.");
 
     public static void writeWrappedObject(final Serializable obj, final ObjectOutputStream out) throws IOException {
         final ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -103,9 +97,9 @@ public final class SerializationUtil {
 
     @SuppressFBWarnings(
             value = "OBJECT_DESERIALIZATION",
-            justification = "Object deserialization uses either Java 9 native filter or our custom filter to limit the kinds of classes deserialized.")
-    public static Object readWrappedObject(final ObjectInputStream in)
-            throws IOException, ClassNotFoundException {
+            justification =
+                    "Object deserialization uses either Java 9 native filter or our custom filter to limit the kinds of classes deserialized.")
+    public static Object readWrappedObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
         assertFiltered(in);
         final byte[] data = (byte[]) in.readObject();
         final ByteArrayInputStream bin = new ByteArrayInputStream(data);
@@ -134,7 +128,8 @@ public final class SerializationUtil {
 
     public static void assertFiltered(final java.io.ObjectInputStream stream) {
         if (!(stream instanceof FilteredObjectInputStream) && setObjectInputFilter == null) {
-            throw new IllegalArgumentException("readObject requires a FilteredObjectInputStream or an ObjectInputStream that accepts an ObjectInputFilter");
+            throw new IllegalArgumentException(
+                    "readObject requires a FilteredObjectInputStream or an ObjectInputStream that accepts an ObjectInputFilter");
         }
     }
 


### PR DESCRIPTION
This PR evaluates the effect of the following Spotless configuration on `log4j-api`:
```xml
<java>
  <palantirJavaFormat>
    <version>2.38.0</version>
  </palantirJavaFormat>
</java>
```

The `log4j-api` source code is about 33k LOCs.
