### PR TITLE
Fix dead link to release notes and support on index.adoc

### DIFF
--- a/src/site/asciidoc/index.adoc
+++ b/src/site/asciidoc/index.adoc
@@ -26,8 +26,8 @@ The project is actively maintained by a link:team.html[team] of several voluntee
 - link:maven-artifacts.html[How can I add Log4j artifacts to my Maven/Ivy/Gradle project?]
 - link:manual/usage.html?[How can I use the Log4j API?]
 - link:manual/configuration.html[How can I configure my `log4j2.xml`?]
-- link:release-notes.adoc[Where are the release notes?]
-- link:support.adoc[**I need help!**]
+- link:release-notes.html[Where are the release notes?]
+- link:support.html[**I need help!**]
 
 [#features]
 == Features


### PR DESCRIPTION
Fixes #2149

This pull request addresses the issue where the hyperlinks to the release notes and support was incorrect on the documentation page. The link was pointing to release-notes.adoc and support.adoc instead of the correct release-notes.html and support.html. This has been corrected to ensure users are directed to the accurate release notes and support page.

