### PR TITLE
Fix Error Prone warnings in `log4j-api`

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/jmx/Agent.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/jmx/Agent.java
@@ -25,6 +25,7 @@ import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;
 
 import org.apache.log4j.Logger;
+import org.apache.logging.log4j.util.LoaderUtil;
 
 /**
  * Manages an instance of com.sun.jdmk.comm.HtmlAdapterServer which was provided for demonstration purposes in the Java
@@ -53,13 +54,9 @@ public class Agent {
     private static Object createServer() {
         Object newInstance = null;
         try {
-            newInstance = Class.forName("com.sun.jdmk.comm.HtmlAdapterServer").newInstance();
-        } catch (final ClassNotFoundException ex) {
-            throw new RuntimeException(ex.toString());
-        } catch (final InstantiationException ex) {
-            throw new RuntimeException(ex.toString());
-        } catch (final IllegalAccessException ex) {
-            throw new RuntimeException(ex.toString());
+            newInstance = LoaderUtil.newInstanceOf("com.sun.jdmk.comm.HtmlAdapterServer");
+        } catch (final ReflectiveOperationException ex) {
+            throw new RuntimeException(ex);
         }
         return newInstance;
     }

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/Base64Util.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/Base64Util.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.util;
 
+import java.nio.charset.Charset;
 import java.util.Base64;
 
 
@@ -31,6 +32,6 @@ public final class Base64Util {
     }
 
     public static String encode(final String str) {
-        return str != null ? encoder.encodeToString(str.getBytes()) : null;
+        return str != null ? encoder.encodeToString(str.getBytes(Charset.defaultCharset())) : null;
     }
 }

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/PropertySourceTokenizerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/PropertySourceTokenizerTest.java
@@ -53,7 +53,7 @@ public class PropertySourceTokenizerTest {
 
     @ParameterizedTest
     @MethodSource("data")
-    public void testTokenize(final CharSequence value, final List<CharSequence> expectedTokens) {
+    public void testTokenize(final String value, final List<CharSequence> expectedTokens) {
         final List<CharSequence> tokens = PropertySource.Util.tokenize(value);
         assertEquals(expectedTokens, tokens);
     }

--- a/log4j-api/pom.xml
+++ b/log4j-api/pom.xml
@@ -57,6 +57,7 @@
   </dependencies>
   <build>
     <plugins>
+
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
@@ -75,6 +76,7 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -104,6 +106,48 @@
           </execution>
         </executions>
       </plugin>
+
+      <!--
+        ~ Remove the following plugin executions after `2.22.0` release!
+        ~ In `2.22.0`, we have removed protected methods from the final (or effectively final) classes:
+        ~  * org.apache.logging.log4j.Level,
+        ~  * org.apache.logging.log4j.util.ProviderUtil.
+        ~
+        ~ BND considers this a major API break.
+        -->
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-baseline-maven-plugin</artifactId>
+        <configuration>
+          <diffpackages>
+            <diffpackage>!org.apache.logging.log4j</diffpackage>
+            <diffpackage>!org.apache.logging.log4j.util</diffpackage>
+            <diffpackage>*</diffpackage>
+          </diffpackages>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>remove-after-release</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireProperty>
+                  <property>revision</property>
+                  <regex>2\.22\.0(-SNAPSHOT)?</regex>
+                  <regexMessage>Remove `bnd-baseline-maven-plugin` config in `log4j-api`.</regexMessage>
+                </requireProperty>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/log4j-api/pom.xml
+++ b/log4j-api/pom.xml
@@ -107,47 +107,6 @@
         </executions>
       </plugin>
 
-      <!--
-        ~ Remove the following plugin executions after `2.22.0` release!
-        ~ In `2.22.0`, we have removed protected methods from the final (or effectively final) classes:
-        ~  * org.apache.logging.log4j.Level,
-        ~  * org.apache.logging.log4j.util.ProviderUtil.
-        ~
-        ~ BND considers this a major API break.
-        -->
-      <plugin>
-        <groupId>biz.aQute.bnd</groupId>
-        <artifactId>bnd-baseline-maven-plugin</artifactId>
-        <configuration>
-          <diffpackages>
-            <diffpackage>!org.apache.logging.log4j</diffpackage>
-            <diffpackage>!org.apache.logging.log4j.util</diffpackage>
-            <diffpackage>*</diffpackage>
-          </diffpackages>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>remove-after-release</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireProperty>
-                  <property>revision</property>
-                  <regex>2\.22\.0(-SNAPSHOT)?</regex>
-                  <regexMessage>Remove `bnd-baseline-maven-plugin` config in `log4j-api`.</regexMessage>
-                </requireProperty>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
 </project>

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import aQute.bnd.annotation.baseline.BaselineIgnore;
 import org.apache.logging.log4j.spi.StandardLevel;
 import org.apache.logging.log4j.util.Strings;
 
@@ -75,6 +76,7 @@ import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
  * used in logging configurations.
  * </p>
  */
