### PR TITLE
Register a single reference counted StatusConsoleListener

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/PropertiesConfiguration.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/PropertiesConfiguration.java
@@ -45,7 +45,6 @@ import org.apache.logging.log4j.core.appender.rolling.TriggeringPolicy;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.config.status.StatusConfiguration;
 import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.util.LoaderUtil;
 
@@ -313,8 +312,7 @@ public class PropertiesConfiguration extends Log4j1Configuration {
             status = OptionConverter.toBoolean(value, false) ? "debug" : "error";
         }
 
-        final StatusConfiguration statusConfig = new StatusConfiguration().withStatus(status);
-        statusConfig.initialize();
+        getStatusConfiguration().withStatus(status).initialize();
 
         // if log4j.reset=true then reset hierarchy
         final String reset = properties.getProperty(RESET_KEY);

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfiguration.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfiguration.java
@@ -46,7 +46,6 @@ import org.apache.logging.log4j.core.appender.rolling.TriggeringPolicy;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.config.status.StatusConfiguration;
 import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
@@ -745,8 +744,7 @@ public class XmlConfiguration extends Log4j1Configuration {
             status = OptionConverter.toBoolean(confDebug, true) ? "debug" : "error";
         }
 
-        final StatusConfiguration statusConfig = new StatusConfiguration().withStatus(status);
-        statusConfig.initialize();
+        getStatusConfiguration().withStatus(status).initialize();
 
         final String threshold = subst(element.getAttribute(THRESHOLD_ATTR));
         if (threshold != null) {

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/StatusLoggerMockExtension.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/StatusLoggerMockExtension.java
@@ -20,9 +20,7 @@ import static org.apache.logging.log4j.test.junit.ExtensionContextAnchor.getAttr
 import static org.apache.logging.log4j.test.junit.ExtensionContextAnchor.setAttribute;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
 
-import org.apache.logging.log4j.status.StatusConsoleListener;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -51,7 +49,6 @@ class StatusLoggerMockExtension implements BeforeAllCallback, BeforeEachCallback
     public void beforeAll(final ExtensionContext context) throws Exception {
         setAttribute(INITIAL_STATUS_LOGGER_KEY, StatusLogger.getLogger(), context);
         final StatusLogger statusLogger = mock(StatusLogger.class);
-        stubFallbackListener(statusLogger);
         StatusLogger.setLogger(statusLogger);
     }
 
@@ -59,12 +56,6 @@ class StatusLoggerMockExtension implements BeforeAllCallback, BeforeEachCallback
     public void beforeEach(final ExtensionContext context) throws Exception {
         final StatusLogger statusLogger = StatusLogger.getLogger();
         reset(statusLogger); // Stubs get reset too!
-        stubFallbackListener(statusLogger);
-    }
-
-    private static void stubFallbackListener(final StatusLogger statusLogger) {
-        final StatusConsoleListener fallbackListener = mock(StatusConsoleListener.class);
-        when(statusLogger.getFallbackListener()).thenReturn(fallbackListener);
     }
 
     @Override

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusConsoleListenerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusConsoleListenerTest.java
@@ -105,7 +105,7 @@ public class StatusConsoleListenerTest {
     }
 
     @Test
-    void close_should_reset_to_initials() {
+    void reset_should_restore_initials() {
 
         // Create the listener
         final PrintStream initialStream = mock(PrintStream.class);
@@ -128,7 +128,7 @@ public class StatusConsoleListenerTest {
         assertThat(listener).hasFieldOrPropertyWithValue("stream", newStream);
 
         // Close the listener
-        listener.close();
+        listener.reset();
 
         // Verify the reset
         verify(newStream).close();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
@@ -51,7 +51,7 @@ public class StatusConsoleListener implements StatusListener {
      * @throws NullPointerException on null {@code level}
      */
     public StatusConsoleListener(final Level level) {
-        this(level, System.out);
+        this(level, System.err);
     }
 
     /**
@@ -149,11 +149,15 @@ public class StatusConsoleListener implements StatusListener {
     @Deprecated
     public void setFilters(final String... filters) {}
 
+    @Override
+    public void close() {
+        closeNonSystemStream(stream);
+    }
+
     /**
      * Resets the level and output stream to its initial values, and closes the output stream, if it is a non-system one.
      */
-    @Override
-    public void close() {
+    public void reset() {
         final OutputStream oldStream;
         lock.lock();
         try {
@@ -171,7 +175,7 @@ public class StatusConsoleListener implements StatusListener {
         if (stream != System.out && stream != System.err) {
             try {
                 stream.close();
-            } catch (IOException error) {
+            } catch (final IOException error) {
                 // We are at the lowest level of the system.
                 // Hence, there is nothing better we can do but dumping the failure.
                 error.printStackTrace(System.err);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -366,21 +366,10 @@ public class StatusLogger extends AbstractLogger {
     }
 
     /**
-     * Returns the fallback listener.
-     *
-     * @return the fallback listener
-     */
-    public StatusConsoleListener getFallbackListener() {
-        return fallbackListener;
-    }
-
-    /**
      * Sets the level of the fallback listener.
      *
      * @param level a level
-     * @deprecated Instead use the {@link StatusConsoleListener#setLevel(Level) setLevel(Level)} method on the fallback listener returned by {@link #getFallbackListener()}.
      */
-    @Deprecated
     public void setLevel(final Level level) {
         requireNonNull(level, "level");
         fallbackListener.setLevel(level);
@@ -421,7 +410,7 @@ public class StatusLogger extends AbstractLogger {
      * Sets the level of the fallback listener.
      *
      * @param level a level
-     * @deprecated Instead use the {@link StatusConsoleListener#setLevel(Level) setLevel(Level)} method on the fallback listener returned by {@link #getFallbackListener()}.
+     * @deprecated Instead use the {@link #setLevel(Level))} method.
      */
     @Deprecated
     public void updateListenerLevel(final Level level) {
@@ -458,7 +447,7 @@ public class StatusLogger extends AbstractLogger {
         } finally {
             listenerWriteLock.unlock();
         }
-        fallbackListener.close();
+        fallbackListener.reset();
         buffer.clear();
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -410,7 +410,7 @@ public class StatusLogger extends AbstractLogger {
      * Sets the level of the fallback listener.
      *
      * @param level a level
-     * @deprecated Instead use the {@link #setLevel(Level))} method.
+     * @deprecated Instead use the {@link #setLevel(Level)} method.
      */
     @Deprecated
     public void updateListenerLevel(final Level level) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/status/StatusConfigurationHelper.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/status/StatusConfigurationHelper.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.config.status;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.status.StatusConsoleListener;
+
+public final class StatusConfigurationHelper {
+
+    private StatusConfigurationHelper() {}
+
+    public static Level getDefaultStatusLevel() {
+        return StatusConfiguration.DEFAULT_LEVEL;
+    }
+
+    public static StatusConsoleListener getStatusConsoleListener() {
+        return StatusConfiguration.listener;
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/xml/XmlConfigurationPropsTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/xml/XmlConfigurationPropsTest.java
@@ -17,20 +17,17 @@
 package org.apache.logging.log4j.core.config.xml;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.status.StatusConfigurationHelper;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.util.Constants;
 import org.apache.logging.log4j.status.StatusConsoleListener;
-import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.test.junit.SetTestProperty;
 import org.apache.logging.log4j.test.junit.UsingStatusLoggerMock;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -45,6 +42,12 @@ class XmlConfigurationPropsTest {
 
     private static final String CONFIG1_NAME = "XmlConfigurationPropsTest1";
 
+    @AfterEach
+    void resetStatusConsoleListenerLevel() {
+        StatusConfigurationHelper.getStatusConsoleListener()
+                .setLevel(StatusConfigurationHelper.getDefaultStatusLevel());
+    }
+
     private void testConfiguration(
             final Configuration config,
             final String expectedConfigName,
@@ -54,12 +57,12 @@ class XmlConfigurationPropsTest {
                 .isInstanceOf(XmlConfiguration.class)
                 .extracting(Configuration::getName)
                 .isEqualTo(expectedConfigName);
-        final StatusConsoleListener fallbackListener = StatusLogger.getLogger().getFallbackListener();
-        if (expectedStatusLevel == null) {
-            verify(fallbackListener, never()).setLevel(any());
-        } else {
-            verify(fallbackListener).setLevel(eq(expectedStatusLevel));
-        }
+        final StatusConsoleListener consoleListener = StatusConfigurationHelper.getStatusConsoleListener();
+        assertThat(consoleListener.getStatusLevel())
+                .isEqualTo(
+                        expectedStatusLevel == null
+                                ? StatusConfigurationHelper.getDefaultStatusLevel()
+                                : expectedStatusLevel);
         assertThat(config.getRootLogger().getExplicitLevel()).isEqualTo(expectedRootLevel);
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
@@ -55,6 +55,7 @@ import org.apache.logging.log4j.core.config.arbiters.SelectArbiter;
 import org.apache.logging.log4j.core.config.plugins.util.PluginBuilder;
 import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.apache.logging.log4j.core.config.plugins.util.PluginType;
+import org.apache.logging.log4j.core.config.status.StatusConfiguration;
 import org.apache.logging.log4j.core.filter.AbstractFilterable;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.lookup.ConfigurationStrSubstitutor;
@@ -145,6 +146,7 @@ public abstract class AbstractConfiguration extends AbstractFilterable implement
     private AsyncWaitStrategyFactory asyncWaitStrategyFactory;
     private NanoClock nanoClock = new DummyNanoClock();
     private final WeakReference<LoggerContext> loggerContext;
+    private final StatusConfiguration statusConfiguration;
 
     /**
      * Constructor.
@@ -158,6 +160,8 @@ public abstract class AbstractConfiguration extends AbstractFilterable implement
         componentMap.put(Configuration.CONTEXT_PROPERTIES, propertyMap);
         pluginManager = new PluginManager(Node.CATEGORY);
         rootNode = new Node();
+        statusConfiguration =
+                new StatusConfiguration().withStatus(getDefaultStatus()).withConfiguration(this);
         setState(State.INITIALIZING);
     }
 
@@ -451,6 +455,7 @@ public abstract class AbstractConfiguration extends AbstractFilterable implement
         }
         setStopped();
         LOGGER.debug("Stopped {} OK", this);
+        statusConfiguration.stop();
         return true;
     }
 
@@ -1230,5 +1235,9 @@ public abstract class AbstractConfiguration extends AbstractFilterable implement
     @Override
     public void setNanoClock(final NanoClock nanoClock) {
         this.nanoClock = Objects.requireNonNull(nanoClock, "nanoClock");
+    }
+
+    protected StatusConfiguration getStatusConfiguration() {
+        return statusConfiguration;
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/BuiltConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/BuiltConfiguration.java
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.core.util.Patterns;
  * @since 2.4
  */
 public class BuiltConfiguration extends AbstractConfiguration {
-    private final StatusConfiguration statusConfig;
     protected Component rootComponent;
     private Component loggersComponent;
     private Component appendersComponent;
@@ -51,7 +50,6 @@ public class BuiltConfiguration extends AbstractConfiguration {
     public BuiltConfiguration(
             final LoggerContext loggerContext, final ConfigurationSource source, final Component rootComponent) {
         super(loggerContext, source);
-        statusConfig = new StatusConfiguration().withStatus(getDefaultStatus());
         for (final Component component : rootComponent.getComponents()) {
             switch (component.getPluginType()) {
                 case "Scripts": {
@@ -131,8 +129,9 @@ public class BuiltConfiguration extends AbstractConfiguration {
         super.createAdvertiser(advertiserString, configSource, buffer, contentType);
     }
 
+    @Override
     public StatusConfiguration getStatusConfiguration() {
-        return statusConfig;
+        return super.getStatusConfiguration();
     }
 
     public void setPluginPackages(final String packages) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/CompositeConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/CompositeConfiguration.java
@@ -76,7 +76,7 @@ public class CompositeConfiguration extends AbstractConfiguration implements Rec
         for (final AbstractConfiguration config : configurations) {
             mergeStrategy.mergeRootProperties(rootNode, config);
         }
-        final StatusConfiguration statusConfig = new StatusConfiguration().withStatus(getDefaultStatus());
+        final StatusConfiguration statusConfig = getStatusConfiguration();
         for (final Map.Entry<String, String> entry : rootNode.getAttributes().entrySet()) {
             final String key = entry.getKey();
             final String value = getConfigurationStrSubstitutor().replace(entry.getValue());

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/composite/package-info.java
@@ -19,7 +19,7 @@
  * Support for composite configurations.
  */
 @Export
-@Version("2.20.1")
+@Version("2.23.0")
 package org.apache.logging.log4j.core.config.composite;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/JsonConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/JsonConfiguration.java
@@ -64,7 +64,7 @@ public class JsonConfiguration extends AbstractConfiguration implements Reconfig
                 }
             }
             processAttributes(rootNode, root);
-            final StatusConfiguration statusConfig = new StatusConfiguration().withStatus(getDefaultStatus());
+            final StatusConfiguration statusConfig = getStatusConfiguration();
             int monitorIntervalSeconds = 0;
             for (final Map.Entry<String, String> entry :
                     rootNode.getAttributes().entrySet()) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/package-info.java
@@ -18,7 +18,7 @@
  * Classes and interfaces supporting configuration of Log4j 2 with JSON.
  */
 @Export
-@Version("2.20.1")
+@Version("2.23.0")
 package org.apache.logging.log4j.core.config.json;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/package-info.java
@@ -18,7 +18,7 @@
  * Configuration of Log4j 2.
  */
 @Export
-@Version("2.21.0")
+@Version("2.23.0")
 package org.apache.logging.log4j.core.config;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/status/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/status/package-info.java
@@ -19,7 +19,7 @@
  * Configuration classes for the {@link org.apache.logging.log4j.status.StatusLogger} API.
  */
 @Export
-@Version("2.20.2")
+@Version("2.23.0")
 package org.apache.logging.log4j.core.config.status;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/XmlConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/XmlConfiguration.java
@@ -106,7 +106,7 @@ public class XmlConfiguration extends AbstractConfiguration implements Reconfigu
             }
             rootElement = document.getDocumentElement();
             final Map<String, String> attrs = processAttributes(rootNode, rootElement);
-            final StatusConfiguration statusConfig = new StatusConfiguration().withStatus(getDefaultStatus());
+            final StatusConfiguration statusConfig = getStatusConfiguration();
             int monitorIntervalSeconds = 0;
             for (final Map.Entry<String, String> entry : attrs.entrySet()) {
                 final String key = entry.getKey();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/package-info.java
@@ -18,7 +18,7 @@
  * Classes and interfaces supporting configuration of Log4j 2 with XML.
  */
 @Export
-@Version("2.20.2")
+@Version("2.23.0")
 package org.apache.logging.log4j.core.config.xml;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/package-info.java
@@ -18,7 +18,7 @@
  * Classes and interfaces supporting configuration of Log4j 2 with YAML.
  */
 @Export
-@Version("2.20.1")
+@Version("2.23.0")
 package org.apache.logging.log4j.core.config.yaml;
 
 import org.osgi.annotation.bundle.Export;

--- a/src/site/_release-notes/_2.x.x.adoc
+++ b/src/site/_release-notes/_2.x.x.adoc
@@ -43,6 +43,7 @@ This releases contains ...
 === Fixed
 
 * Fix regression in `JdkMapAdapterStringMap` performance. (https://github.com/apache/logging-log4j2/issues/2238[2238])
+* Fix the behavior of `Logger#setLevel` and `Logger#getLevel` in the Log4j 1.2 bridge. (https://github.com/apache/logging-log4j2/issues/2282[2282])
 * Allow deserialization of all arrays of allowed classes. (https://issues.apache.org/jira/browse/LOG4J2-3680[LOG4J2-3680])
 * Fix forgotten `threadName` field in `RingBufferLogEvent#clear()` (https://github.com/apache/logging-log4j2/issues/2234[2234])
 * Fix `StringBuilder` cache corruption on recursive access


### PR DESCRIPTION
This adds a single `StatusConsoleListener` that is registered by the first Log4j Core configuration active and removed by the last one.

Compare to the current status this:

1. Prevents users from messing with the stream of the fallback `StatusConsoleListener`. Right now if they set it to something different from `System.out/System.err`, they need to remember to close it at shutdown,
2. Log4j Core configurations are still modifying a **shared** `StatusConsoleListener`, but they don't touch the fallback listener. The fallback listener is disabled when the first configuration starts and enabled again, when the last one stops.
