### PR TITLE
Replaces `spring-test` with custom JNDI mock

### DIFF
--- a/log4j-jdbc/src/test/java/org/apache/logging/log4j/jdbc/appender/DataSourceConnectionSourceTest.java
+++ b/log4j-jdbc/src/test/java/org/apache/logging/log4j/jdbc/appender/DataSourceConnectionSourceTest.java
@@ -40,7 +40,7 @@ public class DataSourceConnectionSourceTest {
     @Parameterized.Parameters(name = "{0}")
     public static Object[][] data() {
         System.setProperty("log4j2.*.JNDI.enableJDBC", "true");
-        return new Object[][] {{"java:/comp/env/jdbc/Logging01"}, {"java:/comp/env/jdbc/Logging02"}};
+        return new Object[][] {{"java:comp/env/jdbc/Logging01"}, {"java:comp/env/jdbc/Logging02"}};
     }
 
     private static final String CONFIG = "log4j-fatalOnly.xml";

--- a/log4j-jdbc/src/test/java/org/apache/logging/log4j/jdbc/appender/JdbcAppenderMapMessageDataSourceTest.java
+++ b/log4j-jdbc/src/test/java/org/apache/logging/log4j/jdbc/appender/JdbcAppenderMapMessageDataSourceTest.java
@@ -70,10 +70,10 @@ public class JdbcAppenderMapMessageDataSourceTest {
     protected JdbcAppenderMapMessageDataSourceTest(final JdbcRule jdbcRule) {
         // @formatter:off
         this.rules = RuleChain.emptyRuleChain()
-                .around(new JndiRule("java:/comp/env/jdbc/TestDataSourceAppender", createMockDataSource()))
+                .around(new JndiRule("java:comp/env/jdbc/TestDataSourceAppender", createMockDataSource()))
                 .around(jdbcRule)
                 .around(new LoggerContextRule(
-                        "org/apache/logging/log4j/jdbc/appender/log4j2-data-source-map-message.xml"));
+                        "org/apache/logging/log4j/jdbc/appender/JdbcAppenderMapMessageDataSourceTest.xml"));
         // @formatter:on
         this.jdbcRule = jdbcRule;
     }

--- a/log4j-jdbc/src/test/resources/org/apache/logging/log4j/jdbc/appender/JdbcAppenderMapMessageDataSourceTest.xml
+++ b/log4j-jdbc/src/test/resources/org/apache/logging/log4j/jdbc/appender/JdbcAppenderMapMessageDataSourceTest.xml
@@ -22,7 +22,7 @@
       <PatternLayout pattern="%C{1.} %m %level MDC%X%n"/>
     </Console>
     <Jdbc name="databaseAppender" tableName="dsLogEntry" ignoreExceptions="false">
-      <DataSource jndiName="java:/comp/env/jdbc/TestDataSourceAppender" />
+      <DataSource jndiName="java:comp/env/jdbc/TestDataSourceAppender" />
       <ColumnMapping name="Id" />
       <ColumnMapping name="ColumnA" />
       <ColumnMapping name="ColumnB" />

--- a/log4j-jndi-test/pom.xml
+++ b/log4j-jndi-test/pom.xml
@@ -53,10 +53,9 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
-    <!-- `org.springframework:spring-test` is required for `org.springframework.mock.jndi.SimpleNamingContextBuilder`: -->
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
+      <groupId>org.apache.tomcat</groupId>
+      <artifactId>tomcat-catalina</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/log4j-jndi-test/src/main/java/org/apache/logging/log4j/jndi/test/junit/JndiFactoryBuilder.java
+++ b/log4j-jndi-test/src/main/java/org/apache/logging/log4j/jndi/test/junit/JndiFactoryBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.jndi.test.junit;
+
+import java.util.Hashtable;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
+import javax.naming.spi.InitialContextFactoryBuilder;
+import org.apache.naming.java.javaURLContextFactory;
+
+class JndiFactoryBuilder implements InitialContextFactoryBuilder {
+
+    static final InitialContextFactoryBuilder INSTANCE = new JndiFactoryBuilder();
+
+    private static final InitialContextFactory FACTORY = new javaURLContextFactory();
+
+    @Override
+    public InitialContextFactory createInitialContextFactory(Hashtable<?, ?> environment) throws NamingException {
+        return FACTORY;
+    }
+}

--- a/log4j-jndi-test/src/test/java/org/apache/logging/log4j/jndi/appender/routing/RoutingAppenderWithJndiTest.java
+++ b/log4j-jndi-test/src/test/java/org/apache/logging/log4j/jndi/appender/routing/RoutingAppenderWithJndiTest.java
@@ -78,7 +78,7 @@ public class RoutingAppenderWithJndiTest {
 
         // now set jndi resource to Application1
         final Context context = new InitialContext();
-        context.bind(JNDI_CONTEXT_NAME, "Application1");
+        JndiRule.recursiveBind(context, JNDI_CONTEXT_NAME, "Application1");
 
         msg = new StructuredDataMessage("Test", "This is a message from Application1", "Context");
         EventLogger.logEvent(msg);

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -155,7 +155,7 @@
     <spring-boot.version>2.7.18</spring-boot.version>
     <spring-framework.version>5.3.31</spring-framework.version>
     <system-stubs.version>2.1.5</system-stubs.version>
-    <tomcat-juli.version>10.1.16</tomcat-juli.version>
+    <tomcat.version>10.1.16</tomcat.version>
     <velocity.version>1.7</velocity.version>
     <wiremock.version>2.35.1</wiremock.version>
     <woodstox.version>6.5.1</woodstox.version>
@@ -857,10 +857,18 @@
         <version>${system-stubs.version}</version>
       </dependency>
 
+      <!-- Used for its JNDI implementation -->
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-catalina</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+
+      <!-- Used in Log4j App Server -->
       <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-juli</artifactId>
-        <version>${tomcat-juli.version}</version>
+        <version>${tomcat.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Since Spring 6.x the JNDI mock is no longer available.

We replace it with a simplified custom version based on Tomcat's JNDI implementation.

