### PR TITLE
Add support for LMAX Disruptor 4.x

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -81,9 +81,10 @@ updates:
     # Json Unit 3.x requires Java 17
     - dependency-name: "net.javacrumbs.json-unit:*"
       versions: ["[3.0.0,)"]
-    # LMAX Disruptor requires Java 11
+    # Update both `disruptor.version` to latest 3.x version
+    # and `disruptor4.version` to latest 4.x version
     - dependency-name: "com.lmax:disruptor"
-      versions: ["[4.0.0,)"]
+      update-types: ["version-update:semver-major"]
     # WebCompere System Stubs requires Java 11
     - dependency-name: "uk.org.webcompere:*"
       versions: ["2.1.0,)"]

--- a/log4j-api-java9/pom.xml
+++ b/log4j-api-java9/pom.xml
@@ -89,8 +89,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <executions>
+          <!-- Uses a different id than `default-test` to ignore the `java8-tests` profile -->
           <execution>
-            <id>test</id>
+            <id>run-tests</id>
             <goals>
               <goal>test</goal>
             </goals>
@@ -100,29 +101,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>java8-tests</id>
-      <activation>
-        <property>
-          <name>env.CI</name>
-          <value>true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration combine.self="override">
-              <reuseForks>false</reuseForks>
-              <systemPropertyVariables>
-                <java.awt.headless>true</java.awt.headless>
-              </systemPropertyVariables>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/log4j-core-test/pom.xml
+++ b/log4j-core-test/pom.xml
@@ -452,6 +452,20 @@
 
     </profile>
 
