### PR TITLE
Workaround Coursier/Ivy dependency resolution bug

### DIFF
--- a/log4j-mongodb3/pom.xml
+++ b/log4j-mongodb3/pom.xml
@@ -42,6 +42,33 @@
     <mongodb.version>3.12.11</mongodb.version>
   </properties>
 
+  <!-- Use explicit versions as a temporary workaround to a Coursier/Ivy bug:
+    https://github.com/apache/logging-log4j2/issues/2065 -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>bson</artifactId>
+        <version>${mongodb.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>mongodb-driver-core</artifactId>
+        <version>${mongodb.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>mongodb-driver-legacy</artifactId>
+        <version>${mongodb.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>mongodb-driver-sync</artifactId>
+        <version>${mongodb.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/log4j-slf4j-impl/pom.xml
+++ b/log4j-slf4j-impl/pom.xml
@@ -28,9 +28,10 @@
   <name>Apache Log4j SLF4J Binding</name>
   <description>The Apache Log4j SLF4J API binding to Log4j 2 Core</description>
   <properties>
+    <slf4j.version>1.7.36</slf4j.version>
     <!-- Do not upgrade the SLF4J version. 1.7.26 broke backward compatibility. Users can update the version if
       they do not require support for SLF4J's EventData -->
-    <slf4j.version>1.7.25</slf4j.version>
+    <slf4j-ext.version>1.7.25</slf4j-ext.version>
 
     <!--
       ~ OSGi and JPMS options
@@ -46,6 +47,25 @@
       org.slf4j;substitute="slf4j-api"
     </bnd-extra-module-options>
   </properties>
+
+  <!-- Use explicit versions as a temporary workaround to a Coursier/Ivy bug:
+    https://github.com/apache/logging-log4j2/issues/2065 -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-ext</artifactId>
+        <version>${slf4j-ext.version}</version>
+        <optional>true</optional>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.osgi</groupId>

--- a/src/changelog/.2.x.x/workaround_coursier_bug.xml
+++ b/src/changelog/.2.x.x/workaround_coursier_bug.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="fixed">
+  <issue id="2065" link="https://github.com/apache/logging-log4j2/pull/2065"/>
+  <description format="asciidoc">
+    Workaround a Coursier/Ivy dependency resolution bug affecting `log4j-slf4j-impl` and `log4j-mongodb3`.
+  </description>
+</entry>


### PR DESCRIPTION
Workaround a Coursier/Ivy dependency resolution bug that affects `log4j-slf4j-impl` and `log4j-mongodb3`.

This bug also affects popular sites like MvnRepository (cf. [`log4j-mongodb3:2.22.0`](https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-mongodb3/2.22.0)).

Closes #2065
