### PR TITLE
Add security threat model to docs

### DIFF
--- a/src/site/asciidoc/download.adoc.vm
+++ b/src/site/asciidoc/download.adoc.vm
@@ -20,7 +20,7 @@
 <link rel="stylesheet" type="text/css" href="css/tables.css">
 ++++
 
-Apache Log4j 2 is distributed under the
+Apache Log4j 3 is distributed under the
 https://www.apache.org/licenses/LICENSE-2.0.html[Apache License, version 2.0].
 
 The link in the Mirrors column should display a list of available
@@ -59,7 +59,7 @@ Server Releases] for more information on why you should verify our
 releases.
 
 The PGP signatures can be verified using PGP or GPG. First download the
-https://www.apache.org/dist/logging/KEYS[KEYS] as well as the asc
+https://downloads.apache.org/logging/KEYS[KEYS] as well as the asc
 signature file for the relevant distribution. Make sure you get these
 files from the https://www.apache.org/dist/logging/[main distribution
 directory], rather than from a mirror. Then verify the signatures using
@@ -87,11 +87,12 @@ use as dependencies from the https://search.maven.org/search?q=org.apache.loggin
 
 == Using Log4j on your classpath
 
-To use Log4j 3.x in your application make sure that both the API and Core
+To use Log4j 3.x in your application make sure that the API, Plugins, and Core
 jars are in the application’s classpath. Add the dependencies listed
 below to your classpath.
 
 * log4j-api-${Log4jReleaseVersion}.jar
+* log4j-plugins-${Log4jReleaseVersion}.jar
 * log4j-core-${Log4jReleaseVersion}.jar
 
 You can do this from the command line or a manifest file.

--- a/src/site/asciidoc/manual/layouts.adoc
+++ b/src/site/asciidoc/manual/layouts.adoc
@@ -686,7 +686,7 @@ Using the HTML encoding format, the following characters are replaced:
 !Character !Replacement
 
 !'\r', '\n'
-!Converted into escaped strings "\\r" and "\\n" respectively
+!Converted into string literals "\r" and "\n" respectively
 
 !&, <, >, ", ', /
 !Replaced with the corresponding HTML entity
@@ -731,7 +731,7 @@ Using the CRLF encoding format, the following characters are replaced:
 !Character !Replacement
 
 !'\r', '\n'
-!Converted into escaped strings "\\r" and "\\n" respectively
+!Converted into literal strings "\r" and "\n" respectively
 !===
 
 |*equals*{pattern}{test}{substitution} +

--- a/src/site/asciidoc/security.adoc
+++ b/src/site/asciidoc/security.adoc
@@ -50,7 +50,7 @@ The threat model that Log4j uses considers configuration files as safe input con
 == Threat Model
 
 Log4j is a low level library where configuration inputs and the classpath are expected to be controlled by the programmer.
-Configurations have the ability to execute arbitrary code through custom plugins.
+Configurations have the ability to execute arbitrary code.
 While specific Log4j plugins (such as a JNDI lookup) may use constraint validators or conditionals to require additional settings to opt in to functionality, this is not universally required by custom plugins.
 Specific security considerations involved in our threat model are detailed below.
 

--- a/src/site/asciidoc/security.adoc
+++ b/src/site/asciidoc/security.adoc
@@ -46,6 +46,89 @@ If you have encountered an unlisted security vulnerability or other unexpected b
 The threat model that Log4j uses considers configuration files as safe input controlled by the programmer; **potential vulnerabilities that require the ability to modify a configuration are not considered vulnerabilities** as the required access to do so implies the attacker can execute arbitrary code.
 ====
 
