### PR TITLE
Expose disruptor discard count in AsyncLoggerContext

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
@@ -802,4 +802,15 @@ public class LoggerContext extends AbstractLifeCycle
     protected Logger newInstance(final LoggerContext ctx, final String name, final MessageFactory messageFactory) {
         return new Logger(ctx, name, messageFactory);
     }
+
+    /**
+     * Returns the number of logging events discarded by the disruptor's queue full policy, or 0 if the disruptor
+     * does not use a discarding policy or has not discarded. This is pulled from the disruptor used by this context's
+     * associated {@link org.apache.logging.log4j.core.async.AsyncLoggerConfigDelegate}
+     *
+     * @return 0 if the disruptor is not configured to discard or has not discarded, otherwise a positive long
+     */
+    public long getDiscardCount() {
+        return configuration.getAsyncLoggerConfigDelegate().getDiscardCount();
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigDelegate.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigDelegate.java
@@ -62,4 +62,14 @@ public interface AsyncLoggerConfigDelegate {
      * @param logEventFactory the factory used
      */
     void setLogEventFactory(LogEventFactory logEventFactory);
+
+    /**
+     * Returns the number of logging events discarded by the disruptor's queue full policy, or 0 if the disruptor
+     * does not use a discarding policy or has not discarded.
+     *
+     * @return 0 if the disruptor is not configured to discard or has not discarded, otherwise a positive long
+     */
+    default long getDiscardCount() {
+        return 0;
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerContext.java
@@ -127,4 +127,15 @@ public class AsyncLoggerContext extends LoggerContext {
     public void setUseThreadLocals(final boolean useThreadLocals) {
         loggerDisruptor.setUseThreadLocals(useThreadLocals);
     }
+
+    /**
+     * Returns the number of logging events discarded by the disruptor's queue full policy, or 0 if the disruptor
+     * does not use a discarding policy or has not discarded.
+     *
+     * @return 0 if the disruptor is not configured to discard or has not discarded, otherwise a positive long
+     */
+    @Override
+    public long getDiscardCount() {
+        return DiscardingAsyncQueueFullPolicy.getDiscardCount(loggerDisruptor.getAsyncQueueFullPolicy());
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
@@ -86,6 +86,10 @@ class AsyncLoggerDisruptor extends AbstractLifeCycle {
         return waitStrategy;
     }
 
+    AsyncQueueFullPolicy getAsyncQueueFullPolicy() {
+        return asyncQueueFullPolicy;
+    }
+
     public String getContextName() {
         return contextName;
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/package-info.java
@@ -18,7 +18,7 @@
  * Provides Asynchronous Logger classes and interfaces for low-latency logging.
  */
 @Export
-@Version("2.23.0")
+@Version("2.24.0")
 package org.apache.logging.log4j.core.async;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/package-info.java
@@ -18,7 +18,7 @@
  * Implementation of Log4j 2.
  */
 @Export
-@Version("2.20.2")
+@Version("2.21.0")
 package org.apache.logging.log4j.core;
 
 import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
I would like to monitor the disruptor's discard count on a periodic basis so that I can tell if events are being discarded due to the queue being full, and how often it is happening if so. As it stands, this count is not accessible outside of the AsyncLoggerDisruptor, and the discard count is only published in a trace log when the logger is stopped.

I considered adding this to RingBufferAdminMBean but since it currently monitors the backing ring buffer, and not the disruptor itself, it did not seem to fit.

This is my first contribution so I'm unsure if this meets the bar for a changelog entry, and whether or not this needs an issue to be cut beforehand, and if I incremented the log4j-core version correctly (it was required for `mvnw verify` to work, otherwise the baseline plugin failed the build).

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
