### PR TITLE
Remove instance of checks for async components

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
@@ -939,4 +939,11 @@ public class LoggerContext extends AbstractLifeCycle
     protected Logger newInstance(final LoggerContext ctx, final String name, final MessageFactory messageFactory) {
         return new Logger(ctx, name, messageFactory);
     }
+
+    /**
+     * If {@code true} loggers will include location by default.
+     */
+    public boolean includeLocation() {
+        return true;
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerContext.java
@@ -130,6 +130,11 @@ public class AsyncLoggerContext extends LoggerContext {
         return true;
     }
 
+    @Override
+    public boolean includeLocation() {
+        return false;
+    }
+
     // package-protected for tests
     AsyncLoggerDisruptor getAsyncLoggerDisruptor() {
         return loggerDisruptor;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerContextSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerContextSelector.java
@@ -18,12 +18,10 @@ package org.apache.logging.log4j.core.async;
 
 import java.net.URI;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.impl.Log4jPropertyKey;
 import org.apache.logging.log4j.core.selector.ClassLoaderContextSelector;
 import org.apache.logging.log4j.plugins.Inject;
 import org.apache.logging.log4j.plugins.Singleton;
 import org.apache.logging.log4j.plugins.di.ConfigurableInstanceFactory;
-import org.apache.logging.log4j.util.PropertiesUtil;
 
 /**
  * {@code ContextSelector} that manages {@code AsyncLoggerContext} instances.
@@ -32,19 +30,6 @@ import org.apache.logging.log4j.util.PropertiesUtil;
  */
 @Singleton
 public class AsyncLoggerContextSelector extends ClassLoaderContextSelector {
-
-    /**
-     * Returns {@code true} if the user specified this selector as the Log4jContextSelector, to make all loggers
-     * asynchronous.
-     *
-     * @return {@code true} if all loggers are asynchronous, {@code false} otherwise.
-     */
-    public static boolean isSelected() {
-        // FIXME(ms): this should check Injector bindings
-        return AsyncLoggerContextSelector.class
-                .getName()
-                .equals(PropertiesUtil.getProperties().getStringProperty(Log4jPropertyKey.CONTEXT_SELECTOR_CLASS_NAME));
-    }
 
     @Inject
     public AsyncLoggerContextSelector(final ConfigurableInstanceFactory instanceFactory) {


### PR DESCRIPTION
This PR removes all occurences of `instanceof Async*` that might prevent the separation of the async support.

The removal requires a couple of new API methods and binary incompatible changes.