+[#model]
+== Threat Model
+
+Log4j is a low level library where configuration inputs and the classpath are expected to be controlled by the programmer.
+Configurations have the ability to execute arbitrary code through custom plugins.
+While specific Log4j plugins (such as a JNDI lookup) may use constraint validators or conditionals to require additional settings to opt in to functionality, this is not universally required by custom plugins.
+Specific security considerations involved in our threat model are detailed below.
+
+=== Parameterized Logging
+
+When using a log message containing template parameters like `{}`, only the format string is evaluated for parameters to be substituted.
+The message parameters themselves are not evaluated for parameters; they are only included in the format string corresponding to their template position.
+The conversion of message parameters into a string is done on-demand depending on the layout being used.
+When structure-preserving transformations of log message data are required, the `Message` API should be used for logging structured data.
+
+=== Unstructured Logging
+
+When using an unstructured layout such as `PatternLayout`, no guarantees can be made about the output format.
+This layout is mainly useful for development purposes and should not be relied on in production applications.
+For example, if a log message contains new lines, these are not escaped or encoded specially unless the configured pattern uses the `%encode{pattern}{CRLF}` wrapper pattern converter (which will encode a carriage return as the string `\r` and a line feed as the string `\n`) or some other `%encode` option.
+Similarly, other encoding options are available for other formats, but pattern layouts cannot make assumptions about the entire output.
+As such, when using unstructured layouts, no user-controlled input should be included in logs.
+It is strongly recommended that a structured layout is used instead for these situations.
+Note that `StrLookup` plugins (those referenced by `${...}` templates in configuration files) that contain user-provided input should not be referenced by a pattern layout.
+
+=== Structured Logging
+
+When using a structured layout (most layouts besides pattern layout), log messages are encoded according to various output formats.
+These safely encode the various fields included in a log message.
+For example, the JSON template layout can be configured to output log messages in various JSON structures where all log data is properly encoded into safely parseable JSON.
+This is the recommended mode of operation for use with log parsing and log collection tools that rely on log files or arbitrary output streams.
+
+=== Code Signing
+
+Log4j artifacts are all signed using PGP using a key from the Logging Services PMC https://downloads.apache.org/logging/KEYS[KEYS file].
+Information on how to verify releases signed with PGP is https://httpd.apache.org/dev/verification.html[documented here].
+Individual jar files are not signed using `jarsigner` (only PGP), and the Log4j plugin system does not rely on signed jars for validation (unlike the Java cryptography APIs for example).
+Thus, PGP signatures should be validated in your build process.
+
+=== Java Security Manager
+
+Log4j no longer supports running in or using a custom `SecurityManager`.
+This Java feature has been deprecated for removal in Java 21.
+Previous versions of Log4j 2.x include partial support for running with a security manager.
+
+=== Log Masking
+
+Log4j, like any other generic logging library, cannot generically support log masking of sensitive data.
+While custom plugins may be developed to attempt to mask various regular expressions (such as a string that looks like a credit card number), the general problem of log masking is equivalent to the halting problem in computer science where sensitive data can always be obfuscated in such a way as to avoid detection by log masking.
+As such, it is the responsibility of the developer to properly demarcate sensitive data such that it can be consistently masked by log masking plugins.
+This sort of use case should make use of the `Message` API for better control over the output of such data.
+
+=== Availability
+
+Log4j goes to great lengths to minimize performance overhead along with options for minimizing latency or maximizing throughput.
+However, we cannot guarantee availability of the application if the appenders cannot keep up with the logs being written.
+Synchronous logging can cause applications to block and wait for a log message to be written.
+Asynchronous logging can also cause applications to block and wait depending on the wait strategy and queue full policy configured.
+Configuring too large or too many buffers in Log4j can also result in out of memory errors.
+
+=== Configuration Sources
+
+All configuration sources to an application must be trusted by the programmer.
+When loading a configuration file from disk (especially when a monitor interval is configured to reload the file periodically), the location of the configuration file must be kept safe from unauthorized modifications.
+Similarly, when loading a configuration file over the network such as through HTTP, this should be configured to use TLS or a secure connection in general with strong authentication guarantees.
+This remote location must be kept safe from unauthorized modifications.
+When configurations are modified through JMX, the JMX server should be safely configured to require authentication and a secure connection if being accessed over the network.
+When configurations are provided through JNDI, these should only use the `java` scheme for sharing configurations in a JavaEE or JakartaEE application service.
+JNDI-sourced configurations should not use other JNDI providers such as LDAP, DNS, or RMI, as all these providers are difficult to properly secure.
+
+=== Cryptographic Logs
+
+When using custom plugins to calculate message authentication codes, signatures, or encrypted logs, proper key management must be considered.
+Cryptography is a tricky subject, and key management lies at the heart of most design problems to solve when using it.
+If a custom plugin relies on a pre-shared key or password of some sort, it is likely broken beyond repair if being used for cryptographic purposes.
+Proper key management typically uses public key infrastructure (PKI) such as X.509 certificates, though this is not the only option.
+It is beyond the scope of Log4j to implement key management as this would depend on other infrastructure in use for validating or decrypting logs combined with the deployment and runtime environment of the logging application.
+
+=== Compressing Logs
+
+If log compression is used along with custom encryption where logs contain user-controlled input, then this can lead to a https://en.wikipedia.org/wiki/CRIME[CRIME attack] style vulnerability where a chosen-plaintext attack is combined with information leakage caused by how the compression algorithm handles different inputs.
+The simplest way to avoid this problem is to never combine compression with encryption when encoding user-controlled input.
+
 [#policy]
 == Vulnerability handling policy
 

--- a/src/site/asciidoc/security.adoc
+++ b/src/site/asciidoc/security.adoc
@@ -68,7 +68,7 @@ This layout is mainly useful for development purposes and should not be relied o
 For example, if a log message contains new lines, these are not escaped or encoded specially unless the configured pattern uses the `%encode{pattern}{CRLF}` wrapper pattern converter (which will encode a carriage return as the string `\r` and a line feed as the string `\n`) or some other `%encode` option.
 Similarly, other encoding options are available for other formats, but pattern layouts cannot make assumptions about the entire output.
 As such, when using unstructured layouts, no user-controlled input should be included in logs.
-It is strongly recommended that a structured layout is used instead for these situations.
+It is strongly recommended that a structured layout (e.g., `JsonTemplateLayout`) is used instead for these situations.
 Note that `StrLookup` plugins (those referenced by `${...}` templates in configuration files) that contain user-provided input should not be referenced by a pattern layout.
 
 === Structured Logging

--- a/src/site/asciidoc/security.adoc
+++ b/src/site/asciidoc/security.adoc
@@ -69,20 +69,19 @@ For example, if a log message contains new lines, these are not escaped or encod
 Similarly, other encoding options are available for other formats, but pattern layouts cannot make assumptions about the entire output.
 As such, when using unstructured layouts, no user-controlled input should be included in logs.
 It is strongly recommended that a structured layout (e.g., `JsonTemplateLayout`) is used instead for these situations.
-Note that `StrLookup` plugins (those referenced by `${...}` templates in configuration files) that contain user-provided input should not be referenced by a pattern layout.
+Note that `StrLookup` plugins (those referenced by `${...}` templates in configuration files) that contain user-provided input should not be referenced by layouts.
 
 === Structured Logging
 
 When using a structured layout (most layouts besides pattern layout), log messages are encoded according to various output formats.
 These safely encode the various fields included in a log message.
-For example, the JSON template layout can be configured to output log messages in various JSON structures where all log data is properly encoded into safely parseable JSON.
+For example, the `JsonTemplateLayout` can be configured to output log messages in various JSON structures where all log data is properly encoded into safely parseable JSON.
 This is the recommended mode of operation for use with log parsing and log collection tools that rely on log files or arbitrary output streams.
 
 === Code Signing
 
 Log4j artifacts are all signed using PGP using a key from the Logging Services PMC https://downloads.apache.org/logging/KEYS[KEYS file].
 Information on how to verify releases signed with PGP is https://httpd.apache.org/dev/verification.html[documented here].
-Individual jar files are not signed using `jarsigner` (only PGP), and the Log4j plugin system does not rely on signed jars for validation (unlike the Java cryptography APIs for example).
 Thus, PGP signatures should be validated in your build process.
 
 === Java Security Manager

--- a/src/site/asciidoc/security.adoc
+++ b/src/site/asciidoc/security.adoc
@@ -59,13 +59,15 @@ Specific security considerations involved in our threat model are detailed below
 When using a log message containing template parameters like `{}`, only the format string is evaluated for parameters to be substituted.
 The message parameters themselves are not evaluated for parameters; they are only included in the format string corresponding to their template position.
 The conversion of message parameters into a string is done on-demand depending on the layout being used.
-When structure-preserving transformations of log message data are required, the `Message` API should be used for logging structured data.
+When structure-preserving transformations of log message data are required, the `Message` API should be used for logging structured data combined with a structured layout (e.g., `JsonTemplateLayout`).
+Format strings should be compile-time constants, and under no circumstances should format strings be built using user-controlled input data.
 
 === Unstructured Logging
 
 When using an unstructured layout such as `PatternLayout`, no guarantees can be made about the output format.
 This layout is mainly useful for development purposes and should not be relied on in production applications.
 For example, if a log message contains new lines, these are not escaped or encoded specially unless the configured pattern uses the `%encode{pattern}{CRLF}` wrapper pattern converter (which will encode a carriage return as the string `\r` and a line feed as the string `\n`) or some other `%encode` option.
+Note that `%xEx` is appended to the pattern unless already present.
 Similarly, other encoding options are available for other formats, but pattern layouts cannot make assumptions about the entire output.
 As such, when using unstructured layouts, no user-controlled input should be included in logs.
 It is strongly recommended that a structured layout (e.g., `JsonTemplateLayout`) is used instead for these situations.
@@ -114,14 +116,6 @@ This remote location must be kept safe from unauthorized modifications.
 When configurations are modified through JMX, the JMX server should be safely configured to require authentication and a secure connection if being accessed over the network.
 When configurations are provided through JNDI, these should only use the `java` scheme for sharing configurations in a JavaEE or JakartaEE application service.
 JNDI-sourced configurations should not use other JNDI providers such as LDAP, DNS, or RMI, as all these providers are difficult to properly secure.
-
-=== Cryptographic Logs
-
-When using custom plugins to calculate message authentication codes, signatures, or encrypted logs, proper key management must be considered.
-Cryptography is a tricky subject, and key management lies at the heart of most design problems to solve when using it.
-If a custom plugin relies on a pre-shared key or password of some sort, it is likely broken beyond repair if being used for cryptographic purposes.
-Proper key management typically uses public key infrastructure (PKI) such as X.509 certificates, though this is not the only option.
-It is beyond the scope of Log4j to implement key management as this would depend on other infrastructure in use for validating or decrypting logs combined with the deployment and runtime environment of the logging application.
 
 === Compressing Logs
 


### PR DESCRIPTION
This updates the security page with notes about the threat model used for Log4j. Some related documentation has been fixed during review of this threat model.

Related to and adapted from commentary in https://github.com/apache/logging-log4j2/issues/2100.