### PR TITLE
Work towards supporting Java 17 builds

### DIFF
--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/StatusLoggerExtension.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/StatusLoggerExtension.java
@@ -18,6 +18,8 @@ package org.apache.logging.log4j.test.junit;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -146,9 +148,15 @@ class StatusLoggerExtension extends TypeBasedParameterResolver<ListStatusListene
                         .withThrowable(data.getThrowable())
                         .withLocation(data.getStackTraceElement())
                         .log("{} {}",
-                                DateTimeFormatter.ISO_LOCAL_TIME.format(Instant.ofEpochMilli(data.getTimestamp())),
+                                formatLocalTime(data.getTimestamp()),
                                 data.getMessage());
             });
+        }
+
+        private static String formatLocalTime(final long epochMilli) {
+            final Instant instant = Instant.ofEpochMilli(epochMilli);
+            final LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+            return localDateTime.format(DateTimeFormatter.ISO_LOCAL_TIME);
         }
     }
 

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/StatusLoggerExtension.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/StatusLoggerExtension.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.test.junit;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -154,9 +153,9 @@ class StatusLoggerExtension extends TypeBasedParameterResolver<ListStatusListene
         }
 
         private static String formatLocalTime(final long epochMilli) {
-            final Instant instant = Instant.ofEpochMilli(epochMilli);
-            final LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
-            return localDateTime.format(DateTimeFormatter.ISO_LOCAL_TIME);
+            return DateTimeFormatter.ISO_LOCAL_TIME
+                    .withZone(ZoneId.systemDefault())
+                    .format(Instant.ofEpochMilli(epochMilli));
         }
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
@@ -83,7 +83,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
 
     private static final long serialVersionUID = -665975803997290697L;
 
