### PR TITLE
Fix 1799 and Spring 33450

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyEnvironment.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyEnvironment.java
@@ -29,6 +29,12 @@ public interface PropertyEnvironment {
     void addPropertySource(PropertySource propertySource);
 
     /**
+     * Allows a PropertySource that was added to be removed.
+     * @param propertySource the PropertySource to remove.
+     */
+    void removePropertySource(PropertySource propertySource);
+
+    /**
      * Returns {@code true} if the specified property is defined, regardless of its value (it may not have a value).
      *
      * @param name the name of the property to verify

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/LoggerContextTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/LoggerContextTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.impl.Log4jContextFactory;
+import org.apache.logging.log4j.core.impl.internal.InternalLoggerContext;
+import org.apache.logging.log4j.core.util.DefaultShutdownCallbackRegistry;
+import org.apache.logging.log4j.core.util.ShutdownCallbackRegistry;
+import org.apache.logging.log4j.spi.LoggerContextFactory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Validate Logging after Shutdown.
+ */
+public class LoggerContextTest {
+
+    @Test
+    public void shutdownTest() {
+        LoggerContextFactory contextFactory = LogManager.getFactory();
+        assertTrue(contextFactory instanceof Log4jContextFactory);
+        Log4jContextFactory factory = (Log4jContextFactory) contextFactory;
+        ShutdownCallbackRegistry registry = factory.getShutdownCallbackRegistry();
+        assertTrue(registry instanceof DefaultShutdownCallbackRegistry);
+        ((DefaultShutdownCallbackRegistry) registry).start();
+        ((DefaultShutdownCallbackRegistry) registry).stop();
+        LoggerContext loggerContext = factory.getContext(LoggerContextTest.class.getName(), null, null, false);
+        assertTrue(loggerContext instanceof InternalLoggerContext);
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/MissingRootLoggerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/MissingRootLoggerTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Map;
@@ -48,7 +49,7 @@ public class MissingRootLoggerTest {
         assertNotNull(map, "Appenders not null");
         assertThat("There should only be two appenders", map, hasSize(2));
         assertThat(map, hasKey("List"));
-        assertThat(map, hasKey("DefaultConsole-2"));
+        assertThat(map, hasKey(startsWith("DefaultConsole-")));
 
         final Map<String, LoggerConfig> loggerMap = config.getLoggers();
         assertNotNull(loggerMap, "loggerMap not null");
@@ -67,7 +68,8 @@ public class MissingRootLoggerTest {
         final Map<String, Appender> rootAppenders = root.getAppenders();
         assertThat("The root logger should only have one appender", rootAppenders, hasSize(1));
         // root only has Console appender!
-        assertThat("The root appender should be a ConsoleAppender", rootAppenders, hasKey("DefaultConsole-2"));
+        assertThat(
+                "The root appender should be a ConsoleAppender", rootAppenders, hasKey(startsWith("DefaultConsole-")));
         assertEquals(Level.ERROR, root.getLevel());
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
@@ -67,6 +67,17 @@ public class Logger extends AbstractLogger implements Supplier<LoggerConfig> {
     }
 
     /**
+     * This is used to construct an InternalLoggerContext, which makes SimpleLoggerContext conmpatible with core.
+     * @param context the InternalLoggerContext.
+     * @param name the Logger name.
+     */
+    protected Logger(final LoggerContext context, final String name) {
+        super(name);
+        this.context = context;
+        privateConfig = null;
+    }
+
+    /**
      * This method is only used for 1.x compatibility. Returns the parent of this Logger. If it doesn't already exist
      * return a temporary Logger.
      *

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
@@ -100,6 +100,15 @@ public class LoggerContext extends AbstractLifeCycle
     private final Lock configLock = new ReentrantLock();
 
     /**
+     * Constructor used to create an InternalLoggerContext.
+     */
+    protected LoggerContext() {
+        setStarted();
+        instanceFactory = null;
+        this.nullConfiguration = null;
+    }
+
+    /**
      * Constructor taking only a name.
      *
      * @param name The context name.
@@ -428,6 +437,7 @@ public class LoggerContext extends AbstractLifeCycle
             }
 
             this.setStopping();
+            String name = getName();
             try {
                 Server.unregisterLoggerContext(getName()); // LOG4J2-406, LOG4J2-500
             } catch (final LinkageError | Exception e) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
@@ -21,12 +21,15 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
 import org.apache.logging.log4j.core.impl.Log4jPropertyKey;
+import org.apache.logging.log4j.core.util.AuthorizationProvider;
 import org.apache.logging.log4j.plugins.Namespace;
 import org.apache.logging.log4j.plugins.di.ConfigurableInstanceFactory;
 import org.apache.logging.log4j.plugins.di.Key;
 import org.apache.logging.log4j.plugins.model.PluginNamespace;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
+import org.apache.logging.log4j.util.PropertiesUtil;
+import org.apache.logging.log4j.util.PropertyEnvironment;
 import org.apache.logging.log4j.util.PropertyKey;
 
 /**
@@ -116,6 +119,15 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
 
     protected boolean isActive() {
         return true;
+    }
+
+    /**
+     * Required for Spring Boot.
+     * @param props PropertiesUtil.
+     * @return the AuthorizationProvider, if any.
+     */
+    public static AuthorizationProvider authorizationProvider(final PropertiesUtil props) {
+        return AuthorizationProvider.getAuthorizationProvider((PropertyEnvironment) props);
     }
 
     public abstract Configuration getConfiguration(final LoggerContext loggerContext, ConfigurationSource source);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/internal/InternalLoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/internal/InternalLoggerContext.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.impl.internal;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogBuilder;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.MessageFactory;
+import org.apache.logging.log4j.simple.SimpleLoggerContext;
+import org.apache.logging.log4j.spi.ExtendedLogger;
+
+/**
+ * Creates a SimpleLoggerContext compatible with log4j-core. This class is internal to Log4j.
+ */
+public class InternalLoggerContext extends LoggerContext {
+
+    private final SimpleLoggerContext simpleLoggerContext = new SimpleLoggerContext();
+
+    private static final LoggerConfig LOGGER_CONFIG = new LoggerConfig.RootLogger();
+
+    public InternalLoggerContext() {
+        super();
+        setStarted();
+    }
+
+    @Override
+    protected Logger newInstance(final LoggerContext ctx, final String name, final MessageFactory messageFactory) {
+        return new InternalLogger(this, name);
+    }
+
+    @Override
+    public boolean stop(final long timeout, final TimeUnit timeUnit) {
+        return false;
+    }
+
+    private class InternalLogger extends Logger {
+        private final ExtendedLogger logger;
+        private final InternalLoggerContext loggerContext;
+
+        public InternalLogger(InternalLoggerContext loggerContext, String name) {
+            super(loggerContext, name);
+            this.loggerContext = loggerContext;
+            this.logger = simpleLoggerContext.getLogger(name);
+        }
+
+        @Override
+        public Logger getParent() {
+            return null;
+        }
+
+        @Override
+        public LoggerContext getContext() {
+            return loggerContext;
+        }
+
+        @Override
+        public void setLevel(final Level level) {}
+
+        @Override
+        public LoggerConfig get() {
+            return LOGGER_CONFIG;
+        }
+
+        @Override
+        protected boolean requiresLocation() {
+            return false;
+        }
+
+        @Override
+        public void logMessage(String fqcn, Level level, Marker marker, Message message, Throwable t) {}
+
+        @Override
+        protected void log(
+                Level level,
+                Marker marker,
+                String fqcn,
+                StackTraceElement location,
+                Message message,
+                Throwable throwable) {
+            logger.log(level, marker, message, throwable);
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Throwable t) {
+            return logger.isEnabled(level, marker, message, t);
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message) {
+            return logger.isEnabled(level, marker, message);
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object... params) {
+            return logger.isEnabled(level, marker, message, params);
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0) {
+            return logger.isEnabled(level, marker, message, p0);
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1) {
+            return logger.isEnabled(level, marker, message, p0, p1);
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2) {
+            return logger.isEnabled(level, marker, message, p0, p1, p2);
+        }
+
+        @Override
+        public boolean isEnabled(
+                Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3) {
+            return logger.isEnabled(level, marker, message, p0, p1, p2, p3);
+        }
+
+        @Override
+        public boolean isEnabled(
+                Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+            return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4);
+        }
+
+        @Override
+        public boolean isEnabled(
+                Level level,
+                Marker marker,
+                String message,
+                Object p0,
+                Object p1,
+                Object p2,
+                Object p3,
+                Object p4,
+                Object p5) {
+            return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5);
+        }
+
+        @Override
+        public boolean isEnabled(
+                Level level,
+                Marker marker,
+                String message,
+                Object p0,
+                Object p1,
+                Object p2,
+                Object p3,
+                Object p4,
+                Object p5,
+                Object p6) {
+            return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6);
+        }
+
+        @Override
+        public boolean isEnabled(
+                Level level,
+                Marker marker,
+                String message,
+                Object p0,
+                Object p1,
+                Object p2,
+                Object p3,
+                Object p4,
+                Object p5,
+                Object p6,
+                Object p7) {
+            return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
+        }
+
+        @Override
+        public boolean isEnabled(
+                Level level,
+                Marker marker,
+                String message,
+                Object p0,
+                Object p1,
+                Object p2,
+                Object p3,
+                Object p4,
+                Object p5,
+                Object p6,
+                Object p7,
+                Object p8) {
+            return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+        }
+
+        @Override
+        public boolean isEnabled(
+                Level level,
+                Marker marker,
+                String message,
+                Object p0,
+                Object p1,
+                Object p2,
+                Object p3,
+                Object p4,
+                Object p5,
+                Object p6,
+                Object p7,
+                Object p8,
+                Object p9) {
+            return logger.isEnabled(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, CharSequence message, Throwable t) {
+            return logger.isEnabled(level, marker, message, t);
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, Object message, Throwable t) {
+            return logger.isEnabled(level, marker, message, t);
+        }
+
+        @Override
+        public boolean isEnabled(Level level, Marker marker, Message message, Throwable t) {
+            return logger.isEnabled(level, marker, message, t);
+        }
+
+        @Override
+        public void addAppender(Appender appender) {}
+
+        @Override
+        public void removeAppender(Appender appender) {}
+
+        @Override
+        public Map<String, Appender> getAppenders() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Iterator<Filter> getFilters() {
+            return Collections.emptyIterator();
+        }
+
+        @Override
+        public Level getLevel() {
+            return logger.getLevel();
+        }
+
+        @Override
+        public int filterCount() {
+            return 0;
+        }
+
+        @Override
+        public void addFilter(Filter filter) {}
+
+        @Override
+        public boolean isAdditive() {
+            return false;
+        }
+
+        @Override
+        public void setAdditive(boolean additive) {}
+
+        @Override
+        public LogBuilder atLevel(Level level) {
+            return logger.atLevel(level);
+        }
+
+        @Override
+        protected void updateConfiguration(Configuration newConfig) {}
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/Server.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/Server.java
@@ -238,12 +238,14 @@ public final class Server {
      * @param loggerContextName name of the logger context to unregister
      */
     public static void unregisterLoggerContext(final String loggerContextName) {
-        if (isJmxDisabled()) {
-            LOGGER.debug("JMX disabled for Log4j2. Not unregistering MBeans.");
-            return;
+        if (loggerContextName != null) {
+            if (isJmxDisabled()) {
+                LOGGER.debug("JMX disabled for Log4j2. Not unregistering MBeans.");
+                return;
+            }
+            final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+            unregisterLoggerContext(loggerContextName, mbs);
         }
-        final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-        unregisterLoggerContext(loggerContextName, mbs);
     }
 
     /**

--- a/src/changelog/.3.x.x/1799_ignore _propertysource_errors.xml
+++ b/src/changelog/.3.x.x/1799_ignore _propertysource_errors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="changed">
+  <issue id="Spring-33450" link="https://github.com/spring-projects/spring-boot/issues/33450"/>
+  <issue id="1799" link="https://github.com/apache/logging-log4j2/issues/1799"/>
+  <author id="rgoers"/>
+  <description format="asciidoc">Ignore exceptions thrown by PropertySources. Eliminate ClassCastException when SimpleLoggerContext is used.</description>
+</entry>


### PR DESCRIPTION
Fix 1799

When errors are encountered creating a LoggerContext Log4j will return a SimpleLoggerContext. This usually fails as it doesn't extend LoggerContext in log4j-core. This change creates an InternalLoggerContext that is a wrapper to SimpleLoggerContext to avaoid this problem.

Spring 33450

During Shutdown a call to PropertiesUtil is made which calls the SpringPropertySource. However the Spring environment has already shutdown so an exception is thrown. This change handles the exception and ignores the ProeprtySource.