+    <!--
+      ~ Dummy profile to force Dependabot to upgrade `disruptor4.version`.
+      ~ Using this profile causes a compilation error.
+      -->
+    <profile>
+      <id>disruptor-4</id>
+      <dependencies>
+        <dependency>
+          <groupId>com.lmax</groupId>
+          <artifactId>disruptor</artifactId>
+          <version>${disruptor4.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
 </project>

--- a/log4j-core-test/pom.xml
+++ b/log4j-core-test/pom.xml
@@ -59,7 +59,11 @@
       java.allocation.instrumenter;substitute="java-allocation-instrumenter",
       spring.test;substitute="spring-test"
     </bnd-extra-module-options>
+
+    <!-- Additional version of LMAX Disruptor to test -->
+    <disruptor4.version>4.0.0</disruptor4.version>
   </properties>
+
   <dependencies>
     <!-- Pull in useful test classes from API -->
     <dependency>
@@ -369,6 +373,32 @@
             </path>
           </annotationProcessorPaths>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>test-disruptor-4</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <additionalClasspathDependencies>
+                <dependency>
+                  <groupId>com.lmax</groupId>
+                  <artifactId>disruptor</artifactId>
+                  <version>${disruptor4.version}</version>
+                </dependency>
+              </additionalClasspathDependencies>
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>com.lmax:disruptor</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+              <groups>org.apache.logging.log4j.core.test.categories.AsyncLoggers</groups>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
     </plugins>

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/Tags.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/Tags.java
@@ -14,23 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.logging.log4j.core.async;
-
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.test.junit.Tags;
-import org.apache.logging.log4j.test.junit.SetTestProperty;
-import org.junit.jupiter.api.Tag;
+package org.apache.logging.log4j.core.test.junit;
 
 /**
- * Tests queue full scenarios with AsyncLoggers in configuration.
+ * Container for a Junit 5 tags used in tests.
  */
-@SetTestProperty(key = "log4j2.formatMsgAsync", value = "true")
-@Tag(Tags.ASYNC_LOGGERS)
-public class QueueFullAsyncLoggerConfigTest2 extends QueueFullAsyncLoggerConfigTest {
+public final class Tags {
 
-    @Override
-    protected void checkConfig(final LoggerContext ctx) throws ReflectiveOperationException {
-        super.checkConfig(ctx);
-        assertFormatMessagesInBackground();
-    }
+    /**
+     * Tests that use LMAX Disruptor. Same name as the JUnit 4 category.
+     */
+    public static final String ASYNC_LOGGERS = "org.apache.logging.log4j.core.test.categories.AsyncLoggers";
+
+    private Tags() {}
 }

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/package-info.java
@@ -20,7 +20,7 @@
  * @see org.junit.rules.TestRule
  */
 @Export
-@Version("2.21.1")
+@Version("2.23.0")
 package org.apache.logging.log4j.core.test.junit;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerClassLoadDeadlock.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerClassLoadDeadlock.java
@@ -18,7 +18,10 @@ package org.apache.logging.log4j.core.async;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.test.junit.Tags;
+import org.junit.jupiter.api.Tag;
 
+@Tag(Tags.ASYNC_LOGGERS)
 class AsyncLoggerClassLoadDeadlock {
     static {
         final Logger log = LogManager.getLogger("com.foo.bar.deadlock");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest.java
@@ -39,13 +39,14 @@ import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.NullConfiguration;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.test.junit.TempLoggingDir;
 import org.apache.logging.log4j.test.junit.UsingStatusListener;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Tag("AsyncLoggers")
+@Tag(Tags.ASYNC_LOGGERS)
 @UsingStatusListener
 public class AsyncLoggerConfigTest {
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerThreadContextTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerThreadContextTest.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.test.TestProperties;
 import org.apache.logging.log4j.test.junit.TempLoggingDir;
@@ -35,7 +36,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Tag("AsyncLoggers")
+@Tag(Tags.ASYNC_LOGGERS)
 @UsingTestProperties
 @UsingStatusListener
 public class AsyncLoggerThreadContextTest {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggersWithAsyncAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggersWithAsyncAppenderTest.java
@@ -25,13 +25,14 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.test.junit.SetTestProperty;
 import org.apache.logging.log4j.test.junit.UsingStatusListener;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-@Tag("AsyncLoggers")
+@Tag(Tags.ASYNC_LOGGERS)
 @SetTestProperty(
         key = Constants.LOG4J_CONTEXT_SELECTOR,
         value = "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector")

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncThreadContextCopyOnWriteTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncThreadContextCopyOnWriteTest.java
@@ -17,13 +17,16 @@
 package org.apache.logging.log4j.core.async;
 
 import java.nio.file.Path;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.test.junit.TempLoggingDir;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 // Note: the different ThreadContextMap implementations cannot be parameterized:
 // ThreadContext initialization will result in static final fields being set in various components.
 // To use a different ThreadContextMap, the test needs to be run in a new JVM.
+@Tag(Tags.ASYNC_LOGGERS)
 public class AsyncThreadContextCopyOnWriteTest extends AbstractAsyncThreadContextTestBase {
 
     @TempLoggingDir

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncThreadContextDefaultTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncThreadContextDefaultTest.java
@@ -17,13 +17,16 @@
 package org.apache.logging.log4j.core.async;
 
 import java.nio.file.Path;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.test.junit.TempLoggingDir;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 // Note: the different ThreadContextMap implementations cannot be parameterized:
 // ThreadContext initialization will result in static final fields being set in various components.
 // To use a different ThreadContextMap, the test needs to be run in a new JVM.
+@Tag(Tags.ASYNC_LOGGERS)
 public class AsyncThreadContextDefaultTest extends AbstractAsyncThreadContextTestBase {
 
     @TempLoggingDir

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncThreadContextGarbageFreeTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncThreadContextGarbageFreeTest.java
@@ -17,13 +17,16 @@
 package org.apache.logging.log4j.core.async;
 
 import java.nio.file.Path;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.test.junit.TempLoggingDir;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 // Note: the different ThreadContextMap implementations cannot be parameterized:
 // ThreadContext initialization will result in static final fields being set in various components.
 // To use a different ThreadContextMap, the test needs to be run in a new JVM.
+@Tag(Tags.ASYNC_LOGGERS)
 public class AsyncThreadContextGarbageFreeTest extends AbstractAsyncThreadContextTestBase {
 
     @TempLoggingDir

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryIncorrectConfigGlobalLoggersTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryIncorrectConfigGlobalLoggersTest.java
@@ -17,7 +17,7 @@
 package org.apache.logging.log4j.core.async;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.logging.log4j.LogManager;
@@ -58,10 +58,14 @@ public class AsyncWaitStrategyFactoryIncorrectConfigGlobalLoggersTest {
 
         final AsyncLogger logger = (AsyncLogger) context.getRootLogger();
         final AsyncLoggerDisruptor delegate = logger.getAsyncLoggerDisruptor();
-        assertEquals(
-                TimeoutBlockingWaitStrategy.class, delegate.getWaitStrategy().getClass());
-        assertThat(
-                "waitstrategy is TimeoutBlockingWaitStrategy",
-                delegate.getWaitStrategy() instanceof TimeoutBlockingWaitStrategy);
+        if (DisruptorUtil.DISRUPTOR_MAJOR_VERSION == 3) {
+            assertEquals(
+                    TimeoutBlockingWaitStrategy.class,
+                    delegate.getWaitStrategy().getClass());
+        } else {
+            assertEquals(
+                    Class.forName("com.lmax.disruptor.TimeoutBlockingWaitStrategy"),
+                    delegate.getWaitStrategy().getClass());
+        }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest.java
@@ -21,8 +21,10 @@ import static org.assertj.core.api.Assertions.*;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.test.junit.SetTestProperty;
 import org.apache.logging.log4j.util.Constants;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -31,6 +33,7 @@ import org.junit.jupiter.api.Test;
 @SetTestProperty(key = "log4j2.enableThreadlocals", value = "true")
 @SetTestProperty(key = "log4j2.isWebapp", value = "false")
 @SetTestProperty(key = "log4j2.asyncLoggerConfigRingBufferSize", value = "128")
+@Tag(Tags.ASYNC_LOGGERS)
 public class QueueFullAsyncLoggerConfigLoggingFromToStringTest extends QueueFullAbstractTest {
 
     @Override

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest2.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigLoggingFromToStringTest2.java
@@ -17,12 +17,15 @@
 package org.apache.logging.log4j.core.async;
 
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.junit.jupiter.api.Tag;
 
 /**
  * Tests queue full scenarios with AsyncLoggers in configuration.
  */
 @SetTestProperty(key = "log4j2.formatMsgAsync", value = "true")
+@Tag(Tags.ASYNC_LOGGERS)
 public class QueueFullAsyncLoggerConfigLoggingFromToStringTest2
         extends QueueFullAsyncLoggerConfigLoggingFromToStringTest {
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerConfigTest.java
@@ -19,13 +19,16 @@ package org.apache.logging.log4j.core.async;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests queue full scenarios with AsyncLoggers in configuration.
  */
 @SetTestProperty(key = "log4j2.asyncLoggerConfigRingBufferSize", value = "128")
+@Tag(Tags.ASYNC_LOGGERS)
 public class QueueFullAsyncLoggerConfigTest extends QueueFullAbstractTest {
 
     @Override

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest.java
@@ -19,8 +19,10 @@ package org.apache.logging.log4j.core.async;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.Test;
         key = Constants.LOG4J_CONTEXT_SELECTOR,
         value = "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector")
 @SetTestProperty(key = "log4j2.asyncLoggerRingBufferSize", value = "128")
+@Tag(Tags.ASYNC_LOGGERS)
 public class QueueFullAsyncLoggerLoggingFromToStringTest extends QueueFullAbstractTest {
 
     @Override

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest2.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerLoggingFromToStringTest2.java
@@ -19,13 +19,16 @@ package org.apache.logging.log4j.core.async;
 import static org.junit.Assert.*;
 
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.test.junit.SetTestProperty;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 
 /**
  * Tests queue full scenarios with pure AsyncLoggers (all loggers async).
  */
 @SetTestProperty(key = "log4j2.formatMsgAsync", value = "true")
+@Tag(Tags.ASYNC_LOGGERS)
 public class QueueFullAsyncLoggerLoggingFromToStringTest2 extends QueueFullAsyncLoggerLoggingFromToStringTest {
 
     @Override

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest.java
@@ -19,8 +19,10 @@ package org.apache.logging.log4j.core.async;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,6 +32,7 @@ import org.junit.jupiter.api.Test;
         key = Constants.LOG4J_CONTEXT_SELECTOR,
         value = "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector")
 @SetTestProperty(key = "log4j2.asyncLoggerRingBufferSize", value = "128")
+@Tag(Tags.ASYNC_LOGGERS)
 public class QueueFullAsyncLoggerTest extends QueueFullAbstractTest {
 
     @Override

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest2.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest2.java
@@ -17,13 +17,16 @@
 package org.apache.logging.log4j.core.async;
 
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.junit.jupiter.api.Tag;
 
 /**
  * Needs to be a separate class since {@link org.apache.logging.log4j.core.util.Constants#FORMAT_MESSAGES_IN_BACKGROUND}
  * is immutable.
  */
 @SetTestProperty(key = "log4j2.formatMsgAsync", value = "true")
+@Tag(Tags.ASYNC_LOGGERS)
 public class QueueFullAsyncLoggerTest2 extends QueueFullAsyncLoggerTest {
 
     @Override

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest3.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLoggerTest3.java
@@ -26,9 +26,11 @@ import org.apache.logging.log4j.core.GarbageCollectionHelper;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
+import org.apache.logging.log4j.core.test.junit.Tags;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -41,6 +43,7 @@ import org.junit.jupiter.api.Timeout;
 @SetTestProperty(key = "log4j2.asyncLoggerRingBufferSize", value = "128")
 @SetTestProperty(key = "log4j2.formatMsgAsync", value = "true")
 @SetTestProperty(key = "log4j2.asyncQueueFullPolicy", value = "Discard")
+@Tag(Tags.ASYNC_LOGGERS)
 public class QueueFullAsyncLoggerTest3 extends QueueFullAbstractTest {
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigDisruptor.java
@@ -17,11 +17,11 @@
 package org.apache.logging.log4j.core.async;
 
 import com.lmax.disruptor.EventFactory;
+import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.EventTranslatorTwoArg;
 import com.lmax.disruptor.ExceptionHandler;
 import com.lmax.disruptor.RingBuffer;
 import com.lmax.disruptor.Sequence;
-import com.lmax.disruptor.SequenceReportingEventHandler;
 import com.lmax.disruptor.TimeoutException;
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.dsl.Disruptor;
@@ -92,7 +92,7 @@ public class AsyncLoggerConfigDisruptor extends AbstractLifeCycle implements Asy
     /**
      * EventHandler performs the work in a separate thread.
      */
-    private static class Log4jEventWrapperHandler implements SequenceReportingEventHandler<Log4jEventWrapper> {
+    private static class Log4jEventWrapperHandler implements EventHandler<Log4jEventWrapper> {
         private static final int NOTIFY_PROGRESS_THRESHOLD = 50;
         private Sequence sequenceCallback;
         private int counter;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigDisruptor.java
@@ -93,6 +93,9 @@ public class AsyncLoggerConfigDisruptor extends AbstractLifeCycle implements Asy
 
     /**
      * EventHandler performs the work in a separate thread.
+     * <p>
+     *     <strong>Warning:</strong> this implementation only works with Disruptor 4.x.
+     * </p>
      */
     private static class Log4jEventWrapperHandler implements EventHandler<Log4jEventWrapper> {
         private static final int NOTIFY_PROGRESS_THRESHOLD = 50;
@@ -129,7 +132,10 @@ public class AsyncLoggerConfigDisruptor extends AbstractLifeCycle implements Asy
     }
 
     /**
-     * A version of Log4jEventWrapperHandler for LMAX Disruptor 3.x.
+     * EventHandler performs the work in a separate thread.
+     * <p>
+     *     <strong>Warning:</strong> this implementation only works with Disruptor 3.x.
+     * </p>
      */
     private static final class Log4jEventWrapperHandler3 extends Log4jEventWrapperHandler
             implements SequenceReportingEventHandler<Log4jEventWrapper> {}
@@ -166,11 +172,13 @@ public class AsyncLoggerConfigDisruptor extends AbstractLifeCycle implements Asy
             };
 
     private Log4jEventWrapperHandler createEventHandler() {
-        try {
-            return LoaderUtil.newInstanceOf(
-                    "org.apache.logging.log4j.core.async.AsyncLoggerConfigDisruptor$Log4jEventWrapperHandler3");
-        } catch (final ReflectiveOperationException | LinkageError e) {
-            LOGGER.debug("LMAX Disruptor 3.x is missing, trying version 4.x.", e);
+        if (DisruptorUtil.DISRUPTOR_MAJOR_VERSION == 3) {
+            try {
+                return LoaderUtil.newInstanceOf(
+                        "org.apache.logging.log4j.core.async.AsyncLoggerConfigDisruptor$Log4jEventWrapperHandler3");
+            } catch (final ReflectiveOperationException | LinkageError e) {
+                LOGGER.warn("Failed to create event handler for LMAX Disruptor 3.x, trying version 4.x.", e);
+            }
         }
         return new Log4jEventWrapperHandler();
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
@@ -122,7 +122,7 @@ class AsyncLoggerDisruptor extends AbstractLifeCycle {
         final ExceptionHandler<RingBufferLogEvent> errorHandler = DisruptorUtil.getAsyncLoggerExceptionHandler();
         disruptor.setDefaultExceptionHandler(errorHandler);
 
-        final RingBufferLogEventHandler[] handlers = {new RingBufferLogEventHandler()};
+        final RingBufferLogEventHandler4[] handlers = {RingBufferLogEventHandler4.create()};
         disruptor.handleEventsWith(handlers);
 
         LOGGER.debug(

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DefaultAsyncWaitStrategyFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DefaultAsyncWaitStrategyFactory.java
@@ -74,17 +74,17 @@ class DefaultAsyncWaitStrategyFactory implements AsyncWaitStrategyFactory {
         LOGGER.trace(
                 "DefaultAsyncWaitStrategyFactory creating TimeoutBlockingWaitStrategy(timeout={}, unit=MILLIS)",
                 timeoutMillis);
-        try {
-            // Check for the v 4.x version of the strategy, the version in 3.x is not garbage-free.
-            if (DisruptorUtil.DISRUPTOR_MAJOR_VERSION == 4) {
+        // Check for the v 4.x version of the strategy, the version in 3.x is not garbage-free.
+        if (DisruptorUtil.DISRUPTOR_MAJOR_VERSION == 4) {
+            try {
                 return (WaitStrategy) Class.forName("com.lmax.disruptor.TimeoutBlockingWaitStrategy")
                         .getConstructor(long.class, TimeUnit.class)
                         .newInstance(timeoutMillis, TimeUnit.MILLISECONDS);
+            } catch (final ReflectiveOperationException | LinkageError e) {
+                LOGGER.debug(
+                        "DefaultAsyncWaitStrategyFactory failed to load 'com.lmax.disruptor.TimeoutBlockingWaitStrategy', using '{}' instead.",
+                        TimeoutBlockingWaitStrategy.class.getName());
             }
-        } catch (final ReflectiveOperationException | LinkageError e) {
-            LOGGER.debug(
-                    "DefaultAsyncWaitStrategyFactory failed to load 'com.lmax.disruptor.TimeoutBlockingWaitStrategy', using '{}' instead.",
-                    TimeoutBlockingWaitStrategy.class.getName());
         }
         // Use our version
         return new TimeoutBlockingWaitStrategy(timeoutMillis, TimeUnit.MILLISECONDS);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DefaultAsyncWaitStrategyFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DefaultAsyncWaitStrategyFactory.java
@@ -74,6 +74,19 @@ class DefaultAsyncWaitStrategyFactory implements AsyncWaitStrategyFactory {
         LOGGER.trace(
                 "DefaultAsyncWaitStrategyFactory creating TimeoutBlockingWaitStrategy(timeout={}, unit=MILLIS)",
                 timeoutMillis);
+        try {
+            // Check for the v 4.x version of the strategy, the version in 3.x is not garbage-free.
+            if (DisruptorUtil.DISRUPTOR_MAJOR_VERSION == 4) {
+                return (WaitStrategy) Class.forName("com.lmax.disruptor.TimeoutBlockingWaitStrategy")
+                        .getConstructor(long.class, TimeUnit.class)
+                        .newInstance(timeoutMillis, TimeUnit.MILLISECONDS);
+            }
+        } catch (final ReflectiveOperationException | LinkageError e) {
+            LOGGER.debug(
+                    "DefaultAsyncWaitStrategyFactory failed to load 'com.lmax.disruptor.TimeoutBlockingWaitStrategy', using '{}' instead.",
+                    TimeoutBlockingWaitStrategy.class.getName());
+        }
+        // Use our version
         return new TimeoutBlockingWaitStrategy(timeoutMillis, TimeUnit.MILLISECONDS);
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
@@ -50,6 +50,9 @@ final class DisruptorUtil {
     static final boolean ASYNC_CONFIG_SYNCHRONIZE_ENQUEUE_WHEN_QUEUE_FULL = PropertiesUtil.getProperties()
             .getBooleanProperty("AsyncLoggerConfig.SynchronizeEnqueueWhenQueueFull", true);
 
+    static final int DISRUPTOR_MAJOR_VERSION =
+            LoaderUtil.isClassAvailable("com.lmax.disruptor.SequenceReportingEventHandler") ? 3 : 4;
+
     private DisruptorUtil() {}
 
     static WaitStrategy createWaitStrategy(

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler.java
@@ -16,9 +16,8 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import com.lmax.disruptor.LifecycleAware;
+import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.Sequence;
-import com.lmax.disruptor.SequenceReportingEventHandler;
 
 /**
  * This event handler gets passed messages from the RingBuffer as they become
@@ -26,7 +25,7 @@ import com.lmax.disruptor.SequenceReportingEventHandler;
  * controlled by the {@code Executor} passed to the {@code Disruptor}
  * constructor.
  */
-public class RingBufferLogEventHandler implements SequenceReportingEventHandler<RingBufferLogEvent>, LifecycleAware {
+public class RingBufferLogEventHandler implements EventHandler<RingBufferLogEvent> {
 
     private static final int NOTIFY_PROGRESS_THRESHOLD = 50;
     private Sequence sequenceCallback;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler.java
@@ -24,13 +24,11 @@ import com.lmax.disruptor.SequenceReportingEventHandler;
  * available. Processing of these messages is done in a separate thread,
  * controlled by the {@code Executor} passed to the {@code Disruptor}
  * constructor.
+ * <p>
+ *     <strong>Warning:</strong> this class only works with Disruptor 3.x.
+ * </p>
+ * @deprecated Only used internally, will be removed in the next major version.
  */
+@Deprecated
 public class RingBufferLogEventHandler extends RingBufferLogEventHandler4
-        implements SequenceReportingEventHandler<RingBufferLogEvent>, LifecycleAware {
-
-    /**
-     * @deprecated Use the {@link RingBufferLogEventHandler4#create()} factory method instead.
-     */
-    @Deprecated
-    public RingBufferLogEventHandler() {}
-}
+        implements SequenceReportingEventHandler<RingBufferLogEvent>, LifecycleAware {}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler4.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler4.java
@@ -18,14 +18,15 @@ package org.apache.logging.log4j.core.async;
 
 import com.lmax.disruptor.EventHandler;
 import com.lmax.disruptor.Sequence;
-import org.apache.logging.log4j.status.StatusLogger;
-import org.apache.logging.log4j.util.LoaderUtil;
 
 /**
  * This event handler gets passed messages from the RingBuffer as they become
  * available. Processing of these messages is done in a separate thread,
  * controlled by the {@code Executor} passed to the {@code Disruptor}
  * constructor.
+ *  * <p>
+ *  *     <strong>Warning:</strong> this class only works with Disruptor 4.x.
+ *  * </p>
  */
 class RingBufferLogEventHandler4 implements EventHandler<RingBufferLogEvent> {
 
@@ -33,18 +34,6 @@ class RingBufferLogEventHandler4 implements EventHandler<RingBufferLogEvent> {
     private Sequence sequenceCallback;
     private int counter;
     private long threadId = -1;
-
-    /**
-     * Returns the appropriate {@link EventHandler} for the version of LMAX Disruptor used.
-     */
-    public static RingBufferLogEventHandler4 create() {
-        try {
-            return LoaderUtil.newInstanceOf("org.apache.logging.log4j.core.async.RingBufferLogEventHandler");
-        } catch (final ReflectiveOperationException | LinkageError e) {
-            StatusLogger.getLogger().debug("LMAX Disruptor 3.x is missing, trying version 4.x.", e);
-        }
-        return new RingBufferLogEventHandler4();
-    }
 
     /*
      * Overrides a method from Disruptor 4.x. Do not remove.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler4.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler4.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.async;
+
+import com.lmax.disruptor.EventHandler;
+import com.lmax.disruptor.Sequence;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.LoaderUtil;
+
+/**
+ * This event handler gets passed messages from the RingBuffer as they become
+ * available. Processing of these messages is done in a separate thread,
+ * controlled by the {@code Executor} passed to the {@code Disruptor}
+ * constructor.
+ */
+class RingBufferLogEventHandler4 implements EventHandler<RingBufferLogEvent> {
+
+    private static final int NOTIFY_PROGRESS_THRESHOLD = 50;
+    private Sequence sequenceCallback;
+    private int counter;
+    private long threadId = -1;
+
+    /**
+     * Returns the appropriate {@link EventHandler} for the version of LMAX Disruptor used.
+     */
+    public static RingBufferLogEventHandler4 create() {
+        try {
+            return LoaderUtil.newInstanceOf("org.apache.logging.log4j.core.async.RingBufferLogEventHandler");
+        } catch (final ReflectiveOperationException | LinkageError e) {
+            StatusLogger.getLogger().debug("LMAX Disruptor 3.x is missing, trying version 4.x.", e);
+        }
+        return new RingBufferLogEventHandler4();
+    }
+
+    /*
+     * Overrides a method from Disruptor 4.x. Do not remove.
+     */
+    public void setSequenceCallback(final Sequence sequenceCallback) {
+        this.sequenceCallback = sequenceCallback;
+    }
+
+    @Override
+    public void onEvent(final RingBufferLogEvent event, final long sequence, final boolean endOfBatch)
+            throws Exception {
+        try {
+            // RingBufferLogEvents are populated by an EventTranslator. If an exception is thrown during event
+            // translation, the event may not be fully populated, but Disruptor requires that the associated sequence
+            // still be published since a slot has already been claimed in the ring buffer. Ignore any such unpopulated
+            // events. The exception that occurred during translation will have already been propagated.
+            if (event.isPopulated()) {
+                event.execute(endOfBatch);
+            }
+        } finally {
+            event.clear();
+            // notify the BatchEventProcessor that the sequence has progressed.
+            // Without this callback the sequence would not be progressed
+            // until the batch has completely finished.
+            notifyCallback(sequence);
+        }
+    }
+
+    private void notifyCallback(final long sequence) {
+        if (++counter > NOTIFY_PROGRESS_THRESHOLD) {
+            sequenceCallback.set(sequence);
+            counter = 0;
+        }
+    }
+
+    /**
+     * Returns the thread ID of the background consumer thread, or {@code -1} if the background thread has not started
+     * yet.
+     *
+     * @return the thread ID of the background consumer thread, or {@code -1}
+     */
+    public long getThreadId() {
+        return threadId;
+    }
+
+    /*
+     * Overrides a method from Disruptor 4.x. Do not remove.
+     */
+    public void onStart() {
+        threadId = Thread.currentThread().getId();
+    }
+
+    /*
+     * Overrides a method from Disruptor 4.x. Do not remove.
+     */
+    public void onShutdown() {}
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/package-info.java
@@ -18,7 +18,7 @@
  * Provides Asynchronous Logger classes and interfaces for low-latency logging.
  */
 @Export
-@Version("2.21.0")
+@Version("2.23.0")
 package org.apache.logging.log4j.core.async;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-jpl/pom.xml
+++ b/log4j-jpl/pom.xml
@@ -65,30 +65,26 @@
     </dependency>
   </dependencies>
 
-  <profiles>
-    <profile>
-      <id>java8-tests</id>
-      <activation>
-        <property>
-          <name>env.CI</name>
-          <value>true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration combine.self="override">
-              <reuseForks>false</reuseForks>
-              <systemPropertyVariables>
-                <java.awt.headless>true</java.awt.headless>
-              </systemPropertyVariables>
-              <useModulePath>false</useModulePath>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <!-- Uses a different id than `default-test` to ignore the `java8-tests` profile -->
+          <execution>
+            <id>run-tests</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-test</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -79,7 +79,7 @@
     <commons-logging.version>1.3.0</commons-logging.version>
     <!-- `com.conversantmedia:disruptor` version 1.2.16 requires Java 9: -->
     <conversant.disruptor.version>1.2.15</conversant.disruptor.version>
-    <disruptor.version>4.0.0</disruptor.version>
+    <disruptor.version>3.4.4</disruptor.version>
     <elasticsearch-java.version>8.11.2</elasticsearch-java.version>
     <embedded-ldap.version>0.9.0</embedded-ldap.version>
     <felix.version>7.0.5</felix.version>

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -79,7 +79,7 @@
     <commons-logging.version>1.3.0</commons-logging.version>
     <!-- `com.conversantmedia:disruptor` version 1.2.16 requires Java 9: -->
     <conversant.disruptor.version>1.2.15</conversant.disruptor.version>
-    <disruptor.version>3.4.4</disruptor.version>
+    <disruptor.version>4.0.0</disruptor.version>
     <elasticsearch-java.version>8.11.2</elasticsearch-java.version>
     <embedded-ldap.version>0.9.0</embedded-ldap.version>
     <felix.version>7.0.5</felix.version>

--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
   <properties>
 
     <!-- project version -->
-    <revision>2.22.2-SNAPSHOT</revision>
+    <revision>2.23.0-SNAPSHOT</revision>
 
     <!-- =================
          Common properties

--- a/pom.xml
+++ b/pom.xml
@@ -825,11 +825,17 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <jdkToolchain>
-                <version>[1.8, 9)</version>
-              </jdkToolchain>
-            </configuration>
+            <executions>
+              <!-- Modifies only the `default-test` run -->
+              <execution>
+                <id>default-test</id>
+                <configuration>
+                  <jdkToolchain>
+                    <version>[1.8, 9)</version>
+                  </jdkToolchain>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/src/changelog/.2.x.x/add_support_for_disruptor_4.xml
+++ b/src/changelog/.2.x.x/add_support_for_disruptor_4.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="added">
+  <issue id="1821" link="https://github.com/apache/logging-log4j2/issues/1821"/>
+  <description format="asciidoc">
+    Added support for LMAX Disruptor 4.x.
+  </description>
+</entry>

--- a/src/changelog/.2.x.x/deprecate_ring_buffer_log_event_handler.xml
+++ b/src/changelog/.2.x.x/deprecate_ring_buffer_log_event_handler.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="deprecated">
+  <description format="asciidoc">
+    Deprecated the `RingBufferLogEventHandler` class for removal from the public API in 3.x.
+  </description>
+</entry>


### PR DESCRIPTION
This PR is based on #1937 and adds support for LMAX Disruptor 4.x by:

- splitting our `EventHandler` classes into two versions: one for 3.x and 4.x,
- using the original `TimeoutBlockingWaitStrategy`,
- adding an additional Maven Surefire run to test our async logger implementation with Disruptor 4.x.

Closes #1829 
