### PR TITLE
Port `log4j-to-jul` changes from `2.x`

### DIFF
--- a/log4j-to-jul/pom.xml
+++ b/log4j-to-jul/pom.xml
@@ -29,9 +29,6 @@
   <name>Apache Log4j to JUL Bridge</name>
   <description>The Apache Log4j binding between Log4j 2 API and java.util.logging (JUL).</description>
   <inceptionYear>2022</inceptionYear>
-  <properties>
-    <log4jParentDir>${basedir}/..</log4jParentDir>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/JULLogger.java
+++ b/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/JULLogger.java
@@ -32,7 +32,7 @@ import org.apache.logging.log4j.spi.AbstractLogger;
  *
  * @author <a href="http://www.vorburger.ch">Michael Vorburger.ch</a> for Google
  */
-public final class JULLogger extends AbstractLogger {
+final class JULLogger extends AbstractLogger {
     private static final long serialVersionUID = 1L;
 
     private final Logger logger;
@@ -162,7 +162,8 @@ public final class JULLogger extends AbstractLogger {
         }
         // This is a safety fallback that is typically never reached, because usually the root Logger.getLogger("") has
         // a Level.
-        return Logger.getGlobal().getLevel();
+        // Since JDK 8 the LogManager$RootLogger does not have a default level, just a default effective level of INFO.
+        return java.util.logging.Level.INFO;
     }
 
     private boolean isEnabledFor(final Level level, final Marker marker) {

--- a/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/JULProvider.java
+++ b/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/JULProvider.java
@@ -16,7 +16,6 @@
  */
 package org.apache.logging.log4j.tojul;
 
-import aQute.bnd.annotation.Resolution;
 import aQute.bnd.annotation.spi.ServiceProvider;
 import org.apache.logging.log4j.spi.Provider;
 
@@ -25,7 +24,7 @@ import org.apache.logging.log4j.spi.Provider;
  *
  * @author <a href="http://www.vorburger.ch">Michael Vorburger.ch</a> for Google
  */
-@ServiceProvider(value = Provider.class, resolution = Resolution.OPTIONAL)
+@ServiceProvider(value = Provider.class)
 public class JULProvider extends Provider {
     public JULProvider() {
         super(20, "3.0.0", JULLoggerContextFactory.class, null);

--- a/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/package-info.java
+++ b/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/package-info.java
@@ -21,7 +21,7 @@
  * @author <a href="http://www.vorburger.ch">Michael Vorburger.ch</a> for Google
  */
 @Export
-@Version("2.20.1")
+@Version("3.0.0")
 package org.apache.logging.log4j.tojul;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-to-jul/src/test/java/org/apache/logging/log4j/tojul/JULLoggerTest.java
+++ b/log4j-to-jul/src/test/java/org/apache/logging/log4j/tojul/JULLoggerTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.tojul;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.Test;
+
+public class JULLoggerTest {
+
+    @Test
+    public void testNotNullEffectiveLevel() {
+        // Emulates the root logger found in Tomcat, with a null level
+        // See: https://bz.apache.org/bugzilla/show_bug.cgi?id=66184
+        final java.util.logging.Logger julLogger = new java.util.logging.Logger("", null) {};
+        final JULLogger logger = new JULLogger("", julLogger);
+        assertEquals(Level.INFO, logger.getLevel());
+    }
+}

--- a/log4j-to-jul/src/test/java/org/apache/logging/log4j/tojul/LoggerTest.java
+++ b/log4j-to-jul/src/test/java/org/apache/logging/log4j/tojul/LoggerTest.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.logging.log4j.tojul.test;
+package org.apache.logging.log4j.tojul;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.tojul.JULLogger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This PR adds to the `log4j-to-jul` module the missing changes from the 2.x branch.

Regarding the `log4j-to-jul` module, the only differences between the 2.x and 3.x version is the absence of an OSGi activator in the 3.x version: we rely on Service Loader Mediator in 3.x.