+@BaselineIgnore("2.22.0")
 public final class Level implements Comparable<Level>, Serializable {
 
     private static final Level[] EMPTY_ARRAY = {};

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
@@ -122,6 +122,8 @@ public final class Level implements Comparable<Level>, Serializable {
     public static final Level ALL = new Level("ALL", StandardLevel.ALL.intLevel());
 
     /**
+     * Category to be used by custom levels.
+     *
      * @since 2.1
      */
     public static final String CATEGORY = "Level";
@@ -365,7 +367,7 @@ public final class Level implements Comparable<Level>, Serializable {
     }
 
     // for deserialization
-    protected Object readResolve() {
+    private Object readResolve() {
         return Level.valueOf(this.name);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
@@ -95,6 +95,7 @@ public interface LogBuilder {
      * @param message The message.
      * @param params Parameters to the message.
      */
+    @SuppressWarnings("deprecation")
     default void log(String message, Supplier<?>... params) {
     }
 
@@ -109,6 +110,7 @@ public interface LogBuilder {
      * Causes all the data collected to be logged along with the message. Interface default method does nothing.
      * @param messageSupplier The supplier of the message to log.
      */
+    @SuppressWarnings("deprecation")
     default void log(Supplier<Message> messageSupplier) {
     }
 
@@ -119,6 +121,7 @@ public interface LogBuilder {
      * @return the message logger or {@code null} if no logging occurred.
      * @since 2.20
      */
+    @SuppressWarnings("deprecation")
     default Message logAndGet(final Supplier<Message> messageSupplier) {
         return null;
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
@@ -65,7 +65,7 @@ public class LogManager {
 
     private static volatile LoggerContextFactory factory;
 
-    /**
+    /*
      * Scans the classpath to find all logging implementation. Currently, only one will be used but this could be
      * extended to allow multiple implementations to be used.
      */
@@ -92,7 +92,7 @@ public class LogManager {
                     final Class<? extends LoggerContextFactory> factoryClass = provider.loadLoggerContextFactory();
                     if (factoryClass != null) {
                         try {
-                            factories.put(provider.getPriority(), factoryClass.newInstance());
+                            factories.put(provider.getPriority(), factoryClass.getDeclaredConstructor().newInstance());
                         } catch (final Exception e) {
                             LOGGER.error("Unable to create class {} specified in provider URL {}",
                                     factoryClass.getName(), provider.getUrl(), e);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
@@ -92,7 +92,7 @@ public class LogManager {
                     final Class<? extends LoggerContextFactory> factoryClass = provider.loadLoggerContextFactory();
                     if (factoryClass != null) {
                         try {
-                            factories.put(provider.getPriority(), factoryClass.getDeclaredConstructor().newInstance());
+                            factories.put(provider.getPriority(), LoaderUtil.newInstanceOf(factoryClass));
                         } catch (final Exception e) {
                             LOGGER.error("Unable to create class {} specified in provider URL {}",
                                     factoryClass.getName(), provider.getUrl(), e);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -70,7 +70,7 @@ import org.apache.logging.log4j.util.Supplier;
  * </pre>
  *
  * <p>
- * Note that although {@link MessageSupplier} is provided, using {@link Supplier<Message>} works just the
+ * Note that although {@link MessageSupplier} is provided, using {@link Supplier Supplier&lt;Message&gt;} works just the
  * same. MessageSupplier was deprecated in 2.6 and un-deprecated in 2.8.1. Anonymous class usage of these APIs
  * should prefer using Supplier instead.
  * </p>

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -70,7 +70,7 @@ import org.apache.logging.log4j.util.Supplier;
  * </pre>
  *
  * <p>
- * Note that although {@link MessageSupplier} is provided, using {@link Supplier {@code Supplier<Message>}} works just the
+ * Note that although {@link MessageSupplier} is provided, using {@link Supplier<Message>} works just the
  * same. MessageSupplier was deprecated in 2.6 and un-deprecated in 2.8.1. Anonymous class usage of these APIs
  * should prefer using Supplier instead.
  * </p>
@@ -200,6 +200,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void debug(Marker marker, String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -221,6 +222,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void debug(Marker marker, Supplier<?> messageSupplier);
 
     /**
@@ -233,6 +235,7 @@ public interface Logger {
      * @param throwable A Throwable or null.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void debug(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
 
     /**
@@ -326,6 +329,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void debug(String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -344,6 +348,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void debug(Supplier<?> messageSupplier);
 
     /**
@@ -355,6 +360,7 @@ public interface Logger {
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void debug(Supplier<?> messageSupplier, Throwable throwable);
 
     /**
@@ -756,6 +762,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void error(Marker marker, String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -777,6 +784,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void error(Marker marker, Supplier<?> messageSupplier);
 
     /**
@@ -789,6 +797,7 @@ public interface Logger {
      * @param throwable A Throwable or null.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void error(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
 
     /**
@@ -882,6 +891,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void error(String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -900,6 +910,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void error(Supplier<?> messageSupplier);
 
     /**
@@ -911,6 +922,7 @@ public interface Logger {
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void error(Supplier<?> messageSupplier, Throwable throwable);
 
     /**
@@ -1304,6 +1316,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void fatal(Marker marker, String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -1325,6 +1338,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void fatal(Marker marker, Supplier<?> messageSupplier);
 
     /**
@@ -1337,6 +1351,7 @@ public interface Logger {
      * @param throwable A Throwable or null.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void fatal(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
 
     /**
@@ -1430,6 +1445,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void fatal(String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -1448,6 +1464,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void fatal(Supplier<?> messageSupplier);
 
     /**
@@ -1459,6 +1476,7 @@ public interface Logger {
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void fatal(Supplier<?> messageSupplier, Throwable throwable);
 
     /**
@@ -1865,6 +1883,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void info(Marker marker, String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -1886,6 +1905,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void info(Marker marker, Supplier<?> messageSupplier);
 
     /**
@@ -1898,6 +1918,7 @@ public interface Logger {
      * @param throwable A Throwable or null.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void info(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
 
     /**
@@ -1991,6 +2012,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void info(String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -2009,6 +2031,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void info(Supplier<?> messageSupplier);
 
     /**
@@ -2020,6 +2043,7 @@ public interface Logger {
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void info(Supplier<?> messageSupplier, Throwable throwable);
 
     /**
@@ -2517,6 +2541,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void log(Level level, Marker marker, String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -2539,6 +2564,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void log(Level level, Marker marker, Supplier<?> messageSupplier);
 
     /**
@@ -2552,6 +2578,7 @@ public interface Logger {
      * @param throwable A Throwable or null.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void log(Level level, Marker marker, Supplier<?> messageSupplier, Throwable throwable);
 
     /**
@@ -2655,6 +2682,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void log(Level level, String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -2675,6 +2703,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void log(Level level, Supplier<?> messageSupplier);
 
     /**
@@ -2687,6 +2716,7 @@ public interface Logger {
      * @param throwable the {@code Throwable} to log, including its stack log.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void log(Level level, Supplier<?> messageSupplier, Throwable throwable);
 
     /**
@@ -3127,6 +3157,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void trace(Marker marker, String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -3149,6 +3180,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void trace(Marker marker, Supplier<?> messageSupplier);
 
     /**
@@ -3161,6 +3193,7 @@ public interface Logger {
      * @param throwable A Throwable or null.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void trace(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
 
     /**
@@ -3256,6 +3289,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void trace(String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -3275,6 +3309,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void trace(Supplier<?> messageSupplier);
 
     /**
@@ -3286,6 +3321,7 @@ public interface Logger {
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void trace(Supplier<?> messageSupplier, Throwable throwable);
 
     /**
@@ -3604,6 +3640,7 @@ public interface Logger {
      *
      * @since 2.6
      */
+    @SuppressWarnings("deprecation")
     EntryMessage traceEntry(Supplier<?>... paramSuppliers);
 
     /**
@@ -3622,6 +3659,7 @@ public interface Logger {
      *
      * @since 2.6
      */
+    @SuppressWarnings("deprecation")
     EntryMessage traceEntry(String format, Supplier<?>... paramSuppliers);
 
     /**
@@ -3840,6 +3878,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void warn(Marker marker, String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -3861,6 +3900,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void warn(Marker marker, Supplier<?> messageSupplier);
 
     /**
@@ -3873,6 +3913,7 @@ public interface Logger {
      * @param throwable A Throwable or null.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void warn(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
 
     /**
@@ -3966,6 +4007,7 @@ public interface Logger {
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void warn(String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -3984,6 +4026,7 @@ public interface Logger {
      *            message factory.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void warn(Supplier<?> messageSupplier);
 
     /**
@@ -3995,6 +4038,7 @@ public interface Logger {
      * @param throwable the {@code Throwable} to log, including its stack warn.
      * @since 2.4
      */
+    @SuppressWarnings("deprecation")
     void warn(Supplier<?> messageSupplier, Throwable throwable);
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/MarkerManager.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/MarkerManager.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import com.google.errorprone.annotations.InlineMe;
 import org.apache.logging.log4j.util.PerformanceSensitive;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
@@ -83,7 +84,7 @@ public final class MarkerManager {
         if (parentMarker == null) {
             throw new IllegalArgumentException("Parent Marker " + parent + " has not been defined");
         }
-        return getMarker(name, parentMarker);
+        return getMarker(name).addParents(parentMarker);
     }
 
     /**
@@ -95,6 +96,9 @@ public final class MarkerManager {
      * @throws IllegalArgumentException if any argument is {@code null}
      * @deprecated Use the Marker add or set methods to add parent Markers. Will be removed by final GA release.
      */
+    @InlineMe(
+            replacement = "MarkerManager.getMarker(name).addParents(parent)",
+            imports = "org.apache.logging.log4j.MarkerManager")
     @Deprecated
     public static Marker getMarker(final String name, final Marker parent) {
         return getMarker(name).addParents(parent);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/internal/DefaultLogBuilder.java
@@ -116,6 +116,7 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public Message logAndGet(final Supplier<Message> messageSupplier) {
         Message message = null;
         if (isValid() && isEnabled(message = messageSupplier.get())) {
@@ -146,6 +147,7 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void log(String message, Supplier<?>... params) {
         final Object[] objs;
         if (isValid() && isEnabled(message, objs = LambdaUtil.getAll(params))) {
@@ -154,6 +156,7 @@ public class DefaultLogBuilder implements BridgeAware, LogBuilder {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void log(final Supplier<Message> messageSupplier) {
         logAndGet(messageSupplier);
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/BasicThreadInformation.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/BasicThreadInformation.java
@@ -29,10 +29,8 @@ class BasicThreadInformation implements ThreadInformation {
     private static final int HASH_MULTIPLIER = 31;
     private final long id;
     private final String name;
-    private final String longName;
     private final Thread.State state;
     private final int priority;
-    private final boolean isAlive;
     private final boolean isDaemon;
     private final String threadGroupName;
 
@@ -43,10 +41,10 @@ class BasicThreadInformation implements ThreadInformation {
     BasicThreadInformation(final Thread thread) {
         this.id = thread.getId();
         this.name = thread.getName();
-        this.longName = thread.toString();
+
         this.state = thread.getState();
         this.priority = thread.getPriority();
-        this.isAlive = thread.isAlive();
+
         this.isDaemon = thread.isDaemon();
         final ThreadGroup group = thread.getThreadGroup();
         threadGroupName = group == null ? null : group.getName();
@@ -57,7 +55,7 @@ class BasicThreadInformation implements ThreadInformation {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof BasicThreadInformation)) {
             return false;
         }
 
@@ -66,11 +64,7 @@ class BasicThreadInformation implements ThreadInformation {
         if (id != that.id) {
             return false;
         }
-        if (name != null ? !name.equals(that.name) : that.name != null) {
-            return false;
-        }
-
-        return true;
+        return name != null ? name.equals(that.name) : that.name == null;
     }
 
     @Override

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
@@ -58,8 +58,8 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
 
     private static MessageFactory createDefaultMessageFactory() {
         try {
-            return AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS.newInstance();
-        } catch (final InstantiationException | IllegalAccessException e) {
+            return AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS.getDeclaredConstructor().newInstance();
+        } catch (final ReflectiveOperationException e) {
             throw new IllegalStateException(e);
         }
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
@@ -19,6 +19,7 @@ package org.apache.logging.log4j.message;
 import java.io.Serializable;
 
 import org.apache.logging.log4j.spi.AbstractLogger;
+import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.StringBuilders;
 import org.apache.logging.log4j.util.Strings;
@@ -58,7 +59,7 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
 
     private static MessageFactory createDefaultMessageFactory() {
         try {
-            return AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS.getDeclaredConstructor().newInstance();
+            return LoaderUtil.newInstanceOf(AbstractLogger.DEFAULT_MESSAGE_FACTORY_CLASS);
         } catch (final ReflectiveOperationException e) {
             throw new IllegalStateException(e);
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/FormattedMessage.java
@@ -137,7 +137,7 @@ public class FormattedMessage implements Message {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof FormattedMessage)) {
             return false;
         }
 
@@ -146,11 +146,7 @@ public class FormattedMessage implements Message {
         if (messagePattern != null ? !messagePattern.equals(that.messagePattern) : that.messagePattern != null) {
             return false;
         }
-        if (!Arrays.equals(stringArgs, that.stringArgs)) {
-            return false;
-        }
-
-        return true;
+        return Arrays.equals(stringArgs, that.stringArgs);
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
@@ -472,7 +472,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
         if (this == o) {
             return true;
         }
-        if (o == null || this.getClass() != o.getClass()) {
+        if (!(o instanceof MapMessage)) {
             return false;
         }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessageJsonFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessageJsonFormatter.java
@@ -267,7 +267,7 @@ enum MapMessageJsonFormatter {;
         } else {
             final long longNumber = number.longValue();
             final double doubleValue = number.doubleValue();
-            if (Double.compare(longNumber, doubleValue) == 0) {
+            if (Double.compare((double) longNumber, doubleValue) == 0) {
                 sb.append(longNumber);
             } else {
                 sb.append(doubleValue);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFormatMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageFormatMessage.java
@@ -29,14 +29,15 @@ import org.apache.logging.log4j.status.StatusLogger;
 
 /**
  * Handles messages that consist of a format string conforming to java.text.MessageFormat.
- *
- * @serial In version 2.1, due to a bug in the serialization format, the serialization format was changed along with
- * its {@code serialVersionUID} value.
  */
 public class MessageFormatMessage implements Message {
 
     private static final Logger LOGGER = StatusLogger.getLogger();
 
+    /**
+     * @serial In version 2.1, due to a bug in the serialization format, the serialization format was changed along with
+     * its {@code serialVersionUID} value.
+     */
     private static final long serialVersionUID = 1L;
 
     private static final int HASHVAL = 31;
@@ -124,7 +125,7 @@ public class MessageFormatMessage implements Message {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof MessageFormatMessage)) {
             return false;
         }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ObjectMessage.java
@@ -102,7 +102,7 @@ public class ObjectMessage implements Message, StringBuilderFormattable {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof ObjectMessage)) {
             return false;
         }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -151,7 +151,8 @@ final class ParameterFormatter {
     }
 
     /**
-     * @see #analyzePattern(String, int, MessagePatternAnalysis)
+     *See {@link #analyzePattern(String, int, MessagePatternAnalysis)}.
+
      */
     static final class MessagePatternAnalysis implements Serializable {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
 
+import com.google.errorprone.annotations.InlineMe;
 import org.apache.logging.log4j.message.ParameterFormatter.MessagePatternAnalysis;
 import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
@@ -112,6 +113,9 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      * @param throwable a {@link Throwable}
      * @deprecated Use {@link #ParameterizedMessage(String, Object[], Throwable)} instead
      */
+    @InlineMe(
+            replacement = "this(pattern, Arrays.stream(args).toArray(Object[]::new), throwable)",
+            imports = "java.util.Arrays")
     @Deprecated
     public ParameterizedMessage(final String pattern, final String[] args, final Throwable throwable) {
         this(pattern, Arrays.stream(args).toArray(Object[]::new), throwable);
@@ -268,9 +272,9 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
     }
 
     /**
+     * Returns the formatted message.
      * @param pattern a message pattern containing argument placeholders
      * @param args arguments to be used to replace placeholders
-     * @return the formatted message
      */
     public static String format(final String pattern, final Object[] args) {
         final int argCount = args != null ? args.length : 0;
@@ -282,7 +286,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
         if (this == object) {
             return true;
         }
-        if (object == null || getClass() != object.getClass()) {
+        if (!(object instanceof ParameterizedMessage)) {
             return false;
         }
         final ParameterizedMessage that = (ParameterizedMessage) object;
@@ -297,8 +301,8 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
     }
 
     /**
+     * Returns the number of argument placeholders.
      * @param pattern the message pattern to be analyzed
-     * @return the number of argument placeholders
      */
     public static int countArgumentPlaceholders(final String pattern) {
         if (pattern == null) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
@@ -30,6 +30,10 @@ import org.apache.logging.log4j.util.PerformanceSensitive;
  * @since 2.6
  */
 @PerformanceSensitive("allocation")
+/*
+ * https://errorprone.info/bugpattern/ThreadLocalUsage
+ * Instance thread locals are not a problem here, since this class is almost a singleton.
+ */
 @SuppressWarnings("ThreadLocalUsage")
 public final class ReusableMessageFactory implements MessageFactory2, Serializable {
 
@@ -127,43 +131,43 @@ public final class ReusableMessageFactory implements MessageFactory2, Serializab
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2,
-            final Object p3) {
+                              final Object p3) {
         return getParameterized().set(message, p0, p1, p2, p3);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4) {
+                              final Object p4) {
         return getParameterized().set(message, p0, p1, p2, p3, p4);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5) {
+                              final Object p4, final Object p5) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6) {
+                              final Object p4, final Object p5, final Object p6) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7) {
+                              final Object p4, final Object p5, final Object p6, final Object p7) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6, p7);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
+                              final Object p4, final Object p5, final Object p6, final Object p7, final Object p8) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
     }
 
     @Override
     public Message newMessage(final String message, final Object p0, final Object p1, final Object p2, final Object p3,
-            final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
+                              final Object p4, final Object p5, final Object p6, final Object p7, final Object p8, final Object p9) {
         return getParameterized().set(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.util.PerformanceSensitive;
  * @since 2.6
  */
 @PerformanceSensitive("allocation")
+@SuppressWarnings("ThreadLocalUsage")
 public final class ReusableMessageFactory implements MessageFactory2, Serializable {
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessage.java
@@ -89,11 +89,12 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
     }
 
     @Override
+    @SuppressWarnings("UndefinedEquals")
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof SimpleMessage)) {
             return false;
         }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/SimpleMessage.java
@@ -19,6 +19,7 @@ package org.apache.logging.log4j.message;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Objects;
 
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
@@ -100,7 +101,13 @@ public class SimpleMessage implements Message, StringBuilderFormattable, CharSeq
 
         final SimpleMessage that = (SimpleMessage) o;
 
-        return !(charSequence != null ? !charSequence.equals(that.charSequence) : that.charSequence != null);
+        /*
+         * https://errorprone.info/bugpattern/UndefinedEquals
+         *
+         * If the char sequences are different, we fall back on string comparison.
+         */
+        return Objects.equals(this.charSequence, that.charSequence)
+                || Objects.equals(this.getFormattedMessage(), that.getFormattedMessage());
     }
 
     @Override

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormattedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StringFormattedMessage.java
@@ -131,7 +131,7 @@ public class StringFormattedMessage implements Message {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof StringFormattedMessage)) {
             return false;
         }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
@@ -18,6 +18,7 @@ package org.apache.logging.log4j.message;
 
 import java.io.Serializable;
 
+import com.google.errorprone.annotations.InlineMe;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.Strings;
 
@@ -143,9 +144,10 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @deprecated Use {@link #StructuredDataId(String, String, String[], String[])} instead.
      */
     @Deprecated
-    public StructuredDataId(final String name, final int enterpriseNumber, final String[] required,
-                            final String[] optional) {
-        this(name, String.valueOf(enterpriseNumber), required, optional, MAX_LENGTH);
+    @InlineMe(replacement = "this(name, String.valueOf(enterpriseNumber), required, optional)")
+    public StructuredDataId(
+            final String name, final int enterpriseNumber, final String[] required, final String[] optional) {
+        this(name, String.valueOf(enterpriseNumber), required, optional);
     }
 
     /**
@@ -190,9 +192,14 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @since 2.9
      * @deprecated Use {@link #StructuredDataId(String, String, String[], String[], int)} instead.
      */
+    @InlineMe(replacement = "this(name, String.valueOf(enterpriseNumber), required, optional, maxLength)")
     @Deprecated
-    public StructuredDataId(final String name, final int enterpriseNumber, final String[] required,
-            final String[] optional, final int maxLength) {
+    public StructuredDataId(
+            final String name,
+            final int enterpriseNumber,
+            final String[] required,
+            final String[] optional,
+            final int maxLength) {
         this(name, String.valueOf(enterpriseNumber), required, optional, maxLength);
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
@@ -252,6 +252,7 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @deprecated Use {@link StructuredDataId#makeId(String, String)} instead
      */
     @Deprecated
+    @InlineMe(replacement = "this.makeId(defaultId, String.valueOf(anEnterpriseNumber))")
     public StructuredDataId makeId(final String defaultId, final int anEnterpriseNumber) {
         return makeId(defaultId, String.valueOf(anEnterpriseNumber));
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
@@ -252,7 +252,6 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @deprecated Use {@link StructuredDataId#makeId(String, String)} instead
      */
     @Deprecated
-    @InlineMe(replacement = "this.makeId(defaultId, String.valueOf(anEnterpriseNumber))")
     public StructuredDataId makeId(final String defaultId, final int anEnterpriseNumber) {
         return makeId(defaultId, String.valueOf(anEnterpriseNumber));
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
@@ -416,7 +416,7 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof StructuredDataMessage)) {
             return false;
         }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/package-info.java
@@ -19,7 +19,10 @@
  * Public Message Types used for Log4j 2. Users may implement their own Messages.
  */
 @Export
-@Version("2.21.0")
+/**
+ * Bumped to 2.22.0, since FormattedMessage behavior changed.
+ */
+@Version("2.22.0")
 package org.apache.logging.log4j.message;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/package-info.java
@@ -19,9 +19,6 @@
  * Public Message Types used for Log4j 2. Users may implement their own Messages.
  */
 @Export
-/**
- * Bumped to 2.21.0, since FormattedMessage behavior changed.
- */
 @Version("2.21.0")
 package org.apache.logging.log4j.message;
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/package-info.java
@@ -32,7 +32,7 @@
  * @see <a href="http://logging.apache.org/log4j/2.x/manual/api.html">Log4j 2 API manual</a>
  */
 @Export
-@Version("2.20.1")
+@Version("2.20.2")
 package org.apache.logging.log4j;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -218,9 +218,10 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     private static MessageFactory2 createDefaultMessageFactory() {
         try {
-            final MessageFactory result = DEFAULT_MESSAGE_FACTORY_CLASS.newInstance();
+            final MessageFactory result =
+                    DEFAULT_MESSAGE_FACTORY_CLASS.getDeclaredConstructor().newInstance();
             return narrow(result);
-        } catch (final InstantiationException | IllegalAccessException e) {
+        } catch (final ReflectiveOperationException e) {
             throw new IllegalStateException(e);
         }
     }
@@ -234,8 +235,8 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     private static FlowMessageFactory createDefaultFlowMessageFactory() {
         try {
-            return DEFAULT_FLOW_MESSAGE_FACTORY_CLASS.newInstance();
-        } catch (final InstantiationException | IllegalAccessException e) {
+            return DEFAULT_FLOW_MESSAGE_FACTORY_CLASS.getDeclaredConstructor().newInstance();
+        } catch (final ReflectiveOperationException e) {
             throw new IllegalStateException(e);
         }
     }
@@ -331,31 +332,37 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void debug(final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, Level.DEBUG, null, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void debug(final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.DEBUG, null, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void debug(final Marker marker, final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, Level.DEBUG, marker, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void debug(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, paramSuppliers);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void debug(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.DEBUG, marker, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void debug(final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, paramSuppliers);
     }
@@ -507,6 +514,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param format Format String for the parameters.
      * @param paramSuppliers The Suppliers of the parameters.
      */
+    @SuppressWarnings("deprecation")
     protected EntryMessage enter(final String fqcn, final String format, final Supplier<?>... paramSuppliers) {
         EntryMessage entryMsg = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
@@ -587,6 +595,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         entry(FQCN, (Object[]) null);
     }
 
+    @Deprecated
     @Override
     public void entry(final Object... params) {
         entry(FQCN, params);
@@ -598,6 +607,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param fqcn The fully qualified class name of the <b>caller</b>.
      * @param params The parameters to the method.
      */
+    @SuppressWarnings("deprecation")
     protected void entry(final String fqcn, final Object... params) {
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
             if (params == null) {
@@ -621,6 +631,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         return entryMsg(format, params);
     }
 
+    @SuppressWarnings("deprecation")
     protected EntryMessage entryMsg(final String format, final Supplier<?>... paramSuppliers) {
         return entryMsg(format, LambdaUtil.getAll(paramSuppliers));
     }
@@ -716,31 +727,37 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void error(final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, Level.ERROR, null, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void error(final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.ERROR, null, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void error(final Marker marker, final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, Level.ERROR, marker, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void error(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, paramSuppliers);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void error(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.ERROR, marker, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void error(final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.ERROR, null, message, paramSuppliers);
     }
@@ -1019,31 +1036,37 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void fatal(final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, Level.FATAL, null, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void fatal(final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.FATAL, null, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void fatal(final Marker marker, final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, Level.FATAL, marker, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void fatal(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, paramSuppliers);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void fatal(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.FATAL, marker, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void fatal(final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.FATAL, null, message, paramSuppliers);
     }
@@ -1291,31 +1314,37 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void info(final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, Level.INFO, null, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void info(final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.INFO, null, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void info(final Marker marker, final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, Level.INFO, marker, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void info(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.INFO, marker, message, paramSuppliers);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void info(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.INFO, marker, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void info(final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.INFO, null, message, paramSuppliers);
     }
@@ -1623,31 +1652,37 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void log(final Level level, final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, level, null, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void log(final Level level, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, level, null, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void log(final Level level, final Marker marker, final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, level, marker, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void log(final Level level, final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, level, marker, message, paramSuppliers);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void log(final Level level, final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, level, marker, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void log(final Level level, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, level, null, message, paramSuppliers);
     }
@@ -1822,6 +1857,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final Supplier<?> messageSupplier,
             final Throwable throwable) {
         if (isEnabled(level, marker, messageSupplier, throwable)) {
@@ -1837,6 +1873,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void logIfEnabled(final String fqcn, final Level level, final Marker marker, final String message,
             final Supplier<?>... paramSuppliers) {
         if (isEnabled(level, marker, message)) {
@@ -1963,6 +2000,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, message, effectiveThrowable);
     }
 
+    @SuppressWarnings("deprecation")
     protected void logMessage(final String fqcn, final Level level, final Marker marker, final Supplier<?> messageSupplier,
             final Throwable throwable) {
         final Message message = LambdaUtil.getMessage(messageSupplier, messageFactory);
@@ -2052,6 +2090,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
+    @SuppressWarnings("deprecation")
     protected void logMessage(final String fqcn, final Level level, final Marker marker, final String message,
             final Supplier<?>... paramSuppliers) {
         final Message msg = messageFactory.newMessage(message, LambdaUtil.getAll(paramSuppliers));
@@ -2311,31 +2350,37 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void trace(final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, Level.TRACE, null, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void trace(final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.TRACE, null, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void trace(final Marker marker, final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, Level.TRACE, marker, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void trace(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, paramSuppliers);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void trace(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.TRACE, marker, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void trace(final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.TRACE, null, message, paramSuppliers);
     }
@@ -2486,11 +2531,13 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public EntryMessage traceEntry(final Supplier<?>... paramSuppliers) {
         return enter(FQCN, null, paramSuppliers);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public EntryMessage traceEntry(final String format, final Supplier<?>... paramSuppliers) {
         return enter(FQCN, format, paramSuppliers);
     }
@@ -2632,31 +2679,37 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void warn(final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, Level.WARN, null, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void warn(final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.WARN, null, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void warn(final Marker marker, final Supplier<?> messageSupplier) {
         logIfEnabled(FQCN, Level.WARN, marker, messageSupplier, (Throwable) null);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void warn(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.WARN, marker, message, paramSuppliers);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void warn(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.WARN, marker, messageSupplier, throwable);
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void warn(final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.WARN, null, message, paramSuppliers);
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -218,8 +218,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     private static MessageFactory2 createDefaultMessageFactory() {
         try {
-            final MessageFactory result =
-                    DEFAULT_MESSAGE_FACTORY_CLASS.getDeclaredConstructor().newInstance();
+            final MessageFactory result = LoaderUtil.newInstanceOf(DEFAULT_MESSAGE_FACTORY_CLASS);
             return narrow(result);
         } catch (final ReflectiveOperationException e) {
             throw new IllegalStateException(e);
@@ -235,7 +234,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     private static FlowMessageFactory createDefaultFlowMessageFactory() {
         try {
-            return DEFAULT_FLOW_MESSAGE_FACTORY_CLASS.getDeclaredConstructor().newInstance();
+            return LoaderUtil.newInstanceOf(DEFAULT_FLOW_MESSAGE_FACTORY_CLASS);
         } catch (final ReflectiveOperationException e) {
             throw new IllegalStateException(e);
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLogger.java
@@ -533,6 +533,7 @@ public interface ExtendedLogger extends Logger {
      * @param message The message format.
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      */
+    @SuppressWarnings("deprecation")
     void logIfEnabled(String fqcn, Level level, Marker marker, String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -545,6 +546,7 @@ public interface ExtendedLogger extends Logger {
      * @param msgSupplier A function, which when called, produces the desired log message.
      * @param t the exception to log, including its stack trace.
      */
+    @SuppressWarnings("deprecation")
     void logIfEnabled(String fqcn, Level level, Marker marker, Supplier<?> msgSupplier, Throwable t);
 
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/Provider.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/Provider.java
@@ -224,7 +224,7 @@ public class Provider {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Provider)) {
             return false;
         }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMapFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMapFactory.java
@@ -88,7 +88,7 @@ public final class ThreadContextMapFactory {
             try {
                 final Class<?> clazz = cl.loadClass(ThreadContextMapName);
                 if (ThreadContextMap.class.isAssignableFrom(clazz)) {
-                    result = (ThreadContextMap) clazz.newInstance();
+                    result = (ThreadContextMap) clazz.getDeclaredConstructor().newInstance();
                 }
             } catch (final ClassNotFoundException cnfe) {
                 LOGGER.error("Unable to locate configured ThreadContextMap {}", ThreadContextMapName);
@@ -103,7 +103,7 @@ public final class ThreadContextMapFactory {
                     final Class<? extends ThreadContextMap> clazz = provider.loadThreadContextMap();
                     if (clazz != null) {
                         try {
-                            result = clazz.newInstance();
+                            result = clazz.getDeclaredConstructor().newInstance();
                             break;
                         } catch (final Exception e) {
                             LOGGER.error("Unable to locate or load configured ThreadContextMap {}",

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMapFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMapFactory.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Constants;
+import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.ProviderUtil;
 
@@ -103,7 +104,7 @@ public final class ThreadContextMapFactory {
                     final Class<? extends ThreadContextMap> clazz = provider.loadThreadContextMap();
                     if (clazz != null) {
                         try {
-                            result = clazz.getDeclaredConstructor().newInstance();
+                            result = LoaderUtil.newInstanceOf(clazz);
                             break;
                         } catch (final Exception e) {
                             LOGGER.error("Unable to locate or load configured ThreadContextMap {}",

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
@@ -144,6 +144,11 @@ public class StatusData implements Serializable {
             sb.append(SPACE);
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             t.printStackTrace(new PrintStream(baos));
+            /*
+             * https://errorprone.info/bugpattern/DefaultCharset
+             *
+             * Since Java 9 we'll be able to provide a charset.
+             */
             sb.append(baos.toString());
         }
         return sb.toString();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
@@ -122,6 +122,7 @@ public class StatusData implements Serializable {
             value = "INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE",
             justification = "Log4j prints stacktraces only to logs, which should be private."
     )
+    @SuppressWarnings("DefaultCharset")
     public String getFormattedStatus() {
         final StringBuilder sb = new StringBuilder();
         final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
@@ -50,6 +50,10 @@ public final class Base64Util {
     private Base64Util() {
     }
 
+    /**
+     * This method does not specify an encoding for the {@code str} parameter and should not be used.
+     */
+    @Deprecated
     public static String encode(final String str) {
         if (str == null) {
             return null;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
@@ -17,6 +17,7 @@
 package org.apache.logging.log4j.util;
 
 import java.lang.reflect.Method;
+import java.nio.charset.Charset;
 
 import org.apache.logging.log4j.LoggingException;
 
@@ -53,7 +54,7 @@ public final class Base64Util {
         if (str == null) {
             return null;
         }
-        final byte [] data = str.getBytes();
+        final byte [] data = str.getBytes(Charset.defaultCharset());
         if (encodeMethod != null) {
             try {
                 return (String) encodeMethod.invoke(encoder, data);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
@@ -107,7 +107,8 @@ public final class Constants {
     }
 
     static int getMajorVersion(final String version) {
-        final String[] parts = version.split("-|\\.", -1);
+        // Split into `major.minor.rest`
+        final String[] parts = version.split("-|\\.", 3);
         boolean isJEP223;
         try {
             final int token = Integer.parseInt(parts[0]);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
@@ -107,7 +107,7 @@ public final class Constants {
     }
 
     static int getMajorVersion(final String version) {
-        final String[] parts = version.split("-|\\.");
+        final String[] parts = version.split("-|\\.", -1);
         boolean isJEP223;
         try {
             final int token = Integer.parseInt(parts[0]);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LambdaUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LambdaUtil.java
@@ -37,6 +37,7 @@ public final class LambdaUtil {
      * @return an array containing the results of evaluating the lambda expressions (or {@code null} if the suppliers
      *         array was {@code null}
      */
+    @SuppressWarnings("deprecation")
     public static Object[] getAll(final Supplier<?>... suppliers) {
         if (suppliers == null) {
             return null;
@@ -55,6 +56,7 @@ public final class LambdaUtil {
      * @return the results of evaluating the lambda expression (or {@code null} if the supplier
      *         was {@code null}
      */
+    @SuppressWarnings("deprecation")
     public static Object get(final Supplier<?> supplier) {
         if (supplier == null) {
             return null;
@@ -83,6 +85,7 @@ public final class LambdaUtil {
      * @return the Message resulting from evaluating the lambda expression or the Message created by the factory for
      * supplied values that are not of type Message
      */
+    @SuppressWarnings("deprecation")
     public static Message getMessage(final Supplier<?> supplier, final MessageFactory messageFactory) {
         if (supplier == null) {
             return null;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
@@ -484,7 +484,7 @@ public final class LoaderUtil {
             if (this == o) {
                 return true;
             }
-            if (o == null || getClass() != o.getClass()) {
+            if (!(o instanceof UrlResource)) {
                 return false;
             }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * <em>Consider this class private.</em> Utility class for ClassLoaders.
@@ -328,11 +329,37 @@ public final class LoaderUtil {
      * @since 2.5
      */
     public static <T> T newCheckedInstanceOfProperty(final String propertyName, final Class<T> clazz)
-            throws ClassNotFoundException, InvocationTargetException, InstantiationException,
-            IllegalAccessException, NoSuchMethodException {
+            throws ClassNotFoundException, InvocationTargetException, InstantiationException, IllegalAccessException,
+                    NoSuchMethodException {
+        return newCheckedInstanceOfProperty(propertyName, clazz, () -> null);
+    }
+
+    /**
+     * Loads and instantiates a class given by a property name.
+     *
+     * @param propertyName The property name to look up a class name for.
+     * @param clazz        The class to cast it to.
+     * @param defaultSupplier Supplier of a default value if the property is not present.
+     * @param <T>          The type to cast it to.
+     * @return new instance of the class given in the property or {@code null} if the property was unset.
+     * @throws ClassNotFoundException      if the class isn't available to the usual ClassLoaders
+     * @throws ExceptionInInitializerError if an exception was thrown while initializing the class
+     * @throws LinkageError                if the linkage of the class fails for any other reason
+     * @throws ClassCastException          if the class is not compatible with the generic type parameter provided
+     * @throws NoSuchMethodException       if no zero-arg constructor exists
+     * @throws SecurityException           if this class is not allowed to access declared members of the provided class
+     * @throws IllegalAccessException      if the class can't be instantiated through a public constructor
+     * @throws InstantiationException      if the provided class is abstract or an interface
+     * @throws InvocationTargetException   if an exception is thrown by the constructor
+     * @since 2.22
+     */
+    public static <T> T newCheckedInstanceOfProperty(
+            final String propertyName, final Class<T> clazz, final Supplier<T> defaultSupplier)
+            throws ClassNotFoundException, InvocationTargetException, InstantiationException, IllegalAccessException,
+                    NoSuchMethodException {
         final String className = PropertiesUtil.getProperties().getStringProperty(propertyName);
         if (className == null) {
-            return null;
+            return defaultSupplier.get();
         }
         return newCheckedInstanceOf(className, clazz);
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LowLevelLogUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LowLevelLogUtil.java
@@ -32,6 +32,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 final class LowLevelLogUtil {
 
+    /*
+     * https://errorprone.info/bugpattern/DefaultCharset
+     *
+     * We intentionally use the system encoding.
+     */
     @SuppressWarnings("DefaultCharset")
     private static PrintWriter writer = new PrintWriter(System.err, true);
 
@@ -69,6 +74,11 @@ final class LowLevelLogUtil {
      */
     @SuppressWarnings("DefaultCharset")
     public static void setOutputStream(final OutputStream out) {
+        /*
+         * https://errorprone.info/bugpattern/DefaultCharset
+         *
+         * We intentionally use the system encoding.
+         */
         LowLevelLogUtil.writer = new PrintWriter(Objects.requireNonNull(out), true);
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LowLevelLogUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LowLevelLogUtil.java
@@ -32,6 +32,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 final class LowLevelLogUtil {
 
+    @SuppressWarnings("DefaultCharset")
     private static PrintWriter writer = new PrintWriter(System.err, true);
 
     /**
@@ -66,6 +67,7 @@ final class LowLevelLogUtil {
      *
      * @param out the OutputStream to log to
      */
+    @SuppressWarnings("DefaultCharset")
     public static void setOutputStream(final OutputStream out) {
         LowLevelLogUtil.writer = new PrintWriter(Objects.requireNonNull(out), true);
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProcessIdUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProcessIdUtil.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 
 /**
+ * Provides the PID of the current JVM.
+ *
  * @since 2.9
  */
 public class ProcessIdUtil {
@@ -38,7 +40,7 @@ public class ProcessIdUtil {
             final Object runtimeMXBean = getRuntimeMXBean.invoke(null);
             final String name = (String) getName.invoke(runtimeMXBean);
             //String name = ManagementFactory.getRuntimeMXBean().getName(); //JMX not allowed on Android
-            return name.split("@")[0]; // likely works on most platforms
+            return name.split("@", -1)[0]; // likely works on most platforms
         } catch (final Exception ex) {
             try {
                 return new File("/proc/self").getCanonicalFile().getName(); // try a Linux-specific way

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProcessIdUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProcessIdUtil.java
@@ -39,8 +39,8 @@ public class ProcessIdUtil {
 
             final Object runtimeMXBean = getRuntimeMXBean.invoke(null);
             final String name = (String) getName.invoke(runtimeMXBean);
-            //String name = ManagementFactory.getRuntimeMXBean().getName(); //JMX not allowed on Android
-            return name.split("@", -1)[0]; // likely works on most platforms
+            // Split into first@rest
+            return name.split("@", 2)[0]; // likely works on most platforms
         } catch (final Exception ex) {
             try {
                 return new File("/proc/self").getCanonicalFile().getName(); // try a Linux-specific way

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -653,7 +653,10 @@ public final class PropertiesUtil {
         HOURS("h,hour,hours", ChronoUnit.HOURS),
         DAYS("d,day,days", ChronoUnit.DAYS);
 
-        // descriptions is effectively immutable
+        /*
+         * https://errorprone.info/bugpattern/ImmutableEnumChecker
+         * This field is effectively immutable.
+         */
         @SuppressWarnings("ImmutableEnumChecker")
         private final String[] descriptions;
         private final ChronoUnit timeUnit;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -195,6 +195,7 @@ public final class PropertiesUtil {
      * @return The value or null if it is not found.
      * @since 2.13.0
      */
+    @SuppressWarnings("deprecation")
     public Boolean getBooleanProperty(final String[] prefixes, final String key, final Supplier<Boolean> supplier) {
         for (String prefix : prefixes) {
             if (hasProperty(prefix + key)) {
@@ -255,6 +256,7 @@ public final class PropertiesUtil {
             try {
                 return Double.parseDouble(prop);
             } catch (final Exception ignored) {
+                // returns default value
             }
         }
         return defaultValue;
@@ -289,6 +291,7 @@ public final class PropertiesUtil {
      * @return The value or null if it is not found.
      * @since 2.13.0
      */
+    @SuppressWarnings("deprecation")
     public Integer getIntegerProperty(final String[] prefixes, final String key, final Supplier<Integer> supplier) {
         for (String prefix : prefixes) {
             if (hasProperty(prefix + key)) {
@@ -311,6 +314,7 @@ public final class PropertiesUtil {
             try {
                 return Long.parseLong(prop);
             } catch (final Exception ignored) {
+                // returns the default value
             }
         }
         return defaultValue;
@@ -325,6 +329,7 @@ public final class PropertiesUtil {
      * @return The value or null if it is not found.
      * @since 2.13.0
      */
+    @SuppressWarnings("deprecation")
     public Long getLongProperty(final String[] prefixes, final String key, final Supplier<Long> supplier) {
         for (String prefix : prefixes) {
             if (hasProperty(prefix + key)) {
@@ -359,6 +364,7 @@ public final class PropertiesUtil {
      * @return The value or null if it is not found.
      * @since 2.13.0
      */
+    @SuppressWarnings("deprecation")
     public Duration getDurationProperty(final String[] prefixes, final String key, final Supplier<Duration> supplier) {
         for (String prefix : prefixes) {
             if (hasProperty(prefix + key)) {
@@ -377,6 +383,7 @@ public final class PropertiesUtil {
      * @return The value or null if it is not found.
      * @since 2.13.0
      */
+    @SuppressWarnings("deprecation")
     public String getStringProperty(final String[] prefixes, final String key, final Supplier<String> supplier) {
         for (String prefix : prefixes) {
             final String result = getStringProperty(prefix + key);
@@ -538,12 +545,13 @@ public final class PropertiesUtil {
 
         private boolean containsKey(final String key) {
             final List<CharSequence> tokens = PropertySource.Util.tokenize(key);
-            return literal.containsKey(key) ||
-                   tokenized.containsKey(tokens) ||
-                   sources.stream().anyMatch(s -> {
+            return literal.containsKey(key)
+                    || tokenized.containsKey(tokens)
+                    || sources.stream().anyMatch(s -> {
                         final CharSequence normalizedKey = s.getNormalForm(tokens);
-                        return s.containsProperty(key) || normalizedKey != null && s.containsProperty(normalizedKey.toString());
-                   });
+                        return s.containsProperty(key)
+                                || (normalizedKey != null && s.containsProperty(normalizedKey.toString()));
+                    });
         }
     }
 
@@ -645,6 +653,8 @@ public final class PropertiesUtil {
         HOURS("h,hour,hours", ChronoUnit.HOURS),
         DAYS("d,day,days", ChronoUnit.DAYS);
 
+        // descriptions is effectively immutable
+        @SuppressWarnings("ImmutableEnumChecker")
         private final String[] descriptions;
         private final ChronoUnit timeUnit;
 
@@ -653,9 +663,7 @@ public final class PropertiesUtil {
             this.timeUnit = timeUnit;
         }
 
-        ChronoUnit getTimeUnit() {
-            return this.timeUnit;
-        }
+
 
         static Duration getDuration(final String time) {
             final String value = time.trim();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
@@ -137,9 +137,12 @@ public interface PropertySource {
          * @param value property name
          * @return the property broken into lower case tokens
          */
+        // https://errorprone.info/bugpattern/CollectionUndefinedEquality
+        @SuppressWarnings("CollectionUndefinedEquality")
         public static List<CharSequence> tokenize(final CharSequence value) {
-            if (CACHE.containsKey(value)) {
-                return CACHE.get(value);
+            // `value` should be a `String`
+            if (CACHE.containsKey(value.toString())) {
+                return CACHE.get(value.toString());
             }
             final List<CharSequence> tokens = new ArrayList<>();
             int start = 0;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderActivator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderActivator.java
@@ -38,6 +38,7 @@ public abstract class ProviderActivator implements BundleActivator {
     }
 
     @Override
+    @SuppressWarnings("JdkObsolete")
     public void start(final BundleContext context) throws Exception {
         final Hashtable<String, String> props = new Hashtable<>();
         props.put(API_VERSION, provider.getVersions());

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderUtil.java
@@ -28,6 +28,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import aQute.bnd.annotation.Cardinality;
 import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.baseline.BaselineIgnore;
 import aQute.bnd.annotation.spi.ServiceConsumer;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.logging.log4j.Logger;
@@ -40,6 +41,7 @@ import org.apache.logging.log4j.status.StatusLogger;
  * {@link #loadProvider(java.net.URL, ClassLoader)} a classpath accordingly.
  */
 @InternalApi
+@BaselineIgnore("2.22.0")
 @ServiceConsumer(value = Provider.class, resolution = Resolution.OPTIONAL, cardinality = Cardinality.MULTIPLE)
 public final class ProviderUtil {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderUtil.java
@@ -46,19 +46,19 @@ public final class ProviderUtil {
     /**
      * Resource name for a Log4j 2 provider properties file.
      */
-    protected static final String PROVIDER_RESOURCE = "META-INF/log4j-provider.properties";
+    static final String PROVIDER_RESOURCE = "META-INF/log4j-provider.properties";
 
     /**
      * Loaded providers.
      */
-    protected static final Collection<Provider> PROVIDERS = new HashSet<>();
+    static final Collection<Provider> PROVIDERS = new HashSet<>();
 
     /**
      * Guards the ProviderUtil singleton instance from lazy initialization. This is primarily used for OSGi support.
      *
      * @since 2.1
      */
-    protected static final Lock STARTUP_LOCK = new ReentrantLock();
+    static final Lock STARTUP_LOCK = new ReentrantLock();
 
     private static final String API_VERSION = "Log4jAPIVersion";
     private static final String[] COMPATIBLE_API_VERSIONS = {"2.6.0"};
@@ -78,7 +78,7 @@ public final class ProviderUtil {
         }
     }
 
-    protected static void addProvider(final Provider provider) {
+    static void addProvider(final Provider provider) {
         PROVIDERS.add(provider);
         LOGGER.debug("Loaded Provider {}", provider);
     }
@@ -94,7 +94,7 @@ public final class ProviderUtil {
             value = "URLCONNECTION_SSRF_FD",
             justification = "Uses a fixed URL that ends in 'META-INF/log4j-provider.properties'."
     )
-    protected static void loadProvider(final URL url, final ClassLoader cl) {
+    static void loadProvider(final URL url, final ClassLoader cl) {
         try {
             final Properties props = PropertiesUtil.loadClose(url.openStream(), url);
             if (validVersion(props.getProperty(API_VERSION))) {
@@ -111,7 +111,7 @@ public final class ProviderUtil {
      *
      * @param classLoader null can be used to mark the bootstrap class loader.
      */
-    protected static void loadProviders(final ClassLoader classLoader) {
+    static void loadProviders(final ClassLoader classLoader) {
         ServiceLoaderUtil.loadClassloaderServices(Provider.class, MethodHandles.lookup(), classLoader, true)
                 .filter(provider -> validVersion(provider.getVersions()))
                 .forEach(PROVIDERS::add);
@@ -121,7 +121,7 @@ public final class ProviderUtil {
      * @deprecated Use {@link #loadProvider(java.net.URL, ClassLoader)} instead. Will be removed in 3.0.
      */
     @Deprecated
-    protected static void loadProviders(final Enumeration<URL> urls, final ClassLoader cl) {
+    static void loadProviders(final Enumeration<URL> urls, final ClassLoader cl) {
         if (urls != null) {
             while (urls.hasMoreElements()) {
                 loadProvider(urls.nextElement(), cl);
@@ -144,7 +144,7 @@ public final class ProviderUtil {
      *
      * @since 2.1
      */
-    protected static void lazyInit() {
+    static void lazyInit() {
         // noinspection DoubleCheckedLocking
         if (instance == null) {
             try {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -22,7 +22,9 @@ import java.util.Deque;
 import java.util.function.Predicate;
 
 /**
- * <em>Consider this class private.</em> Provides various methods to determine the caller class. <h3>Background</h3>
+ * <em>Consider this class private.</em> Provides various methods to determine the caller class.
+ *
+ * <h2>Background</h2>
  * <p>
  * This method, available only in the Oracle/Sun/OpenJDK implementations of the Java Virtual Machine, is a much more
  * efficient mechanism for determining the {@link Class} of the caller of a particular method. When it is not available,

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
@@ -23,7 +23,7 @@ import java.util.function.Predicate;
 import org.apache.logging.log4j.status.StatusLogger;
 
 /**
- * <em>Consider this class private.</em> Provides various methods to determine the caller class. <h3>Background</h3>
+ * <em>Consider this class private.</em> Provides various methods to determine the caller class.
  */
 @InternalApi
 public final class StackLocatorUtil {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
@@ -62,6 +62,10 @@ public class Unbox {
      * Such memory leaks will not occur if only JDK classes are stored in ThreadLocals.
      * </p>
      */
+    /*
+     * https://errorprone.info/bugpattern/ThreadLocalUsage
+     * Instance thread locals are not a problem here, since this class is a singleton.
+     */
     @SuppressWarnings("ThreadLocalUsage")
     private static class WebSafeState {
         private final ThreadLocal<StringBuilder[]> ringBuffer = new ThreadLocal<>();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
@@ -62,6 +62,7 @@ public class Unbox {
      * Such memory leaks will not occur if only JDK classes are stored in ThreadLocals.
      * </p>
      */
+    @SuppressWarnings("ThreadLocalUsage")
     private static class WebSafeState {
         private final ThreadLocal<StringBuilder[]> ringBuffer = new ThreadLocal<>();
         private final ThreadLocal<int[]> current = new ThreadLocal<>();
@@ -82,18 +83,6 @@ public class Unbox {
             return result;
         }
 
-        public boolean isBoxedPrimitive(final StringBuilder text) {
-            final StringBuilder[] array = ringBuffer.get();
-            if (array == null) {
-                return false;
-            }
-            for (int i = 0; i < array.length; i++) {
-                if (text == array[i]) {
-                    return true;
-                }
-            }
-            return false;
-        }
     }
 
     private static class State {
@@ -111,14 +100,7 @@ public class Unbox {
             return result;
         }
 
-        public boolean isBoxedPrimitive(final StringBuilder text) {
-            for (int i = 0; i < ringBuffer.length; i++) {
-                if (text == ringBuffer[i]) {
-                    return true;
-                }
-            }
-            return false;
-        }
+
     }
     private static ThreadLocal<State> threadLocalState = new ThreadLocal<>();
     private static WebSafeState webSafeState = new WebSafeState();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/package-info.java
@@ -20,7 +20,7 @@
  * There are no guarantees for binary or logical compatibility in this package.
  */
 @Export
-@Version("2.21.0")
+@Version("2.22.0")
 package org.apache.logging.log4j.util;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactoryTest.java
@@ -91,7 +91,7 @@ public class AsyncQueueFullPolicyFactoryTest {
         }
     }
 
-    static class CustomRouterDefaultConstructor implements AsyncQueueFullPolicy {
+    public static class CustomRouterDefaultConstructor implements AsyncQueueFullPolicy {
         public CustomRouterDefaultConstructor() {
         }
 
@@ -101,7 +101,7 @@ public class AsyncQueueFullPolicyFactoryTest {
         }
     }
 
-    static class DoesNotImplementInterface {
+    public static class DoesNotImplementInterface {
     }
 
     @Test

--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -296,7 +296,7 @@
         </executions>
       </plugin>
 
-      <!-- Remove this override after `2.22.0` release!
+      <!-- Remove the following plugin executions after `2.22.0` release!
            In `2.22.0`, we have removed *unused* `FastDateParser` due to LOG4J2-3672 and #1848.
            Though `bnd-baseline-m-p` doesn't allow such breaking changes in non-major version upgrades.
            Hence, we suppress it until `2.22.0` gets released. -->
@@ -309,6 +309,27 @@
             <diffpackage>*</diffpackage>
           </diffpackages>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>remove-after-release</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireProperty>
+                  <property>revision</property>
+                  <regex>2\.22\.0(-SNAPSHOT)?</regex>
+                  <regexMessage>Remove `bnd-baseline-maven-plugin` config in `log4j-core`.</regexMessage>
+                </requireProperty>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
     </plugins>

--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -296,42 +296,6 @@
         </executions>
       </plugin>
 
-      <!-- Remove the following plugin executions after `2.22.0` release!
-           In `2.22.0`, we have removed *unused* `FastDateParser` due to LOG4J2-3672 and #1848.
-           Though `bnd-baseline-m-p` doesn't allow such breaking changes in non-major version upgrades.
-           Hence, we suppress it until `2.22.0` gets released. -->
-      <plugin>
-        <groupId>biz.aQute.bnd</groupId>
-        <artifactId>bnd-baseline-maven-plugin</artifactId>
-        <configuration>
-          <diffpackages>
-            <diffpackage>!org.apache.logging.log4j.core.util.datetime</diffpackage>
-            <diffpackage>*</diffpackage>
-          </diffpackages>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>remove-after-release</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireProperty>
-                  <property>revision</property>
-                  <regex>2\.22\.0(-SNAPSHOT)?</regex>
-                  <regexMessage>Remove `bnd-baseline-maven-plugin` config in `log4j-core`.</regexMessage>
-                </requireProperty>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
 </project>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/SocketAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/SocketAppender.java
@@ -55,12 +55,12 @@ public class SocketAppender extends AbstractOutputStreamAppender<AbstractSocketM
 
     /**
      * Subclasses can extend this abstract Builder.
-     * <h1>Defaults</h1>
+     * <h2>Defaults</h2>
      * <ul>
      * <li>host: "localhost"</li>
      * <li>protocol: "TCP"</li>
      * </ul>
-     * <h1>Changes</h1>
+     * <h2>Changes</h2>
      * <ul>
      * <li>Removed deprecated "delayMillis", use "reconnectionDelayMillis".</li>
      * <li>Removed deprecated "reconnectionDelay", use "reconnectionDelayMillis".</li>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactory.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.core.async;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.PropertiesUtil;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactory.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.PropertiesUtil;
 
 /**
@@ -88,12 +89,14 @@ public class AsyncQueueFullPolicyFactory {
 
     private static AsyncQueueFullPolicy createCustomRouter(final String router) {
         try {
-            final Class<? extends AsyncQueueFullPolicy> cls = Loader.loadClass(router).asSubclass(AsyncQueueFullPolicy.class);
             LOGGER.debug("Creating custom AsyncQueueFullPolicy '{}'", router);
-            return cls.newInstance();
+            return LoaderUtil.newCheckedInstanceOf(router, AsyncQueueFullPolicy.class);
         } catch (final Exception ex) {
-            LOGGER.debug("Using DefaultAsyncQueueFullPolicy. Could not create custom AsyncQueueFullPolicy '{}': {}", router,
-                    ex.toString());
+            LOGGER.debug(
+                    "Using DefaultAsyncQueueFullPolicy. Could not create custom AsyncQueueFullPolicy '{}': {}",
+                    router,
+                    ex.getMessage(),
+                    ex);
             return new DefaultAsyncQueueFullPolicy();
         }
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfig.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
 import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.LoaderUtil;
 
 /**
  * This class allows users to configure the factory used to create
@@ -85,17 +86,17 @@ public class AsyncWaitStrategyFactoryConfig {
 
     public AsyncWaitStrategyFactory createWaitStrategyFactory() {
         try {
-            @SuppressWarnings("unchecked")
-            final Class<? extends AsyncWaitStrategyFactory> klass = (Class<? extends AsyncWaitStrategyFactory>) Loader.loadClass(factoryClassName);
-            if (AsyncWaitStrategyFactory.class.isAssignableFrom(klass)) {
-                return klass.newInstance();
-            }
+            return LoaderUtil.newCheckedInstanceOf(factoryClassName, AsyncWaitStrategyFactory.class);
+        } catch (final ClassCastException e) {
             LOGGER.error("Ignoring factory '{}': it is not assignable to AsyncWaitStrategyFactory", factoryClassName);
             return null;
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
-            LOGGER.info("Invalid implementation class name value: error creating AsyncWaitStrategyFactory {}: {}", factoryClassName, e);
+        } catch (ReflectiveOperationException e) {
+            LOGGER.info(
+                    "Invalid implementation class name value: error creating AsyncWaitStrategyFactory {}: {}",
+                    factoryClassName,
+                    e.getMessage(),
+                    e);
             return null;
         }
-
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfig.java
@@ -23,7 +23,6 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
-import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
@@ -24,7 +24,6 @@ import com.lmax.disruptor.WaitStrategy;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.Integers;
-import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.PropertiesUtil;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
@@ -84,31 +84,25 @@ final class DisruptorUtil {
     }
 
     static ExceptionHandler<RingBufferLogEvent> getAsyncLoggerExceptionHandler() {
-        ExceptionHandler<RingBufferLogEvent> handler = null;
         try {
-            handler =
-                    LoaderUtil.newCheckedInstanceOfProperty(LOGGER_EXCEPTION_HANDLER_PROPERTY, ExceptionHandler.class);
+            return LoaderUtil.newCheckedInstanceOfProperty(
+                    LOGGER_EXCEPTION_HANDLER_PROPERTY, ExceptionHandler.class, AsyncLoggerDefaultExceptionHandler::new);
         } catch (final ReflectiveOperationException e) {
             LOGGER.debug("Invalid AsyncLogger.ExceptionHandler value: {}", e.getMessage(), e);
+            return new AsyncLoggerDefaultExceptionHandler();
         }
-        if (handler != null) {
-            return handler;
-        }
-        return new AsyncLoggerDefaultExceptionHandler();
     }
 
     static ExceptionHandler<AsyncLoggerConfigDisruptor.Log4jEventWrapper> getAsyncLoggerConfigExceptionHandler() {
-        ExceptionHandler<AsyncLoggerConfigDisruptor.Log4jEventWrapper> handler = null;
         try {
-            handler = LoaderUtil.newCheckedInstanceOfProperty(
-                    LOGGER_CONFIG_EXCEPTION_HANDLER_PROPERTY, ExceptionHandler.class);
+            return LoaderUtil.newCheckedInstanceOfProperty(
+                    LOGGER_CONFIG_EXCEPTION_HANDLER_PROPERTY,
+                    ExceptionHandler.class,
+                    AsyncLoggerConfigDefaultExceptionHandler::new);
         } catch (final ReflectiveOperationException e) {
             LOGGER.debug("Invalid AsyncLogger.ExceptionHandler value: {}", e.getMessage(), e);
+            return new AsyncLoggerConfigDefaultExceptionHandler();
         }
-        if (handler != null) {
-            return handler;
-        }
-        return new AsyncLoggerConfigDefaultExceptionHandler();
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
@@ -77,6 +77,7 @@ import org.apache.logging.log4j.core.util.Source;
 import org.apache.logging.log4j.core.util.WatchManager;
 import org.apache.logging.log4j.core.util.Watcher;
 import org.apache.logging.log4j.core.util.WatcherFactory;
+import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.PropertiesUtil;
 
 /**
@@ -501,7 +502,7 @@ public abstract class AbstractConfiguration extends AbstractFilterable implement
             if (type != null) {
                 final Class<? extends Advertiser> clazz = type.getPluginClass().asSubclass(Advertiser.class);
                 try {
-                    advertiser = clazz.newInstance();
+                    advertiser = LoaderUtil.newInstanceOf(clazz);
                     advertisement = advertiser.advertise(advertiserNode.getAttributes());
                 } catch (final ReflectiveOperationException e) {
                     LOGGER.error("{} attempting to instantiate advertiser: {}", e.getClass().getSimpleName(), nodeName, e);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -82,15 +82,18 @@ public class LoggerConfig extends AbstractFilterable implements LocationAware {
 
     static {
         try {
-            LOG_EVENT_FACTORY =
-                    LoaderUtil.newCheckedInstanceOfProperty(Constants.LOG4J_LOG_EVENT_FACTORY, LogEventFactory.class);
+            LOG_EVENT_FACTORY = LoaderUtil.newCheckedInstanceOfProperty(
+                    Constants.LOG4J_LOG_EVENT_FACTORY,
+                    LogEventFactory.class,
+                    LoggerConfig::createDefaultLogEventFactory);
         } catch (final Exception ex) {
             LOGGER.error("Unable to create LogEventFactory: {}", ex.getMessage(), ex);
+            LOG_EVENT_FACTORY = createDefaultLogEventFactory();
         }
-        if (LOG_EVENT_FACTORY == null) {
-            LOG_EVENT_FACTORY =
-                    Constants.ENABLE_THREADLOCALS ? new ReusableLogEventFactory() : new DefaultLogEventFactory();
-        }
+    }
+
+    private static LogEventFactory createDefaultLogEventFactory() {
+        return Constants.ENABLE_THREADLOCALS ? new ReusableLogEventFactory() : new DefaultLogEventFactory();
     }
 
     @PluginBuilderFactory

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -53,6 +53,7 @@ import org.apache.logging.log4j.core.util.Booleans;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.PerformanceSensitive;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.StackLocatorUtil;
@@ -82,21 +83,15 @@ public class LoggerConfig extends AbstractFilterable implements LocationAware {
     private final ReliabilityStrategy reliabilityStrategy;
 
     static {
-        final String factory = PropertiesUtil.getProperties().getStringProperty(Constants.LOG4J_LOG_EVENT_FACTORY);
-        if (factory != null) {
-            try {
-                final Class<?> clazz = Loader.loadClass(factory);
-                if (clazz != null && LogEventFactory.class.isAssignableFrom(clazz)) {
-                    LOG_EVENT_FACTORY = (LogEventFactory) clazz.newInstance();
-                }
-            } catch (final Exception ex) {
-                LOGGER.error("Unable to create LogEventFactory {}", factory, ex);
-            }
+        try {
+            LOG_EVENT_FACTORY =
+                    LoaderUtil.newCheckedInstanceOfProperty(Constants.LOG4J_LOG_EVENT_FACTORY, LogEventFactory.class);
+        } catch (final Exception ex) {
+            LOGGER.error("Unable to create LogEventFactory: {}", ex.getMessage(), ex);
         }
         if (LOG_EVENT_FACTORY == null) {
-            LOG_EVENT_FACTORY = Constants.ENABLE_THREADLOCALS
-                    ? new ReusableLogEventFactory()
-                    : new DefaultLogEventFactory();
+            LOG_EVENT_FACTORY =
+                    Constants.ENABLE_THREADLOCALS ? new ReusableLogEventFactory() : new DefaultLogEventFactory();
         }
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -51,11 +51,9 @@ import org.apache.logging.log4j.core.impl.ReusableLogEventFactory;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 import org.apache.logging.log4j.core.util.Booleans;
 import org.apache.logging.log4j.core.util.Constants;
-import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.PerformanceSensitive;
-import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.StackLocatorUtil;
 import org.apache.logging.log4j.util.Strings;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginVisitors.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginVisitors.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Annotation;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.plugins.PluginVisitorStrategy;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.LoaderUtil;
 
 /**
  * Utility class to locate an appropriate {@link PluginVisitor} implementation for an annotation.
@@ -46,7 +47,7 @@ public final class PluginVisitors {
             return null;
         }
         try {
-            return strategy.value().newInstance();
+            return LoaderUtil.newInstanceOf(strategy.value());
         } catch (final Exception e) {
             LOGGER.error("Error loading PluginVisitor [{}] for annotation [{}].", strategy.value(), annotation, e);
             return null;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ContextDataFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ContextDataFactory.java
@@ -55,8 +55,9 @@ public class ContextDataFactory {
      * In graalvm doc (https://github.com/oracle/graal/blob/master/substratevm/LIMITATIONS.md),
      * graalvm is not support MethodHandle now, so the Constructor need not to return MethodHandle.
      */
-    private static final Constructor<?> DEFAULT_CONSTRUCTOR = createDefaultConstructor(CACHED_CLASS);
-    private static final Constructor<?> INITIAL_CAPACITY_CONSTRUCTOR = createInitialCapacityConstructor(CACHED_CLASS);
+    private static final Constructor<? extends StringMap> DEFAULT_CONSTRUCTOR = createDefaultConstructor(CACHED_CLASS);
+    private static final Constructor<? extends StringMap> INITIAL_CAPACITY_CONSTRUCTOR =
+            createInitialCapacityConstructor(CACHED_CLASS);
 
     private static final StringMap EMPTY_STRING_MAP = createContextData(0);
 
@@ -75,7 +76,8 @@ public class ContextDataFactory {
         }
     }
 
-    private static Constructor<?> createDefaultConstructor(final Class<? extends StringMap> cachedClass){
+    private static Constructor<? extends StringMap> createDefaultConstructor(
+            final Class<? extends StringMap> cachedClass) {
         if (cachedClass == null) {
             return null;
         }
@@ -86,7 +88,8 @@ public class ContextDataFactory {
         }
     }
 
-    private static Constructor<?> createInitialCapacityConstructor(final Class<? extends StringMap> cachedClass){
+    private static Constructor<? extends StringMap> createInitialCapacityConstructor(
+            final Class<? extends StringMap> cachedClass) {
         if (cachedClass == null) {
             return null;
         }
@@ -102,7 +105,7 @@ public class ContextDataFactory {
             return new SortedArrayStringMap();
         }
         try {
-            return (IndexedStringMap) DEFAULT_CONSTRUCTOR.newInstance();
+            return DEFAULT_CONSTRUCTOR.newInstance();
         } catch (final Throwable ignored) {
             return new SortedArrayStringMap();
         }
@@ -113,7 +116,7 @@ public class ContextDataFactory {
             return new SortedArrayStringMap(initialCapacity);
         }
         try {
-            return (IndexedStringMap) INITIAL_CAPACITY_CONSTRUCTOR.newInstance(initialCapacity);
+            return INITIAL_CAPACITY_CONSTRUCTOR.newInstance(initialCapacity);
         } catch (final Throwable ignored) {
             return new SortedArrayStringMap(initialCapacity);
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ContextDataInjectorFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ContextDataInjectorFactory.java
@@ -19,13 +19,11 @@ package org.apache.logging.log4j.core.impl;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.ContextDataInjector;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.spi.CopyOnWrite;
 import org.apache.logging.log4j.spi.DefaultThreadContextMap;
 import org.apache.logging.log4j.spi.ReadOnlyThreadContextMap;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
-import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 
 /**
@@ -43,7 +41,7 @@ import org.apache.logging.log4j.util.ReadOnlyStringMap;
  */
 public class ContextDataInjectorFactory {
 
-    public static final String CONTEXT_DATA_INJECTOR_PROPERTY = "log4j2.ContextDataInjector";
+    private static final String CONTEXT_DATA_INJECTOR_PROPERTY = "log4j2.ContextDataInjector";
 
     /**
      * Returns a new {@code ContextDataInjector} instance based on the value of system property

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ContextDataInjectorFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ContextDataInjectorFactory.java
@@ -67,17 +67,15 @@ public class ContextDataInjectorFactory {
      * @see ContextDataInjector
      */
     public static ContextDataInjector createInjector() {
-        ContextDataInjector injector = null;
         try {
-            injector =
-                    LoaderUtil.newCheckedInstanceOfProperty(CONTEXT_DATA_INJECTOR_PROPERTY, ContextDataInjector.class);
+            return LoaderUtil.newCheckedInstanceOfProperty(
+                    CONTEXT_DATA_INJECTOR_PROPERTY,
+                    ContextDataInjector.class,
+                    ContextDataInjectorFactory::createDefaultInjector);
         } catch (final ReflectiveOperationException e) {
             StatusLogger.getLogger().warn("Could not create ContextDataInjector: {}", e.getMessage(), e);
+            return createDefaultInjector();
         }
-        if (injector != null) {
-            return injector;
-        }
-        return createDefaultInjector();
     }
 
     private static ContextDataInjector createDefaultInjector() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/JsonLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/JsonLayout.java
@@ -39,7 +39,7 @@ import org.apache.logging.log4j.core.util.KeyValuePair;
  *
  * Appends a series of JSON events as strings serialized as bytes.
  *
- * <h3>Complete well-formed JSON vs. fragment JSON</h3>
+ * <h2>Complete well-formed JSON vs. fragment JSON</h2>
  * <p>
  * If you configure {@code complete="true"}, the appender outputs a well-formed JSON document. By default, with
  * {@code complete="false"}, you should include the output as an <em>external file</em> in a separate file to form a
@@ -49,18 +49,18 @@ import org.apache.logging.log4j.core.util.KeyValuePair;
  * If {@code complete="false"}, the appender does not write the JSON open array character "[" at the start
  * of the document, "]" and the end, nor comma "," between records.
  * </p>
- * <h3>Encoding</h3>
+ * <h2>Encoding</h2>
  * <p>
  * Appenders using this layout should have their {@code charset} set to {@code UTF-8} or {@code UTF-16}, otherwise
  * events containing non ASCII characters could result in corrupted log files.
  * </p>
- * <h3>Pretty vs. compact JSON</h3>
+ * <h2>Pretty vs. compact JSON</h2>
  * <p>
  * By default, the JSON layout is not compact (a.k.a. "pretty") with {@code compact="false"}, which means the
  * appender uses end-of-line characters and indents lines to format the text. If {@code compact="true"}, then no
  * end-of-line or indentation is used. Message content may contain, of course, escaped end-of-lines.
  * </p>
- * <h3>Additional Fields</h3>
+ * <h2>Additional Fields</h2>
  * <p>
  * This property allows addition of custom fields into generated JSON.
  * {@code <JsonLayout><KeyValuePair key="foo" value="bar"/></JsonLayout>} inserts {@code "foo":"bar"} directly

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/XmlLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/XmlLayout.java
@@ -32,7 +32,7 @@ import org.apache.logging.log4j.core.util.KeyValuePair;
 /**
  * Appends a series of {@code event} elements as defined in the <a href="log4j.dtd">log4j.dtd</a>.
  *
- * <h3>Complete well-formed XML vs. fragment XML</h3>
+ * <h2>Complete well-formed XML vs. fragment XML</h2>
  * <p>
  * If you configure {@code complete="true"}, the appender outputs a well-formed XML document where the default namespace
  * is the log4j namespace {@value XmlConstants#XML_NAMESPACE}. By default, with {@code complete="false"}, you should
@@ -41,18 +41,18 @@ import org.apache.logging.log4j.core.util.KeyValuePair;
  * <p>
  * If {@code complete="false"}, the appender does not write the XML processing instruction and the root element.
  * </p>
- * <h3>Encoding</h3>
+ * <h2>Encoding</h2>
  * <p>
  * Appenders using this layout should have their {@code charset} set to {@code UTF-8} or {@code UTF-16}, otherwise
  * events containing non-ASCII characters could result in corrupted log files.
  * </p>
- * <h3>Pretty vs. compact XML</h3>
+ * <h2>Pretty vs. compact XML</h2>
  * <p>
  * By default, the XML layout is not compact (compact = not "pretty") with {@code compact="false"}, which means the
  * appender uses end-of-line characters and indents lines to format the XML. If {@code compact="true"}, then no
  * end-of-line or indentation is used. Message content may contain, of course, end-of-lines.
  * </p>
- * <h3>Additional Fields</h3>
+ * <h2>Additional Fields</h2>
  * <p>
  * This property allows addition of custom fields into generated JSON.
  * {@code <XmlLayout><KeyValuePair key="foo" value="bar"/></XmlLayout>} inserts {@code <foo>bar</foo>} directly

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/YamlLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/YamlLayout.java
@@ -33,12 +33,12 @@ import org.apache.logging.log4j.util.Strings;
 /**
  * Appends a series of YAML events as strings serialized as bytes.
  *
- * <h3>Encoding</h3>
+ * <h2>Encoding</h2>
  * <p>
  * Appenders using this layout should have their {@code charset} set to {@code UTF-8} or {@code UTF-16}, otherwise
  * events containing non ASCII characters could result in corrupted log files.
  * </p>
- * <h3>Additional Fields</h3>
+ * <h2>Additional Fields</h2>
  * <p>
  * This property allows addition of custom fields into generated JSON.
  * {@code <YamlLayout><KeyValuePair key="foo" value="bar"/></YamlLayout>} inserts {@code foo: "bar"} directly

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/MulticastDnsAdvertiser.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/MulticastDnsAdvertiser.java
@@ -135,7 +135,7 @@ public class MulticastDnsAdvertiser implements Advertiser {
 
     private static Object createJmDnsVersion1() {
         try {
-            return jmDNSClass.getConstructor().newInstance();
+            return LoaderUtil.newInstanceOf(jmDNSClass);
         } catch (final InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
             LOGGER.warn("Unable to instantiate JMDNS", e);
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/picocli/CommandLine.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/tools/picocli/CommandLine.java
@@ -2806,7 +2806,7 @@ public class CommandLine {
     /**
      * A collection of methods and inner classes that provide fine-grained control over the contents and layout of
      * the usage help message to display to end users when help is requested or invalid input values were specified.
-     * <h3>Layered API</h3>
+     * <h2>Layered API</h2>
      * <p>The {@link Command} annotation provides the easiest way to customize usage help messages. See
      * the <a href="https://remkop.github.io/picocli/index.html#_usage_help">Manual</a> for details.</p>
      * <p>This Help class provides high-level functions to create sections of the usage help message and headings
@@ -2814,7 +2814,7 @@ public class CommandLine {
      * method, application authors may want to create a custom usage help message by reorganizing sections in a
      * different order and/or adding custom sections.</p>
      * <p>Finally, the Help class contains inner classes and interfaces that can be used to create custom help messages.</p>
-     * <h4>IOptionRenderer and IParameterRenderer</h4>
+     * <h3>IOptionRenderer and IParameterRenderer</h3>
      * <p>Renders a field annotated with {@link Option} or {@link Parameters} to an array of {@link Text} values.
      * By default, these values are</p><ul>
      * <li>mandatory marker character (if the option/parameter is {@link Option#required() required})</li>
@@ -2824,15 +2824,15 @@ public class CommandLine {
      * <li>description</li>
      * </ul>
      * <p>Other components rely on this ordering.</p>
-     * <h4>Layout</h4>
+     * <h3>Layout</h3>
      * <p>Delegates to the renderers to create {@link Text} values for the annotated fields, and uses a
      * {@link TextTable} to display these values in tabular format. Layout is responsible for deciding which values
      * to display where in the table. By default, Layout shows one option or parameter per table row.</p>
-     * <h4>TextTable</h4>
+     * <h3>TextTable</h3>
      * <p>Responsible for spacing out {@link Text} values according to the {@link Column} definitions the table was
      * created with. Columns have a width, indentation, and an overflow policy that decides what to do if a value is
      * longer than the column's width.</p>
-     * <h4>Text</h4>
+     * <h3>Text</h3>
      * <p>Encapsulates rich text with styles and colors in a way that other components like {@link TextTable} are
      * unaware of the embedded ANSI escape codes.</p>
      */

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/OptionConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/OptionConverter.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.Strings;
 
@@ -303,7 +304,7 @@ public final class OptionConverter {
                         superClass.getName(), superClass.getClassLoader(), classObj.getTypeName(), classObj.getName());
                     return defaultValue;
                 }
-                return classObj.newInstance();
+                return LoaderUtil.newInstanceOf(classObj);
             } catch (final Exception e) {
                 LOGGER.error("Could not instantiate class [{}].", className, e);
             }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/StringBuilderWriter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/StringBuilderWriter.java
@@ -28,7 +28,7 @@ import java.io.Writer;
  * For safe usage with multiple {@link Thread}s then
  * <code>java.io.StringWriter</code> should be used.
  *
- * <h3>History</h3>
+ * <h2>History</h2>
  * <ol>
  * <li>Copied from Apache Commons IO revision 1681000.</li>
  * <li>Pick up Javadoc updates from revision 1722253.</li>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/package-info.java
@@ -18,8 +18,10 @@
  * Log4j 2 date formatting classes.
  */
 @Export
-@Version("2.21.0")
+@Version("2.21.1")
+@BaselineIgnore("2.22.0")
 package org.apache.logging.log4j.core.util.datetime;
 
+import aQute.bnd.annotation.baseline.BaselineIgnore;
 import org.osgi.annotation.bundle.Export;
 import org.osgi.annotation.versioning.Version;

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumePersistentManager.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumePersistentManager.java
@@ -60,6 +60,7 @@ import org.apache.logging.log4j.core.util.FileUtils;
 import org.apache.logging.log4j.core.util.Log4jThread;
 import org.apache.logging.log4j.core.util.Log4jThreadFactory;
 import org.apache.logging.log4j.core.util.SecretKeyProvider;
+import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.Strings;
 
 /**
@@ -449,7 +450,7 @@ public class FlumePersistentManager extends FlumeAvroManager {
                                 found = true;
                                 final Class<?> cl = entry.getValue().getPluginClass();
                                 try {
-                                    final SecretKeyProvider provider = (SecretKeyProvider) cl.newInstance();
+                                    final SecretKeyProvider provider = (SecretKeyProvider) LoaderUtil.newInstanceOf(cl);
                                     secretKey = provider.getSecretKey();
                                     LOGGER.debug("Persisting events using SecretKeyProvider {}", cl.getName());
                                 } catch (final Exception ex) {

--- a/log4j-jpa/src/main/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ThrowableAttributeConverter.java
+++ b/log4j-jpa/src/main/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ThrowableAttributeConverter.java
@@ -232,7 +232,7 @@ public class ThrowableAttributeConverter implements AttributeConverter<Throwable
 
     private Throwable getThrowable(final Class<Throwable> throwableClass) {
         try {
-            return throwableClass.newInstance();
+            return LoaderUtil.newInstanceOf(throwableClass);
         } catch (final Exception e) {
             return null;
         }

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -1067,6 +1067,13 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>${error-prone.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.osgi</groupId>
       <artifactId>osgi.annotation</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
This suppresses or fixes most Error Prone warning in `log4j-api`.

Only two dozens warnings are left, mainly in the
[TypeParameterUnusedInFormals](https://errorprone.info/bugpattern/TypeParameterUnusedInFormals), which can not be removed for source compatibility reasons.

Closes #1850.

