### PR TITLE
Allow arbitrary position of `<Properties>` element

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationPropertiesOrderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationPropertiesOrderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.junit.jupiter.api.Test;
+
+public class ConfigurationPropertiesOrderTest {
+
+    @Test
+    void propertiesCanComeLast() {
+        final Configuration config = new AbstractConfiguration(null, ConfigurationSource.NULL_SOURCE) {
+            @Override
+            public void setup() {
+                // Nodes
+                final Node appenders = newNode(rootNode, "Appenders");
+                rootNode.getChildren().add(appenders);
+
+                final Node console = newNode(appenders, "Console");
+                console.getAttributes().put("name", "${console.name}");
+                appenders.getChildren().add(console);
+
+                final Node loggers = newNode(rootNode, "Loggers");
+                rootNode.getChildren().add(loggers);
+
+                final Node rootLogger = newNode(loggers, "Root");
+                rootLogger.getAttributes().put("level", "INFO");
+                loggers.getChildren().add(rootLogger);
+
+                final Node properties = newNode(rootNode, "Properties");
+                rootNode.getChildren().add(properties);
+
+                final Node property = newNode(properties, "Property");
+                property.getAttributes().put("name", "console.name");
+                property.getAttributes().put("value", "CONSOLE");
+                properties.getChildren().add(property);
+            }
+
+            private Node newNode(final Node parent, final String name) {
+                return new Node(rootNode, name, pluginManager.getPluginType(name));
+            }
+        };
+        config.initialize();
+
+        final Appender noInterpolation = config.getAppender("${console.name}");
+        assertThat(noInterpolation).as("No interpolation for '${console.name}'").isNull();
+        final Appender console = config.getAppender("CONSOLE");
+        assertThat(console).isInstanceOf(ConsoleAppender.class);
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
@@ -674,9 +674,7 @@ public abstract class AbstractConfiguration extends AbstractFilterable implement
         boolean setRoot = false;
         for (final Node child : rootNode.getChildren()) {
             if ("Properties".equalsIgnoreCase(child.getName())) {
-                if (tempLookup == runtimeStrSubstitutor.getVariableResolver()) {
-                    LOGGER.error("Properties declaration must be the first element in the configuration");
-                }
+                // We already used this node
                 continue;
             }
             createConfiguration(child, null);

--- a/src/changelog/.2.x.x/allow_arbitrary_properties_order.xml
+++ b/src/changelog/.2.x.x/allow_arbitrary_properties_order.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="fixed">
+  <description format="asciidoc">
+    Allow the &lt;Properties&gt; node to appear in any position in the configuration element.
+  </description>
+</entry>


### PR DESCRIPTION
Until now the `<Properties>` element had to be the first child of `<Configuration>`. In the current architecture this restriction is no longer necessary and can be lifted.

This is related to #2274.
