### PR TITLE
[LOG4J2-3680] Allow deserialization of arrays

### DIFF
--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/internal/DefaultObjectInputFilter.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/internal/DefaultObjectInputFilter.java
@@ -44,7 +44,7 @@ public class DefaultObjectInputFilter implements ObjectInputFilter {
 
     @Override
     public Status checkInput(final FilterInfo filterInfo) {
-        Status status = null;
+        Status status;
         if (delegate != null) {
             status = delegate.checkInput(filterInfo);
             if (status != Status.UNDECIDED) {
@@ -59,9 +59,10 @@ public class DefaultObjectInputFilter implements ObjectInputFilter {
                 return status;
             }
         }
-        if (filterInfo.serialClass() != null) {
-            final String name = filterInfo.serialClass().getName();
-            if (isAllowedByDefault(name) || isRequiredPackage(name)) {
+        final Class<?> serialClass = filterInfo.serialClass();
+        if (serialClass != null) {
+            final String name = SerializationUtil.stripArray(serialClass);
+            if (isAllowedByDefault(name)) {
                 return Status.ALLOWED;
             }
         } else {

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
@@ -24,4 +24,8 @@ import java.util.List;
 public final class SerializationUtil {
     public static final List<String> REQUIRED_JAVA_CLASSES = List.of();
     public static final List<String> REQUIRED_JAVA_PACKAGES = List.of();
+
+    public static String stripArray(final Class<?> clazz) {
+        return null;
+    }
 }

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/package-info.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the license.
  */
 @Export
-@Version("2.21.1")
+@Version("2.23.0")
 package org.apache.logging.log4j.test.junit;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ObjectMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ObjectMessageTest.java
@@ -92,7 +92,13 @@ public class ObjectMessageTest {
                 return other instanceof NonSerializable; // a very lenient equals()
             }
         }
-        return Stream.of("World", new NonSerializable(), new BigDecimal("123.456"), null);
+        return Stream.of(
+                "World",
+                new NonSerializable(),
+                new BigDecimal("123.456"),
+                // LOG4J2-3680
+                new RuntimeException(),
+                null);
     }
 
     @ParameterizedTest

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterizedMessageTest.java
@@ -19,6 +19,7 @@ package org.apache.logging.log4j.message;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.math.BigDecimal;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.test.junit.Mutable;
 import org.apache.logging.log4j.test.junit.SerialUtil;
@@ -149,7 +150,20 @@ public class ParameterizedMessageTest {
     }
 
     static Stream<Object> testSerializable() {
-        return Stream.of("World", new Object(), null);
+        @SuppressWarnings("EqualsHashCode")
+        class NonSerializable {
+            @Override
+            public boolean equals(final Object other) {
+                return other instanceof NonSerializable; // a very lenient equals()
+            }
+        }
+        return Stream.of(
+                "World",
+                new NonSerializable(),
+                new BigDecimal("123.456"),
+                // LOG4J2-3680
+                new RuntimeException(),
+                null);
     }
 
     @ParameterizedTest

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/SortedArrayStringMapTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/SortedArrayStringMapTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.util;
 
+import static org.apache.logging.log4j.test.junit.SerialUtil.deserialize;
+import static org.apache.logging.log4j.test.junit.SerialUtil.serialize;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -27,14 +29,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLDecoder;
@@ -189,20 +186,6 @@ public class SortedArrayStringMapTest {
         }
         location = URLDecoder.decode(location, Charset.defaultCharset().name()); // replace %20 with ' ' etc
         return location.isEmpty() ? "." : location;
-    }
-
-    private byte[] serialize(final SortedArrayStringMap data) throws IOException {
-        final ByteArrayOutputStream arr = new ByteArrayOutputStream();
-        final ObjectOutputStream out = new ObjectOutputStream(arr);
-        out.writeObject(data);
-        return arr.toByteArray();
-    }
-
-    private SortedArrayStringMap deserialize(final byte[] binary) throws IOException, ClassNotFoundException {
-        final ByteArrayInputStream inArr = new ByteArrayInputStream(binary);
-        try (final ObjectInputStream in = new FilteredObjectInputStream(inArr)) {
-            return (SortedArrayStringMap) in.readObject();
-        }
     }
 
     @Test

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/internal/SerializationUtilTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/internal/SerializationUtilTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.util.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SerializationUtilTest {
+
+    static Stream<Arguments> arrays() {
+        return Stream.of(
+                Arguments.of(boolean[].class, boolean.class),
+                Arguments.of(char[].class, char.class),
+                Arguments.of(byte[].class, byte.class),
+                Arguments.of(short[].class, short.class),
+                Arguments.of(int[].class, int.class),
+                Arguments.of(long[].class, long.class),
+                Arguments.of(float[].class, float.class),
+                Arguments.of(double[].class, double.class),
+                Arguments.of(String.class, String.class),
+                Arguments.of(String[].class, String.class),
+                Arguments.of(String[][].class, String.class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("arrays")
+    void stripArrayClass(final Class<?> arrayClass, final Class<?> componentClazz) {
+        assertThat(SerializationUtil.stripArray(arrayClass)).isEqualTo(componentClazz.getName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("arrays")
+    void stripArrayString(final Class<?> arrayClass, final Class<?> componentClazz) {
+        assertThat(SerializationUtil.stripArray(arrayClass.getName())).isEqualTo(componentClazz.getName());
+    }
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/FilteredObjectInputStream.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/FilteredObjectInputStream.java
@@ -26,6 +26,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
 import java.util.Collection;
 import java.util.Collections;
+import org.apache.logging.log4j.util.internal.SerializationUtil;
 
 /**
  * Extends {@link ObjectInputStream} to only allow some built-in Log4j classes and caller-specified classes to be
@@ -63,7 +64,7 @@ public class FilteredObjectInputStream extends ObjectInputStream {
 
     @Override
     protected Class<?> resolveClass(final ObjectStreamClass desc) throws IOException, ClassNotFoundException {
-        final String name = desc.getName();
+        final String name = SerializationUtil.stripArray(desc.getName());
         if (!(isAllowedByDefault(name) || allowedExtraClasses.contains(name))) {
             throw new InvalidObjectException("Class is not allowed for deserialization: " + name);
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
@@ -163,8 +163,7 @@ public final class SerializationUtil {
      * @see Class#getName()
      */
     public static String stripArray(final String name) {
-        int offset;
-        for (offset = 0; offset < name.length() && name.charAt(offset) == '['; offset++) {}
+        final int offset = name.lastIndexOf('[') + 1;
         if (offset == 0) {
             return name;
         }
@@ -191,8 +190,7 @@ public final class SerializationUtil {
             case "S":
                 return "short";
             default:
-                // Should never happen
-                return name;
+                throw new IllegalArgumentException("Unsupported array class signature '" + name + "'");
         }
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/internal/SerializationUtil.java
@@ -79,12 +79,18 @@ public final class SerializationUtil {
             "java.math.BigInteger",
             // for Message delegate
             "java.rmi.MarshalledObject",
-            "[B",
-            // for MessagePatternAnalysis
-            "[I");
+            // all primitives
+            "boolean",
+            "byte",
+            "char",
+            "double",
+            "float",
+            "int",
+            "long",
+            "short");
 
-    public static final List<String> REQUIRED_JAVA_PACKAGES = Arrays.asList(
-            "java.lang.", "java.time", "java.util.", "org.apache.logging.log4j.", "[Lorg.apache.logging.log4j.");
+    public static final List<String> REQUIRED_JAVA_PACKAGES =
+            Arrays.asList("java.lang.", "java.time.", "java.util.", "org.apache.logging.log4j.");
 
     public static void writeWrappedObject(final Serializable obj, final ObjectOutputStream out) throws IOException {
         final ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -130,6 +136,63 @@ public final class SerializationUtil {
         if (!(stream instanceof FilteredObjectInputStream) && setObjectInputFilter == null) {
             throw new IllegalArgumentException(
                     "readObject requires a FilteredObjectInputStream or an ObjectInputStream that accepts an ObjectInputFilter");
+        }
+    }
+
+    /**
+     * Gets the class name of an array component recursively.
+     * <p>
+     *     If {@code clazz} is not an array class its name is returned.
+     * </p>
+     * @param clazz the binary name of a class.
+     */
+    public static String stripArray(final Class<?> clazz) {
+        Class<?> currentClazz = clazz;
+        while (currentClazz.isArray()) {
+            currentClazz = currentClazz.getComponentType();
+        }
+        return currentClazz.getName();
+    }
+
+    /**
+     * Gets the class name of an array component recursively.
+     * <p>
+     *     If {@code name} is not the name of an array class it is returned unchanged.
+     * </p>
+     * @param name the name of a class.
+     * @see Class#getName()
+     */
+    public static String stripArray(final String name) {
+        int offset;
+        for (offset = 0; offset < name.length() && name.charAt(offset) == '['; offset++) {}
+        if (offset == 0) {
+            return name;
+        }
+        // Reference types
+        if (name.charAt(offset) == 'L') {
+            return name.substring(offset + 1, name.length() - 1);
+        }
+        // Primitive classes
+        switch (name.substring(offset)) {
+            case "Z":
+                return "boolean";
+            case "B":
+                return "byte";
+            case "C":
+                return "char";
+            case "D":
+                return "double";
+            case "F":
+                return "float";
+            case "I":
+                return "int";
+            case "J":
+                return "long";
+            case "S":
+                return "short";
+            default:
+                // Should never happen
+                return name;
         }
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/mom/kafka/KafkaAppenderTest.java
@@ -22,9 +22,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.ObjectInput;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
@@ -46,7 +43,7 @@ import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.test.categories.Appenders;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.message.SimpleMessage;
-import org.apache.logging.log4j.util.FilteredObjectInputStream;
+import org.apache.logging.log4j.test.junit.SerialUtil;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -141,7 +138,9 @@ public class KafkaAppenderTest {
         assertNotNull(item);
         assertEquals(TOPIC_NAME, item.topic());
         assertNull(item.key());
-        assertEquals(LOG_MESSAGE, deserializeLogEvent(item.value()).getMessage().getFormattedMessage());
+        final byte[] data = item.value();
+        assertEquals(
+                LOG_MESSAGE, SerialUtil.<LogEvent>deserialize(data).getMessage().getFormattedMessage());
     }
 
     @Test
@@ -222,13 +221,6 @@ public class KafkaAppenderTest {
         assertArrayEquals(item.key(), keyValue);
         assertNotEquals(Long.valueOf(logEvent.getTimeMillis()), item.timestamp());
         assertEquals(LOG_MESSAGE, new String(item.value(), StandardCharsets.UTF_8));
-    }
-
-    private LogEvent deserializeLogEvent(final byte[] data) throws IOException, ClassNotFoundException {
-        final ByteArrayInputStream bis = new ByteArrayInputStream(data);
-        try (final ObjectInput ois = new FilteredObjectInputStream(bis)) {
-            return (LogEvent) ois.readObject();
-        }
     }
 
     //    public void shouldRetryWhenTimeoutExceptionOccursOnSend() throws Exception {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/RingBufferLogEventTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/RingBufferLogEventTest.java
@@ -24,11 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
@@ -44,7 +40,7 @@ import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ReusableMessageFactory;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.spi.MutableThreadContextStack;
-import org.apache.logging.log4j.util.FilteredObjectInputStream;
+import org.apache.logging.log4j.test.junit.SerialUtil;
 import org.apache.logging.log4j.util.StringMap;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Tag;
@@ -227,12 +223,7 @@ class RingBufferLogEventTest {
                 new DummyNanoClock(1));
         ((StringMap) evt.getContextData()).putValue("key", "value");
 
-        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        final ObjectOutputStream out = new ObjectOutputStream(baos);
-        out.writeObject(evt);
-
-        final ObjectInputStream in = new FilteredObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
-        final RingBufferLogEvent other = (RingBufferLogEvent) in.readObject();
+        final RingBufferLogEvent other = SerialUtil.deserialize(SerialUtil.serialize(evt));
         assertThat(other.getLoggerName()).isEqualTo(loggerName);
         assertThat(other.getMarker()).isEqualTo(marker);
         assertThat(other.getLoggerFqcn()).isEqualTo(fqcn);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/Log4jLogEventTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/Log4jLogEventTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.core.impl;
 
+import static org.apache.logging.log4j.test.junit.SerialUtil.deserialize;
+import static org.apache.logging.log4j.test.junit.SerialUtil.serialize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -25,11 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.lang.reflect.Field;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
@@ -47,7 +44,6 @@ import org.apache.logging.log4j.message.ObjectMessage;
 import org.apache.logging.log4j.message.ReusableMessage;
 import org.apache.logging.log4j.message.ReusableObjectMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
-import org.apache.logging.log4j.util.FilteredObjectInputStream;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
 import org.apache.logging.log4j.util.StringMap;
 import org.apache.logging.log4j.util.Strings;
@@ -156,20 +152,6 @@ public class Log4jLogEventTest {
         assertEquals(evt.getThrownProxy(), evt2.getThrownProxy());
         assertEquals(evt.isEndOfBatch(), evt2.isEndOfBatch());
         assertEquals(evt.isIncludeLocation(), evt2.isIncludeLocation());
-    }
-
-    private byte[] serialize(final Log4jLogEvent event) throws IOException {
-        final ByteArrayOutputStream arr = new ByteArrayOutputStream();
-        final ObjectOutputStream out = new ObjectOutputStream(arr);
-        out.writeObject(event);
-        return arr.toByteArray();
-    }
-
-    private Log4jLogEvent deserialize(final byte[] binary) throws IOException, ClassNotFoundException {
-        final ByteArrayInputStream inArr = new ByteArrayInputStream(binary);
-        final ObjectInputStream in = new FilteredObjectInputStream(inArr);
-        final Log4jLogEvent result = (Log4jLogEvent) in.readObject();
-        return result;
     }
 
     // DO NOT REMOVE THIS COMMENT:

--- a/src/changelog/.2.x.x/LOG4J2-3680_fix_serial_filter_arrays.xml
+++ b/src/changelog/.2.x.x/LOG4J2-3680_fix_serial_filter_arrays.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="fixed">
+  <issue id="LOG4J2-3680" link="https://issues.apache.org/jira/browse/LOG4J2-3680"/>
+  <description format="asciidoc">
+    Allow deserialization of all arrays of allowed classes.
+  </description>
+</entry>

--- a/src/changelog/2.22.0/1906_harden_serialization_process.xml
+++ b/src/changelog/2.22.0/1906_harden_serialization_process.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="fixed">
+  <issue id="1906" link="https://github.com/apache/logging-log4j2/issues/1884"/>
+  <description format="asciidoc">
+    Harden deserialization process by requiring the usage of `FilteredObjectInputStream` on Java 8 and `ObjectInputFilter` on Java 9+ to deserialize custom classes.
+  </description>
+</entry>


### PR DESCRIPTION
The `DefaultObjectInputFilter` is too restrictive and it does not allow the deserialization of **arrays** of whitelisted classes.

Most notably `RuntimeException` can not be deserialized, since it contains an array of `StackTraceElement`s. Both classes are allowed, but deserialization of the `StackTraceElement[]` array fails.

We also replace all manual serializations/deserializations in test classes to calls to `SerialUtil`. This guarantees a consistent behavior of all tests under Java 8 and Java 9+.