### PR TITLE
Mark `JdkMapAdapterStringMap` as frozen if map is immutable

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMapTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMapTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.core.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -24,11 +25,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.util.BiConsumer;
 import org.apache.logging.log4j.util.TriConsumer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests the JdkMapAdapterStringMap class.
@@ -811,5 +817,19 @@ public class JdkMapAdapterStringMapTest {
         state.data = original;
         original.forEach(COUNTER, state);
         assertEquals(state.count, original.size());
+    }
+
+    static Stream<Arguments> testImmutability() {
+        return Stream.of(
+                Arguments.of(new HashMap<>(), false),
+                Arguments.of(Map.of(), true),
+                Arguments.of(Collections.emptyMap(), true),
+                Arguments.of(Collections.unmodifiableMap(new HashMap<>()), true));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testImmutability(final Map<String, String> map, final boolean frozen) {
+        assertThat(new JdkMapAdapterStringMap(map).isFrozen()).as("Frozen").isEqualTo(frozen);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMap.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMap.java
@@ -52,6 +52,11 @@ public class JdkMapAdapterStringMap implements StringMap {
 
     public JdkMapAdapterStringMap(final Map<String, String> map) {
         this.map = Objects.requireNonNull(map, "map");
+        try {
+            map.replace(Strings.EMPTY, Strings.EMPTY, Strings.EMPTY);
+        } catch (final UnsupportedOperationException ignored) {
+            immutable = true;
+        }
     }
 
     @Override

--- a/src/changelog/.3.x.x/2098_JdkMapAdapterStringMap_detect_immutability.xml
+++ b/src/changelog/.3.x.x/2098_JdkMapAdapterStringMap_detect_immutability.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="fixed">
+  <issue id="2098" link="https://github.com/apache/logging-log4j2/issues/2098"/>
+  <description format="asciidoc">
+    Mark `JdkMapAdapterStringMap` as frozen if map is immutable.
+  </description>
+</entry>


### PR DESCRIPTION
This PR marks `StringMap`s generated from Java `Map`s as frozen if the wrapped map is immutable.

Fixes #2098

