### PR TITLE
Upgrade to Spring Boot 3

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -115,15 +115,6 @@ updates:
     # EclipseLink 3.x is Jakarta EE 9
     - dependency-name: "org.eclipse.persistence:*"
       update-types: ["version-update:semver-major"]
-    # Spring 6.x is Jakarta EE 9
-    - dependency-name: "org.springframework:*"
-      update-types: ["version-update:semver-major"]
-    # Spring Boot 3.x is Jakarta EE 9
-    - dependency-name: "org.springframework.boot:*"
-      update-types: ["version-update:semver-major"]
-    # Spring Cloud 2022.x is Jakarta EE 9
-    - dependency-name: "org.springframework.cloud:*"
-      update-types: ["version-update:semver-major"]
     # Keep Logback version 1.2.x
     - dependency-name: "ch.qos.logback:*"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
@@ -121,6 +121,11 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
         return true;
     }
 
+    @Deprecated(since = "3.0.0", forRemoval = true)
+    public static ConfigurationFactory getInstance() {
+        return LoggerContext.getContext(false).getInstanceFactory().getInstance(KEY);
+    }
+
     /**
      * Required for Spring Boot.
      * @param props PropertiesUtil.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/UrlConnectionFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/UrlConnectionFactory.java
@@ -56,6 +56,16 @@ public class UrlConnectionFactory {
     private static final String NO_PROTOCOLS = "_none";
     public static final String ALLOWED_PROTOCOLS = "log4j2.Configuration.allowedProtocols";
 
+    @Deprecated(since = "3.0.0", forRemoval = true)
+    public static <T extends URLConnection> T createConnection(
+            final URL url,
+            final long lastModifiedMillis,
+            final SslConfiguration sslConfiguration,
+            final AuthorizationProvider authorizationProvider)
+            throws IOException {
+        return createConnection(url, lastModifiedMillis, sslConfiguration, authorizationProvider, PropertiesUtil.getProperties());
+    }
+
     @SuppressFBWarnings(
             value = "URLCONNECTION_SSRF_FD",
             justification = "The URL parameter originates only from secure sources.")

--- a/log4j-jdbc/src/main/java/org/apache/logging/log4j/jdbc/appender/internal/JndiUtil.java
+++ b/log4j-jdbc/src/main/java/org/apache/logging/log4j/jdbc/appender/internal/JndiUtil.java
@@ -29,13 +29,17 @@ import org.apache.logging.log4j.status.StatusLogger;
 public final class JndiUtil {
     private static final Logger LOGGER = StatusLogger.getLogger();
 
+    /**
+     * Manager name used for accessing the {@link JndiManager} instance.
+     */
+    public static final String JNDI_MANAGER_NAME = DataSourceConnectionSource.class.getCanonicalName();
+
     private JndiUtil() {}
 
     public static DataSource getDataSource(final String jndiName) {
         try {
-            final DataSource dataSource = JndiManager.getDefaultManager(
-                            DataSourceConnectionSource.class.getCanonicalName())
-                    .lookup(jndiName);
+            final DataSource dataSource =
+                    JndiManager.getDefaultManager(JNDI_MANAGER_NAME).lookup(jndiName);
             if (dataSource == null) {
                 LOGGER.error("No data source found with JNDI name [" + jndiName + "].");
                 return null;

--- a/log4j-jdbc/src/test/java/org/apache/logging/log4j/jdbc/appender/AbstractJdbcAppenderDataSourceTest.java
+++ b/log4j-jdbc/src/test/java/org/apache/logging/log4j/jdbc/appender/AbstractJdbcAppenderDataSourceTest.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.core.util.Throwables;
+import org.apache.logging.log4j.jdbc.appender.internal.JndiUtil;
 import org.apache.logging.log4j.jndi.test.junit.JndiRule;
 import org.h2.util.IOUtils;
 import org.junit.BeforeClass;
@@ -57,7 +58,10 @@ public abstract class AbstractJdbcAppenderDataSourceTest {
 
     protected AbstractJdbcAppenderDataSourceTest(final JdbcRule jdbcRule) {
         this.rules = RuleChain.emptyRuleChain()
-                .around(new JndiRule("java:/comp/env/jdbc/TestDataSourceAppender", createMockDataSource()))
+                .around(new JndiRule(
+                        JndiUtil.JNDI_MANAGER_NAME,
+                        "java:/comp/env/jdbc/TestDataSourceAppender",
+                        createMockDataSource()))
                 .around(jdbcRule)
                 .around(new LoggerContextRule("org/apache/logging/log4j/jdbc/appender/log4j2-data-source.xml"));
         this.jdbcRule = jdbcRule;

--- a/log4j-jdbc/src/test/java/org/apache/logging/log4j/jdbc/appender/DataSourceConnectionSourceTest.java
+++ b/log4j-jdbc/src/test/java/org/apache/logging/log4j/jdbc/appender/DataSourceConnectionSourceTest.java
@@ -27,6 +27,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import javax.sql.DataSource;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.jdbc.appender.internal.JndiUtil;
 import org.apache.logging.log4j.jndi.test.junit.JndiRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,7 +53,8 @@ public class DataSourceConnectionSourceTest {
     private final String jndiURL;
 
     public DataSourceConnectionSourceTest(final String jndiURL) {
-        this.rules = RuleChain.outerRule(new JndiRule(jndiURL, dataSource)).around(new LoggerContextRule(CONFIG));
+        this.rules = RuleChain.outerRule(new JndiRule(JndiUtil.JNDI_MANAGER_NAME, jndiURL, dataSource))
+                .around(new LoggerContextRule(CONFIG));
         this.jndiURL = jndiURL;
     }
 

--- a/log4j-jdbc/src/test/java/org/apache/logging/log4j/jdbc/appender/JdbcAppenderMapMessageDataSourceTest.java
+++ b/log4j-jdbc/src/test/java/org/apache/logging/log4j/jdbc/appender/JdbcAppenderMapMessageDataSourceTest.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.core.util.Throwables;
+import org.apache.logging.log4j.jdbc.appender.internal.JndiUtil;
 import org.apache.logging.log4j.jndi.test.junit.JndiRule;
 import org.apache.logging.log4j.message.MapMessage;
 import org.junit.Assert;
@@ -70,7 +71,10 @@ public class JdbcAppenderMapMessageDataSourceTest {
     protected JdbcAppenderMapMessageDataSourceTest(final JdbcRule jdbcRule) {
         // @formatter:off
         this.rules = RuleChain.emptyRuleChain()
-                .around(new JndiRule("java:/comp/env/jdbc/TestDataSourceAppender", createMockDataSource()))
+                .around(new JndiRule(
+                        JndiUtil.JNDI_MANAGER_NAME,
+                        "java:/comp/env/jdbc/TestDataSourceAppender",
+                        createMockDataSource()))
                 .around(jdbcRule)
                 .around(new LoggerContextRule(
                         "org/apache/logging/log4j/jdbc/appender/log4j2-data-source-map-message.xml"));

--- a/log4j-jndi-test/pom.xml
+++ b/log4j-jndi-test/pom.xml
@@ -31,6 +31,7 @@
   <properties>
     <log4jParentDir>${basedir}/..</log4jParentDir>
     <module.name>org.apache.logging.log4j.jndi.test</module.name>
+    <simple-jndi.version>0.23.0</simple-jndi.version>
   </properties>
   <dependencies>
     <dependency>
@@ -53,10 +54,10 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
-    <!-- `org.springframework:spring-test` is required for `org.springframework.mock.jndi.SimpleNamingContextBuilder`: -->
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
+      <groupId>com.github.h-thurow</groupId>
+      <artifactId>simple-jndi</artifactId>
+      <version>${simple-jndi.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/log4j-jndi-test/src/main/java/org/apache/logging/log4j/jndi/test/junit/JndiRule.java
+++ b/log4j-jndi-test/src/main/java/org/apache/logging/log4j/jndi/test/junit/JndiRule.java
@@ -118,7 +118,7 @@ public class JndiRule implements TestRule {
         });
     }
 
-    private void addBindings(Context context) throws NamingException {
+    private void addBindings(final Context context) throws NamingException {
         for (final Map.Entry<String, Object> entry : bindings.entrySet()) {
             final String name = entry.getKey();
             final Object object = entry.getValue();

--- a/log4j-jndi-test/src/main/java/org/apache/logging/log4j/jndi/test/junit/JndiRule.java
+++ b/log4j-jndi-test/src/main/java/org/apache/logging/log4j/jndi/test/junit/JndiRule.java
@@ -16,29 +16,66 @@
  */
 package org.apache.logging.log4j.jndi.test.junit;
 
+import static java.util.Objects.requireNonNull;
+import static org.junit.Assert.assertNotNull;
+
 import java.util.Collections;
+import java.util.Hashtable;
 import java.util.Map;
+import java.util.Set;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
 import javax.naming.Context;
+import javax.naming.NameClassPair;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactoryBuilder;
+import javax.naming.spi.NamingManager;
+import org.apache.logging.log4j.jndi.JndiManager;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.springframework.mock.jndi.SimpleNamingContextBuilder;
+import org.osjava.sj.jndi.MemoryContext;
 
 /**
  * JUnit rule to create a mock {@link Context} and bind an object to a name.
  *
  * @since 2.8
  */
+@SuppressWarnings("BanJNDI")
 public class JndiRule implements TestRule {
 
-    private final Map<String, Object> initialBindings;
-
-    public JndiRule(final String name, final Object value) {
-        this.initialBindings = Collections.singletonMap(name, value);
+    static {
+        final InitialContextFactoryBuilder factoryBuilder =
+                factoryBuilderEnv -> factoryEnv -> new MemoryContext(new Hashtable<>()) {};
+        try {
+            NamingManager.setInitialContextFactoryBuilder(factoryBuilder);
+        } catch (final NamingException error) {
+            throw new RuntimeException(error);
+        }
     }
 
-    public JndiRule(final Map<String, Object> initialBindings) {
-        this.initialBindings = initialBindings;
+    @Nullable
+    private final String managerName;
+
+    private final Map<String, Object> bindings;
+
+    public JndiRule(final String name, final Object value) {
+        this(null, Collections.singletonMap(name, value));
+    }
+
+    public JndiRule(@Nullable final String managerName, final String name, final Object value) {
+        this(managerName, Collections.singletonMap(name, value));
+    }
+
+    public JndiRule(final Map<String, Object> bindings) {
+        this(null, bindings);
+    }
+
+    public JndiRule(@Nullable final String managerName, final Map<String, Object> bindings) {
+        this.managerName = managerName;
+        this.bindings = requireNonNull(bindings, "bindings");
     }
 
     @Override
@@ -46,12 +83,46 @@ public class JndiRule implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                final SimpleNamingContextBuilder builder = SimpleNamingContextBuilder.emptyActivatedContextBuilder();
-                for (final Map.Entry<String, Object> entry : initialBindings.entrySet()) {
-                    builder.bind(entry.getKey(), entry.getValue());
-                }
+                resetJndiManager();
                 base.evaluate();
             }
         };
+    }
+
+    private void resetJndiManager() throws NamingException {
+        if (JndiManager.isJndiEnabled()) {
+            final Context context = getContext();
+            clearBindings(context);
+            addBindings(context);
+        }
+    }
+
+    private Context getContext() {
+        final JndiManager manager =
+                managerName == null ? JndiManager.getDefaultManager() : JndiManager.getDefaultManager(managerName);
+        @Nullable final Context context = manager.getContext();
+        assertNotNull(context);
+        return context;
+    }
+
+    private static void clearBindings(final Context context) throws NamingException {
+        final Set<NameClassPair> existingBindings = StreamSupport.stream(
+                        Spliterators.spliteratorUnknownSize(context.list("").asIterator(), 0), false)
+                .collect(Collectors.toSet());
+        existingBindings.forEach(binding -> {
+            try {
+                context.unbind(binding.getName());
+            } catch (NamingException error) {
+                throw new RuntimeException(error);
+            }
+        });
+    }
+
+    private void addBindings(Context context) throws NamingException {
+        for (final Map.Entry<String, Object> entry : bindings.entrySet()) {
+            final String name = entry.getKey();
+            final Object object = entry.getValue();
+            context.bind(name, object);
+        }
     }
 }

--- a/log4j-jndi-test/src/test/java/org/apache/logging/log4j/jndi/appender/routing/RoutingAppenderWithJndiTest.java
+++ b/log4j-jndi-test/src/test/java/org/apache/logging/log4j/jndi/appender/routing/RoutingAppenderWithJndiTest.java
@@ -21,11 +21,11 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.util.Collections;
 import javax.naming.Context;
-import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import org.apache.logging.log4j.EventLogger;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.jndi.JndiManager;
 import org.apache.logging.log4j.jndi.test.junit.JndiRule;
 import org.apache.logging.log4j.message.StructuredDataMessage;
 import org.junit.After;
@@ -77,7 +77,8 @@ public class RoutingAppenderWithJndiTest {
         assertTrue("The default log file was not created", defaultLogFile.exists());
 
         // now set jndi resource to Application1
-        final Context context = new InitialContext();
+        final Context context = JndiManager.getDefaultManager().getContext();
+        assertNotNull(context);
         context.bind(JNDI_CONTEXT_NAME, "Application1");
 
         msg = new StructuredDataMessage("Test", "This is a message from Application1", "Context");

--- a/log4j-jndi/src/main/java/org/apache/logging/log4j/jndi/JndiManager.java
+++ b/log4j-jndi/src/main/java/org/apache/logging/log4j/jndi/JndiManager.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -192,6 +193,14 @@ public class JndiManager extends AbstractManager {
     @Override
     protected boolean releaseSub(final long timeout, final TimeUnit timeUnit) {
         return JndiCloser.closeSilently(this.context);
+    }
+
+    /**
+     * @return the active context
+     */
+    @Nullable
+    public Context getContext() {
+        return context;
     }
 
     /**

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -152,8 +152,6 @@
     <slf4j.version>2.0.9</slf4j.version>
     <!-- Last version before a breaking change -->
     <slf4j-ext.version>1.7.25</slf4j-ext.version>
-    <spring-boot.version>2.7.18</spring-boot.version>
-    <spring-framework.version>5.3.31</spring-framework.version>
     <system-stubs.version>2.1.5</system-stubs.version>
     <tomcat-juli.version>10.1.16</tomcat-juli.version>
     <velocity.version>1.7</velocity.version>
@@ -818,30 +816,6 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-ext</artifactId>
         <version>${slf4j-ext.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot</artifactId>
-        <version>${spring-boot.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-test</artifactId>
-        <version>${spring-boot.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-test</artifactId>
-        <version>${spring-framework.version}</version>
       </dependency>
 
       <dependency>

--- a/log4j-spring-cloud-config-client/pom.xml
+++ b/log4j-spring-cloud-config-client/pom.xml
@@ -45,6 +45,7 @@
     <Fragment-Host>org.apache.logging.log4j.core</Fragment-Host>
 
     <!-- dependency versions -->
+    <spring-boot.version>3.2.0</spring-boot.version>
     <spring-cloud.version>2021.0.8</spring-cloud.version>
 
   </properties>
@@ -66,6 +67,18 @@
         <version>${spring-cloud.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-test</artifactId>
+        <version>${spring-boot.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
     </dependencies>

--- a/log4j-spring-cloud-config-client/pom.xml
+++ b/log4j-spring-cloud-config-client/pom.xml
@@ -46,7 +46,7 @@
 
     <!-- dependency versions -->
     <spring-boot.version>3.2.0</spring-boot.version>
-    <spring-cloud.version>2021.0.8</spring-cloud.version>
+    <spring-cloud.version>2022.0.4</spring-cloud.version>
 
   </properties>
 
@@ -88,27 +88,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-spring-boot</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.cloud</groupId>
-      <artifactId>spring-cloud-bus</artifactId>
     </dependency>
 
     <dependency>
@@ -128,18 +108,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
@@ -148,6 +116,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-log4j2</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/log4j-spring-cloud-config-client/src/test/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2EventListenerTest.java
+++ b/log4j-spring-cloud-config-client/src/test/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2EventListenerTest.java
@@ -27,7 +27,6 @@ import org.apache.logging.log4j.core.config.Reconfigurable;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.core.util.Source;
 import org.apache.logging.log4j.core.util.Watcher;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -41,8 +40,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 /**
  * Class Description goes here.
  */
-@Ignore(
-        "Fails with `java.lang.NoClassDefFoundError: org/apache/logging/log4j/internal/LogManagerStatus` since `log4j-spring-boot` of `2.x` is injected due to Spring Boot 2 BOM import. Spring Boot must be updated from version 2 to 3. (#2018)")
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {SpringConfiguration.class})
 public class Log4j2EventListenerTest {


### PR DESCRIPTION
This PR addresses ports `log4j-spring-cloud-config-client` changes from `2.x` (#2018) and upgrades to Spring Boot 3.