### PR TITLE
Fix use of AccessController in LoaderUtil

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/LoaderUtilSecurityManagerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/LoaderUtilSecurityManagerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.security.Permission;
+import org.apache.logging.log4j.test.junit.SecurityManagerTestRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+@ResourceLock("java.lang.SecurityManager")
+public class LoaderUtilSecurityManagerTest {
+    @Rule
+    public final SecurityManagerTestRule rule = new SecurityManagerTestRule(new TestSecurityManager());
+
+    private static class TestSecurityManager extends SecurityManager {
+        @Override
+        public void checkPermission(final Permission perm) {
+            if (perm.equals(LoaderUtil.GET_CLASS_LOADER)) {
+                throw new SecurityException("disabled");
+            }
+        }
+    }
+
+    @Test
+    public void canGetClassLoaderThroughPrivileges() {
+        assertFalse(LoaderUtil.GET_CLASS_LOADER_DISABLED);
+        assertDoesNotThrow(() -> LoaderUtil.getClassLoader(LoaderUtilSecurityManagerTest.class, String.class));
+    }
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
@@ -50,36 +50,31 @@ public final class LoaderUtil {
     // wants to use PropertiesUtil, but then PropertiesUtil wants to use LoaderUtil.
     private static Boolean ignoreTCCL;
 
-    private static final RuntimePermission GET_CLASS_LOADER = new RuntimePermission("getClassLoader");
-    private static final boolean GET_CLASS_LOADER_DISABLED;
+    static final RuntimePermission GET_CLASS_LOADER = new RuntimePermission("getClassLoader");
+    static final LazyBoolean GET_CLASS_LOADER_DISABLED = new LazyBoolean(() -> {
+        if (System.getSecurityManager() == null) {
+            return false;
+        }
+        try {
+            AccessController.checkPermission(GET_CLASS_LOADER);
+            // seems like we'll be ok
+            return false;
+        } catch (final SecurityException ignored) {
+            try {
+                // let's see if we can obtain that permission
+                AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                    AccessController.checkPermission(GET_CLASS_LOADER);
+                    return null;
+                });
+                return false;
+            } catch (final SecurityException ignore) {
+                // no chance
+                return true;
+            }
+        }
+    });
 
     private static final PrivilegedAction<ClassLoader> TCCL_GETTER = new ThreadContextClassLoaderGetter();
-
-    static {
-        if (System.getSecurityManager() != null) {
-            boolean getClassLoaderDisabled;
-            try {
-                AccessController.checkPermission(GET_CLASS_LOADER);
-                // seems like we'll be ok
-                getClassLoaderDisabled = false;
-            } catch (final SecurityException ignored) {
-                try {
-                    // let's see if we can obtain that permission
-                    runPrivilegedActionWithGetClassLoaderPermission((PrivilegedAction<Void>) () -> {
-                        AccessController.checkPermission(GET_CLASS_LOADER);
-                        return null;
-                    });
-                    getClassLoaderDisabled = false;
-                } catch (final SecurityException ignore) {
-                    // no chance
-                    getClassLoaderDisabled = true;
-                }
-            }
-            GET_CLASS_LOADER_DISABLED = getClassLoaderDisabled;
-        } else {
-            GET_CLASS_LOADER_DISABLED = false;
-        }
-    }
 
     private LoaderUtil() {}
 
