### PR TITLE
Adds lighter v3 `Logger` interface (PoC)

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/Category.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/Category.java
@@ -334,7 +334,7 @@ public class Category implements AppenderAttachable {
         final org.apache.logging.log4j.Level lvl = level.getVersion2Level();
         final Message msg = createMessage(message);
         if (logger instanceof ExtendedLogger) {
-            ((ExtendedLogger) logger).logMessage(fqcn, lvl, null, msg, t);
+            ((ExtendedLogger) logger).logIfEnabled(fqcn, lvl, null, msg, t);
         } else {
             logger.log(lvl, msg, t);
         }
@@ -573,7 +573,7 @@ public class Category implements AppenderAttachable {
         if (logger.isEnabled(level)) {
             final Message msg = createMessage(message);
             if (logger instanceof ExtendedLogger) {
-                ((ExtendedLogger) logger).logMessage(fqcn, level, null, msg, throwable);
+                ((ExtendedLogger) logger).logIfEnabled(fqcn, level, null, msg, throwable);
             } else {
                 logger.log(level, msg, throwable);
             }

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/TestLogger.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/TestLogger.java
@@ -54,17 +54,11 @@ public class TestLogger extends AbstractLogger {
     }
 
     @Override
-    public void logMessage(
-            final String fqcn, final Level level, final Marker marker, final Message msg, final Throwable throwable) {
-        log(level, marker, fqcn, null, msg, throwable);
-    }
-
-    @Override
-    protected void log(
-            final Level level,
-            final Marker marker,
+    protected void doLogMessage(
             final String fqcn,
             final StackTraceElement location,
+            final Level level,
+            final Marker marker,
             final Message message,
             final Throwable throwable) {
         final StringBuilder sb = new StringBuilder();

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/AbstractLoggerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/AbstractLoggerTest.java
@@ -1195,8 +1195,13 @@ public class AbstractLoggerTest {
         }
 
         @Override
-        public void logMessage(
-                final String fqcn, final Level level, final Marker marker, final Message data, final Throwable t) {
+        protected void doLogMessage(
+                final String fqcn,
+                final StackTraceElement location,
+                final Level level,
+                final Marker marker,
+                final Message data,
+                final Throwable t) {
             assertEquals(level, currentLevel, "Incorrect Level. Expected " + currentLevel + ", actual " + level);
             if (marker == null) {
                 if (currentEvent.markerName != null) {
@@ -1424,8 +1429,13 @@ public class AbstractLoggerTest {
         }
 
         @Override
-        public void logMessage(
-                final String fqcn, final Level level, final Marker marker, final Message message, final Throwable t) {
+        protected void doLogMessage(
+                final String fqcn,
+                final StackTraceElement location,
+                final Level level,
+                final Marker marker,
+                final Message message,
+                final Throwable t) {
             if (expectingThrowables) {
                 assertNotNull(t, "Expected a Throwable but received null!");
             } else {

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/LambdaLoggerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/LambdaLoggerTest.java
@@ -220,8 +220,13 @@ public class LambdaLoggerTest {
         }
 
         @Override
-        public void logMessage(
-                final String fqcn, final Level level, final Marker marker, final Message message, final Throwable t) {
+        protected void doLogMessage(
+                final String fqcn,
+                final StackTraceElement location,
+                final Level level,
+                final Marker marker,
+                final Message message,
+                final Throwable t) {
             list.add(new LogEvent(fqcn, level, marker, message, t));
         }
 

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/TraceLoggingTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/TraceLoggingTest.java
@@ -280,8 +280,13 @@ public class TraceLoggingTest extends AbstractLogger {
     }
 
     @Override
-    public void logMessage(
-            final String fqcn, final Level level, final Marker marker, final Message data, final Throwable t) {
+    protected void doLogMessage(
+            final String fqcn,
+            final StackTraceElement location,
+            final Level level,
+            final Marker marker,
+            final Message data,
+            final Throwable t) {
         assertEquals(level, currentLevel, "Incorrect Level. Expected " + currentLevel + ", actual " + level);
         if (marker == null) {
             if (currentEvent.markerName != null) {

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/LambdaUtilTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/LambdaUtilTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.apache.logging.log4j.message.Message;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.junit.jupiter.api.Test;
 
@@ -31,45 +31,30 @@ import org.junit.jupiter.api.Test;
 public class LambdaUtilTest {
 
     @Test
-    public void testGetSupplierResultOfSupplier() {
+    public void testGetResultOfStringSupplier() {
         final String expected = "result";
-        final Object actual = LambdaUtil.get((Supplier<String>) () -> expected);
+        final Object actual = LambdaUtil.get(() -> expected);
         assertSame(expected, actual);
     }
 
     @Test
-    public void testGetMessageSupplierResultOfSupplier() {
-        final Message expected = new SimpleMessage("hi");
-        final Message actual = LambdaUtil.get(() -> expected);
+    public void testGetResultOfMessageSupplier() {
+        final String expected = "hi";
+        final Object actual = LambdaUtil.get(() -> new SimpleMessage("hi"));
         assertSame(expected, actual);
     }
 
     @Test
-    public void testGetSupplierReturnsNullIfSupplierNull() {
-        final Object actual = LambdaUtil.get((Supplier<?>) null);
+    public void testGetResultOfNull() {
+        final Object actual = LambdaUtil.get(null);
         assertNull(actual);
     }
 
     @Test
-    public void testGetMessageSupplierReturnsNullIfSupplierNull() {
-        final Object actual = LambdaUtil.get((MessageSupplier) null);
-        assertNull(actual);
-    }
-
-    @Test
-    public void testGetSupplierExceptionIfSupplierThrowsException() {
+    public void testGetExceptionIfSupplierThrowsException() {
         assertThrows(
                 RuntimeException.class,
                 () -> LambdaUtil.get((Supplier<String>) () -> {
-                    throw new RuntimeException();
-                }));
-    }
-
-    @Test
-    public void testGetMessageSupplierExceptionIfSupplierThrowsException() {
-        assertThrows(
-                RuntimeException.class,
-                () -> LambdaUtil.get(() -> {
                     throw new RuntimeException();
                 }));
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -16,12 +16,12 @@
  */
 package org.apache.logging.log4j;
 
+import java.util.Arrays;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.message.EntryMessage;
 import org.apache.logging.log4j.message.FlowMessageFactory;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MessageFactory;
-import org.apache.logging.log4j.util.MessageSupplier;
-import org.apache.logging.log4j.util.Supplier;
 
 /**
  * This is the central interface in the log4j package. Most logging operations, except configuration, are done through
@@ -69,12 +69,12 @@ import org.apache.logging.log4j.util.Supplier;
  * </pre>
  *
  * <p>
- * Note that although {@link MessageSupplier} is provided, using {@link Supplier Supplier&lt;Message&gt;} works just the
- * same. MessageSupplier was deprecated in 2.6 and un-deprecated in 2.8.1. Anonymous class usage of these APIs
- * should prefer using Supplier instead.
+ * Note that although {@link org.apache.logging.log4j.util.MessageSupplier} is provided, using {@link org.apache.logging.log4j.util.Supplier org.apache.logging.log4j.util.Supplier&lt;Message&gt;} works just the
+ * same. org.apache.logging.log4j.util.MessageSupplier was deprecated in 2.6 and un-deprecated in 2.8.1. Anonymous class usage of these APIs
+ * should prefer using org.apache.logging.log4j.util.Supplier instead.
  * </p>
  */
-public interface Logger {
+public interface Logger extends org.apache.logging.log4j.v3.Logger {
 
     /**
      * Logs a {@link Throwable} that has been caught to a specific logging level.
@@ -97,62 +97,34 @@ public interface Logger {
     void catching(Throwable throwable);
 
     /**
-     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     */
-    void debug(Marker marker, Message message);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void debug(Marker marker, Message message, Throwable throwable);
-
-    /**
      * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level with
-     * the specified Marker. The {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the
+     * the specified Marker. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the
      * {@code Message}.
      *
      * @param marker the marker data specific to this log statement
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void debug(Marker marker, MessageSupplier messageSupplier);
+    default void debug(final Marker marker, final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        debug(marker, (Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) with the
      * specified Marker and including the stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The
-     * {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
+     * {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param marker the marker data specific to this log statement
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @param throwable A Throwable or null.
      * @since 2.4
      */
-    void debug(Marker marker, MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message CharSequence to log.
-     */
-    void debug(Marker marker, CharSequence message);
-
-    /**
-     * Logs a message CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the
-     * {@link Throwable} <code>throwable</code> passed as parameter.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     */
-    void debug(Marker marker, CharSequence message, Throwable throwable);
+    default void debug(
+            final Marker marker,
+            final org.apache.logging.log4j.util.MessageSupplier messageSupplier,
+            final Throwable throwable) {
+        debug(marker, (Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the {@link Level#DEBUG DEBUG} level.
@@ -181,16 +153,6 @@ public interface Logger {
     void debug(Marker marker, String message);
 
     /**
-     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void debug(Marker marker, String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
      * DEBUG} level.
      *
@@ -200,7 +162,14 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void debug(Marker marker, String message, Supplier<?>... paramSuppliers);
+    default void debug(
+            final Marker marker,
+            final String message,
+            final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isDebugEnabled(marker)) {
+            debug(marker, message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the {@link Level#DEBUG DEBUG} level including the stack trace of the {@link Throwable}
@@ -222,7 +191,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void debug(Marker marker, Supplier<?> messageSupplier);
+    default void debug(final Marker marker, final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        debug(marker, (Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) with the
@@ -235,58 +206,36 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void debug(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
-     *
-     * @param message the message string to be logged
-     */
-    void debug(Message message);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
-     *
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void debug(Message message, Throwable throwable);
+    default void debug(
+            final Marker marker,
+            final org.apache.logging.log4j.util.Supplier<?> messageSupplier,
+            final Throwable throwable) {
+        debug(marker, (Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level. The
-     * {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
+     * {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void debug(MessageSupplier messageSupplier);
+    default void debug(final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        debug((Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) including the
-     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code MessageSupplier} may or may
+     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may
      * not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @since 2.4
      */
-    void debug(MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
-     *
-     * @param message the message object to log.
-     */
-    void debug(CharSequence message);
-
-    /**
-     * Logs a CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the {@link Throwable}
-     * <code>throwable</code> passed as parameter.
-     *
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     */
-    void debug(CharSequence message, Throwable throwable);
+    default void debug(final org.apache.logging.log4j.util.MessageSupplier messageSupplier, final Throwable throwable) {
+        debug((Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the {@link Level#DEBUG DEBUG} level.
@@ -312,15 +261,6 @@ public interface Logger {
     void debug(String message);
 
     /**
-     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void debug(String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
      * DEBUG} level.
      *
@@ -329,7 +269,11 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void debug(String message, Supplier<?>... paramSuppliers);
+    default void debug(final String message, final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isDebugEnabled()) {
+            debug(message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the {@link Level#DEBUG DEBUG} level including the stack trace of the {@link Throwable}
@@ -348,7 +292,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void debug(Supplier<?> messageSupplier);
+    default void debug(final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        debug((Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) including the
@@ -360,26 +306,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void debug(Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with parameters at debug level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     */
-    void debug(Marker marker, String message, Object p0);
-
-    /**
-     * Logs a message with parameters at debug level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void debug(Marker marker, String message, Object p0, Object p1);
+    default void debug(final org.apache.logging.log4j.util.Supplier<?> messageSupplier, final Throwable throwable) {
+        debug((Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message with parameters at debug level.
@@ -536,23 +465,6 @@ public interface Logger {
      *
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-     */
-    void debug(String message, Object p0);
-
-    /**
-     * Logs a message with parameters at debug level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void debug(String message, Object p0, Object p1);
-
-    /**
-     * Logs a message with parameters at debug level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      */
@@ -678,62 +590,34 @@ public interface Logger {
             Object p9);
 
     /**
-     * Logs a message with the specific Marker at the {@link Level#ERROR ERROR} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     */
-    void error(Marker marker, Message message);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#ERROR ERROR} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void error(Marker marker, Message message, Throwable throwable);
-
-    /**
      * Logs a message which is only to be constructed if the logging level is the {@link Level#ERROR ERROR} level with
-     * the specified Marker. The {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the
+     * the specified Marker. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the
      * {@code Message}.
      *
      * @param marker the marker data specific to this log statement
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void error(Marker marker, MessageSupplier messageSupplier);
+    default void error(final Marker marker, final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        error(marker, (Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#ERROR ERROR} level) with the
      * specified Marker and including the stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The
-     * {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
+     * {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param marker the marker data specific to this log statement
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @param throwable A Throwable or null.
      * @since 2.4
      */
-    void error(Marker marker, MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the {@link Level#ERROR ERROR} level.
-     *
-     * @param marker the marker data specific to this log statement.
-     * @param message the message CharSequence to log.
-     */
-    void error(Marker marker, CharSequence message);
-
-    /**
-     * Logs a CharSequence at the {@link Level#ERROR ERROR} level including the stack trace of the {@link Throwable}
-     * <code>throwable</code> passed as parameter.
-     *
-     * @param marker the marker data specific to this log statement.
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     */
-    void error(Marker marker, CharSequence message, Throwable throwable);
+    default void error(
+            final Marker marker,
+            final org.apache.logging.log4j.util.MessageSupplier messageSupplier,
+            final Throwable throwable) {
+        error(marker, (Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the {@link Level#ERROR ERROR} level.
@@ -762,16 +646,6 @@ public interface Logger {
     void error(Marker marker, String message);
 
     /**
-     * Logs a message with parameters at the {@link Level#ERROR ERROR} level.
-     *
-     * @param marker the marker data specific to this log statement.
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void error(Marker marker, String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#ERROR
      * ERROR} level.
      *
@@ -781,7 +655,14 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void error(Marker marker, String message, Supplier<?>... paramSuppliers);
+    default void error(
+            final Marker marker,
+            final String message,
+            final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isErrorEnabled(marker)) {
+            error(marker, message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the {@link Level#ERROR ERROR} level including the stack trace of the {@link Throwable}
@@ -803,7 +684,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void error(Marker marker, Supplier<?> messageSupplier);
+    default void error(final Marker marker, final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        error(marker, (Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#ERROR ERROR} level) with the
@@ -816,58 +699,36 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void error(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#ERROR ERROR} level.
-     *
-     * @param message the message string to be logged
-     */
-    void error(Message message);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#ERROR ERROR} level.
-     *
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void error(Message message, Throwable throwable);
+    default void error(
+            final Marker marker,
+            final org.apache.logging.log4j.util.Supplier<?> messageSupplier,
+            final Throwable throwable) {
+        error(marker, (Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message which is only to be constructed if the logging level is the {@link Level#ERROR ERROR} level. The
-     * {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
+     * {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void error(MessageSupplier messageSupplier);
+    default void error(final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        error((Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#ERROR ERROR} level) including the
-     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code MessageSupplier} may or may
+     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may
      * not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @since 2.4
      */
-    void error(MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the {@link Level#ERROR ERROR} level.
-     *
-     * @param message the message CharSequence to log.
-     */
-    void error(CharSequence message);
-
-    /**
-     * Logs a CharSequence at the {@link Level#ERROR ERROR} level including the stack trace of the {@link Throwable}
-     * <code>throwable</code> passed as parameter.
-     *
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     */
-    void error(CharSequence message, Throwable throwable);
+    default void error(final org.apache.logging.log4j.util.MessageSupplier messageSupplier, final Throwable throwable) {
+        error((Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the {@link Level#ERROR ERROR} level.
@@ -893,15 +754,6 @@ public interface Logger {
     void error(String message);
 
     /**
-     * Logs a message with parameters at the {@link Level#ERROR ERROR} level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void error(String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#ERROR
      * ERROR} level.
      *
@@ -910,7 +762,11 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void error(String message, Supplier<?>... paramSuppliers);
+    default void error(final String message, final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isErrorEnabled()) {
+            error(message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the {@link Level#ERROR ERROR} level including the stack trace of the {@link Throwable}
@@ -929,7 +785,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void error(Supplier<?> messageSupplier);
+    default void error(final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        error((Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#ERROR ERROR} level) including the
@@ -941,26 +799,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void error(Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with parameters at error level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     */
-    void error(Marker marker, String message, Object p0);
-
-    /**
-     * Logs a message with parameters at error level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void error(Marker marker, String message, Object p0, Object p1);
+    default void error(final org.apache.logging.log4j.util.Supplier<?> messageSupplier, final Throwable throwable) {
+        error((Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message with parameters at error level.
@@ -1117,23 +958,6 @@ public interface Logger {
      *
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-     */
-    void error(String message, Object p0);
-
-    /**
-     * Logs a message with parameters at error level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void error(String message, Object p0, Object p1);
-
-    /**
-     * Logs a message with parameters at error level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      */
@@ -1259,62 +1083,34 @@ public interface Logger {
             Object p9);
 
     /**
-     * Logs a message with the specific Marker at the {@link Level#FATAL FATAL} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     */
-    void fatal(Marker marker, Message message);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#FATAL FATAL} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void fatal(Marker marker, Message message, Throwable throwable);
-
-    /**
      * Logs a message which is only to be constructed if the logging level is the {@link Level#FATAL FATAL} level with
-     * the specified Marker. The {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the
+     * the specified Marker. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the
      * {@code Message}.
      *
      * @param marker the marker data specific to this log statement
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void fatal(Marker marker, MessageSupplier messageSupplier);
+    default void fatal(final Marker marker, final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        fatal(marker, (Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#FATAL FATAL} level) with the
      * specified Marker and including the stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The
-     * {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
+     * {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param marker the marker data specific to this log statement
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @param throwable A Throwable or null.
      * @since 2.4
      */
-    void fatal(Marker marker, MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the {@link Level#FATAL FATAL} level.
-     *
-     * @param marker The marker data specific to this log statement.
-     * @param message the message CharSequence to log.
-     */
-    void fatal(Marker marker, CharSequence message);
-
-    /**
-     * Logs a CharSequence at the {@link Level#FATAL FATAL} level including the stack trace of the {@link Throwable}
-     * <code>throwable</code> passed as parameter.
-     *
-     * @param marker The marker data specific to this log statement.
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     */
-    void fatal(Marker marker, CharSequence message, Throwable throwable);
+    default void fatal(
+            final Marker marker,
+            final org.apache.logging.log4j.util.MessageSupplier messageSupplier,
+            final Throwable throwable) {
+        fatal(marker, (Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the {@link Level#FATAL FATAL} level.
@@ -1343,16 +1139,6 @@ public interface Logger {
     void fatal(Marker marker, String message);
 
     /**
-     * Logs a message with parameters at the {@link Level#FATAL FATAL} level.
-     *
-     * @param marker The marker data specific to this log statement.
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void fatal(Marker marker, String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#FATAL
      * FATAL} level.
      *
@@ -1362,7 +1148,14 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void fatal(Marker marker, String message, Supplier<?>... paramSuppliers);
+    default void fatal(
+            final Marker marker,
+            final String message,
+            final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isFatalEnabled(marker)) {
+            fatal(marker, message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the {@link Level#FATAL FATAL} level including the stack trace of the {@link Throwable}
@@ -1384,7 +1177,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void fatal(Marker marker, Supplier<?> messageSupplier);
+    default void fatal(final Marker marker, final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        fatal(marker, (Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#FATAL FATAL} level) with the
@@ -1397,58 +1192,36 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void fatal(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#FATAL FATAL} level.
-     *
-     * @param message the message string to be logged
-     */
-    void fatal(Message message);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#FATAL FATAL} level.
-     *
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void fatal(Message message, Throwable throwable);
+    default void fatal(
+            final Marker marker,
+            final org.apache.logging.log4j.util.Supplier<?> messageSupplier,
+            final Throwable throwable) {
+        fatal(marker, (Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message which is only to be constructed if the logging level is the {@link Level#FATAL FATAL} level. The
-     * {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
+     * {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void fatal(MessageSupplier messageSupplier);
+    default void fatal(final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        fatal((Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#FATAL FATAL} level) including the
-     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code MessageSupplier} may or may
+     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may
      * not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @since 2.4
      */
-    void fatal(MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the {@link Level#FATAL FATAL} level.
-     *
-     * @param message the message CharSequence to log.
-     */
-    void fatal(CharSequence message);
-
-    /**
-     * Logs a CharSequence at the {@link Level#FATAL FATAL} level including the stack trace of the {@link Throwable}
-     * <code>throwable</code> passed as parameter.
-     *
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     */
-    void fatal(CharSequence message, Throwable throwable);
+    default void fatal(final org.apache.logging.log4j.util.MessageSupplier messageSupplier, final Throwable throwable) {
+        fatal((Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the {@link Level#FATAL FATAL} level.
@@ -1474,15 +1247,6 @@ public interface Logger {
     void fatal(String message);
 
     /**
-     * Logs a message with parameters at the {@link Level#FATAL FATAL} level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void fatal(String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#FATAL
      * FATAL} level.
      *
@@ -1491,7 +1255,11 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void fatal(String message, Supplier<?>... paramSuppliers);
+    default void fatal(final String message, final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isFatalEnabled()) {
+            fatal(message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the {@link Level#FATAL FATAL} level including the stack trace of the {@link Throwable}
@@ -1510,7 +1278,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void fatal(Supplier<?> messageSupplier);
+    default void fatal(final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        fatal((Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#FATAL FATAL} level) including the
@@ -1522,26 +1292,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void fatal(Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with parameters at fatal level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     */
-    void fatal(Marker marker, String message, Object p0);
-
-    /**
-     * Logs a message with parameters at fatal level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void fatal(Marker marker, String message, Object p0, Object p1);
+    default void fatal(final org.apache.logging.log4j.util.Supplier<?> messageSupplier, final Throwable throwable) {
+        fatal((Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message with parameters at fatal level.
@@ -1698,23 +1451,6 @@ public interface Logger {
      *
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-     */
-    void fatal(String message, Object p0);
-
-    /**
-     * Logs a message with parameters at fatal level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void fatal(String message, Object p0, Object p1);
-
-    /**
-     * Logs a message with parameters at fatal level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      */
@@ -1840,20 +1576,14 @@ public interface Logger {
             Object p9);
 
     /**
-     * Gets the Level associated with the Logger.
-     *
-     * @return the Level associate with the Logger.
-     */
-    Level getLevel();
-
-    /**
      * Gets the message factory used to convert message Objects and Strings/CharSequences into actual log Messages.
-     *
+     * <p>
      * Since version 2.6, Log4j internally uses message factories that implement the {@link MessageFactory} interface.
      * From version 2.6.2, the return type of this method was changed from {@link MessageFactory} to
      * {@code <MF extends MessageFactory> MF}. The returned factory will always implement {@link MessageFactory},
      * but the return type of this method could not be changed to {@link MessageFactory} without breaking binary
      * compatibility.
+     * </p>
      *
      * @return the message factory, as an instance of {@link MessageFactory}
      */
@@ -1868,69 +1598,34 @@ public interface Logger {
     FlowMessageFactory getFlowMessageFactory();
 
     /**
-     * Gets the logger name.
-     *
-     * @return the logger name.
-     */
-    String getName();
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#INFO INFO} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     */
-    void info(Marker marker, Message message);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#INFO INFO} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void info(Marker marker, Message message, Throwable throwable);
-
-    /**
      * Logs a message which is only to be constructed if the logging level is the {@link Level#INFO INFO} level with the
-     * specified Marker. The {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the
+     * specified Marker. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the
      * {@code Message}.
      *
      * @param marker the marker data specific to this log statement
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void info(Marker marker, MessageSupplier messageSupplier);
+    default void info(final Marker marker, final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        info(marker, (Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#INFO INFO} level) with the
      * specified Marker and including the stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The
-     * {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
+     * {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param marker the marker data specific to this log statement
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @param throwable A Throwable or null.
      * @since 2.4
      */
-    void info(Marker marker, MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the {@link Level#INFO INFO} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message CharSequence to log.
-     */
-    void info(Marker marker, CharSequence message);
-
-    /**
-     * Logs a CharSequence at the {@link Level#INFO INFO} level including the stack trace of the {@link Throwable}
-     * <code>throwable</code> passed as parameter.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     */
-    void info(Marker marker, CharSequence message, Throwable throwable);
+    default void info(
+            final Marker marker,
+            final org.apache.logging.log4j.util.MessageSupplier messageSupplier,
+            final Throwable throwable) {
+        info(marker, (Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the {@link Level#INFO INFO} level.
@@ -1959,16 +1654,6 @@ public interface Logger {
     void info(Marker marker, String message);
 
     /**
-     * Logs a message with parameters at the {@link Level#INFO INFO} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void info(Marker marker, String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#INFO
      * INFO} level.
      *
@@ -1978,7 +1663,14 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void info(Marker marker, String message, Supplier<?>... paramSuppliers);
+    default void info(
+            final Marker marker,
+            final String message,
+            final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isInfoEnabled(marker)) {
+            info(marker, message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the {@link Level#INFO INFO} level including the stack trace of the {@link Throwable}
@@ -2000,7 +1692,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void info(Marker marker, Supplier<?> messageSupplier);
+    default void info(final Marker marker, final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        info(marker, (Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#INFO INFO} level) with the
@@ -2013,58 +1707,36 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void info(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#INFO INFO} level.
-     *
-     * @param message the message string to be logged
-     */
-    void info(Message message);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#INFO INFO} level.
-     *
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void info(Message message, Throwable throwable);
+    default void info(
+            final Marker marker,
+            final org.apache.logging.log4j.util.Supplier<?> messageSupplier,
+            final Throwable throwable) {
+        info(marker, (Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message which is only to be constructed if the logging level is the {@link Level#INFO INFO} level. The
-     * {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
+     * {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void info(MessageSupplier messageSupplier);
+    default void info(final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        info((Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#INFO INFO} level) including the
-     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code MessageSupplier} may or may
+     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may
      * not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @since 2.4
      */
-    void info(MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the {@link Level#INFO INFO} level.
-     *
-     * @param message the message CharSequence to log.
-     */
-    void info(CharSequence message);
-
-    /**
-     * Logs a CharSequence at the {@link Level#INFO INFO} level including the stack trace of the {@link Throwable}
-     * <code>throwable</code> passed as parameter.
-     *
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     */
-    void info(CharSequence message, Throwable throwable);
+    default void info(final org.apache.logging.log4j.util.MessageSupplier messageSupplier, final Throwable throwable) {
+        info((Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the {@link Level#INFO INFO} level.
@@ -2090,15 +1762,6 @@ public interface Logger {
     void info(String message);
 
     /**
-     * Logs a message with parameters at the {@link Level#INFO INFO} level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void info(String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#INFO
      * INFO} level.
      *
@@ -2107,7 +1770,11 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void info(String message, Supplier<?>... paramSuppliers);
+    default void info(final String message, final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isInfoEnabled()) {
+            info(message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the {@link Level#INFO INFO} level including the stack trace of the {@link Throwable}
@@ -2126,7 +1793,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void info(Supplier<?> messageSupplier);
+    default void info(final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        info((Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#INFO INFO} level) including the
@@ -2138,26 +1807,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void info(Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with parameters at info level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     */
-    void info(Marker marker, String message, Object p0);
-
-    /**
-     * Logs a message with parameters at info level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void info(Marker marker, String message, Object p0, Object p1);
+    default void info(final org.apache.logging.log4j.util.Supplier<?> messageSupplier, final Throwable throwable) {
+        info((Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message with parameters at info level.
@@ -2314,23 +1966,6 @@ public interface Logger {
      *
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-     */
-    void info(String message, Object p0);
-
-    /**
-     * Logs a message with parameters at info level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void info(String message, Object p0, Object p1);
-
-    /**
-     * Logs a message with parameters at info level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      */
@@ -2456,143 +2091,8 @@ public interface Logger {
             Object p9);
 
     /**
-     * Checks whether this Logger is enabled for the {@link Level#DEBUG DEBUG} Level.
-     *
-     * @return boolean - {@code true} if this Logger is enabled for level DEBUG, {@code false} otherwise.
-     */
-    boolean isDebugEnabled();
-
-    /**
-     * Checks whether this Logger is enabled for the {@link Level#DEBUG DEBUG} Level.
-     *
-     * @param marker The Marker to check
-     * @return boolean - {@code true} if this Logger is enabled for level DEBUG, {@code false} otherwise.
-     */
-    boolean isDebugEnabled(Marker marker);
-
-    /**
-     * Checks whether this Logger is enabled for the given Level.
-     * <p>
-     * Note that passing in {@link Level#OFF OFF} always returns {@code true}.
-     * </p>
-     *
-     * @param level the Level to check
-     * @return boolean - {@code true} if this Logger is enabled for level, {@code false} otherwise.
-     */
-    boolean isEnabled(Level level);
-
-    /**
-     * Checks whether this Logger is enabled for the given Level and Marker.
-     *
-     * @param level The Level to check
-     * @param marker The Marker to check
-     * @return boolean - {@code true} if this Logger is enabled for level and marker, {@code false} otherwise.
-     */
-    boolean isEnabled(Level level, Marker marker);
-
-    /**
-     * Checks whether this Logger is enabled for the {@link Level#ERROR ERROR} Level.
-     *
-     * @return boolean - {@code true} if this Logger is enabled for level {@link Level#ERROR ERROR}, {@code false}
-     *         otherwise.
-     */
-    boolean isErrorEnabled();
-
-    /**
-     * Checks whether this Logger is enabled for the {@link Level#ERROR ERROR} Level.
-     *
-     * @param marker The Marker to check
-     * @return boolean - {@code true} if this Logger is enabled for level {@link Level#ERROR ERROR}, {@code false}
-     *         otherwise.
-     */
-    boolean isErrorEnabled(Marker marker);
-
-    /**
-     * Checks whether this Logger is enabled for the {@link Level#FATAL FATAL} Level.
-     *
-     * @return boolean - {@code true} if this Logger is enabled for level {@link Level#FATAL FATAL}, {@code false}
-     *         otherwise.
-     */
-    boolean isFatalEnabled();
-
-    /**
-     * Checks whether this Logger is enabled for the {@link Level#FATAL FATAL} Level.
-     *
-     * @param marker The Marker to check
-     * @return boolean - {@code true} if this Logger is enabled for level {@link Level#FATAL FATAL}, {@code false}
-     *         otherwise.
-     */
-    boolean isFatalEnabled(Marker marker);
-
-    /**
-     * Checks whether this Logger is enabled for the {@link Level#INFO INFO} Level.
-     *
-     * @return boolean - {@code true} if this Logger is enabled for level INFO, {@code false} otherwise.
-     */
-    boolean isInfoEnabled();
-
-    /**
-     * Checks whether this Logger is enabled for the {@link Level#INFO INFO} Level.
-     *
-     * @param marker The Marker to check
-     * @return boolean - {@code true} if this Logger is enabled for level INFO, {@code false} otherwise.
-     */
-    boolean isInfoEnabled(Marker marker);
-
-    /**
-     * Checks whether this Logger is enabled for the {@link Level#TRACE TRACE} level.
-     *
-     * @return boolean - {@code true} if this Logger is enabled for level TRACE, {@code false} otherwise.
-     */
-    boolean isTraceEnabled();
-
-    /**
-     * Checks whether this Logger is enabled for the {@link Level#TRACE TRACE} level.
-     *
-     * @param marker The Marker to check
-     * @return boolean - {@code true} if this Logger is enabled for level TRACE, {@code false} otherwise.
-     */
-    boolean isTraceEnabled(Marker marker);
-
-    /**
-     * Checks whether this Logger is enabled for the {@link Level#WARN WARN} Level.
-     *
-     * @return boolean - {@code true} if this Logger is enabled for level {@link Level#WARN WARN}, {@code false}
-     *         otherwise.
-     */
-    boolean isWarnEnabled();
-
-    /**
-     * Checks whether this Logger is enabled for the {@link Level#WARN WARN} Level.
-     *
-     * @param marker The Marker to check
-     * @return boolean - {@code true} if this Logger is enabled for level {@link Level#WARN WARN}, {@code false}
-     *         otherwise.
-     */
-    boolean isWarnEnabled(Marker marker);
-
-    /**
-     * Logs a message with the specific Marker at the given level.
-     *
-     * @param level the logging level
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     */
-    void log(Level level, Marker marker, Message message);
-
-    /**
-     * Logs a message with the specific Marker at the given level.
-     *
-     * @param level the logging level
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void log(Level level, Marker marker, Message message, Throwable throwable);
-
-    /**
      * Logs a message which is only to be constructed if the logging level is the specified level with the specified
-     * Marker. The {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the
+     * Marker. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the
      * {@code Message}.
      *
      * @param level the logging level
@@ -2600,11 +2100,16 @@ public interface Logger {
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void log(Level level, Marker marker, MessageSupplier messageSupplier);
+    default void log(
+            final Level level,
+            final Marker marker,
+            final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        log(level, marker, (Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the specified level) with the specified Marker and
-     * including the stack log of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code MessageSupplier}
+     * including the stack log of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code org.apache.logging.log4j.util.MessageSupplier}
      * may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param level the logging level
@@ -2613,27 +2118,13 @@ public interface Logger {
      * @param throwable A Throwable or null.
      * @since 2.4
      */
-    void log(Level level, Marker marker, MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the given level.
-     *
-     * @param level the logging level
-     * @param marker the marker data specific to this log statement
-     * @param message the message CharSequence to log.
-     */
-    void log(Level level, Marker marker, CharSequence message);
-
-    /**
-     * Logs a CharSequence at the given level including the stack trace of the {@link Throwable} <code>throwable</code> passed as
-     * parameter.
-     *
-     * @param level the logging level
-     * @param marker the marker data specific to this log statement
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     */
-    void log(Level level, Marker marker, CharSequence message, Throwable throwable);
+    default void log(
+            final Level level,
+            final Marker marker,
+            final org.apache.logging.log4j.util.MessageSupplier messageSupplier,
+            final Throwable throwable) {
+        log(level, marker, (Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the given level.
@@ -2665,17 +2156,6 @@ public interface Logger {
     void log(Level level, Marker marker, String message);
 
     /**
-     * Logs a message with parameters at the given level.
-     *
-     * @param level the logging level
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void log(Level level, Marker marker, String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the specified level.
      *
      * @param level the logging level
@@ -2685,7 +2165,15 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void log(Level level, Marker marker, String message, Supplier<?>... paramSuppliers);
+    default void log(
+            final Level level,
+            final Marker marker,
+            final String message,
+            final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isEnabled(level, marker)) {
+            log(level, marker, message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the given level including the stack trace of the {@link Throwable} <code>throwable</code> passed as
@@ -2708,7 +2196,10 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void log(Level level, Marker marker, Supplier<?> messageSupplier);
+    default void log(
+            final Level level, final Marker marker, final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        log(level, marker, (Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the specified level) with the specified Marker and
@@ -2722,38 +2213,29 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void log(Level level, Marker marker, Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with the specific Marker at the given level.
-     *
-     * @param level the logging level
-     * @param message the message string to be logged
-     */
-    void log(Level level, Message message);
-
-    /**
-     * Logs a message with the specific Marker at the given level.
-     *
-     * @param level the logging level
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void log(Level level, Message message, Throwable throwable);
+    default void log(
+            final Level level,
+            final Marker marker,
+            final org.apache.logging.log4j.util.Supplier<?> messageSupplier,
+            final Throwable throwable) {
+        log(level, marker, (Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message which is only to be constructed if the logging level is the specified level. The
-     * {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
+     * {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param level the logging level
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void log(Level level, MessageSupplier messageSupplier);
+    default void log(final Level level, final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        log(level, (Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the specified level) including the stack log of
-     * the {@link Throwable} <code>throwable</code> passed as parameter. The {@code MessageSupplier} may or may not use the
+     * the {@link Throwable} <code>throwable</code> passed as parameter. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the
      * {@link MessageFactory} to construct the {@code Message}.
      *
      * @param level the logging level
@@ -2761,25 +2243,12 @@ public interface Logger {
      * @param throwable the {@code Throwable} to log, including its stack log.
      * @since 2.4
      */
-    void log(Level level, MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the given level.
-     *
-     * @param level the logging level
-     * @param message the message CharSequence to log.
-     */
-    void log(Level level, CharSequence message);
-
-    /**
-     * Logs a CharSequence at the given level including the stack trace of the {@link Throwable} <code>throwable</code> passed as
-     * parameter.
-     *
-     * @param level the logging level
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     */
-    void log(Level level, CharSequence message, Throwable throwable);
+    default void log(
+            final Level level,
+            final org.apache.logging.log4j.util.MessageSupplier messageSupplier,
+            final Throwable throwable) {
+        log(level, (Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the given level.
@@ -2808,16 +2277,6 @@ public interface Logger {
     void log(Level level, String message);
 
     /**
-     * Logs a message with parameters at the given level.
-     *
-     * @param level the logging level
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void log(Level level, String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the specified level.
      *
      * @param level the logging level
@@ -2826,7 +2285,14 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void log(Level level, String message, Supplier<?>... paramSuppliers);
+    default void log(
+            final Level level,
+            final String message,
+            final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isEnabled(level)) {
+            log(level, message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the given level including the stack trace of the {@link Throwable} <code>throwable</code> passed as
@@ -2847,7 +2313,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void log(Level level, Supplier<?> messageSupplier);
+    default void log(final Level level, final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        log(level, (Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the specified level) including the stack log of
@@ -2860,28 +2328,12 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void log(Level level, Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with parameters at the specified level.
-     *
-     * @param level the logging level
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     */
-    void log(Level level, Marker marker, String message, Object p0);
-
-    /**
-     * Logs a message with parameters at the specified level.
-     *
-     * @param level the logging level
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void log(Level level, Marker marker, String message, Object p0, Object p1);
+    default void log(
+            final Level level,
+            final org.apache.logging.log4j.util.Supplier<?> messageSupplier,
+            final Throwable throwable) {
+        log(level, (Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message with parameters at the specified level.
@@ -3061,25 +2513,6 @@ public interface Logger {
             Object p7,
             Object p8,
             Object p9);
-
-    /**
-     * Logs a message with parameters at the specified level.
-     *
-     * @param level the logging level
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     */
-    void log(Level level, String message, Object p0);
-
-    /**
-     * Logs a message with parameters at the specified level.
-     *
-     * @param level the logging level
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void log(Level level, String message, Object p0, Object p1);
 
     /**
      * Logs a message with parameters at the specified level.
@@ -3278,63 +2711,34 @@ public interface Logger {
     <T extends Throwable> T throwing(T throwable);
 
     /**
-     * Logs a message with the specific Marker at the {@link Level#TRACE TRACE} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     */
-    void trace(Marker marker, Message message);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#TRACE TRACE} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void trace(Marker marker, Message message, Throwable throwable);
-
-    /**
      * Logs a message which is only to be constructed if the logging level is the {@link Level#TRACE TRACE} level with
-     * the specified Marker. The {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the
+     * the specified Marker. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the
      * {@code Message}.
      *
      * @param marker the marker data specific to this log statement
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void trace(Marker marker, MessageSupplier messageSupplier);
+    default void trace(final Marker marker, final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        trace(marker, (Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#TRACE TRACE} level) with the
      * specified Marker and including the stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The
-     * {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
+     * {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param marker the marker data specific to this log statement
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @param throwable A Throwable or null.
      * @since 2.4
      */
-    void trace(Marker marker, MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the {@link Level#TRACE TRACE} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message CharSequence to log.
-     */
-    void trace(Marker marker, CharSequence message);
-
-    /**
-     * Logs a CharSequence at the {@link Level#TRACE TRACE} level including the stack trace of the {@link Throwable}
-     * <code>throwable</code> passed as parameter.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     * @see #debug(String)
-     */
-    void trace(Marker marker, CharSequence message, Throwable throwable);
+    default void trace(
+            final Marker marker,
+            final org.apache.logging.log4j.util.MessageSupplier messageSupplier,
+            final Throwable throwable) {
+        trace(marker, (Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the {@link Level#TRACE TRACE} level.
@@ -3364,16 +2768,6 @@ public interface Logger {
     void trace(Marker marker, String message);
 
     /**
-     * Logs a message with parameters at the {@link Level#TRACE TRACE} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void trace(Marker marker, String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#TRACE
      * TRACE} level.
      *
@@ -3383,7 +2777,14 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void trace(Marker marker, String message, Supplier<?>... paramSuppliers);
+    default void trace(
+            final Marker marker,
+            final String message,
+            final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isTraceEnabled(marker)) {
+            trace(marker, message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the {@link Level#TRACE TRACE} level including the stack trace of the {@link Throwable}
@@ -3406,7 +2807,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void trace(Marker marker, Supplier<?> messageSupplier);
+    default void trace(final Marker marker, final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        trace(marker, (Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#TRACE TRACE} level) with the
@@ -3419,59 +2822,36 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void trace(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#TRACE TRACE} level.
-     *
-     * @param message the message string to be logged
-     */
-    void trace(Message message);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#TRACE TRACE} level.
-     *
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void trace(Message message, Throwable throwable);
+    default void trace(
+            final Marker marker,
+            final org.apache.logging.log4j.util.Supplier<?> messageSupplier,
+            final Throwable throwable) {
+        trace(marker, (Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message which is only to be constructed if the logging level is the {@link Level#TRACE TRACE} level. The
-     * {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
+     * {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void trace(MessageSupplier messageSupplier);
+    default void trace(final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        trace((Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#TRACE TRACE} level) including the
-     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code MessageSupplier} may or may
+     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may
      * not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @since 2.4
      */
-    void trace(MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the {@link Level#TRACE TRACE} level.
-     *
-     * @param message the message CharSequence to log.
-     */
-    void trace(CharSequence message);
-
-    /**
-     * Logs a CharSequence at the {@link Level#TRACE TRACE} level including the stack trace of the {@link Throwable}
-     * <code>throwable</code> passed as parameter.
-     *
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     * @see #debug(String)
-     */
-    void trace(CharSequence message, Throwable throwable);
+    default void trace(final org.apache.logging.log4j.util.MessageSupplier messageSupplier, final Throwable throwable) {
+        trace((Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the {@link Level#TRACE TRACE} level.
@@ -3498,15 +2878,6 @@ public interface Logger {
     void trace(String message);
 
     /**
-     * Logs a message with parameters at the {@link Level#TRACE TRACE} level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void trace(String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#TRACE
      * TRACE} level.
      *
@@ -3515,7 +2886,11 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void trace(String message, Supplier<?>... paramSuppliers);
+    default void trace(final String message, final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isTraceEnabled()) {
+            trace(message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the {@link Level#TRACE TRACE} level including the stack trace of the {@link Throwable}
@@ -3535,7 +2910,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void trace(Supplier<?> messageSupplier);
+    default void trace(final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        trace((Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#TRACE TRACE} level) including the
@@ -3547,26 +2924,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void trace(Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with parameters at trace level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     */
-    void trace(Marker marker, String message, Object p0);
-
-    /**
-     * Logs a message with parameters at trace level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void trace(Marker marker, String message, Object p0, Object p1);
+    default void trace(final org.apache.logging.log4j.util.Supplier<?> messageSupplier, final Throwable throwable) {
+        trace((Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message with parameters at trace level.
@@ -3717,23 +3077,6 @@ public interface Logger {
             Object p7,
             Object p8,
             Object p9);
-
-    /**
-     * Logs a message with parameters at trace level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     */
-    void trace(String message, Object p0);
-
-    /**
-     * Logs a message with parameters at trace level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void trace(String message, Object p0, Object p1);
 
     /**
      * Logs a message with parameters at trace level.
@@ -3909,13 +3252,13 @@ public interface Logger {
      * }
      * }</pre>
      *
-     * @param paramSuppliers The Suppliers for the parameters to the method.
+     * @param paramSuppliers The org.apache.logging.log4j.util.Suppliers for the parameters to the method.
      * @return built message
      *
      * @since 2.6
      */
     @SuppressWarnings("deprecation")
-    EntryMessage traceEntry(Supplier<?>... paramSuppliers);
+    EntryMessage traceEntry(org.apache.logging.log4j.util.Supplier<?>... paramSuppliers);
 
     /**
      * Logs entry to a method along with its parameters. For example,
@@ -3928,13 +3271,13 @@ public interface Logger {
      * }</pre>
      *
      * @param format The format String for the parameters.
-     * @param paramSuppliers The Suppliers for the parameters to the method.
+     * @param paramSuppliers The org.apache.logging.log4j.util.Suppliers for the parameters to the method.
      * @return built message
      *
      * @since 2.6
      */
     @SuppressWarnings("deprecation")
-    EntryMessage traceEntry(String format, Supplier<?>... paramSuppliers);
+    EntryMessage traceEntry(String format, org.apache.logging.log4j.util.Supplier<?>... paramSuppliers);
 
     /**
      * Logs entry to a method using a Message to describe the parameters.
@@ -4050,62 +3393,34 @@ public interface Logger {
     <R> R traceExit(Message message, R result);
 
     /**
-     * Logs a message with the specific Marker at the {@link Level#WARN WARN} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     */
-    void warn(Marker marker, Message message);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#WARN WARN} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void warn(Marker marker, Message message, Throwable throwable);
-
-    /**
      * Logs a message which is only to be constructed if the logging level is the {@link Level#WARN WARN} level with the
-     * specified Marker. The {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the
+     * specified Marker. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the
      * {@code Message}.
      *
      * @param marker the marker data specific to this log statement
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void warn(Marker marker, MessageSupplier messageSupplier);
+    default void warn(final Marker marker, final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        warn(marker, (Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#WARN WARN} level) with the
      * specified Marker and including the stack warn of the {@link Throwable} <code>throwable</code> passed as parameter. The
-     * {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
+     * {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param marker the marker data specific to this log statement
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @param throwable A Throwable or null.
      * @since 2.4
      */
-    void warn(Marker marker, MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the {@link Level#WARN WARN} level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message CharSequence to log.
-     */
-    void warn(Marker marker, CharSequence message);
-
-    /**
-     * Logs a CharSequence at the {@link Level#WARN WARN} level including the stack trace of the {@link Throwable}
-     * <code>throwable</code> passed as parameter.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     */
-    void warn(Marker marker, CharSequence message, Throwable throwable);
+    default void warn(
+            final Marker marker,
+            final org.apache.logging.log4j.util.MessageSupplier messageSupplier,
+            final Throwable throwable) {
+        warn(marker, (Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the {@link Level#WARN WARN} level.
@@ -4134,16 +3449,6 @@ public interface Logger {
     void warn(Marker marker, String message);
 
     /**
-     * Logs a message with parameters at the {@link Level#WARN WARN} level.
-     *
-     * @param marker the marker data specific to this log statement.
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void warn(Marker marker, String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#WARN
      * WARN} level.
      *
@@ -4153,7 +3458,14 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void warn(Marker marker, String message, Supplier<?>... paramSuppliers);
+    default void warn(
+            final Marker marker,
+            final String message,
+            final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isWarnEnabled(marker)) {
+            warn(marker, message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the {@link Level#WARN WARN} level including the stack trace of the {@link Throwable}
@@ -4175,7 +3487,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void warn(Marker marker, Supplier<?> messageSupplier);
+    default void warn(final Marker marker, final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        warn(marker, (Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#WARN WARN} level) with the
@@ -4188,58 +3502,36 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void warn(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#WARN WARN} level.
-     *
-     * @param message the message string to be logged
-     */
-    void warn(Message message);
-
-    /**
-     * Logs a message with the specific Marker at the {@link Level#WARN WARN} level.
-     *
-     * @param message the message string to be logged
-     * @param throwable A Throwable or null.
-     */
-    void warn(Message message, Throwable throwable);
+    default void warn(
+            final Marker marker,
+            final org.apache.logging.log4j.util.Supplier<?> messageSupplier,
+            final Throwable throwable) {
+        warn(marker, (Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message which is only to be constructed if the logging level is the {@link Level#WARN WARN} level. The
-     * {@code MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
+     * {@code org.apache.logging.log4j.util.MessageSupplier} may or may not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @since 2.4
      */
-    void warn(MessageSupplier messageSupplier);
+    default void warn(final org.apache.logging.log4j.util.MessageSupplier messageSupplier) {
+        warn((Supplier<Message>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#WARN WARN} level) including the
-     * stack warn of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code MessageSupplier} may or may
+     * stack warn of the {@link Throwable} <code>throwable</code> passed as parameter. The {@code org.apache.logging.log4j.util.MessageSupplier} may or may
      * not use the {@link MessageFactory} to construct the {@code Message}.
      *
      * @param messageSupplier A function, which when called, produces the desired log message.
      * @param throwable the {@code Throwable} to log, including its stack warn.
      * @since 2.4
      */
-    void warn(MessageSupplier messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message CharSequence with the {@link Level#WARN WARN} level.
-     *
-     * @param message the message CharSequence to log.
-     */
-    void warn(CharSequence message);
-
-    /**
-     * Logs a CharSequence at the {@link Level#WARN WARN} level including the stack trace of the {@link Throwable}
-     * <code>throwable</code> passed as parameter.
-     *
-     * @param message the message CharSequence to log.
-     * @param throwable the {@code Throwable} to log, including its stack trace.
-     */
-    void warn(CharSequence message, Throwable throwable);
+    default void warn(final org.apache.logging.log4j.util.MessageSupplier messageSupplier, final Throwable throwable) {
+        warn((Supplier<Message>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message object with the {@link Level#WARN WARN} level.
@@ -4265,15 +3557,6 @@ public interface Logger {
     void warn(String message);
 
     /**
-     * Logs a message with parameters at the {@link Level#WARN WARN} level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param params parameters to the message.
-     * @see #getMessageFactory()
-     */
-    void warn(String message, Object... params);
-
-    /**
      * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#WARN
      * WARN} level.
      *
@@ -4282,7 +3565,11 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void warn(String message, Supplier<?>... paramSuppliers);
+    default void warn(final String message, final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
+        if (isWarnEnabled()) {
+            warn(message, Arrays.copyOf(paramSuppliers, paramSuppliers.length, Supplier[].class));
+        }
+    }
 
     /**
      * Logs a message at the {@link Level#WARN WARN} level including the stack trace of the {@link Throwable}
@@ -4301,7 +3588,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void warn(Supplier<?> messageSupplier);
+    default void warn(final org.apache.logging.log4j.util.Supplier<?> messageSupplier) {
+        warn((Supplier<?>) messageSupplier);
+    }
 
     /**
      * Logs a message (only to be constructed if the logging level is the {@link Level#WARN WARN} level) including the
@@ -4313,26 +3602,9 @@ public interface Logger {
      * @since 2.4
      */
     @SuppressWarnings("deprecation")
-    void warn(Supplier<?> messageSupplier, Throwable throwable);
-
-    /**
-     * Logs a message with parameters at warn level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     */
-    void warn(Marker marker, String message, Object p0);
-
-    /**
-     * Logs a message with parameters at warn level.
-     *
-     * @param marker the marker data specific to this log statement
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void warn(Marker marker, String message, Object p0, Object p1);
+    default void warn(final org.apache.logging.log4j.util.Supplier<?> messageSupplier, final Throwable throwable) {
+        warn((Supplier<?>) messageSupplier, throwable);
+    }
 
     /**
      * Logs a message with parameters at warn level.
@@ -4489,23 +3761,6 @@ public interface Logger {
      *
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
-     */
-    void warn(String message, Object p0);
-
-    /**
-     * Logs a message with parameters at warn level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
-     * @param p1 parameter to the message.
-     */
-    void warn(String message, Object p0, Object p1);
-
-    /**
-     * Logs a message with parameters at warn level.
-     *
-     * @param message the message to log; the format depends on the message factory.
-     * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      */
@@ -4641,81 +3896,6 @@ public interface Logger {
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @since 2.13.0
      */
-    default void logMessage(
-            Level level, Marker marker, String fqcn, StackTraceElement location, Message message, Throwable throwable) {
-        // noop
-    }
-
-    /**
-     * Construct a trace log event.
-     * @return a LogBuilder.
-     * @since 2.13.0
-     */
-    default LogBuilder atTrace() {
-        return LogBuilder.NOOP;
-    }
-
-    /**
-     * Construct a trace log event.
-     * @return a LogBuilder.
-     * @since 2.13.0
-     */
-    default LogBuilder atDebug() {
-        return LogBuilder.NOOP;
-    }
-
-    /**
-     * Construct a trace log event.
-     * @return a LogBuilder.
-     * @since 2.13.0
-     */
-    default LogBuilder atInfo() {
-        return LogBuilder.NOOP;
-    }
-
-    /**
-     * Construct a trace log event.
-     * @return a LogBuilder.
-     * @since 2.13.0
-     */
-    default LogBuilder atWarn() {
-        return LogBuilder.NOOP;
-    }
-
-    /**
-     * Construct a trace log event.
-     * @return a LogBuilder.
-     * @since 2.13.0
-     */
-    default LogBuilder atError() {
-        return LogBuilder.NOOP;
-    }
-
-    /**
-     * Construct a trace log event.
-     * @return a LogBuilder.
-     * @since 2.13.0
-     */
-    default LogBuilder atFatal() {
-        return LogBuilder.NOOP;
-    }
-
-    /**
-     * Construct a log event that will always be logged.
-     * @return a LogBuilder.
-     * @since 2.13.0
-     */
-    default LogBuilder always() {
-        return LogBuilder.NOOP;
-    }
-
-    /**
-     * Construct a log event.
-     * @param level Any level (ignoreed here).
-     * @return a LogBuilder.
-     * @since 2.13.0
-     */
-    default LogBuilder atLevel(Level level) {
-        return LogBuilder.NOOP;
-    }
+    void logMessage(
+            Level level, Marker marker, String fqcn, StackTraceElement location, Message message, Throwable throwable);
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLogger.java
@@ -265,11 +265,12 @@ public class SimpleLogger extends AbstractLogger {
     @SuppressFBWarnings(
             value = "INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE",
             justification = "Log4j prints stacktraces only to logs, which should be private.")
-    public void logMessage(
+    protected void doLogMessage(
             final String fqcn,
-            final Level mgsLevel,
+            final StackTraceElement location,
+            final Level level,
             final Marker marker,
-            final Message msg,
+            final Message message,
             final Throwable throwable) {
         final StringBuilder sb = new StringBuilder();
         // Append date-time if so configured
@@ -286,13 +287,13 @@ public class SimpleLogger extends AbstractLogger {
             sb.append(SPACE);
         }
 
-        sb.append(mgsLevel.toString());
+        sb.append(level.toString());
         sb.append(SPACE);
         if (Strings.isNotEmpty(logName)) {
             sb.append(logName);
             sb.append(SPACE);
         }
-        sb.append(msg.getFormattedMessage());
+        sb.append(message.getFormattedMessage());
         if (showContextMap) {
             final Map<String, String> mdc = ThreadContext.getImmutableContext();
             if (mdc.size() > 0) {
@@ -301,7 +302,7 @@ public class SimpleLogger extends AbstractLogger {
                 sb.append(SPACE);
             }
         }
-        final Object[] params = msg.getParameters();
+        final Object[] params = message.getParameters();
         final Throwable t;
         if (throwable == null
                 && params != null

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.spi;
 
+import java.util.function.Supplier;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogBuilder;
 import org.apache.logging.log4j.LoggingException;
@@ -32,10 +33,8 @@ import org.apache.logging.log4j.spi.recycler.RecyclerFactory;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Cast;
 import org.apache.logging.log4j.util.LambdaUtil;
-import org.apache.logging.log4j.util.MessageSupplier;
 import org.apache.logging.log4j.util.PerformanceSensitive;
 import org.apache.logging.log4j.util.StackLocatorUtil;
-import org.apache.logging.log4j.util.Supplier;
 
 /**
  * Base implementation of a Logger. It is highly recommended that any Logger implementation extend this class.
@@ -125,10 +124,10 @@ public abstract class AbstractLogger implements ExtendedLogger {
                 flowMessageFactory != null ? flowMessageFactory : LoggingSystem.getFlowMessageFactory();
         final RecyclerFactory effectiveRecyclerFactory =
                 recyclerFactory != null ? recyclerFactory : LoggingSystem.getRecyclerFactory();
-        this.recycler = effectiveRecyclerFactory.create(DefaultLogBuilder::new);
+        recycler = effectiveRecyclerFactory.create(DefaultLogBuilder::new);
     }
 
-    private static String createNameFromClass(String name, Class<?> clazz) {
+    private static String createNameFromClass(final String name, final Class<?> clazz) {
         if (name != null) {
             return name;
         }
@@ -198,6 +197,11 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
+    public void debug(final Marker marker, final Throwable throwable) {
+        logIfEnabled(FQCN, Level.DEBUG, marker, (Message) null, throwable);
+    }
+
+    @Override
     public void debug(final Marker marker, final CharSequence message) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, null);
     }
@@ -240,6 +244,11 @@ public abstract class AbstractLogger implements ExtendedLogger {
     @Override
     public void debug(final Marker marker, final String message, final Throwable t) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, t);
+    }
+
+    @Override
+    public void debug(final Throwable throwable) {
+        logIfEnabled(FQCN, Level.DEBUG, null, (Message) null, throwable);
     }
 
     @Override
@@ -288,59 +297,33 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void debug(final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, Level.DEBUG, null, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, Level.DEBUG, null, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void debug(final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.DEBUG, null, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void debug(final Marker marker, final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, Level.DEBUG, marker, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, Level.DEBUG, marker, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void debug(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, paramSuppliers);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void debug(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.DEBUG, marker, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void debug(final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, paramSuppliers);
-    }
-
-    @Override
-    public void debug(final Marker marker, final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, Level.DEBUG, marker, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void debug(final Marker marker, final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, Level.DEBUG, marker, msgSupplier, t);
-    }
-
-    @Override
-    public void debug(final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, Level.DEBUG, null, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void debug(final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, Level.DEBUG, null, msgSupplier, t);
     }
 
     @Override
@@ -350,6 +333,16 @@ public abstract class AbstractLogger implements ExtendedLogger {
 
     @Override
     public void debug(final Marker marker, final String message, final Object p0, final Object p1) {
+        logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1);
+    }
+
+    @Override
+    public void debug(final Marker marker, final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, Level.DEBUG, marker, message, p0);
+    }
+
+    @Override
+    public void debug(final Marker marker, final String message, final Supplier<?> p0, final Supplier<?> p1) {
         logIfEnabled(FQCN, Level.DEBUG, marker, message, p0, p1);
     }
 
@@ -467,6 +460,16 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
+    public void debug(final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, Level.DEBUG, null, message, p0);
+    }
+
+    @Override
+    public void debug(final String message, final Supplier<?> p0, final Supplier<?> p1) {
+        logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1);
+    }
+
+    @Override
     public void debug(final String message, final Object p0, final Object p1, final Object p2) {
         logIfEnabled(FQCN, Level.DEBUG, null, message, p0, p1, p2);
     }
@@ -560,7 +563,6 @@ public abstract class AbstractLogger implements ExtendedLogger {
      * @param paramSuppliers The Suppliers of the parameters.
      * @return The EntryMessage.
      */
-    @SuppressWarnings("deprecation")
     protected EntryMessage enter(final String fqcn, final String format, final Supplier<?>... paramSuppliers) {
         EntryMessage entryMsg = null;
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
@@ -618,14 +620,14 @@ public abstract class AbstractLogger implements ExtendedLogger {
      * @param fqcn The fully qualified class name of the <b>caller</b>.
      * @param params The parameters to the method.
      */
-    @SuppressWarnings("deprecation")
     protected void entry(final String fqcn, final Object... params) {
         if (isEnabled(Level.TRACE, ENTRY_MARKER, (Object) null, null)) {
-            if (params == null) {
-                logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg(null, (Supplier<?>[]) null), null);
-            } else {
-                logMessageSafely(fqcn, Level.TRACE, ENTRY_MARKER, entryMsg(null, params), null);
-            }
+            logMessageSafely(
+                    fqcn,
+                    Level.TRACE,
+                    ENTRY_MARKER,
+                    params == null ? entryMsg(null, (Supplier<?>[]) null) : entryMsg(null, params),
+                    null);
         }
     }
 
@@ -633,18 +635,13 @@ public abstract class AbstractLogger implements ExtendedLogger {
         return flowMessageFactory.newEntryMessage(format, params);
     }
 
-    protected EntryMessage entryMsg(final String format, final MessageSupplier... paramSuppliers) {
-        final int count = paramSuppliers == null ? 0 : paramSuppliers.length;
-        final Object[] params = new Object[count];
-        for (int i = 0; i < count; i++) {
-            params[i] = paramSuppliers[i].get();
-        }
-        return entryMsg(format, params);
-    }
-
-    @SuppressWarnings("deprecation")
     protected EntryMessage entryMsg(final String format, final Supplier<?>... paramSuppliers) {
         return entryMsg(format, LambdaUtil.getAll(paramSuppliers));
+    }
+
+    @Override
+    public void error(final Marker marker, final Throwable throwable) {
+        logIfEnabled(FQCN, Level.ERROR, marker, (Message) null, throwable);
     }
 
     @Override
@@ -693,6 +690,11 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
+    public void error(final Throwable throwable) {
+        logIfEnabled(FQCN, Level.ERROR, null, (Message) null, throwable);
+    }
+
+    @Override
     public void error(final Message msg) {
         logIfEnabled(FQCN, Level.ERROR, null, msg, msg != null ? msg.getThrowable() : null);
     }
@@ -738,59 +740,33 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void error(final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, Level.ERROR, null, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, Level.ERROR, null, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void error(final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.ERROR, null, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void error(final Marker marker, final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, Level.ERROR, marker, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, Level.ERROR, marker, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void error(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, paramSuppliers);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void error(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.ERROR, marker, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void error(final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.ERROR, null, message, paramSuppliers);
-    }
-
-    @Override
-    public void error(final Marker marker, final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, Level.ERROR, marker, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void error(final Marker marker, final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, Level.ERROR, marker, msgSupplier, t);
-    }
-
-    @Override
-    public void error(final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, Level.ERROR, null, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void error(final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, Level.ERROR, null, msgSupplier, t);
     }
 
     @Override
@@ -800,6 +776,16 @@ public abstract class AbstractLogger implements ExtendedLogger {
 
     @Override
     public void error(final Marker marker, final String message, final Object p0, final Object p1) {
+        logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1);
+    }
+
+    @Override
+    public void error(final Marker marker, final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, Level.ERROR, marker, message, p0);
+    }
+
+    @Override
+    public void error(final Marker marker, final String message, final Supplier<?> p0, final Supplier<?> p1) {
         logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1);
     }
 
@@ -913,6 +899,16 @@ public abstract class AbstractLogger implements ExtendedLogger {
 
     @Override
     public void error(final String message, final Object p0, final Object p1) {
+        logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1);
+    }
+
+    @Override
+    public void error(final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, Level.ERROR, null, message, p0);
+    }
+
+    @Override
+    public void error(final String message, final Supplier<?> p0, final Supplier<?> p1) {
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1);
     }
 
@@ -1038,6 +1034,11 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
+    public void fatal(final Marker marker, final Throwable throwable) {
+        logIfEnabled(FQCN, Level.FATAL, marker, (Message) null, throwable);
+    }
+
+    @Override
     public void fatal(final Marker marker, final Message msg) {
         logIfEnabled(FQCN, Level.FATAL, marker, msg, msg != null ? msg.getThrowable() : null);
     }
@@ -1080,6 +1081,11 @@ public abstract class AbstractLogger implements ExtendedLogger {
     @Override
     public void fatal(final Marker marker, final String message, final Throwable t) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, t);
+    }
+
+    @Override
+    public void fatal(final Throwable throwable) {
+        logIfEnabled(FQCN, Level.FATAL, null, (Message) null, throwable);
     }
 
     @Override
@@ -1128,59 +1134,33 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void fatal(final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, Level.FATAL, null, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, Level.FATAL, null, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void fatal(final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.FATAL, null, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void fatal(final Marker marker, final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, Level.FATAL, marker, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, Level.FATAL, marker, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void fatal(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, paramSuppliers);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void fatal(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.FATAL, marker, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void fatal(final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.FATAL, null, message, paramSuppliers);
-    }
-
-    @Override
-    public void fatal(final Marker marker, final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, Level.FATAL, marker, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void fatal(final Marker marker, final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, Level.FATAL, marker, msgSupplier, t);
-    }
-
-    @Override
-    public void fatal(final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, Level.FATAL, null, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void fatal(final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, Level.FATAL, null, msgSupplier, t);
     }
 
     @Override
@@ -1191,6 +1171,16 @@ public abstract class AbstractLogger implements ExtendedLogger {
     @Override
     public void fatal(final Marker marker, final String message, final Object p0, final Object p1) {
         logIfEnabled(FQCN, Level.FATAL, marker, message, p0, p1);
+    }
+
+    @Override
+    public void fatal(final Marker marker, final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, Level.ERROR, marker, message, p0);
+    }
+
+    @Override
+    public void fatal(final Marker marker, final String message, final Supplier<?> p0, final Supplier<?> p1) {
+        logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1);
     }
 
     @Override
@@ -1307,6 +1297,16 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
+    public void fatal(final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, Level.FATAL, null, message, p0);
+    }
+
+    @Override
+    public void fatal(final String message, final Supplier<?> p0, final Supplier<?> p1) {
+        logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1);
+    }
+
+    @Override
     public void fatal(final String message, final Object p0, final Object p1, final Object p2) {
         logIfEnabled(FQCN, Level.FATAL, null, message, p0, p1, p2);
     }
@@ -1408,6 +1408,11 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
+    public void info(final Marker marker, final Throwable throwable) {
+        logIfEnabled(FQCN, Level.INFO, marker, (Message) null, throwable);
+    }
+
+    @Override
     public void info(final Marker marker, final Message msg) {
         logIfEnabled(FQCN, Level.INFO, marker, msg, msg != null ? msg.getThrowable() : null);
     }
@@ -1450,6 +1455,11 @@ public abstract class AbstractLogger implements ExtendedLogger {
     @Override
     public void info(final Marker marker, final String message, final Throwable t) {
         logIfEnabled(FQCN, Level.INFO, marker, message, t);
+    }
+
+    @Override
+    public void info(final Throwable throwable) {
+        logIfEnabled(FQCN, Level.INFO, null, (Message) null, throwable);
     }
 
     @Override
@@ -1498,59 +1508,33 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void info(final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, Level.INFO, null, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, Level.INFO, null, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void info(final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.INFO, null, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void info(final Marker marker, final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, Level.INFO, marker, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, Level.INFO, marker, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void info(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.INFO, marker, message, paramSuppliers);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void info(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.INFO, marker, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void info(final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.INFO, null, message, paramSuppliers);
-    }
-
-    @Override
-    public void info(final Marker marker, final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, Level.INFO, marker, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void info(final Marker marker, final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, Level.INFO, marker, msgSupplier, t);
-    }
-
-    @Override
-    public void info(final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, Level.INFO, null, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void info(final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, Level.INFO, null, msgSupplier, t);
     }
 
     @Override
@@ -1561,6 +1545,16 @@ public abstract class AbstractLogger implements ExtendedLogger {
     @Override
     public void info(final Marker marker, final String message, final Object p0, final Object p1) {
         logIfEnabled(FQCN, Level.INFO, marker, message, p0, p1);
+    }
+
+    @Override
+    public void info(final Marker marker, final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, Level.ERROR, marker, message, p0);
+    }
+
+    @Override
+    public void info(final Marker marker, final String message, final Supplier<?> p0, final Supplier<?> p1) {
+        logIfEnabled(FQCN, Level.ERROR, marker, message, p0, p1);
     }
 
     @Override
@@ -1673,6 +1667,16 @@ public abstract class AbstractLogger implements ExtendedLogger {
 
     @Override
     public void info(final String message, final Object p0, final Object p1) {
+        logIfEnabled(FQCN, Level.INFO, null, message, p0, p1);
+    }
+
+    @Override
+    public void info(final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, Level.INFO, null, message, p0);
+    }
+
+    @Override
+    public void info(final String message, final Supplier<?> p0, final Supplier<?> p1) {
         logIfEnabled(FQCN, Level.INFO, null, message, p0, p1);
     }
 
@@ -1833,6 +1837,11 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
+    public void log(final Level level, final Marker marker, final Throwable throwable) {
+        logIfEnabled(FQCN, level, marker, (Message) null, throwable);
+    }
+
+    @Override
     public void log(final Level level, final Marker marker, final Message msg) {
         logIfEnabled(FQCN, level, marker, msg, msg != null ? msg.getThrowable() : null);
     }
@@ -1844,7 +1853,7 @@ public abstract class AbstractLogger implements ExtendedLogger {
 
     @Override
     public void log(final Level level, final Marker marker, final CharSequence message) {
-        logIfEnabled(FQCN, level, marker, message, (Throwable) null);
+        logIfEnabled(FQCN, level, marker, message, null);
     }
 
     @Override
@@ -1856,7 +1865,7 @@ public abstract class AbstractLogger implements ExtendedLogger {
 
     @Override
     public void log(final Level level, final Marker marker, final Object message) {
-        logIfEnabled(FQCN, level, marker, message, (Throwable) null);
+        logIfEnabled(FQCN, level, marker, message, null);
     }
 
     @Override
@@ -1879,6 +1888,11 @@ public abstract class AbstractLogger implements ExtendedLogger {
     @Override
     public void log(final Level level, final Marker marker, final String message, final Throwable t) {
         logIfEnabled(FQCN, level, marker, message, t);
+    }
+
+    @Override
+    public void log(final Level level, final Throwable throwable) {
+        logIfEnabled(FQCN, level, null, (Message) null, throwable);
     }
 
     @Override
@@ -1927,60 +1941,34 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void log(final Level level, final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, level, null, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, level, null, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void log(final Level level, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, level, null, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void log(final Level level, final Marker marker, final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, level, marker, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, level, marker, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void log(final Level level, final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, level, marker, message, paramSuppliers);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void log(
             final Level level, final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, level, marker, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void log(final Level level, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, level, null, message, paramSuppliers);
-    }
-
-    @Override
-    public void log(final Level level, final Marker marker, final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, level, marker, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void log(final Level level, final Marker marker, final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, level, marker, msgSupplier, t);
-    }
-
-    @Override
-    public void log(final Level level, final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, level, null, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void log(final Level level, final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, level, null, msgSupplier, t);
     }
 
     @Override
@@ -1990,6 +1978,17 @@ public abstract class AbstractLogger implements ExtendedLogger {
 
     @Override
     public void log(final Level level, final Marker marker, final String message, final Object p0, final Object p1) {
+        logIfEnabled(FQCN, level, marker, message, p0, p1);
+    }
+
+    @Override
+    public void log(final Level level, final Marker marker, final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, level, marker, message, p0);
+    }
+
+    @Override
+    public void log(
+            final Level level, final Marker marker, final String message, final Supplier<?> p0, final Supplier<?> p1) {
         logIfEnabled(FQCN, level, marker, message, p0, p1);
     }
 
@@ -2120,6 +2119,16 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
+    public void log(final Level level, final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, level, null, message, p0);
+    }
+
+    @Override
+    public void log(final Level level, final String message, final Supplier<?> p0, final Supplier<?> p1) {
+        logIfEnabled(FQCN, level, null, message, p0, p1);
+    }
+
+    @Override
     public void log(final Level level, final String message, final Object p0, final Object p1, final Object p2) {
         logIfEnabled(FQCN, level, null, message, p0, p1, p2);
     }
@@ -2223,22 +2232,31 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
-    public void logIfEnabled(
-            final String fqcn, final Level level, final Marker marker, final Message msg, final Throwable t) {
-        if (isEnabled(level, marker, msg, t)) {
-            logMessageSafely(fqcn, level, marker, msg, t);
+    public void log(
+            final Level level,
+            final Marker marker,
+            final Message message,
+            final Throwable throwable,
+            final StackTraceElement location) {
+        // TODO: split within inlining limits.
+        if (isEnabled(level, marker, message, throwable)) {
+            try {
+                incrementRecursionDepth();
+                doLogMessage(FQCN, location, level, marker, message, throwable);
+            } catch (final Throwable ex) {
+                handleLogMessageException(ex, FQCN, message);
+            } finally {
+                decrementRecursionDepth();
+                messageFactory.recycle(message);
+            }
         }
     }
 
     @Override
     public void logIfEnabled(
-            final String fqcn,
-            final Level level,
-            final Marker marker,
-            final MessageSupplier msgSupplier,
-            final Throwable t) {
-        if (isEnabled(level, marker, msgSupplier, t)) {
-            logMessage(fqcn, level, marker, msgSupplier, t);
+            final String fqcn, final Level level, final Marker marker, final Message msg, final Throwable t) {
+        if (isEnabled(level, marker, msg, t)) {
+            logMessageSafely(fqcn, level, marker, msg, t);
         }
     }
 
@@ -2259,7 +2277,6 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void logIfEnabled(
             final String fqcn,
             final Level level,
@@ -2279,7 +2296,6 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void logIfEnabled(
             final String fqcn,
             final Level level,
@@ -2315,6 +2331,27 @@ public abstract class AbstractLogger implements ExtendedLogger {
             final String message,
             final Object p0,
             final Object p1) {
+        if (isEnabled(level, marker, message, p0, p1)) {
+            logMessage(fqcn, level, marker, message, p0, p1);
+        }
+    }
+
+    @Override
+    public void logIfEnabled(
+            final String fqcn, final Level level, final Marker marker, final String message, final Supplier<?> p0) {
+        if (isEnabled(level, marker, message, p0)) {
+            logMessage(fqcn, level, marker, message, p0);
+        }
+    }
+
+    @Override
+    public void logIfEnabled(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Supplier<?> p0,
+            final Supplier<?> p1) {
         if (isEnabled(level, marker, message, p0, p1)) {
             logMessage(fqcn, level, marker, message, p0, p1);
         }
@@ -2478,17 +2515,6 @@ public abstract class AbstractLogger implements ExtendedLogger {
         logMessageSafely(fqcn, level, marker, messageFactory.newMessage(message), t);
     }
 
-    protected void logMessage(
-            final String fqcn,
-            final Level level,
-            final Marker marker,
-            final MessageSupplier msgSupplier,
-            final Throwable t) {
-        final Message message = LambdaUtil.get(msgSupplier);
-        logMessageSafely(fqcn, level, marker, message, (t == null && message != null) ? message.getThrowable() : t);
-    }
-
-    @SuppressWarnings("deprecation")
     protected void logMessage(
             final String fqcn,
             final Level level,
@@ -2658,7 +2684,23 @@ public abstract class AbstractLogger implements ExtendedLogger {
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    @SuppressWarnings("deprecation")
+    protected void logMessage(
+            final String fqcn, final Level level, final Marker marker, final String message, final Supplier<?> p0) {
+        final Message msg = messageFactory.newMessage(message, p0.get());
+        logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
+    }
+
+    protected void logMessage(
+            final String fqcn,
+            final Level level,
+            final Marker marker,
+            final String message,
+            final Supplier<?> p0,
+            final Supplier<?> p1) {
+        final Message msg = messageFactory.newMessage(message, p0.get(), p1.get());
+        logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
+    }
+
     protected void logMessage(
             final String fqcn,
             final Level level,
@@ -2668,6 +2710,9 @@ public abstract class AbstractLogger implements ExtendedLogger {
         final Message msg = messageFactory.newMessage(message, LambdaUtil.getAll(paramSuppliers));
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
+
+    protected abstract void doLogMessage(
+            String fqcn, StackTraceElement location, Level level, Marker marker, Message message, Throwable throwable);
 
     @Override
     public void logMessage(
@@ -2679,23 +2724,13 @@ public abstract class AbstractLogger implements ExtendedLogger {
             final Throwable throwable) {
         try {
             incrementRecursionDepth();
-            log(level, marker, fqcn, location, message, throwable);
-        } catch (Throwable ex) {
+            doLogMessage(fqcn, location, level, marker, message, throwable);
+        } catch (final Throwable ex) {
             handleLogMessageException(ex, fqcn, message);
         } finally {
             decrementRecursionDepth();
             messageFactory.recycle(message);
         }
-    }
-
-    protected void log(
-            final Level level,
-            final Marker marker,
-            final String fqcn,
-            final StackTraceElement location,
-            final Message message,
-            final Throwable throwable) {
-        logMessage(fqcn, level, marker, message, throwable);
     }
 
     @Override
@@ -2781,7 +2816,7 @@ public abstract class AbstractLogger implements ExtendedLogger {
             final Message message,
             final Throwable throwable) {
         try {
-            log(level, marker, fqcn, location, message, throwable);
+            doLogMessage(fqcn, location, level, marker, message, throwable);
         } catch (final Throwable t) {
             // LOG4J2-1990 Log4j2 suppresses all exceptions that occur once application called the logger
             handleLogMessageException(t, fqcn, message);
@@ -2842,6 +2877,11 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
+    public void trace(final Marker marker, final Throwable throwable) {
+        logIfEnabled(FQCN, Level.TRACE, marker, (Message) null, throwable);
+    }
+
+    @Override
     public void trace(final Marker marker, final Message msg) {
         logIfEnabled(FQCN, Level.TRACE, marker, msg, msg != null ? msg.getThrowable() : null);
     }
@@ -2884,6 +2924,11 @@ public abstract class AbstractLogger implements ExtendedLogger {
     @Override
     public void trace(final Marker marker, final String message, final Throwable t) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, t);
+    }
+
+    @Override
+    public void trace(final Throwable throwable) {
+        logIfEnabled(FQCN, Level.TRACE, null, (Message) null, throwable);
     }
 
     @Override
@@ -2932,59 +2977,33 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void trace(final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, Level.TRACE, null, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, Level.TRACE, null, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void trace(final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.TRACE, null, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void trace(final Marker marker, final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, Level.TRACE, marker, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, Level.TRACE, marker, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void trace(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, paramSuppliers);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void trace(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.TRACE, marker, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void trace(final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.TRACE, null, message, paramSuppliers);
-    }
-
-    @Override
-    public void trace(final Marker marker, final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, Level.TRACE, marker, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void trace(final Marker marker, final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, Level.TRACE, marker, msgSupplier, t);
-    }
-
-    @Override
-    public void trace(final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, Level.TRACE, null, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void trace(final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, Level.TRACE, null, msgSupplier, t);
     }
 
     @Override
@@ -2994,6 +3013,16 @@ public abstract class AbstractLogger implements ExtendedLogger {
 
     @Override
     public void trace(final Marker marker, final String message, final Object p0, final Object p1) {
+        logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1);
+    }
+
+    @Override
+    public void trace(final Marker marker, final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, Level.TRACE, marker, message, p0);
+    }
+
+    @Override
+    public void trace(final Marker marker, final String message, final Supplier<?> p0, final Supplier<?> p1) {
         logIfEnabled(FQCN, Level.TRACE, marker, message, p0, p1);
     }
 
@@ -3111,6 +3140,16 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
+    public void trace(final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, Level.TRACE, null, message, p0);
+    }
+
+    @Override
+    public void trace(final String message, final Supplier<?> p0, final Supplier<?> p1) {
+        logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1);
+    }
+
+    @Override
     public void trace(final String message, final Object p0, final Object p1, final Object p2) {
         logIfEnabled(FQCN, Level.TRACE, null, message, p0, p1, p2);
     }
@@ -3207,14 +3246,13 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    public EntryMessage traceEntry(final Supplier<?>... paramSuppliers) {
+    public EntryMessage traceEntry(final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
         return enter(FQCN, null, paramSuppliers);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    public EntryMessage traceEntry(final String format, final Supplier<?>... paramSuppliers) {
+    public EntryMessage traceEntry(
+            final String format, final org.apache.logging.log4j.util.Supplier<?>... paramSuppliers) {
         return enter(FQCN, format, paramSuppliers);
     }
 
@@ -3268,6 +3306,11 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
+    public void warn(final Marker marker, final Throwable throwable) {
+        logIfEnabled(FQCN, Level.WARN, marker, (Message) null, throwable);
+    }
+
+    @Override
     public void warn(final Marker marker, final Message msg) {
         logIfEnabled(FQCN, Level.WARN, marker, msg, msg != null ? msg.getThrowable() : null);
     }
@@ -3310,6 +3353,11 @@ public abstract class AbstractLogger implements ExtendedLogger {
     @Override
     public void warn(final Marker marker, final String message, final Throwable t) {
         logIfEnabled(FQCN, Level.WARN, marker, message, t);
+    }
+
+    @Override
+    public void warn(final Throwable throwable) {
+        logIfEnabled(FQCN, Level.WARN, null, (Message) null, throwable);
     }
 
     @Override
@@ -3358,59 +3406,33 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void warn(final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, Level.WARN, null, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, Level.WARN, null, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void warn(final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.WARN, null, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void warn(final Marker marker, final Supplier<?> messageSupplier) {
-        logIfEnabled(FQCN, Level.WARN, marker, messageSupplier, (Throwable) null);
+        logIfEnabled(FQCN, Level.WARN, marker, messageSupplier, null);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void warn(final Marker marker, final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.WARN, marker, message, paramSuppliers);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void warn(final Marker marker, final Supplier<?> messageSupplier, final Throwable throwable) {
         logIfEnabled(FQCN, Level.WARN, marker, messageSupplier, throwable);
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public void warn(final String message, final Supplier<?>... paramSuppliers) {
         logIfEnabled(FQCN, Level.WARN, null, message, paramSuppliers);
-    }
-
-    @Override
-    public void warn(final Marker marker, final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, Level.WARN, marker, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void warn(final Marker marker, final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, Level.WARN, marker, msgSupplier, t);
-    }
-
-    @Override
-    public void warn(final MessageSupplier msgSupplier) {
-        logIfEnabled(FQCN, Level.WARN, null, msgSupplier, (Throwable) null);
-    }
-
-    @Override
-    public void warn(final MessageSupplier msgSupplier, final Throwable t) {
-        logIfEnabled(FQCN, Level.WARN, null, msgSupplier, t);
     }
 
     @Override
@@ -3420,6 +3442,16 @@ public abstract class AbstractLogger implements ExtendedLogger {
 
     @Override
     public void warn(final Marker marker, final String message, final Object p0, final Object p1) {
+        logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1);
+    }
+
+    @Override
+    public void warn(final Marker marker, final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, Level.WARN, marker, message, p0);
+    }
+
+    @Override
+    public void warn(final Marker marker, final String message, final Supplier<?> p0, final Supplier<?> p1) {
         logIfEnabled(FQCN, Level.WARN, marker, message, p0, p1);
     }
 
@@ -3533,6 +3565,16 @@ public abstract class AbstractLogger implements ExtendedLogger {
 
     @Override
     public void warn(final String message, final Object p0, final Object p1) {
+        logIfEnabled(FQCN, Level.WARN, null, message, p0, p1);
+    }
+
+    @Override
+    public void warn(final String message, final Supplier<?> p0) {
+        logIfEnabled(FQCN, Level.WARN, null, message, p0);
+    }
+
+    @Override
+    public void warn(final String message, final Supplier<?> p0, final Supplier<?> p1) {
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1);
     }
 
@@ -3703,10 +3745,7 @@ public abstract class AbstractLogger implements ExtendedLogger {
      */
     @Override
     public LogBuilder atLevel(final Level level) {
-        if (isEnabled(level)) {
-            return getLogBuilder(level);
-        }
-        return LogBuilder.NOOP;
+        return isEnabled(level) ? getLogBuilder(level) : LogBuilder.NOOP;
     }
 
     /**
@@ -3714,8 +3753,8 @@ public abstract class AbstractLogger implements ExtendedLogger {
      *
      * @since 2.20.0
      */
-    protected LogBuilder getLogBuilder(Level level) {
-        DefaultLogBuilder builder = recycler.acquire();
+    protected LogBuilder getLogBuilder(final Level level) {
+        final DefaultLogBuilder builder = recycler.acquire();
         return builder.reset(this, level);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLogger.java
@@ -16,12 +16,11 @@
  */
 package org.apache.logging.log4j.spi;
 
+import java.util.function.Supplier;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.util.MessageSupplier;
-import org.apache.logging.log4j.util.Supplier;
 
 /**
  * Extends the {@code Logger} interface with methods that facilitate implementing or extending {@code Logger}s. Users
@@ -612,29 +611,29 @@ public interface ExtendedLogger extends Logger {
             Object p9);
 
     /**
-     * Logs a message at the specified level. It is the responsibility of the caller to ensure the specified
-     * level is enabled.
+     * Logs a message whose parameters are only to be constructed if the specified level is active.
      *
      * @param fqcn The fully qualified class name of the logger entry point, used to determine the caller class and
      *            method when location information needs to be logged.
      * @param level The logging Level to check.
      * @param marker A Marker or null.
-     * @param message The Message.
-     * @param t the exception to log, including its stack trace.
+     * @param message The message format.
+     * @param s0 lambda that provides the first argument.
      */
-    void logMessage(String fqcn, Level level, Marker marker, Message message, Throwable t);
+    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Supplier<?> s0);
 
     /**
-     * Logs a message which is only to be constructed if the specified level is active.
+     * Logs a message whose parameters are only to be constructed if the specified level is active.
      *
      * @param fqcn The fully qualified class name of the logger entry point, used to determine the caller class and
      *            method when location information needs to be logged.
      * @param level The logging Level to check.
      * @param marker A Marker or null.
-     * @param msgSupplier A function, which when called, produces the desired log message.
-     * @param t the exception to log, including its stack trace.
+     * @param message The message format.
+     * @param s0 lambda that provides the first argument.
+     * @param s1 lambda that provides the second argument.
      */
-    void logIfEnabled(String fqcn, Level level, Marker marker, MessageSupplier msgSupplier, Throwable t);
+    void logIfEnabled(String fqcn, Level level, Marker marker, String message, Supplier<?> s0, Supplier<?> s1);
 
     /**
      * Logs a message whose parameters are only to be constructed if the specified level is active.
@@ -646,7 +645,6 @@ public interface ExtendedLogger extends Logger {
      * @param message The message format.
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
      */
-    @SuppressWarnings("deprecation")
     void logIfEnabled(String fqcn, Level level, Marker marker, String message, Supplier<?>... paramSuppliers);
 
     /**
@@ -659,6 +657,5 @@ public interface ExtendedLogger extends Logger {
      * @param msgSupplier A function, which when called, produces the desired log message.
      * @param t the exception to log, including its stack trace.
      */
-    @SuppressWarnings("deprecation")
     void logIfEnabled(String fqcn, Level level, Marker marker, Supplier<?> msgSupplier, Throwable t);
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLoggerWrapper.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLoggerWrapper.java
@@ -20,7 +20,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MessageFactory;
-import org.apache.logging.log4j.util.StackLocatorUtil;
 
 /**
  * Wrapper class that exposes the protected AbstractLogger methods to support wrapped loggers.
@@ -263,19 +262,20 @@ public class ExtendedLoggerWrapper extends AbstractLogger {
      * Always log an event. This tends to be already guarded by an enabled check, so this method should not check for
      * the logger level again
      *
-     * @param fqcn The fully qualified class name of the <b>caller</b>
-     * @param level The logging level
-     * @param marker The Marker
-     * @param message The Message.
-     * @param t A Throwable or null.
+     * @param fqcn      The fully qualified class name of the <b>caller</b>
+     * @param level     The logging level
+     * @param marker    The Marker
+     * @param message   The Message.
+     * @param throwable A Throwable or null.
      */
     @Override
-    public void logMessage(
-            final String fqcn, final Level level, final Marker marker, final Message message, final Throwable t) {
-        if (requiresLocation()) {
-            logger.logMessage(level, marker, fqcn, StackLocatorUtil.calcLocation(fqcn), message, t);
-        } else {
-            logger.logMessage(fqcn, level, marker, message, t);
-        }
+    public void doLogMessage(
+            final String fqcn,
+            final StackTraceElement location,
+            final Level level,
+            final Marker marker,
+            final Message message,
+            final Throwable throwable) {
+        logger.logMessage(level, marker, fqcn, location, message, throwable);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LambdaUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LambdaUtil.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.util;
 
+import java.util.function.Supplier;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MessageFactory;
 
@@ -35,7 +36,6 @@ public final class LambdaUtil {
      * @return an array containing the results of evaluating the lambda expressions (or {@code null} if the suppliers
      *         array was {@code null}
      */
-    @SuppressWarnings("deprecation")
     public static Object[] getAll(final Supplier<?>... suppliers) {
         if (suppliers == null) {
             return null;
@@ -54,26 +54,12 @@ public final class LambdaUtil {
      * @return the results of evaluating the lambda expression (or {@code null} if the supplier
      *         was {@code null}
      */
-    @SuppressWarnings("deprecation")
     public static Object get(final Supplier<?> supplier) {
         if (supplier == null) {
             return null;
         }
         final Object result = supplier.get();
-        return result instanceof Message ? ((Message) result).getFormattedMessage() : result;
-    }
-
-    /**
-     * Returns the Message supplied by the specified function.
-     * @param supplier a lambda expression or {@code null}
-     * @return the Message resulting from evaluating the lambda expression (or {@code null} if the supplier was
-     * {@code null}
-     */
-    public static Message get(final MessageSupplier supplier) {
-        if (supplier == null) {
-            return null;
-        }
-        return supplier.get();
+        return result instanceof final Message message ? message.getFormattedMessage() : result;
     }
 
     /**
@@ -84,12 +70,11 @@ public final class LambdaUtil {
      * @return the Message resulting from evaluating the lambda expression or the Message created by the factory for
      * supplied values that are not of type Message
      */
-    @SuppressWarnings("deprecation")
     public static Message getMessage(final Supplier<?> supplier, final MessageFactory messageFactory) {
         if (supplier == null) {
             return null;
         }
         final Object result = supplier.get();
-        return result instanceof Message ? (Message) result : messageFactory.newMessage(result);
+        return result instanceof final Message message ? message : messageFactory.newMessage(result);
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/v3/LogManager.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/v3/LogManager.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.v3;
+
+import org.apache.logging.log4j.message.MessageFactory;
+import org.apache.logging.log4j.simple.SimpleLoggerContextFactory;
+import org.apache.logging.log4j.spi.LoggerContext;
+import org.apache.logging.log4j.spi.LoggingSystem;
+import org.apache.logging.log4j.spi.Terminable;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.StackLocatorUtil;
+
+public final class LogManager {
+
+    private static final org.apache.logging.log4j.Logger LOGGER = StatusLogger.getLogger();
+    private static final String FQCN = "org.apache.logging.log4j.v3.LogManager";
+
+    /**
+     * Shutdown using the LoggerContext appropriate for the caller of this method.
+     * This is equivalent to calling {@code LogManager.shutdown(false)}.
+     * <p>
+     * This call is synchronous and will block until shut down is complete.
+     * This may include flushing pending log events over network connections.
+     *
+     * @since 2.6
+     */
+    public static void shutdown() {
+        if (getContext() instanceof final Terminable terminable) {
+            terminable.terminate();
+        }
+    }
+
+    /**
+     * Returns a Logger with the name of the calling class.
+     *
+     * @return The Logger for the calling class.
+     * @throws UnsupportedOperationException if the calling class cannot be determined.
+     */
+    public static Logger getLogger() {
+        return getLogger(StackLocatorUtil.getCallerClass(2));
+    }
+
+    /**
+     * Returns a Logger using the fully qualified name of the Class as the Logger name.
+     *
+     * @param clazz The Class whose name should be used as the Logger name. If null it will default to the calling
+     *              class.
+     * @return The Logger.
+     * @throws UnsupportedOperationException if {@code clazz} is {@code null} and the calling class cannot be
+     *                                       determined.
+     */
+    public static Logger getLogger(final Class<?> clazz) {
+        return getContext().getLogger(clazz, LoggingSystem.getMessageFactory());
+    }
+
+    /**
+     * Returns a Logger using the fully qualified name of the Class as the Logger name.
+     *
+     * @param clazz          The Class whose name should be used as the Logger name. If null it will default to the calling
+     *                       class.
+     * @param messageFactory The message factory is used only when creating a logger, subsequent use does not change the
+     *                       logger but will log a warning if mismatched.
+     * @return The Logger.
+     * @throws UnsupportedOperationException if {@code clazz} is {@code null} and the calling class cannot be
+     *                                       determined.
+     */
+    public static Logger getLogger(final Class<?> clazz, final MessageFactory messageFactory) {
+        return getContext().getLogger(clazz, messageFactory);
+    }
+
+    /**
+     * Returns a Logger with the name of the calling class.
+     *
+     * @param messageFactory The message factory is used only when creating a logger, subsequent use does not change the
+     *                       logger but will log a warning if mismatched.
+     * @return The Logger for the calling class.
+     * @throws UnsupportedOperationException if the calling class cannot be determined.
+     */
+    public static Logger getLogger(final MessageFactory messageFactory) {
+        return getLogger(StackLocatorUtil.getCallerClass(2), messageFactory);
+    }
+
+    /**
+     * Returns a Logger with the specified name.
+     *
+     * @param name The logger name. If null the name of the calling class will be used.
+     * @return The Logger.
+     * @throws UnsupportedOperationException if {@code name} is {@code null} and the calling class cannot be determined.
+     */
+    public static Logger getLogger(final String name) {
+        return getContext().getLogger(name, LoggingSystem.getMessageFactory());
+    }
+
+    /**
+     * Returns a Logger with the specified name.
+     *
+     * @param name           The logger name. If null the name of the calling class will be used.
+     * @param messageFactory The message factory is used only when creating a logger, subsequent use does not change the
+     *                       logger but will log a warning if mismatched.
+     * @return The Logger.
+     * @throws UnsupportedOperationException if {@code name} is {@code null} and the calling class cannot be determined.
+     */
+    public static Logger getLogger(final String name, final MessageFactory messageFactory) {
+        return getContext().getLogger(name, messageFactory);
+    }
+
+    /**
+     * Returns the root logger.
+     *
+     * @return the root logger.
+     */
+    public static Logger getRootLogger() {
+        return getLogger("", LoggingSystem.getMessageFactory());
+    }
+
+    private static LoggerContext getContext() {
+        try {
+            return LoggingSystem.getLoggerContextFactory().getContext(FQCN, null, null, false, null, null);
+        } catch (final IllegalStateException e) {
+            LOGGER.warn("{} Using SimpleLogger", e.getMessage(), e);
+        }
+        return SimpleLoggerContextFactory.INSTANCE.getContext(FQCN, null, null, false, null, null);
+    }
+
+    private LogManager() {}
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/v3/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/v3/Logger.java
@@ -1,0 +1,1848 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.v3;
+
+import java.util.function.Supplier;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogBuilder;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.message.Message;
+
+public interface Logger {
+    /**
+     * Logs a message object with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param throwable the error to log.
+     */
+    void debug(Marker marker, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message CharSequence to log.
+     */
+    void debug(Marker marker, CharSequence message);
+
+    /**
+     * Logs a message CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the
+     * {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void debug(Marker marker, CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void debug(Marker marker, String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void debug(Marker marker, String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void debug(Marker marker, String message, Object... params);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void debug(Marker marker, String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void debug(Marker marker, String message, Supplier<?> p0, Supplier<?> p1);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param marker         the marker data specific to this log statement
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void debug(Marker marker, String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message string to be logged
+     */
+    void debug(Marker marker, Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void debug(Marker marker, Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level with
+     * the specified Marker.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void debug(Marker marker, Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) with the
+     * specified Marker and including the stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       A Throwable or null.
+     * @since 2.4
+     */
+    void debug(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     */
+    void debug(Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message object to log.
+     */
+    void debug(CharSequence message);
+
+    /**
+     * Logs a CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the {@link Throwable}
+     * <code>throwable</code> passed as parameter.
+     *
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void debug(CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void debug(String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void debug(String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void debug(String message, Object... params);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void debug(String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void debug(String message, Supplier<?> p0, Supplier<?> p1);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void debug(String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message string to be logged
+     */
+    void debug(Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void debug(Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void debug(Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) including the
+     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       the {@code Throwable} to log, including its stack trace.
+     * @since 2.4
+     */
+    void debug(Supplier<?> messageSupplier, Throwable throwable);
+
+    /**
+     * Logs a message object with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param throwable the error to log.
+     */
+    void error(Marker marker, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message CharSequence to log.
+     */
+    void error(Marker marker, CharSequence message);
+
+    /**
+     * Logs a message CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the
+     * {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void error(Marker marker, CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void error(Marker marker, String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void error(Marker marker, String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void error(Marker marker, String message, Object... params);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void error(Marker marker, String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void error(Marker marker, String message, Supplier<?> p0, Supplier<?> p1);
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param marker         the marker data specific to this log statement
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void error(Marker marker, String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message string to be logged
+     */
+    void error(Marker marker, Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void error(Marker marker, Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level with
+     * the specified Marker.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void error(Marker marker, Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) with the
+     * specified Marker and including the stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       A Throwable or null.
+     * @since 2.4
+     */
+    void error(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     */
+    void error(Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message object to log.
+     */
+    void error(CharSequence message);
+
+    /**
+     * Logs a CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the {@link Throwable}
+     * <code>throwable</code> passed as parameter.
+     *
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void error(CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void error(String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void error(String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void error(String message, Object... params);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void error(String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void error(String message, Supplier<?> p0, Supplier<?> p1);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void error(String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message string to be logged
+     */
+    void error(Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void error(Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void error(Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) including the
+     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       the {@code Throwable} to log, including its stack trace.
+     * @since 2.4
+     */
+    void error(Supplier<?> messageSupplier, Throwable throwable);
+    /**
+     * Logs a message object with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param throwable the error to log.
+     */
+    void fatal(Marker marker, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message CharSequence to log.
+     */
+    void fatal(Marker marker, CharSequence message);
+
+    /**
+     * Logs a message CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the
+     * {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void fatal(Marker marker, CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void fatal(Marker marker, String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void fatal(Marker marker, String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void fatal(Marker marker, String message, Object... params);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void fatal(Marker marker, String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void fatal(Marker marker, String message, Supplier<?> p0, Supplier<?> p1);
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param marker         the marker data specific to this log statement
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void fatal(Marker marker, String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message string to be logged
+     */
+    void fatal(Marker marker, Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void fatal(Marker marker, Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level with
+     * the specified Marker.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void fatal(Marker marker, Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) with the
+     * specified Marker and including the stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       A Throwable or null.
+     * @since 2.4
+     */
+    void fatal(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     */
+    void fatal(Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message object to log.
+     */
+    void fatal(CharSequence message);
+
+    /**
+     * Logs a CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the {@link Throwable}
+     * <code>throwable</code> passed as parameter.
+     *
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void fatal(CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void fatal(String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void fatal(String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void fatal(String message, Object... params);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void fatal(String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void fatal(String message, Supplier<?> p0, Supplier<?> p1);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void fatal(String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message string to be logged
+     */
+    void fatal(Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void fatal(Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void fatal(Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) including the
+     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       the {@code Throwable} to log, including its stack trace.
+     * @since 2.4
+     */
+    void fatal(Supplier<?> messageSupplier, Throwable throwable);
+
+    /**
+     * Logs a message object with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param throwable the error to log.
+     */
+    void info(Marker marker, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message CharSequence to log.
+     */
+    void info(Marker marker, CharSequence message);
+
+    /**
+     * Logs a message CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the
+     * {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void info(Marker marker, CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void info(Marker marker, String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void info(Marker marker, String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void info(Marker marker, String message, Object... params);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void info(Marker marker, String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void info(Marker marker, String message, Supplier<?> p0, Supplier<?> p1);
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param marker         the marker data specific to this log statement
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void info(Marker marker, String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message string to be logged
+     */
+    void info(Marker marker, Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void info(Marker marker, Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level with
+     * the specified Marker.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void info(Marker marker, Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) with the
+     * specified Marker and including the stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       A Throwable or null.
+     * @since 2.4
+     */
+    void info(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     */
+    void info(Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message object to log.
+     */
+    void info(CharSequence message);
+
+    /**
+     * Logs a CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the {@link Throwable}
+     * <code>throwable</code> passed as parameter.
+     *
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void info(CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void info(String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void info(String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void info(String message, Object... params);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void info(String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void info(String message, Supplier<?> p0, Supplier<?> p1);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void info(String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message string to be logged
+     */
+    void info(Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void info(Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void info(Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) including the
+     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       the {@code Throwable} to log, including its stack trace.
+     * @since 2.4
+     */
+    void info(Supplier<?> messageSupplier, Throwable throwable);
+
+    /**
+     * Logs a message object with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param throwable the error to log.
+     */
+    void trace(Marker marker, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message CharSequence to log.
+     */
+    void trace(Marker marker, CharSequence message);
+
+    /**
+     * Logs a message CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the
+     * {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void trace(Marker marker, CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void trace(Marker marker, String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void trace(Marker marker, String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void trace(Marker marker, String message, Object... params);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void trace(Marker marker, String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void trace(Marker marker, String message, Supplier<?> p0, Supplier<?> p1);
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param marker         the marker data specific to this log statement
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void trace(Marker marker, String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message string to be logged
+     */
+    void trace(Marker marker, Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void trace(Marker marker, Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level with
+     * the specified Marker.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void trace(Marker marker, Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) with the
+     * specified Marker and including the stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       A Throwable or null.
+     * @since 2.4
+     */
+    void trace(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     */
+    void trace(Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message object to log.
+     */
+    void trace(CharSequence message);
+
+    /**
+     * Logs a CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the {@link Throwable}
+     * <code>throwable</code> passed as parameter.
+     *
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void trace(CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void trace(String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void trace(String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void trace(String message, Object... params);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void trace(String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void trace(String message, Supplier<?> p0, Supplier<?> p1);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void trace(String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message string to be logged
+     */
+    void trace(Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void trace(Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void trace(Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) including the
+     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       the {@code Throwable} to log, including its stack trace.
+     * @since 2.4
+     */
+    void trace(Supplier<?> messageSupplier, Throwable throwable);
+
+    /**
+     * Logs a message object with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param throwable the error to log.
+     */
+    void warn(Marker marker, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message CharSequence to log.
+     */
+    void warn(Marker marker, CharSequence message);
+
+    /**
+     * Logs a message CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the
+     * {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void warn(Marker marker, CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void warn(Marker marker, String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void warn(Marker marker, String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void warn(Marker marker, String message, Object... params);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void warn(Marker marker, String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void warn(Marker marker, String message, Supplier<?> p0, Supplier<?> p1);
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param marker         the marker data specific to this log statement
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void warn(Marker marker, String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message string to be logged
+     */
+    void warn(Marker marker, Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void warn(Marker marker, Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level with
+     * the specified Marker.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void warn(Marker marker, Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) with the
+     * specified Marker and including the stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       A Throwable or null.
+     * @since 2.4
+     */
+    void warn(Marker marker, Supplier<?> messageSupplier, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     */
+    void warn(Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message object to log.
+     */
+    void warn(CharSequence message);
+
+    /**
+     * Logs a CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the {@link Throwable}
+     * <code>throwable</code> passed as parameter.
+     *
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void warn(CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void warn(String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void warn(String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void warn(String message, Object... params);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void warn(String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void warn(String message, Supplier<?> p0, Supplier<?> p1);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void warn(String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message string to be logged
+     */
+    void warn(Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void warn(Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void warn(Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) including the
+     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       the {@code Throwable} to log, including its stack trace.
+     * @since 2.4
+     */
+    void warn(Supplier<?> messageSupplier, Throwable throwable);
+
+    /**
+     * Logs a message object with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param throwable the error to log.
+     */
+    void log(Level level, Marker marker, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message CharSequence to log.
+     */
+    void log(Level level, Marker marker, CharSequence message);
+
+    /**
+     * Logs a message CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the
+     * {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void log(Level level, Marker marker, CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void log(Level level, Marker marker, String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void log(Level level, Marker marker, String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void log(Level level, Marker marker, String message, Object... params);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void log(Level level, Marker marker, String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void log(Level level, Marker marker, String message, Supplier<?> p0, Supplier<?> p1);
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param marker         the marker data specific to this log statement
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void log(Level level, Marker marker, String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker  the marker data specific to this log statement
+     * @param message the message string to be logged
+     */
+    void log(Level level, Marker marker, Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param marker    the marker data specific to this log statement
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void log(Level level, Marker marker, Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level with
+     * the specified Marker.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void log(Level level, Marker marker, Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) with the
+     * specified Marker and including the stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param marker          the marker data specific to this log statement
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       A Throwable or null.
+     * @since 2.4
+     */
+    void log(Level level, Marker marker, Supplier<?> messageSupplier, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     */
+    void log(Level level, Throwable throwable);
+
+    /**
+     * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message object to log.
+     */
+    void log(Level level, CharSequence message);
+
+    /**
+     * Logs a CharSequence at the {@link Level#DEBUG DEBUG} level including the stack trace of the {@link Throwable}
+     * <code>throwable</code> passed as parameter.
+     *
+     * @param message   the message CharSequence to log.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     */
+    void log(Level level, CharSequence message, Throwable throwable);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     */
+    void log(Level level, String message, Object p0);
+
+    /**
+     * Logs a message with parameters at debug level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param p0      parameter to the message.
+     * @param p1      parameter to the message.
+     */
+    void log(Level level, String message, Object p0, Object p1);
+
+    /**
+     * Logs a message with parameters at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message to log; the format depends on the message factory.
+     * @param params  parameters to the message.
+     */
+    void log(Level level, String message, Object... params);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void log(Level level, String message, Supplier<?> p0);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @since 2.4
+     */
+    void log(Level level, String message, Supplier<?> p0, Supplier<?> p1);
+
+    /**
+     * Logs a message with parameters which are only to be constructed if the logging level is the {@link Level#DEBUG
+     * DEBUG} level.
+     *
+     * @param message        the message to log; the format depends on the message factory.
+     * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
+     */
+    void log(Level level, String message, Supplier<?>... paramSuppliers);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message the message string to be logged
+     */
+    void log(Level level, Message message);
+
+    /**
+     * Logs a message with the specific Marker at the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param message   the message string to be logged
+     * @param throwable A Throwable or null.
+     */
+    void log(Level level, Message message, Throwable throwable);
+
+    /**
+     * Logs a message which is only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @since 2.4
+     */
+    void log(Level level, Supplier<?> messageSupplier);
+
+    /**
+     * Logs a message (only to be constructed if the logging level is the {@link Level#DEBUG DEBUG} level) including the
+     * stack trace of the {@link Throwable} <code>throwable</code> passed as parameter.
+     *
+     * @param messageSupplier A function, which when called, produces the desired log message; the format depends on the
+     *                        message factory.
+     * @param throwable       the {@code Throwable} to log, including its stack trace.
+     * @since 2.4
+     */
+    void log(Level level, Supplier<?> messageSupplier, Throwable throwable);
+
+    /**
+     * Gets the Level associated with the Logger.
+     *
+     * @return the Level associate with the Logger.
+     */
+    Level getLevel();
+
+    /**
+     * Gets the logger name.
+     *
+     * @return the logger name.
+     */
+    String getName();
+
+    /**
+     * Checks whether this Logger is enabled for the {@link Level#DEBUG DEBUG} Level.
+     *
+     * @return boolean - {@code true} if this Logger is enabled for level DEBUG, {@code false} otherwise.
+     */
+    boolean isDebugEnabled();
+
+    /**
+     * Checks whether this Logger is enabled for the {@link Level#DEBUG DEBUG} Level.
+     *
+     * @param marker The Marker to check
+     * @return boolean - {@code true} if this Logger is enabled for level DEBUG, {@code false} otherwise.
+     */
+    boolean isDebugEnabled(Marker marker);
+
+    /**
+     * Checks whether this Logger is enabled for the given Level.
+     * <p>
+     * Note that passing in {@link Level#OFF OFF} always returns {@code true}.
+     * </p>
+     *
+     * @param level the Level to check
+     * @return boolean - {@code true} if this Logger is enabled for level, {@code false} otherwise.
+     */
+    boolean isEnabled(Level level);
+
+    /**
+     * Checks whether this Logger is enabled for the given Level and Marker.
+     *
+     * @param level The Level to check
+     * @param marker The Marker to check
+     * @return boolean - {@code true} if this Logger is enabled for level and marker, {@code false} otherwise.
+     */
+    boolean isEnabled(Level level, Marker marker);
+
+    /**
+     * Checks whether this Logger is enabled for the {@link Level#ERROR ERROR} Level.
+     *
+     * @return boolean - {@code true} if this Logger is enabled for level {@link Level#ERROR ERROR}, {@code false}
+     *         otherwise.
+     */
+    boolean isErrorEnabled();
+
+    /**
+     * Checks whether this Logger is enabled for the {@link Level#ERROR ERROR} Level.
+     *
+     * @param marker The Marker to check
+     * @return boolean - {@code true} if this Logger is enabled for level {@link Level#ERROR ERROR}, {@code false}
+     *         otherwise.
+     */
+    boolean isErrorEnabled(Marker marker);
+
+    /**
+     * Checks whether this Logger is enabled for the {@link Level#FATAL FATAL} Level.
+     *
+     * @return boolean - {@code true} if this Logger is enabled for level {@link Level#FATAL FATAL}, {@code false}
+     *         otherwise.
+     */
+    boolean isFatalEnabled();
+
+    /**
+     * Checks whether this Logger is enabled for the {@link Level#FATAL FATAL} Level.
+     *
+     * @param marker The Marker to check
+     * @return boolean - {@code true} if this Logger is enabled for level {@link Level#FATAL FATAL}, {@code false}
+     *         otherwise.
+     */
+    boolean isFatalEnabled(Marker marker);
+
+    /**
+     * Checks whether this Logger is enabled for the {@link Level#INFO INFO} Level.
+     *
+     * @return boolean - {@code true} if this Logger is enabled for level INFO, {@code false} otherwise.
+     */
+    boolean isInfoEnabled();
+
+    /**
+     * Checks whether this Logger is enabled for the {@link Level#INFO INFO} Level.
+     *
+     * @param marker The Marker to check
+     * @return boolean - {@code true} if this Logger is enabled for level INFO, {@code false} otherwise.
+     */
+    boolean isInfoEnabled(Marker marker);
+
+    /**
+     * Checks whether this Logger is enabled for the {@link Level#TRACE TRACE} level.
+     *
+     * @return boolean - {@code true} if this Logger is enabled for level TRACE, {@code false} otherwise.
+     */
+    boolean isTraceEnabled();
+
+    /**
+     * Checks whether this Logger is enabled for the {@link Level#TRACE TRACE} level.
+     *
+     * @param marker The Marker to check
+     * @return boolean - {@code true} if this Logger is enabled for level TRACE, {@code false} otherwise.
+     */
+    boolean isTraceEnabled(Marker marker);
+
+    /**
+     * Checks whether this Logger is enabled for the {@link Level#WARN WARN} Level.
+     *
+     * @return boolean - {@code true} if this Logger is enabled for level {@link Level#WARN WARN}, {@code false}
+     *         otherwise.
+     */
+    boolean isWarnEnabled();
+
+    /**
+     * Checks whether this Logger is enabled for the {@link Level#WARN WARN} Level.
+     *
+     * @param marker The Marker to check
+     * @return boolean - {@code true} if this Logger is enabled for level {@link Level#WARN WARN}, {@code false}
+     *         otherwise.
+     */
+    boolean isWarnEnabled(Marker marker);
+
+    /**
+     * Logs a Message.
+     *
+     * @param level     The logging Level to check.
+     * @param marker    A Marker or null.
+     * @param message   The message format.
+     * @param throwable the {@code Throwable} to log, including its stack trace.
+     * @param location  The location of the caller.
+     * @since 2.13.0
+     */
+    void log(Level level, Marker marker, Message message, Throwable throwable, StackTraceElement location);
+
+    /**
+     * Construct a trace log event.
+     * @return a LogBuilder.
+     * @since 2.13.0
+     */
+    LogBuilder atTrace();
+
+    /**
+     * Construct a trace log event.
+     * @return a LogBuilder.
+     * @since 2.13.0
+     */
+    LogBuilder atDebug();
+
+    /**
+     * Construct a trace log event.
+     * @return a LogBuilder.
+     * @since 2.13.0
+     */
+    LogBuilder atInfo();
+
+    /**
+     * Construct a trace log event.
+     * @return a LogBuilder.
+     * @since 2.13.0
+     */
+    LogBuilder atWarn();
+
+    /**
+     * Construct a trace log event.
+     * @return a LogBuilder.
+     * @since 2.13.0
+     */
+    LogBuilder atError();
+
+    /**
+     * Construct a trace log event.
+     * @return a LogBuilder.
+     * @since 2.13.0
+     */
+    LogBuilder atFatal();
+
+    /**
+     * Construct a log event that will always be logged.
+     * @return a LogBuilder.
+     * @since 2.13.0
+     */
+    LogBuilder always();
+
+    /**
+     * Construct a log event.
+     * @param level Any level.
+     * @return a LogBuilder.
+     * @since 2.13.0
+     */
+    LogBuilder atLevel(Level level);
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/v3/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/v3/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+@Export
+@Version("3.0.0")
+package org.apache.logging.log4j.v3;
+
+import org.osgi.annotation.bundle.Export;
+import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigTest.java
@@ -109,7 +109,7 @@ public class AsyncLoggerConfigTest {
                 (AsyncLoggerConfigDisruptor) configuration.getAsyncLoggerConfigDelegate();
         disruptor.start();
         try {
-            config.log(FQCN, FQCN, null, Level.INFO, new SimpleMessage(), null);
+            config.log(FQCN, FQCN, null, null, Level.INFO, new SimpleMessage(), null);
             verify(appender, timeout(100).times(1)).append(any());
             verify(filter, times(1)).filter(any());
         } finally {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigUseAfterShutdownTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigUseAfterShutdownTest.java
@@ -19,10 +19,11 @@ package org.apache.logging.log4j.core.async;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.impl.Log4jPropertyKey;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
+import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.SimpleMessage;
-import org.apache.logging.log4j.spi.AbstractLogger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetSystemProperty;
@@ -37,8 +38,6 @@ public class AsyncLoggerConfigUseAfterShutdownTest {
         log.info("some message");
         CoreLoggerContexts.stopLoggerContext(); // stop async thread
 
-        // call the #logMessage() method to bypass the isEnabled check:
-        // before the LOG4J2-639 fix this would throw a NPE
-        ((AbstractLogger) log).logMessage("com.foo.Bar", Level.INFO, null, new SimpleMessage("msg"), null);
+        log.log(Level.INFO, (Marker) null, (Message) new SimpleMessage("msg"), null);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerEventTranslationExceptionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerEventTranslationExceptionTest.java
@@ -25,12 +25,12 @@ import com.lmax.disruptor.ExceptionHandler;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.impl.Log4jPropertyKey;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
 import org.apache.logging.log4j.core.test.junit.ContextSelectorType;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ReusableSimpleMessage;
-import org.apache.logging.log4j.spi.AbstractLogger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetSystemProperty;
@@ -58,8 +58,8 @@ class AsyncLoggerEventTranslationExceptionTest {
         assertTrue(TestExceptionHandler.INSTANTIATED, "TestExceptionHandler was not configured properly");
 
         final Message exceptionThrowingMessage = new ExceptionThrowingMessage();
-        assertThrows(TestMessageException.class, () -> ((AbstractLogger) log)
-                .logMessage("com.foo.Bar", Level.INFO, null, exceptionThrowingMessage, null));
+        assertThrows(
+                TestMessageException.class, () -> log.log(Level.INFO, (Marker) null, exceptionThrowingMessage, null));
 
         CoreLoggerContexts.stopLoggerContext(); // stop async thread
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerUseAfterShutdownTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerUseAfterShutdownTest.java
@@ -19,10 +19,11 @@ package org.apache.logging.log4j.core.async;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.impl.Log4jPropertyKey;
 import org.apache.logging.log4j.core.test.CoreLoggerContexts;
+import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.SimpleMessage;
-import org.apache.logging.log4j.spi.AbstractLogger;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetSystemProperty;
@@ -44,8 +45,6 @@ public class AsyncLoggerUseAfterShutdownTest {
         log.info(msg, new InternalError("this is not a real error"));
         CoreLoggerContexts.stopLoggerContext(); // stop async thread
 
-        // call the #logMessage() method to bypass the isEnabled check:
-        // before the LOG4J2-639 fix this would throw a NPE
-        ((AbstractLogger) log).logMessage("com.foo.Bar", Level.INFO, null, new SimpleMessage("msg"), null);
+        log.log(Level.INFO, (Marker) null, (Message) new SimpleMessage("msg"), null);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/LoggerConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/LoggerConfigTest.java
@@ -67,7 +67,7 @@ public class LoggerConfigTest {
             actualList[0] = properties;
             return new Builder().setTimeMillis(System.currentTimeMillis()).build();
         });
-        loggerConfig.log("name", "fqcn", null, Level.INFO, new SimpleMessage("msg"), null);
+        loggerConfig.log("name", "fqcn", null, null, Level.INFO, new SimpleMessage("msg"), null);
         assertSame(list, actualList[0], "propertiesList passed in as is if no substitutions required");
     }
 
@@ -86,7 +86,7 @@ public class LoggerConfigTest {
             actualListHolder[0] = properties;
             return new Builder().setTimeMillis(System.currentTimeMillis()).build();
         });
-        loggerConfig.log("name", "fqcn", null, Level.INFO, new SimpleMessage("msg"), null);
+        loggerConfig.log("name", "fqcn", null, null, Level.INFO, new SimpleMessage("msg"), null);
         assertNotSame(list, actualListHolder[0], "propertiesList with substitutions");
 
         @SuppressWarnings("unchecked")
@@ -135,7 +135,7 @@ public class LoggerConfigTest {
         when(appender.getName()).thenReturn("test");
         config.addAppender(appender, null, null);
 
-        config.log(FQCN, FQCN, null, Level.INFO, new SimpleMessage(), null);
+        config.log(FQCN, FQCN, null, null, Level.INFO, new SimpleMessage(), null);
         verify(appender, times(1)).append(any());
         verify(filter, times(1)).filter(any());
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/MockReliabilityStrategy.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/MockReliabilityStrategy.java
@@ -21,13 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.util.Supplier;
 import org.opentest4j.MultipleFailuresError;
 
 /**
@@ -40,18 +40,6 @@ public class MockReliabilityStrategy implements ReliabilityStrategy {
 
     public MockReliabilityStrategy(final LoggerConfig config) {
         this.config = config;
-    }
-
-    @Override
-    public void log(
-            final Supplier<LoggerConfig> reconfigured,
-            final String loggerName,
-            final String fqcn,
-            final Marker marker,
-            final Level level,
-            final Message data,
-            final Throwable t) {
-        config.log(loggerName, fqcn, marker, level, data, t);
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogBuilder;
 import org.apache.logging.log4j.Marker;
@@ -30,10 +31,8 @@ import org.apache.logging.log4j.core.config.ReliabilityStrategy;
 import org.apache.logging.log4j.core.filter.CompositeFilter;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.MessageFactory;
-import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.util.Strings;
-import org.apache.logging.log4j.util.Supplier;
 
 /**
  * The core implementation of the {@link org.apache.logging.log4j.Logger} interface. Besides providing an implementation
@@ -149,19 +148,11 @@ public class Logger extends AbstractLogger implements Supplier<LoggerConfig> {
     }
 
     @Override
-    public void logMessage(
-            final String fqcn, final Level level, final Marker marker, final Message message, final Throwable t) {
-        final Message msg = message == null ? new SimpleMessage(Strings.EMPTY) : message;
-        final ReliabilityStrategy strategy = privateConfig.loggerConfig.getReliabilityStrategy();
-        strategy.log(this, getName(), fqcn, marker, level, msg, t);
-    }
-
-    @Override
-    protected void log(
-            final Level level,
-            final Marker marker,
+    protected void doLogMessage(
             final String fqcn,
             final StackTraceElement location,
+            final Level level,
+            final Marker marker,
             final Message message,
             final Throwable throwable) {
         final ReliabilityStrategy strategy = privateConfig.loggerConfig.getReliabilityStrategy();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventTranslator.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventTranslator.java
@@ -47,7 +47,7 @@ public class RingBufferLogEventTranslator implements EventTranslator<RingBufferL
     private long threadId = Thread.currentThread().getId();
     private String threadName = Thread.currentThread().getName();
     private int threadPriority = Thread.currentThread().getPriority();
-    private StackTraceElement location;
+    protected StackTraceElement location;
     private Clock clock;
     private NanoClock nanoClock;
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AwaitCompletionReliabilityStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AwaitCompletionReliabilityStrategy.java
@@ -23,11 +23,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.util.Supplier;
 
 /**
  * ReliabilityStrategy that counts the number of threads that have started to log an event but have not completed yet,
@@ -43,31 +43,6 @@ public class AwaitCompletionReliabilityStrategy implements ReliabilityStrategy {
 
     public AwaitCompletionReliabilityStrategy(final LoggerConfig loggerConfig) {
         this.loggerConfig = Objects.requireNonNull(loggerConfig, "loggerConfig is null");
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.apache.logging.log4j.core.config.ReliabilityStrategy#log(org.apache.logging.log4j.util.Supplier,
-     * java.lang.String, java.lang.String, org.apache.logging.log4j.Marker, org.apache.logging.log4j.Level,
-     * org.apache.logging.log4j.message.Message, java.lang.Throwable)
-     */
-    @Override
-    public void log(
-            final Supplier<LoggerConfig> reconfigured,
-            final String loggerName,
-            final String fqcn,
-            final Marker marker,
-            final Level level,
-            final Message data,
-            final Throwable t) {
-
-        final LoggerConfig config = getActiveLoggerConfig(reconfigured);
-        try {
-            config.log(loggerName, fqcn, marker, level, data, t);
-        } finally {
-            config.getReliabilityStrategy().afterLogEvent();
-        }
     }
 
     /*

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AwaitUnconditionallyReliabilityStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AwaitUnconditionallyReliabilityStrategy.java
@@ -17,6 +17,7 @@
 package org.apache.logging.log4j.core.config;
 
 import java.util.Objects;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.LogEvent;
@@ -24,7 +25,6 @@ import org.apache.logging.log4j.core.impl.Log4jPropertyKey;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.PropertiesUtil;
-import org.apache.logging.log4j.util.Supplier;
 
 /**
  * Reliability strategy that sleeps unconditionally for some time before allowing a Configuration to be stopped.
@@ -44,25 +44,6 @@ public class AwaitUnconditionallyReliabilityStrategy implements ReliabilityStrat
                 .getLongProperty(
                         Log4jPropertyKey.CONFIG_RELIABILITY_STRATEGY_AWAIT_UNCONDITIONALLY_MILLIS,
                         DEFAULT_SLEEP_MILLIS);
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.apache.logging.log4j.core.config.ReliabilityStrategy#log(org.apache.logging.log4j.util.Supplier,
-     * java.lang.String, java.lang.String, org.apache.logging.log4j.Marker, org.apache.logging.log4j.Level,
-     * org.apache.logging.log4j.message.Message, java.lang.Throwable)
-     */
-    @Override
-    public void log(
-            final Supplier<LoggerConfig> reconfigured,
-            final String loggerName,
-            final String fqcn,
-            final Marker marker,
-            final Level level,
-            final Message data,
-            final Throwable t) {
-        loggerConfig.log(loggerName, fqcn, marker, level, data, t);
     }
 
     /*

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/DefaultReliabilityStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/DefaultReliabilityStrategy.java
@@ -17,11 +17,11 @@
 package org.apache.logging.log4j.core.config;
 
 import java.util.Objects;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.util.Supplier;
 
 /**
  * Reliability strategy that assumes reconfigurations will never take place.
@@ -32,25 +32,6 @@ public class DefaultReliabilityStrategy implements ReliabilityStrategy {
 
     public DefaultReliabilityStrategy(final LoggerConfig loggerConfig) {
         this.loggerConfig = Objects.requireNonNull(loggerConfig, "loggerConfig is null");
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.apache.logging.log4j.core.config.ReliabilityStrategy#log(org.apache.logging.log4j.util.Supplier,
-     * java.lang.String, java.lang.String, org.apache.logging.log4j.Marker, org.apache.logging.log4j.Level,
-     * org.apache.logging.log4j.message.Message, java.lang.Throwable)
-     */
-    @Override
-    public void log(
-            final Supplier<LoggerConfig> reconfigured,
-            final String loggerName,
-            final String fqcn,
-            final Marker marker,
-            final Level level,
-            final Message data,
-            final Throwable t) {
-        loggerConfig.log(loggerName, fqcn, marker, level, data, t);
     }
 
     /*

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LockingReliabilityStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LockingReliabilityStrategy.java
@@ -19,11 +19,11 @@ package org.apache.logging.log4j.core.config;
 import java.util.Objects;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.util.Supplier;
 
 /**
  * ReliabilityStrategy that uses read/write locks to prevent the LoggerConfig from stopping while it is in use.
@@ -41,47 +41,22 @@ public class LockingReliabilityStrategy implements ReliabilityStrategy {
      * (non-Javadoc)
      *
      * @see org.apache.logging.log4j.core.config.ReliabilityStrategy#log(org.apache.logging.log4j.util.Supplier,
-     * java.lang.String, java.lang.String, org.apache.logging.log4j.Marker, org.apache.logging.log4j.Level,
-     * org.apache.logging.log4j.message.Message, java.lang.Throwable)
-     */
-    @Override
-    public void log(
-            final Supplier<LoggerConfig> reconfigured,
-            final String loggerName,
-            final String fqcn,
-            final Marker marker,
-            final Level level,
-            final Message data,
-            final Throwable t) {
-
-        final LoggerConfig config = getActiveLoggerConfig(reconfigured);
-        try {
-            config.log(loggerName, fqcn, marker, level, data, t);
-        } finally {
-            config.getReliabilityStrategy().afterLogEvent();
-        }
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.apache.logging.log4j.core.config.ReliabilityStrategy#log(org.apache.logging.log4j.util.Supplier,
      * java.lang.String, java.lang.String, java.lang.StackTraceElement, org.apache.logging.log4j.Marker,
      * org.apache.logging.log4j.Level, org.apache.logging.log4j.message.Message, java.lang.Throwable)
      */
     @Override
     public void log(
-            final Supplier<LoggerConfig> reconfigured,
-            final String loggerName,
-            final String fqcn,
-            final StackTraceElement location,
-            final Marker marker,
-            final Level level,
-            final Message data,
-            final Throwable t) {
+            Supplier<LoggerConfig> reconfigured,
+            String loggerName,
+            String fqcn,
+            StackTraceElement location,
+            Marker marker,
+            Level level,
+            Message message,
+            Throwable throwable) {
         final LoggerConfig config = getActiveLoggerConfig(reconfigured);
         try {
-            config.log(loggerName, fqcn, location, marker, level, data, t);
+            config.log(loggerName, fqcn, location, marker, level, message, throwable);
         } finally {
             config.getReliabilityStrategy().afterLogEvent();
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -473,35 +473,6 @@ public class LoggerConfig extends AbstractFilterable {
         return propertiesRequireLookup;
     }
 
-    /**
-     * Logs an event.
-     *
-     * @param loggerName The name of the Logger.
-     * @param fqcn The fully qualified class name of the caller.
-     * @param marker A Marker or null if none is present.
-     * @param level The event Level.
-     * @param data The Message.
-     * @param t A Throwable or null.
-     */
-    @PerformanceSensitive("allocation")
-    public void log(
-            final String loggerName,
-            final String fqcn,
-            final Marker marker,
-            final Level level,
-            final Message data,
-            final Throwable t) {
-        final List<Property> props = getProperties(loggerName, fqcn, marker, level, data, t);
-        final LogEvent logEvent =
-                logEventFactory.createEvent(loggerName, marker, fqcn, location(fqcn), level, data, props, t);
-        try {
-            log(logEvent, LoggerConfigPredicate.ALL);
-        } finally {
-            // LOG4J2-1583 prevent scrambled logs when logging calls are nested (logging in toString())
-            logEventFactory.recycle(logEvent);
-        }
-    }
-
     private StackTraceElement location(final String fqcn) {
         return requiresLocation() ? StackLocatorUtil.calcLocation(fqcn) : null;
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ReliabilityStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ReliabilityStrategy.java
@@ -16,11 +16,11 @@
  */
 package org.apache.logging.log4j.core.config;
 
+import java.util.function.Supplier;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.util.Supplier;
 
 /**
  * Interface for objects that know how to ensure delivery of log events to the appropriate appenders, even during and
@@ -34,41 +34,22 @@ public interface ReliabilityStrategy {
      * @param reconfigured supplies the next LoggerConfig if the strategy's LoggerConfig is no longer active
      * @param loggerName The name of the Logger.
      * @param fqcn The fully qualified class name of the caller.
+     * @param location The location of the caller or null.
      * @param marker A Marker or null if none is present.
      * @param level The event Level.
-     * @param data The Message.
-     * @param t A Throwable or null.
+     * @param message The Message.
+     * @param throwable A Throwable or null.
+     * @since 3.0
      */
     void log(
             Supplier<LoggerConfig> reconfigured,
             String loggerName,
             String fqcn,
+            StackTraceElement location,
             Marker marker,
             Level level,
-            Message data,
-            Throwable t);
-    /**
-     * Logs an event.
-     *
-     * @param reconfigured supplies the next LoggerConfig if the strategy's LoggerConfig is no longer active
-     * @param loggerName The name of the Logger.
-     * @param fqcn The fully qualified class name of the caller.
-     * @param location The location of the caller or null.
-     * @param marker A Marker or null if none is present.
-     * @param level The event Level.
-     * @param data The Message.
-     * @param t A Throwable or null.
-     * @since 3.0
-     */
-    default void log(
-            final Supplier<LoggerConfig> reconfigured,
-            final String loggerName,
-            final String fqcn,
-            final StackTraceElement location,
-            final Marker marker,
-            final Level level,
-            final Message data,
-            final Throwable t) {}
+            Message message,
+            Throwable throwable);
 
     /**
      * Logs an event.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/internal/InternalLoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/internal/InternalLoggerContext.java
@@ -92,14 +92,11 @@ public class InternalLoggerContext extends LoggerContext {
         }
 
         @Override
-        public void logMessage(String fqcn, Level level, Marker marker, Message message, Throwable t) {}
-
-        @Override
-        protected void log(
-                Level level,
-                Marker marker,
+        protected void doLogMessage(
                 String fqcn,
                 StackTraceElement location,
+                Level level,
+                Marker marker,
                 Message message,
                 Throwable throwable) {
             logger.log(level, marker, message, throwable);

--- a/log4j-slf4j-impl/src/main/java/org/apache/logging/slf4j/Log4jLogger.java
+++ b/log4j-slf4j-impl/src/main/java/org/apache/logging/slf4j/Log4jLogger.java
@@ -364,7 +364,7 @@ public class Log4jLogger implements LocationAwareLogger {
             msg = new ParameterizedMessage(message, params, throwable);
             actualThrowable = throwable != null ? throwable : msg.getThrowable();
         }
-        logger.logMessage(fqcn, log4jLevel, log4jMarker, msg, actualThrowable);
+        logger.logMessage(log4jLevel, log4jMarker, fqcn, null, msg, actualThrowable);
     }
 
     @Override

--- a/log4j-slf4j2-impl/src/main/java/org/apache/logging/slf4j/Log4jLogger.java
+++ b/log4j-slf4j2-impl/src/main/java/org/apache/logging/slf4j/Log4jLogger.java
@@ -365,7 +365,7 @@ public class Log4jLogger implements LocationAwareLogger {
             msg = new ParameterizedMessage(message, params, throwable);
             actualThrowable = throwable != null ? throwable : msg.getThrowable();
         }
-        logger.logMessage(fqcn, log4jLevel, log4jMarker, msg, actualThrowable);
+        logger.logMessage(log4jLevel, log4jMarker, fqcn, null, msg, actualThrowable);
     }
 
     @Override

--- a/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/JULLogger.java
+++ b/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/JULLogger.java
@@ -54,17 +54,22 @@ final class JULLogger extends AbstractLogger {
     }
 
     @Override
-    public void logMessage(
-            final String fqcn, final Level level, final Marker marker, final Message message, final Throwable t) {
+    protected void doLogMessage(
+            final String fqcn,
+            final StackTraceElement location,
+            final Level level,
+            final Marker marker,
+            final Message message,
+            final Throwable throwable) {
         final java.util.logging.Level julLevel = convertLevel(level);
         if (!logger.isLoggable(julLevel)) {
             return;
         }
         final LazyLog4jLogRecord record =
-                new LazyLog4jLogRecord(fqcn, julLevel, message.getFormattedMessage()); // NOT getFormat()
+                new LazyLog4jLogRecord(fqcn, location, julLevel, message.getFormattedMessage()); // NOT getFormat()
         // NOT record.setParameters(message.getParameters()); BECAUSE getFormattedMessage() NOT getFormat()
         record.setLoggerName(getName());
-        record.setThrown(t == null ? message.getThrowable() : t);
+        record.setThrown(throwable == null ? message.getThrowable() : throwable);
         logger.log(record);
     }
 

--- a/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/LazyLog4jLogRecord.java
+++ b/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/LazyLog4jLogRecord.java
@@ -31,10 +31,12 @@ final class LazyLog4jLogRecord extends LogRecord {
     private transient boolean inferCaller = true;
 
     private final String fqcn;
+    private final StackTraceElement location;
 
-    LazyLog4jLogRecord(final String fqcn, final Level level, final String msg) {
+    LazyLog4jLogRecord(final String fqcn, final StackTraceElement location, final Level level, final String msg) {
         super(level, msg);
         this.fqcn = fqcn;
+        this.location = location;
     }
 
     @Override
@@ -54,8 +56,8 @@ final class LazyLog4jLogRecord extends LogRecord {
     }
 
     private void inferCaller() {
-        StackTraceElement location = null;
-        if (fqcn != null) {
+        StackTraceElement location = this.location;
+        if (location == null && fqcn != null) {
             location = StackLocatorUtil.calcLocation(fqcn);
         }
         if (location != null) {

--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogBuilder.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogBuilder.java
@@ -79,7 +79,7 @@ public class SLF4JLogBuilder implements LogBuilder {
 
     private void logMessage(Message message) {
         try {
-            logger.logMessage(FQCN, level, marker, message, throwable);
+            logger.logMessage(level, marker, FQCN, null, message, throwable);
         } finally {
             inUse = false;
         }

--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogger.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogger.java
@@ -296,8 +296,13 @@ public class SLF4JLogger extends AbstractLogger {
     }
 
     @Override
-    public void logMessage(
-            final String fqcn, final Level level, final Marker marker, final Message message, final Throwable t) {
+    protected void doLogMessage(
+            final String fqcn,
+            final StackTraceElement location,
+            final Level level,
+            final Marker marker,
+            final Message message,
+            final Throwable t) {
         final org.slf4j.Marker slf4jMarker = getMarker(marker);
         final String formattedMessage = message.getFormattedMessage();
         if (locationAwareLogger != null) {


### PR DESCRIPTION
This is a proof-of-concept to provide a lighter `Logger` interface without breaking compatibility with libraries compiled against v2 `Logger`.

In the `v3.Logger` interface:

 - we replace `o.a.l.l.util.Supplier` with `java.util.function.Supplier`,
 - we provide the methods available in SLF4J,
 - we replace methods that log `Object` with three methods that accept a `CharSequence` (as better "lazy" string), `Message` or `Throwable`,
 - we unroll the `(String, Supplier<?>..)` methods up to two arguments,
 - we replace `logMessage` with `log` and remove the FQCN argument (normal users don't need it).

## How to evaluate this draft?

Look at the `o.a.l.l.v3` package and the modifications to `o.a.l.l.Logger`. A user of `v3.LogManager` will have a lighter interface and his code will use `java.util.function.Supplier`. A user of `LogManager` will have access to the old v2 methods and his code will use `o.a.l.l.util.Supplier` (without the user noticing it).