### PR TITLE
Fix regression in `JdkMapAdapterStringMap` performance

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMapTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMapTest.java
@@ -44,6 +44,7 @@ public class JdkMapAdapterStringMapTest {
     @Test
     public void testConstructorDisallowsNull() {
         assertThrows(NullPointerException.class, () -> new JdkMapAdapterStringMap(null));
+        assertThrows(NullPointerException.class, () -> new JdkMapAdapterStringMap(null, false));
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMapTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMapTest.java
@@ -43,7 +43,6 @@ public class JdkMapAdapterStringMapTest {
 
     @Test
     public void testConstructorDisallowsNull() {
-        assertThrows(NullPointerException.class, () -> new JdkMapAdapterStringMap(null));
         assertThrows(NullPointerException.class, () -> new JdkMapAdapterStringMap(null, false));
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMap.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMap.java
@@ -21,6 +21,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.WeakHashMap;
 import org.apache.logging.log4j.util.BiConsumer;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.StringMap;
@@ -41,13 +42,16 @@ public class JdkMapAdapterStringMap implements StringMap {
         }
         return left.compareTo(right);
     };
+    // Cache of known unmodifiable map implementations.
+    // It is a cache, no need to synchronise it between threads.
+    private static Map<Class<?>, Void> UNMODIFIABLE_MAPS_CACHE = new WeakHashMap<>();
 
     private final Map<String, String> map;
     private boolean immutable = false;
     private transient String[] sortedKeys;
 
     public JdkMapAdapterStringMap() {
-        this(new HashMap<String, String>(), false);
+        this(new HashMap<>(), false);
     }
 
     /**
@@ -57,25 +61,41 @@ public class JdkMapAdapterStringMap implements StringMap {
     @Deprecated
     public JdkMapAdapterStringMap(final Map<String, String> map) {
         this.map = Objects.requireNonNull(map, "map");
-        try {
-            map.replace(Strings.EMPTY, Strings.EMPTY, Strings.EMPTY);
-        } catch (final UnsupportedOperationException ignored) {
+        // Known immutable implementations
+        if (UNMODIFIABLE_MAPS_CACHE.containsKey(map.getClass())) {
             immutable = true;
+        } else {
+            // Check with a NO-OP replacement
+            try {
+                map.replace(Strings.EMPTY, Strings.EMPTY, Strings.EMPTY);
+            } catch (final UnsupportedOperationException ignored) {
+                final WeakHashMap<Class<?>, Void> cache = new WeakHashMap<>(UNMODIFIABLE_MAPS_CACHE);
+                cache.put(map.getClass(), null);
+                UNMODIFIABLE_MAPS_CACHE = cache;
+                immutable = true;
+            }
         }
     }
 
     /**
+     * Constructs a new {@link StringMap}, based on a JDK map.
+     * <p>
+     *     The underlying map should not be modified after this call.
+     * </p>
+     * <p>
+     *     If the {@link Map} implementation does not allow modifications, {@code frozen} should be set to {@code true}.
+     * </p>
      * @param map a JDK map,
-     * @param immutable must be {@code true} if the map is immutable or it should not be modified.
+     * @param frozen if {@code true} this collection will be immutable.
      */
-    public JdkMapAdapterStringMap(final Map<String, String> map, final boolean immutable) {
+    public JdkMapAdapterStringMap(final Map<String, String> map, final boolean frozen) {
         this.map = Objects.requireNonNull(map, "map");
-        this.immutable = immutable;
+        this.immutable = frozen;
     }
 
     @Override
     public Map<String, String> toMap() {
-        return map;
+        return new HashMap<>(map);
     }
 
     private void assertNotFrozen() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMap.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/JdkMapAdapterStringMap.java
@@ -47,9 +47,14 @@ public class JdkMapAdapterStringMap implements StringMap {
     private transient String[] sortedKeys;
 
     public JdkMapAdapterStringMap() {
-        this(new HashMap<String, String>());
+        this(new HashMap<String, String>(), false);
     }
 
+    /**
+     * @deprecated for performance reasons since 2.23.
+     *             Use {@link #JdkMapAdapterStringMap(Map, boolean)} instead.
+     */
+    @Deprecated
     public JdkMapAdapterStringMap(final Map<String, String> map) {
         this.map = Objects.requireNonNull(map, "map");
         try {
@@ -57,6 +62,15 @@ public class JdkMapAdapterStringMap implements StringMap {
         } catch (final UnsupportedOperationException ignored) {
             immutable = true;
         }
+    }
+
+    /**
+     * @param map a JDK map,
+     * @param immutable must be {@code true} if the map is immutable or it should not be modified.
+     */
+    public JdkMapAdapterStringMap(final Map<String, String> map, final boolean immutable) {
+        this.map = Objects.requireNonNull(map, "map");
+        this.immutable = immutable;
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThreadContextDataInjector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/ThreadContextDataInjector.java
@@ -121,7 +121,7 @@ public class ThreadContextDataInjector {
             // data. Note that we cannot reuse the specified StringMap: some Loggers may have properties defined
             // and others not, so the LogEvent's context data may have been replaced with an immutable copy from
             // the ThreadContext - this will throw an UnsupportedOperationException if we try to modify it.
-            final StringMap result = new JdkMapAdapterStringMap(new HashMap<>(copy));
+            final StringMap result = new JdkMapAdapterStringMap(new HashMap<>(copy), false);
             for (int i = 0; i < props.size(); i++) {
                 final Property prop = props.get(i);
                 if (!copy.containsKey(prop.getName())) {
@@ -133,20 +133,20 @@ public class ThreadContextDataInjector {
         }
 
         private static JdkMapAdapterStringMap frozenStringMap(final Map<String, String> copy) {
-            final JdkMapAdapterStringMap result = new JdkMapAdapterStringMap(copy);
-            result.freeze();
-            return result;
+            return new JdkMapAdapterStringMap(copy, true);
         }
 
         @Override
         public ReadOnlyStringMap rawContextData() {
             final ReadOnlyThreadContextMap map = ThreadContext.getThreadContextMap();
-            if (map instanceof ReadOnlyStringMap) {
-                return (ReadOnlyStringMap) map;
+            if (map != null) {
+                return map.getReadOnlyContextData();
             }
             // note: default ThreadContextMap is null
             final Map<String, String> copy = ThreadContext.getImmutableContext();
-            return copy.isEmpty() ? ContextDataFactory.emptyFrozenContextData() : new JdkMapAdapterStringMap(copy);
+            return copy.isEmpty()
+                    ? ContextDataFactory.emptyFrozenContextData()
+                    : new JdkMapAdapterStringMap(copy, true);
         }
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/ContextDataProvider.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/ContextDataProvider.java
@@ -27,12 +27,20 @@ public interface ContextDataProvider {
 
     /**
      * Returns a Map containing context data to be injected into the event or null if no context data is to be added.
+     * <p>
+     *     Thread-safety note: The returned object can safely be passed off to another thread: future changes in the
+     *     underlying context data will not be reflected in the returned object.
+     * </p>
      * @return A Map containing the context data or null.
      */
     Map<String, String> supplyContextData();
 
     /**
      * Returns the context data as a StringMap.
+     * <p>
+     *     Thread-safety note: The returned object can safely be passed off to another thread: future changes in the
+     *     underlying context data will not be reflected in the returned object.
+     * </p>
      * @return the context data in a StringMap.
      */
     default StringMap supplyStringMap() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/ContextDataProvider.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/ContextDataProvider.java
@@ -36,6 +36,6 @@ public interface ContextDataProvider {
      * @return the context data in a StringMap.
      */
     default StringMap supplyStringMap() {
-        return new JdkMapAdapterStringMap(supplyContextData());
+        return new JdkMapAdapterStringMap(supplyContextData(), true);
     }
 }

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/util/JsonWriterTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/util/JsonWriterTest.java
@@ -149,7 +149,7 @@ class JsonWriterTest {
 
     @Test
     void test_writeObject_StringMap() {
-        final StringMap map = new JdkMapAdapterStringMap(Collections.singletonMap("a", "b"));
+        final StringMap map = new JdkMapAdapterStringMap(Collections.singletonMap("a", "b"), true);
         final String expectedJson = "{'a':'b'}".replace('\'', '"');
         final String actualJson = withLockedWriterReturning(writer -> writer.use(() -> writer.writeObject(map)));
         Assertions.assertThat(actualJson).isEqualTo(expectedJson);
@@ -224,7 +224,7 @@ class JsonWriterTest {
                                         put("foo", "bar");
                                     }
                                 }),
-                                new JdkMapAdapterStringMap(Collections.singletonMap("a", "b"))));
+                                new JdkMapAdapterStringMap(Collections.singletonMap("a", "b"), true)));
                 put("key7", (StringBuilderFormattable) buffer -> buffer.append(7.7777777777777D));
             }
         };

--- a/src/changelog/.3.x.x/2238_fix_jdk_string_map.xml
+++ b/src/changelog/.3.x.x/2238_fix_jdk_string_map.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="fixed">
+  <issue id="2238" link="https://github.com/apache/logging-log4j2/issues/2238"/>
+  <description format="asciidoc">
+    Fix regression in `JdkMapAdapterStringMap` performance.
+  </description>
+</entry>


### PR DESCRIPTION
We introduce a new constructor for `JdkMapAdapterStringMap` to prevent the performance penalty of an exception if the map is immutable. The regression was introduced in #2101.

Closes #2238.