### PR TITLE
Switch Basic Authentication encoding to UTF-8

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/BasicAuthorizationProvider.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/BasicAuthorizationProvider.java
@@ -17,12 +17,15 @@
 package org.apache.logging.log4j.core.util;
 
 import java.net.URLConnection;
+import java.nio.charset.Charset;
+import java.util.Base64;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
-import org.apache.logging.log4j.util.Base64Util;
 import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.PropertiesUtil;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Provides the Basic Authorization header to a request.
@@ -35,6 +38,11 @@ public class BasicAuthorizationProvider implements AuthorizationProvider {
     public static final String CONFIG_USER_NAME = "log4j2.configurationUserName";
     public static final String CONFIG_PASSWORD = "log4j2.configurationPassword";
     public static final String PASSWORD_DECRYPTOR = "log4j2.passwordDecryptor";
+    /*
+     * Properties used to specify the encoding in HTTP Basic Authentication
+     */
+    private static final String BASIC_AUTH_ENCODING = "log4j2.configurationAuthorizationEncoding";
+    private static final String SPRING_BASIC_AUTH_ENCODING = "logging.auth.encoding";
 
     private static final Logger LOGGER = StatusLogger.getLogger();
 
@@ -47,6 +55,11 @@ public class BasicAuthorizationProvider implements AuthorizationProvider {
                 () -> props.getStringProperty(CONFIG_PASSWORD));
         final String decryptor = props.getStringProperty(PREFIXES, AUTH_PASSWORD_DECRYPTOR,
                 () -> props.getStringProperty(PASSWORD_DECRYPTOR));
+        // Password encoding
+        Charset passwordCharset = props.getCharsetProperty(BASIC_AUTH_ENCODING);
+        if (passwordCharset == null) {
+            props.getCharsetProperty(SPRING_BASIC_AUTH_ENCODING, UTF_8);
+        }
         if (decryptor != null) {
             try {
                 final Object obj = LoaderUtil.newInstanceOf(decryptor);
@@ -58,7 +71,13 @@ public class BasicAuthorizationProvider implements AuthorizationProvider {
             }
         }
         if (userName != null && password != null) {
-            authString = "Basic " + Base64Util.encode(userName + ":" + password);
+            /*
+             * https://datatracker.ietf.org/doc/html/rfc7617#appendix-B
+             *
+             * If the user didn't specify a charset to use, we fallback to UTF-8
+             */
+            authString = "Basic "
+                    + Base64.getEncoder().encodeToString((userName + ":" + password).getBytes(passwordCharset));
         }
     }
 

--- a/src/changelog/.2.x.x/change_basic_auth_encoding.xml
+++ b/src/changelog/.2.x.x/change_basic_auth_encoding.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="changed">
+  <issue id="1970" link="https://github.com/apache/logging-log4j2/issues/1970"/>
+  <description format="asciidoc">
+    Change default encoding of HTTP Basic Authentication to UTF-8 and add `log4j2.configurationAuthorizationEncoding` property to overwrite it.
+  </description>
+</entry>

--- a/src/site/_release-notes/_2.x.x.adoc
+++ b/src/site/_release-notes/_2.x.x.adoc
@@ -47,6 +47,7 @@ The module name of four bridges (`log4j-slf4j-impl`, `log4j-slf4j2-impl`, `log4j
 === Changed
 
 * Change the order of evaluation of `FormattedMessage` formatters. Messages are evaluated using `java.util.Format` only if they don't comply to the `java.text.MessageFormat` or `ParameterizedMessage` format. (https://github.com/apache/logging-log4j2/issues/1223[1223])
+* Change default encoding of HTTP Basic Authentication to UTF-8 and add `log4j2.configurationAuthorizationEncoding` property to overwrite it. (https://github.com/apache/logging-log4j2/issues/1961[1961])
 * Fix MDC pattern converter causing issues for `%notEmpty` (https://github.com/apache/logging-log4j2/issues/1922[1922])
 * Fix `NotSerializableException` when `Logger` is serialized with a `ReusableMessageFactory` (https://github.com/apache/logging-log4j2/issues/1884[1884])
 * Update `co.elastic.clients:elasticsearch-java` to version `8.11.0` (https://github.com/apache/logging-log4j2/pull/1953[1953])

--- a/src/site/markdown/log4j-spring-cloud-config-client.md
+++ b/src/site/markdown/log4j-spring-cloud-config-client.md
@@ -66,7 +66,8 @@ the alternatives may be used in any configuration location.
 |----------|---------|---------|---------|
 | log4j2.configurationUserName | log4j2.config.username | logging.auth.username | User name for basic authentication |
 | log4j2.configurationPassword | log4j2.config.password | logging.auth.password | Password for basic authentication |
-| log4j2.authorizationProvider | log4j2.config.authorizationProvider | logging.auth.authorizationProvider | Class used to create HTTP Authorization header |
+| log4j2.configurationAuthorizationEncoding | | logging.auth.encoding | Encoding for basic authentication (defaults to UTF-8) |
+| log4j2.configurationAuthorizationProvider | log4j2.config.authorizationProvider | logging.auth.authorizationProvider | Class used to create HTTP Authorization header |
 
 ```
 log4j2.configurationUserName=guest

--- a/src/site/xdoc/manual/configuration.xml.vm
+++ b/src/site/xdoc/manual/configuration.xml.vm
@@ -2128,6 +2128,14 @@ public class AwesomeTest {
     </td>
   </tr>
   <tr>
+    <td><a name="log4j2.configurationAuthorizationEncoding"/>log4j2.configurationAuthorizationEncoding</td>
+    <td>LOG4J_CONFIGURATION_AUTHORIZATION_ENCODING</td>
+    <td>UTF-8</td>
+    <td>
+      The encoding used in Basic Authentication (cf. <a href="https://datatracker.ietf.org/doc/html/rfc7617">RFC 7617</a>).
+    </td>
+  </tr>
+  <tr>
     <td><a name="configurationAuthorizationProvider"/>log4j2.Configuration.authorizationProvider
       <br />
       (<a name="log4j.configurationAuthorizationProvider"/>log4j.configurationAuthorizationProvider


### PR DESCRIPTION
[RFC 7617](https://datatracker.ietf.org/doc/html/rfc7617) introduces a new `charset` parameter for the Basic authentication scheme with a single allowed value "UTF-8".

Clients that comply to this RFC should encode the user name and password using UTF-8 if the parameter is present. Clients that **always** use UTF-8 obviously comply to this rule.

Up until now Log4j used the system encoding for Basic authentication. This PR:

- switches the default encoding to UTF-8,
- adds a `log4j2.configurationAuthorizationEncoding` property to overwrite the default value.

This problem was detected by Error Prone in #1961.