@@ -97,7 +92,7 @@ public final class LoaderUtil {
         PrivilegedAction<ClassLoader> action = () -> {
             final ClassLoader loader1 = class1 == null ? null : class1.getClassLoader();
             final ClassLoader loader2 = class2 == null ? null : class2.getClassLoader();
-            final ClassLoader referenceLoader = GET_CLASS_LOADER_DISABLED
+            final ClassLoader referenceLoader = GET_CLASS_LOADER_DISABLED.getAsBoolean()
                     ? getThisClassLoader()
                     : Thread.currentThread().getContextClassLoader();
             if (isChild(referenceLoader, loader1)) {
@@ -105,7 +100,7 @@ public final class LoaderUtil {
             }
             return isChild(loader1, loader2) ? loader1 : loader2;
         };
-        return runActionInvolvingGetClassLoaderPermission(action);
+        return runPrivileged(action);
     }
 
     /**
@@ -141,9 +136,7 @@ public final class LoaderUtil {
      */
     public static ClassLoader getThreadContextClassLoader() {
         try {
-            return GET_CLASS_LOADER_DISABLED
-                    ? getThisClassLoader()
-                    : runActionInvolvingGetClassLoaderPermission(TCCL_GETTER);
+            return GET_CLASS_LOADER_DISABLED.getAsBoolean() ? getThisClassLoader() : runPrivileged(TCCL_GETTER);
         } catch (final SecurityException ignored) {
             return null;
         }
@@ -153,14 +146,8 @@ public final class LoaderUtil {
         return LoaderUtil.class.getClassLoader();
     }
 
-    private static <T> T runActionInvolvingGetClassLoaderPermission(final PrivilegedAction<T> action) {
-        return System.getSecurityManager() != null
-                ? runPrivilegedActionWithGetClassLoaderPermission(action)
-                : action.run();
-    }
-
-    private static <T> T runPrivilegedActionWithGetClassLoaderPermission(final PrivilegedAction<T> action) {
-        return AccessController.doPrivileged(action, null, GET_CLASS_LOADER);
+    private static <T> T runPrivileged(final PrivilegedAction<T> action) {
+        return System.getSecurityManager() != null ? AccessController.doPrivileged(action) : action.run();
     }
 
     private static class ThreadContextClassLoaderGetter implements PrivilegedAction<ClassLoader> {
@@ -171,7 +158,7 @@ public final class LoaderUtil {
                 return contextClassLoader;
             }
             final ClassLoader thisClassLoader = getThisClassLoader();
-            if (thisClassLoader != null || GET_CLASS_LOADER_DISABLED) {
+            if (thisClassLoader != null || GET_CLASS_LOADER_DISABLED.getAsBoolean()) {
                 return thisClassLoader;
             }
             return ClassLoader.getSystemClassLoader();
@@ -476,7 +463,7 @@ public final class LoaderUtil {
         final ClassLoader[] candidates = {
             useTccl ? getThreadContextClassLoader() : null,
             LoaderUtil.class.getClassLoader(),
-            GET_CLASS_LOADER_DISABLED ? null : ClassLoader.getSystemClassLoader()
+            GET_CLASS_LOADER_DISABLED.getAsBoolean() ? null : ClassLoader.getSystemClassLoader()
         };
         // @formatter:on
         final Collection<UrlResource> resources = new LinkedHashSet<>();

--- a/src/changelog/.2.x.x/fix_security_manager_use_in_LoaderUtil.xml
+++ b/src/changelog/.2.x.x/fix_security_manager_use_in_LoaderUtil.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="fixed">
+  <issue id="2129" link="https://github.com/apache/logging-log4j2/issues/2129"/>
+  <description format="asciidoc">
+    Fixed use of `SecurityManager` in `LoaderUtil` where `AccessController::doPrivileged` should only be invoked when
+    a `SecurityManager` is installed. Some runtimes do not seem to have this method available.
+  </description>
+</entry>

--- a/src/site/_release-notes/_2.x.x.adoc
+++ b/src/site/_release-notes/_2.x.x.adoc
@@ -38,6 +38,11 @@ This releases contains ...
 
 * Deprecated the `RingBufferLogEventHandler` class for removal from the public API in 3.x.
 
+[#release-notes-2-x-x-fixed]
+=== Fixed
+
+* Fixed use of `SecurityManager` in `LoaderUtil` where `AccessController::doPrivileged` should only be invoked when a `SecurityManager` is installed. Some runtimes do not seem to have this method available. (https://github.com/apache/logging-log4j2/issues/2129[2129])
+
 [#release-notes-2-x-x-updated]
 === Updated
 


### PR DESCRIPTION
This fixes issue #2129 where `AccessController::doPrivileged` is needlessly invoked when no `SecurityManager` is installed.