-    private static final ThreadLocal<StringBuilder> STRING_BUILDER_HOLDER = Constants.ENABLE_THREADLOCALS
+    private static final ThreadLocal<StringBuilder> STRING_BUILDER_HOLDER = Constants.isUseThreadLocals()
             ? ThreadLocal.withInitial(() -> new StringBuilder(Constants.MAX_REUSABLE_MESSAGE_SIZE))
             : null;
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -197,7 +197,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
             final Class<ReusableMessageFactory> reusableParameterizedMessageFactoryClass,
             final Class<ParameterizedMessageFactory> parameterizedMessageFactoryClass) {
         try {
-            final String fallback = Constants.ENABLE_THREADLOCALS ? reusableParameterizedMessageFactoryClass.getName()
+            final String fallback = Constants.isUseThreadLocals() ? reusableParameterizedMessageFactoryClass.getName()
                     : parameterizedMessageFactoryClass.getName();
             final String clsName = PropertiesUtil.getProperties().getStringProperty(property, fallback);
             return LoaderUtil.loadClass(clsName).asSubclass(MessageFactory.class);
@@ -2889,7 +2889,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @since 2.20.0
      */
     protected LogBuilder getLogBuilder(final Level level) {
-        if (Constants.ENABLE_THREADLOCALS) {
+        if (Constants.isUseThreadLocals()) {
             final DefaultLogBuilder builder = logBuilder.get();
             if (!builder.isInUse()) {
                 return builder.reset(this, level);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMapFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMapFactory.java
@@ -27,7 +27,7 @@ import org.apache.logging.log4j.util.ProviderUtil;
 /**
  * Creates the ThreadContextMap instance used by the ThreadContext.
  * <p>
- * If {@link Constants#ENABLE_THREADLOCALS Log4j can use ThreadLocals}, a garbage-free StringMap-based context map can
+ * If {@linkplain Constants#isUseThreadLocals() Log4j can use ThreadLocals}, a garbage-free StringMap-based context map can
  * be installed by setting system property {@code log4j2.garbagefree.threadContextMap} to {@code true}.
  * </p><p>
  * Furthermore, any custom {@code ThreadContextMap} can be installed by setting system property
@@ -121,7 +121,7 @@ public final class ThreadContextMapFactory {
     }
 
     private static ThreadContextMap createDefaultThreadContextMap() {
-        if (Constants.ENABLE_THREADLOCALS) {
+        if (Constants.isUseThreadLocals()) {
             if (GcFreeThreadContextKey) {
                 return new GarbageFreeSortedArrayThreadContextMap();
             }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Unbox.java
@@ -263,7 +263,7 @@ public class Unbox {
     }
 
     private static StringBuilder getSB() {
-        return Constants.ENABLE_THREADLOCALS ? getState().getStringBuilder() : webSafeState.getStringBuilder();
+        return Constants.isUseThreadLocals() ? getState().getStringBuilder() : webSafeState.getStringBuilder();
     }
 
     /** For testing. */

--- a/log4j-core-its/src/test/java/org/apache/logging/log4j/core/async/perftest/ResponseTimeTest.java
+++ b/log4j-core-its/src/test/java/org/apache/logging/log4j/core/async/perftest/ResponseTimeTest.java
@@ -141,7 +141,7 @@ public class ResponseTimeTest {
         runLatencyTest(logger, WARMUP_DURATION_MILLIS, WARMUP_COUNT, loadMessagesPerSec, idleStrategy,
                 warmupServiceTmHistograms, warmupResponseTmHistograms, threadCount);
         System.out.println("-----------------Warmup done. load=" + loadMessagesPerSec);
-        if (!Constants.ENABLE_DIRECT_ENCODERS || !Constants.ENABLE_THREADLOCALS) {
+        if (!Constants.ENABLE_DIRECT_ENCODERS || !org.apache.logging.log4j.util.Constants.isUseThreadLocals()) {
             //System.gc();
             //Thread.sleep(5000);
         }

--- a/log4j-core-test/pom.xml
+++ b/log4j-core-test/pom.xml
@@ -379,6 +379,22 @@
           </annotationProcessorPaths>
         </configuration>
       </plugin>
+      <!--
+      https://junit-pioneer.org/docs/environment-variables/#warnings-for-reflective-access
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>
+            <!-- for environment variable access -->
+            --add-opens java.base/java.util=ALL-UNNAMED
+            --add-opens java.base/java.lang=ALL-UNNAMED
+            <!-- for URLStreamHandlerFactory access -->
+            --add-opens java.base/java.net=ALL-UNNAMED
+          </argLine>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/GcFreeLoggingTestUtil.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/GcFreeLoggingTestUtil.java
@@ -48,15 +48,15 @@ public enum GcFreeLoggingTestUtil {
     public static void executeLogging(final String configurationFile,
                                       final Class<?> testClass) throws Exception {
 
-        System.setProperty("log4j2.enable.threadlocals", "true");
+        org.apache.logging.log4j.util.Constants.setWebApp(false);
+        org.apache.logging.log4j.util.Constants.setUseThreadLocals(true);
         System.setProperty("log4j2.enable.direct.encoders", "true");
-        System.setProperty("log4j2.is.webapp", "false");
         System.setProperty("log4j.configurationFile", configurationFile);
         System.setProperty("log4j2.clock", "SystemMillisClock");
 
-        assertTrue(Constants.ENABLE_THREADLOCALS, "Constants.ENABLE_THREADLOCALS");
+        assertTrue(org.apache.logging.log4j.util.Constants.isUseThreadLocals(), "Constants.ENABLE_THREADLOCALS");
         assertTrue(Constants.ENABLE_DIRECT_ENCODERS, "Constants.ENABLE_DIRECT_ENCODERS");
-        assertFalse(Constants.IS_WEB_APP, "Constants.IS_WEB_APP");
+        assertFalse(org.apache.logging.log4j.util.Constants.isWebApp(), "Constants.IS_WEB_APP");
 
         final MyCharSeq myCharSeq = new MyCharSeq();
         final Marker testGrandParent = MarkerManager.getMarker("testGrandParent");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/EventParameterMemoryLeakTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/EventParameterMemoryLeakTest.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
+import org.apache.logging.log4j.util.Constants;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -39,9 +40,9 @@ public class EventParameterMemoryLeakTest {
 
     @BeforeAll
     public static void beforeClass() {
-        System.setProperty("log4j2.enable.threadlocals", "true");
+        Constants.setUseThreadLocals(true);
+        Constants.setWebApp(false);
         System.setProperty("log4j2.enable.direct.encoders", "true");
-        System.setProperty("log4j2.is.webapp", "false");
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "EventParameterMemoryLeakTest.xml");
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AbstractAsyncThreadContextTestBase.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AbstractAsyncThreadContextTestBase.java
@@ -40,6 +40,7 @@ import org.apache.logging.log4j.test.TestProperties;
 import org.apache.logging.log4j.test.junit.Resources;
 import org.apache.logging.log4j.test.junit.UsingStatusListener;
 import org.apache.logging.log4j.test.junit.UsingTestProperties;
+import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.Unbox;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.parallel.ResourceLock;
@@ -58,7 +59,7 @@ public abstract class AbstractAsyncThreadContextTestBase {
 
     @BeforeAll
     public static void beforeClass() {
-        props.setProperty("log4j2.is.webapp", false);
+        Constants.setWebApp(false);
         props.setProperty("AsyncLogger.RingBufferSize", 128); // minimum ringbuffer size
         props.setProperty("AsyncLoggerConfig.RingBufferSize", 128); // minimum ringbuffer size
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigErrorOnFormat.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigErrorOnFormat.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.core.test.CoreLoggerContexts;
 import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.message.AsynchronouslyFormattable;
 import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.util.Constants;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,7 +44,7 @@ public class AsyncLoggerConfigErrorOnFormat {
 
     @BeforeClass
     public static void beforeClass() {
-        System.setProperty("log4j2.is.webapp", "false");
+        Constants.setWebApp(false);
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigErrorOnFormat.xml");
         // Log4jLogEvent.toString invokes message.toString
         System.setProperty("log4j2.logEventFactory", DefaultLogEventFactory.class.getName());
@@ -51,7 +52,7 @@ public class AsyncLoggerConfigErrorOnFormat {
 
     @AfterClass
     public static void afterClass() {
-        System.clearProperty("log4j2.is.webapp");
+        Constants.resetWebApp();
         System.clearProperty("log4j2.logEventFactory");
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest4.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest4.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
 import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
+import org.apache.logging.log4j.util.Constants;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -40,13 +41,13 @@ public class AsyncLoggerConfigTest4 {
 
     @BeforeClass
     public static void beforeClass() {
-        System.setProperty("log4j2.is.webapp", "false");
+        Constants.setWebApp(false);
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigTest4.xml");
     }
 
     @AfterClass
     public static void afterClass() {
-        System.clearProperty("log4j2.is.webapp");
+        Constants.resetWebApp();
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigWithAsyncEnabledTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigWithAsyncEnabledTest.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
 import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
+import org.apache.logging.log4j.util.Constants;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -39,7 +40,7 @@ public class AsyncLoggerConfigWithAsyncEnabledTest {
 
     @BeforeClass
     public static void beforeClass() {
-        System.setProperty("log4j2.is.webapp", "false");
+        Constants.setWebApp(false);
         System.setProperty("Log4jContextSelector", AsyncLoggerContextSelector.class.getCanonicalName());
         // Reuse the configuration from AsyncLoggerConfigTest4
         System.setProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY, "AsyncLoggerConfigTest4.xml");
@@ -47,7 +48,7 @@ public class AsyncLoggerConfigWithAsyncEnabledTest {
 
     @AfterClass
     public static void afterClass() {
-        System.clearProperty("log4j2.is.webapp");
+        Constants.resetWebApp();
         System.clearProperty("Log4jContextSelector");
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestArgumentFreedOnError.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerTestArgumentFreedOnError.java
@@ -38,9 +38,9 @@ public class AsyncLoggerTestArgumentFreedOnError {
 
     @BeforeClass
     public static void beforeClass() {
-        System.setProperty("log4j2.enable.threadlocals", "true");
+        org.apache.logging.log4j.util.Constants.setUseThreadLocals(true);
+        org.apache.logging.log4j.util.Constants.setWebApp(false);
         System.setProperty("log4j2.enable.direct.encoders", "true");
-        System.setProperty("log4j2.is.webapp", "false");
         System.setProperty("log4j.format.msg.async", "true");
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR,
                 AsyncLoggerContextSelector.class.getName());
@@ -48,6 +48,8 @@ public class AsyncLoggerTestArgumentFreedOnError {
 
     @AfterClass
     public static void afterClass() {
+        org.apache.logging.log4j.util.Constants.resetWebApp();
+        org.apache.logging.log4j.util.Constants.resetUseThreadLocals();
         System.setProperty(Constants.LOG4J_CONTEXT_SELECTOR, Strings.EMPTY);
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest.java
@@ -21,16 +21,21 @@ import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
 import org.apache.logging.log4j.test.junit.SetTestProperty;
 import org.apache.logging.log4j.util.Constants;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 /**
  * Tests queue full scenarios with AsyncLoggers in configuration.
  */
-@SetTestProperty(key = "log4j2.enableThreadlocals", value = "true")
-@SetTestProperty(key = "log4j2.isWebapp", value= "false")
 @SetTestProperty(key = "log4j2.asyncLoggerConfigRingBufferSize", value = "128")
 public class QueueFullAsyncLoggerConfigLoggingFromToStringTest extends QueueFullAbstractTest {
+
+    @BeforeEach
+    void setUp() {
+        Constants.setWebApp(false);
+        Constants.setUseThreadLocals(true);
+    }
 
     @Override
     @Test
@@ -44,7 +49,7 @@ public class QueueFullAsyncLoggerConfigLoggingFromToStringTest extends QueueFull
     @Override
     protected void checkConfig(final LoggerContext ctx) throws ReflectiveOperationException {
         assertAsyncLoggerConfig(ctx, 128);
-        assertThat(Constants.IS_WEB_APP).isFalse();
-        assertThat(Constants.ENABLE_THREADLOCALS).isTrue();
+        assertThat(Constants.isWebApp()).isFalse();
+        assertThat(Constants.isUseThreadLocals()).isTrue();
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/NestedLoggingFromThrowableMessageTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/NestedLoggingFromThrowableMessageTest.java
@@ -28,6 +28,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.util.Constants;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -48,7 +50,12 @@ public class NestedLoggingFromThrowableMessageTest {
     public static void beforeClass() {
         file1.delete();
         file2.delete();
-        System.setProperty("log4j2.is.webapp", "false");
+        Constants.setWebApp(false);
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        Constants.resetWebApp();
     }
 
     @Rule

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/NestedLoggingFromToStringTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/NestedLoggingFromToStringTest.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.util.Constants;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -48,7 +49,7 @@ public class NestedLoggingFromToStringTest {
 
     @BeforeClass
     public static void beforeClass() {
-        System.setProperty("log4j2.is.webapp", "false");
+        Constants.setWebApp(false);
     }
 
     @Rule

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/ThrowableProxyTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/ThrowableProxyTest.java
@@ -47,6 +47,8 @@ import org.apache.logging.log4j.core.pattern.PlainTextRenderer;
 import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -151,6 +153,7 @@ public class ThrowableProxyTest {
     }
 
     @Test
+    @DisabledForJreRange(min = JRE.JAVA_21, disabledReason = "The Security Manager is deprecated and will be removed in a future release")
     public void testLogStackTraceWithClassThatWillCauseSecurityException() throws IOException {
         final SecurityManager sm = System.getSecurityManager();
         try {
@@ -178,6 +181,7 @@ public class ThrowableProxyTest {
     }
 
     @Test
+    @DisabledForJreRange(min = JRE.JAVA_21, disabledReason = "The Security Manager is deprecated and will be removed in a future release")
     public void testLogStackTraceWithClassLoaderThatWithCauseSecurityException() throws Exception {
         final SecurityManager sm = System.getSecurityManager();
         try {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/DatePatternConverterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/DatePatternConverterTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.logging.log4j.core.pattern;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -29,20 +27,21 @@ import org.apache.logging.log4j.core.AbstractLogEvent;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.time.Instant;
 import org.apache.logging.log4j.core.time.MutableInstant;
-import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedTimeZoneFormat;
+import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(Parameterized.class)
 public class DatePatternConverterTest {
 
-    private class MyLogEvent extends AbstractLogEvent {
+    private static class MyLogEvent extends AbstractLogEvent {
         private static final long serialVersionUID = 0;
 
         @Override
@@ -88,18 +87,8 @@ public class DatePatternConverterTest {
         return Arrays.asList(new Object[][]{{Boolean.TRUE}, {Boolean.FALSE}});
     }
 
-    public DatePatternConverterTest(final Boolean threadLocalEnabled) throws Exception {
-        // Setting the system property does not work: the Constant field has already been initialized...
-        //System.setProperty("log4j2.enable.threadlocals", threadLocalEnabled.toString());
-
-        final Field field = Constants.class.getDeclaredField("ENABLE_THREADLOCALS");
-        field.setAccessible(true); // make non-private
-
-        final Field modifiersField = Field.class.getDeclaredField("modifiers");
-        modifiersField.setAccessible(true);
-        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL); // make non-final
-
-        field.setBoolean(null, threadLocalEnabled.booleanValue());
+    public DatePatternConverterTest(final Boolean threadLocalEnabled) {
+        Constants.setUseThreadLocals(threadLocalEnabled);
     }
 
     private static Date date(final int year, final int month, final int date) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/ClockFactoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/ClockFactoryTest.java
@@ -16,32 +16,15 @@
  */
 package org.apache.logging.log4j.core.util;
 
-import java.lang.reflect.Field;
-
-import org.apache.commons.lang3.reflect.FieldUtils;
-import org.apache.logging.log4j.core.async.AsyncLogger;
-import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnJre;
-import org.junit.jupiter.api.condition.JRE;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-// as of Java 12, final fields can no longer be overwritten via reflection
-@EnabledOnJre({ JRE.JAVA_8, JRE.JAVA_9, JRE.JAVA_10, JRE.JAVA_11 })
 public class ClockFactoryTest {
 
-    public static void resetClocks() throws IllegalAccessException {
-        resetClock(Log4jLogEvent.class);
-        resetClock(AsyncLogger.class);
-    }
-
-    public static void resetClock(final Class<?> clazz) throws IllegalAccessException {
-        System.clearProperty(ClockFactory.PROPERTY_NAME);
-        final Field field = FieldUtils.getField(clazz, "CLOCK", true);
-        FieldUtils.removeFinalModifier(field);
-        FieldUtils.writeStaticField(field, ClockFactory.getClock(), false);
+    public static void resetClocks() {
+        ClockFactory.setClock(null);
     }
 
     @BeforeEach

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/ShutdownCallbackRegistryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/ShutdownCallbackRegistryTest.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.core.impl.Log4jContextFactory;
 import org.apache.logging.log4j.core.selector.ContextSelector;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Constants;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -40,14 +41,14 @@ public class ShutdownCallbackRegistryTest {
 
     @BeforeAll
     public static void setUpClass() {
-        System.setProperty("log4j2.is.webapp", "false");
+        Constants.setWebApp(false);
         System.setProperty(ShutdownCallbackRegistry.SHUTDOWN_CALLBACK_REGISTRY, Registry.class.getName());
     }
 
     @AfterAll
     public static void afterClass() {
         System.clearProperty(ShutdownCallbackRegistry.SHUTDOWN_CALLBACK_REGISTRY);
-        System.clearProperty("log4j2.is.webapp");
+        Constants.resetWebApp();
     }
 
     @Test

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLogger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLogger.java
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.config.ReliabilityStrategy;
 import org.apache.logging.log4j.core.impl.ContextDataFactory;
 import org.apache.logging.log4j.core.impl.ContextDataInjectorFactory;
-import org.apache.logging.log4j.core.util.Clock;
 import org.apache.logging.log4j.core.util.ClockFactory;
 import org.apache.logging.log4j.core.util.NanoClock;
 import org.apache.logging.log4j.message.Message;
@@ -70,7 +69,6 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
     // immediate inlining instead of waiting until they are designated "hot enough".
 
     private static final StatusLogger LOGGER = StatusLogger.getLogger();
-    private static final Clock CLOCK = ClockFactory.getClock(); // not reconfigurable
     private static final ContextDataInjector CONTEXT_DATA_INJECTOR = ContextDataInjectorFactory.createInjector();
 
     private static final ThreadNameCachingStrategy THREAD_NAME_CACHING_STRATEGY = ThreadNameCachingStrategy.create();
@@ -269,7 +267,7 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
             ThreadContext.getImmutableStack(), //
 
             location,
-            CLOCK, //
+            ClockFactory.getClock(), //
             nanoClock //
         );
     }
@@ -286,7 +284,7 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
 
                 // location (expensive to calculate)
                 calcLocationIfRequested(fqcn), //
-                CLOCK, //
+                ClockFactory.getClock(), //
                 nanoClock //
         );
     }
@@ -415,7 +413,7 @@ public class AsyncLogger extends Logger implements EventTranslatorVararg<RingBuf
                 // in the AsyncLogger#actualAsyncLog method
                 CONTEXT_DATA_INJECTOR.injectContextData(null, (StringMap) event.getContextData()),
                 contextStack, currentThread.getId(), threadName, currentThread.getPriority(), location,
-                CLOCK, nanoClock);
+                ClockFactory.getClock(), nanoClock);
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
@@ -22,7 +22,6 @@ import java.util.concurrent.Future;
 import com.lmax.disruptor.ExceptionHandler;
 import com.lmax.disruptor.WaitStrategy;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.Integers;
 import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.status.StatusLogger;
@@ -64,7 +63,7 @@ final class DisruptorUtil {
     }
 
     static int calculateRingBufferSize(final String propertyName) {
-        int ringBufferSize = Constants.ENABLE_THREADLOCALS ? RINGBUFFER_NO_GC_DEFAULT_SIZE : RINGBUFFER_DEFAULT_SIZE;
+        int ringBufferSize = org.apache.logging.log4j.util.Constants.isUseThreadLocals() ? RINGBUFFER_NO_GC_DEFAULT_SIZE : RINGBUFFER_DEFAULT_SIZE;
         final String userPreferredRBSize = PropertiesUtil.getProperties().getStringProperty(propertyName,
                 String.valueOf(ringBufferSize));
         try {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEvent.java
@@ -424,7 +424,7 @@ public class RingBufferLogEvent implements LogEvent, ReusableMessage, CharSequen
         }
 
         // ensure that excessively long char[] arrays are not kept in memory forever
-        if (Constants.ENABLE_THREADLOCALS) {
+        if (org.apache.logging.log4j.util.Constants.isUseThreadLocals()) {
             StringBuilders.trimToMaxSize(messageText, Constants.MAX_REUSABLE_MESSAGE_SIZE);
 
             if (parameters != null) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -94,7 +94,7 @@ public class LoggerConfig extends AbstractFilterable implements LocationAware {
             }
         }
         if (LOG_EVENT_FACTORY == null) {
-            LOG_EVENT_FACTORY = Constants.ENABLE_THREADLOCALS
+            LOG_EVENT_FACTORY = org.apache.logging.log4j.util.Constants.isUseThreadLocals()
                     ? new ReusableLogEventFactory()
                     : new DefaultLogEventFactory();
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jContextFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jContextFactory.java
@@ -49,7 +49,7 @@ public class Log4jContextFactory implements LoggerContextFactory, ShutdownCallba
     private static final StatusLogger LOGGER = StatusLogger.getLogger();
     private static final boolean SHUTDOWN_HOOK_ENABLED =
         PropertiesUtil.getProperties().getBooleanProperty(ShutdownCallbackRegistry.SHUTDOWN_HOOK_ENABLED, true) &&
-                !Constants.IS_WEB_APP;
+                !org.apache.logging.log4j.util.Constants.isWebApp();
 
     private final ContextSelector selector;
     private final ShutdownCallbackRegistry shutdownCallbackRegistry;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/Log4jLogEvent.java
@@ -56,7 +56,6 @@ import org.apache.logging.log4j.util.Strings;
 public class Log4jLogEvent implements LogEvent {
 
     private static final long serialVersionUID = -8393305700508709443L;
-    private static final Clock CLOCK = ClockFactory.getClock();
     private static volatile NanoClock nanoClock = new DummyNanoClock();
     private static final ContextDataInjector CONTEXT_DATA_INJECTOR = ContextDataInjectorFactory.createInjector();
 
@@ -274,7 +273,7 @@ public class Log4jLogEvent implements LogEvent {
 
         private void initTimeFields() {
             if (instant.getEpochMillisecond() == 0) {
-                instant.initFrom(CLOCK);
+                instant.initFrom(ClockFactory.getClock());
             }
         }
     }
@@ -289,7 +288,7 @@ public class Log4jLogEvent implements LogEvent {
 
     public Log4jLogEvent() {
         this(Strings.EMPTY, null, Strings.EMPTY, null, null, (Throwable) null, null, null, null, 0, null,
-                0, null, CLOCK, nanoClock.nanoTime());
+                0, null, ClockFactory.getClock(), nanoClock.nanoTime());
     }
 
     /**
@@ -337,7 +336,7 @@ public class Log4jLogEvent implements LogEvent {
            null, // thread name
            0, // thread priority
            null, // StackTraceElement source
-           CLOCK, //
+           ClockFactory.getClock(), //
            nanoClock.nanoTime());
    }
 
@@ -361,7 +360,7 @@ public class Log4jLogEvent implements LogEvent {
             null, // thread name
             0, // thread priority
             source, // StackTraceElement source
-            CLOCK, //
+            ClockFactory.getClock(), //
             nanoClock.nanoTime());
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/Server.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/Server.java
@@ -40,7 +40,6 @@ import org.apache.logging.log4j.core.async.AsyncLoggerContext;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.impl.Log4jContextFactory;
 import org.apache.logging.log4j.core.selector.ContextSelector;
-import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.Log4jThreadFactory;
 import org.apache.logging.log4j.spi.LoggerContextFactory;
 import org.apache.logging.log4j.status.StatusLogger;
@@ -76,7 +75,7 @@ public final class Server {
      * @see <a href="https://issues.apache.org/jira/browse/LOG4J2-938">LOG4J2-938</a>
      */
     private static ExecutorService createExecutor() {
-        final boolean defaultAsync = !Constants.IS_WEB_APP;
+        final boolean defaultAsync = !org.apache.logging.log4j.util.Constants.isWebApp();
         final boolean async = PropertiesUtil.getProperties().getBooleanProperty(PROPERTY_ASYNC_NOTIF, defaultAsync);
         return async ? Executors.newFixedThreadPool(1, Log4jThreadFactory.createDaemonThreadFactory(THREAD_NAME_PREFIX))
                 : null;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/DatePatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/DatePatternConverter.java
@@ -27,7 +27,6 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.time.Instant;
 import org.apache.logging.log4j.core.time.MutableInstant;
-import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.datetime.FastDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat;
 import org.apache.logging.log4j.core.util.datetime.FixedDateFormat.FixedFormat;
@@ -292,7 +291,7 @@ public final class DatePatternConverter extends LogEventPatternConverter impleme
     }
 
     private MutableInstant getMutableInstant() {
-        if (Constants.ENABLE_THREADLOCALS) {
+        if (org.apache.logging.log4j.util.Constants.isUseThreadLocals()) {
             MutableInstant result = threadLocalMutableInstant.get();
             if (result == null) {
                 result = new MutableInstant();
@@ -304,7 +303,7 @@ public final class DatePatternConverter extends LogEventPatternConverter impleme
     }
 
     public void format(final Instant instant, final StringBuilder output) {
-        if (Constants.ENABLE_THREADLOCALS) {
+        if (org.apache.logging.log4j.util.Constants.isUseThreadLocals()) {
             formatWithoutAllocation(instant, output);
         } else {
             formatWithoutThreadLocals(instant, output);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/ClockFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/ClockFactory.java
@@ -18,11 +18,13 @@ package org.apache.logging.log4j.core.util;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.apache.logging.log4j.core.time.PreciseClock;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.InternalApi;
+import org.apache.logging.log4j.util.Lazy;
 import org.apache.logging.log4j.util.PropertiesUtil;
-import org.apache.logging.log4j.util.Supplier;
 
 /**
  * Factory for {@code Clock} objects.
@@ -35,6 +37,7 @@ public final class ClockFactory {
      */
     public static final String PROPERTY_NAME = "log4j.Clock";
     private static final StatusLogger LOGGER = StatusLogger.getLogger();
+    private static final Lazy<Clock> CLOCK = Lazy.lazy(ClockFactory::createClock);
 
     // private static final Clock clock = createClock();
 
@@ -64,7 +67,12 @@ public final class ClockFactory {
      * @return a {@code Clock} instance
      */
     public static Clock getClock() {
-        return createClock();
+        return CLOCK.get();
+    }
+
+    @InternalApi
+    public static void setClock(final Clock clock) {
+        CLOCK.set(clock);
     }
 
     private static Map<String, Supplier<Clock>> aliases() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
@@ -76,8 +76,10 @@ public final class Constants {
      * {@code true} if we think we are running in a web container, based on the boolean value of system property
      * "log4j2.is.webapp", or (if this system property is not set) whether the  {@code javax.servlet.Servlet} class
      * is present in the classpath.
+     * @deprecated use {@link org.apache.logging.log4j.util.Constants#isWebApp()}
      */
-    public static final boolean IS_WEB_APP = org.apache.logging.log4j.util.Constants.IS_WEB_APP;
+    @Deprecated
+    public static final boolean IS_WEB_APP = org.apache.logging.log4j.util.Constants.isWebApp();
 
     /**
      * Kill switch for object pooling in ThreadLocals that enables much of the LOG4J2-1270 no-GC behaviour.
@@ -86,8 +88,10 @@ public final class Constants {
      * "log4j2.enable.threadlocals" to "false".
      *
      * @since 2.6
+     * @deprecated use {@link org.apache.logging.log4j.util.Constants#isUseThreadLocals()}
      */
-    public static final boolean ENABLE_THREADLOCALS = org.apache.logging.log4j.util.Constants.ENABLE_THREADLOCALS;
+    @Deprecated
+    public static final boolean ENABLE_THREADLOCALS = org.apache.logging.log4j.util.Constants.isUseThreadLocals();
 
     /**
      * Kill switch for garbage-free Layout behaviour that encodes LogEvents directly into

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/package-info.java
@@ -18,7 +18,7 @@
  * Log4j 2 helper classes.
  */
 @Export
-@Version("2.20.2")
+@Version("2.22.0")
 package org.apache.logging.log4j.core.util;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-jakarta-web/src/test/java/org/apache/logging/log4j/web/PropertyTest.java
+++ b/log4j-jakarta-web/src/test/java/org/apache/logging/log4j/web/PropertyTest.java
@@ -37,6 +37,6 @@ public class PropertyTest {
 
     @Test
     public void testIsWebApp() {
-        assertTrue(Constants.IS_WEB_APP, "When servlet classes are available IS_WEB_APP should default to true");
+        assertTrue(Constants.isWebApp(), "When servlet classes are available IS_WEB_APP should default to true");
     }
 }

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/RecyclerFactories.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/RecyclerFactories.java
@@ -25,7 +25,6 @@ import java.util.Queue;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.function.Supplier;
 
-import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.core.util.Integers;
 import org.apache.logging.log4j.util.LoaderUtil;
 import org.jctools.queues.MpmcArrayQueue;
@@ -60,7 +59,7 @@ public final class RecyclerFactories {
 
         // TLA-, MPMC-, or ABQ-based queueing factory -- if nothing is specified.
         if (recyclerFactorySpec == null) {
-            if (Constants.ENABLE_THREADLOCALS) {
+            if (org.apache.logging.log4j.util.Constants.isUseThreadLocals()) {
                 return ThreadLocalRecyclerFactory.getInstance();
             } else {
                 final Supplier<Queue<Object>> queueSupplier =

--- a/log4j-perf-test/src/main/java/org/apache/logging/log4j/perf/jmh/ConcurrentAsyncLoggerToFileBenchmark.java
+++ b/log4j-perf-test/src/main/java/org/apache/logging/log4j/perf/jmh/ConcurrentAsyncLoggerToFileBenchmark.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.core.async.AsyncQueueFullPolicy;
 import org.apache.logging.log4j.core.async.EventRoute;
 import org.apache.logging.log4j.perf.util.BenchmarkMessageParams;
+import org.apache.logging.log4j.util.Constants;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -93,7 +94,7 @@ public class ConcurrentAsyncLoggerToFileBenchmark {
         @Setup
         public final void before() {
             new File("target/ConcurrentAsyncLoggerToFileBenchmark.log").delete();
-            System.setProperty("log4j2.is.webapp", "false");
+            Constants.setWebApp(false);
             asyncLoggerType.setProperties();
             queueFullPolicy.setProperties();
             logger = LogManager.getLogger(ConcurrentAsyncLoggerToFileBenchmark.class);

--- a/log4j-perf-test/src/main/java/org/apache/logging/log4j/perf/jmh/FileAppenderThrowableBenchmark.java
+++ b/log4j-perf-test/src/main/java/org/apache/logging/log4j/perf/jmh/FileAppenderThrowableBenchmark.java
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
 public class FileAppenderThrowableBenchmark {
     static {
         // log4j2
-        System.setProperty("log4j2.is.webapp", "false");
+        org.apache.logging.log4j.util.Constants.setWebApp(false);
         System.setProperty("log4j.configurationFile", "log4j2-perf-file-throwable.xml");
         // log4j 1.2
         System.setProperty("log4j.configuration", "log4j12-perf-file-throwable.xml");

--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogger.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogger.java
@@ -305,7 +305,7 @@ public class SLF4JLogger extends AbstractLogger {
     @Override
     protected LogBuilder getLogBuilder(final Level level) {
         final SLF4JLogBuilder builder = logBuilder.get();
-        return Constants.ENABLE_THREADLOCALS && !builder.isInUse() ? builder.reset(this, level)
+        return Constants.isUseThreadLocals() && !builder.isInUse() ? builder.reset(this, level)
                 : new SLF4JLogBuilder(this, level);
     }
 

--- a/log4j-web/src/test/java/org/apache/logging/log4j/web/PropertyTest.java
+++ b/log4j-web/src/test/java/org/apache/logging/log4j/web/PropertyTest.java
@@ -37,6 +37,6 @@ public class PropertyTest {
 
     @Test
     public void testIsWebApp() {
-        assertTrue(Constants.IS_WEB_APP, "When servlet classes are available IS_WEB_APP should default to true");
+        assertTrue(Constants.isWebApp(), "When servlet classes are available IS_WEB_APP should default to true");
     }
 }


### PR DESCRIPTION
If you add a dependency on GraalJS to `log4j-core-test`, that brings down the test failure count to 14 when run with Java 21. There are some tests that have to be disabled for later versions due to Java changes such as the removal of custom security managers (throws an exception right now in Java 21) and the removal of Nashorn (we need an explicit JavaScript `ScriptEngine` dependency in Java 17+). It's possible that Nashorn is available as a standalone dependency somewhere, but I haven't looked yet. When run without a JavaScript engine, we get 36 test failures and 2 test errors, all of which are script-related tests. Thus, this gets everything working again except for JavaScript `ScriptEngine` use.