### PR TITLE
Fix NPE caused by MDCContextMap

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
@@ -356,7 +356,11 @@ public class RollingFileManager extends FileManager {
     @Override
     protected void createParentDir(File file) {
         if (directWrite) {
-            file.getParentFile().mkdirs();
+            final File parent = file.getParentFile();
+            // If the parent is null the file is in the current working directory.
+            if (parent != null) {
+                parent.mkdirs();
+            }
         }
     }
 

--- a/log4j-to-slf4j/pom.xml
+++ b/log4j-to-slf4j/pom.xml
@@ -103,6 +103,11 @@
       <artifactId>log4j-api-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/MDCContextMap.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/MDCContextMap.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.slf4j;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.apache.logging.log4j.spi.CleanableThreadContextMap;
@@ -75,13 +76,12 @@ public class MDCContextMap implements CleanableThreadContextMap {
     }
 
     @Override
-    @SuppressWarnings("unchecked") // nothing we can do about this, restricted by SLF4J API
     public Map<String, String> getCopy() {
-        return MDC.getCopyOfContextMap();
+        final Map<String, String> contextMap = MDC.getCopyOfContextMap();
+        return contextMap != null ? contextMap : new HashMap<>();
     }
 
     @Override
-    @SuppressWarnings("unchecked") // nothing we can do about this, restricted by SLF4J API
     public Map<String, String> getImmutableMapOrNull() {
         return MDC.getCopyOfContextMap();
     }

--- a/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/MDCContextMapTest.java
+++ b/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/MDCContextMapTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.slf4j;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.apache.logging.log4j.spi.ThreadContextMap;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.Issue;
+import org.slf4j.MDCTestHelper;
+import org.slf4j.spi.MDCAdapter;
+
+class MDCContextMapTest {
+
+    @Test
+    @Issue("https://github.com/apache/logging-log4j2/issues/1426")
+    void nonNullGetCopy() {
+        final ThreadContextMap contextMap = new MDCContextMap();
+        final MDCAdapter mockAdapter = mock(MDCAdapter.class);
+        when(mockAdapter.getCopyOfContextMap()).thenReturn(null);
+        final MDCAdapter adapter = MDCTestHelper.replaceMDCAdapter(mockAdapter);
+        try {
+            assertThat(contextMap.getImmutableMapOrNull()).isNull();
+            assertThat(contextMap.getCopy()).isNotNull();
+            verify(mockAdapter, times(2)).getCopyOfContextMap();
+            verifyNoMoreInteractions(mockAdapter);
+        } finally {
+            MDCTestHelper.replaceMDCAdapter(adapter);
+        }
+    }
+}

--- a/log4j-to-slf4j/src/test/java/org/slf4j/MDCTestHelper.java
+++ b/log4j-to-slf4j/src/test/java/org/slf4j/MDCTestHelper.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.slf4j;
+
+import org.slf4j.spi.MDCAdapter;
+
+public class MDCTestHelper {
+
+    public static MDCAdapter replaceMDCAdapter(final MDCAdapter adapter) {
+        final MDCAdapter old = MDC.mdcAdapter;
+        MDC.mdcAdapter = adapter;
+        return old;
+    }
+}

--- a/src/changelog/.2.x.x/fix_NPE_in_closeable_thread_context.xml
+++ b/src/changelog/.2.x.x/fix_NPE_in_closeable_thread_context.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="fixed">
+  <issue id="1426" link="https://github.com/apache/logging-log4j2/pull/1426"/>
+  <description format="asciidoc">
+    Fix NPE in `CloseableThreadContext`.
+  </description>
+</entry>

--- a/src/changelog/.2.x.x/fix_create_parent_dir.xml
+++ b/src/changelog/.2.x.x/fix_create_parent_dir.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="fixed">
+  <issue id="1645" link="https://github.com/apache/logging-log4j2/pull/1645"/>
+  <description format="asciidoc">
+    Fix NPE in `RollingFileManager`.
+  </description>
+</entry>


### PR DESCRIPTION
Fixes an NPE caused by `MDCContextMap`: the [`MDC#getCopyOfContextMap`](https://www.slf4j.org/api/org/slf4j/MDC.html#getCopyOfContextMap--) method can return `null`, but [`ThreadContextMap#getCopy`](https://logging.apache.org/log4j/2.x/javadoc/log4j-api/org/apache/logging/log4j/spi/ThreadContextMap.html) can not return `null`.

Closes #1426 