### PR TITLE
Fix NPE in `RollingFileManger`

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
@@ -356,7 +356,11 @@ public class RollingFileManager extends FileManager {
     @Override
     protected void createParentDir(File file) {
         if (directWrite) {
-            file.getParentFile().mkdirs();
+            final File parent = file.getParentFile();
+            // If the parent is null the file is in the current working directory.
+            if (parent != null) {
+                parent.mkdirs();
+            }
         }
     }
 

--- a/src/changelog/.2.x.x/fix_create_parent_dir.xml
+++ b/src/changelog/.2.x.x/fix_create_parent_dir.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="fixed">
+  <issue id="1645" link="https://github.com/apache/logging-log4j2/pull/1645"/>
+  <description format="asciidoc">
+    Fix NPE in `RollingFileManager`.
+  </description>
+</entry>


### PR DESCRIPTION
This PR fixes a `NullPointerException` in
`RollingFileManager#createParentDir`.

Closes #1645
