### PR TITLE
Fix `StatusLogger` time-zone issues and stack overflow

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerBufferCapacityTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerBufferCapacityTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.status;
+
+import static org.apache.logging.log4j.status.StatusLogger.DEFAULT_FALLBACK_LISTENER_BUFFER_CAPACITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import uk.org.webcompere.systemstubs.SystemStubs;
+
+class StatusLoggerBufferCapacityTest {
+
+    @Test
+    void valid_buffer_capacity_should_be_effective() {
+
+        // Create a `StatusLogger` configuration
+        final Properties statusLoggerConfigProperties = new Properties();
+        final int bufferCapacity = 10;
+        assertThat(bufferCapacity).isNotEqualTo(DEFAULT_FALLBACK_LISTENER_BUFFER_CAPACITY);
+        statusLoggerConfigProperties.put(StatusLogger.MAX_STATUS_ENTRIES, "" + bufferCapacity);
+        final StatusLogger.Config statusLoggerConfig = new StatusLogger.Config(statusLoggerConfigProperties);
+
+        // Verify the buffer capacity
+        assertThat(statusLoggerConfig.bufferCapacity).isEqualTo(bufferCapacity);
+    }
+
+    @Test
+    void invalid_buffer_capacity_should_cause_fallback_to_defaults() throws Exception {
+
+        // Create a `StatusLogger` configuration using an invalid buffer capacity
+        final Properties statusLoggerConfigProperties = new Properties();
+        final int invalidBufferCapacity = -10;
+        statusLoggerConfigProperties.put(StatusLogger.MAX_STATUS_ENTRIES, "" + invalidBufferCapacity);
+        final StatusLogger.Config[] statusLoggerConfigRef = {null};
+        final String stderr = SystemStubs.tapSystemErr(
+                () -> statusLoggerConfigRef[0] = new StatusLogger.Config(statusLoggerConfigProperties));
+        final StatusLogger.Config statusLoggerConfig = statusLoggerConfigRef[0];
+
+        // Verify the stderr dump
+        assertThat(stderr).contains("Failed reading the buffer capacity");
+
+        // Verify the buffer capacity
+        assertThat(statusLoggerConfig.bufferCapacity).isEqualTo(DEFAULT_FALLBACK_LISTENER_BUFFER_CAPACITY);
+    }
+}

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerDateTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerDateTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.function.Supplier;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.message.ParameterizedNoReferenceMessageFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+class StatusLoggerDateTest {
+
+    private static final String INSTANT_YEAR = "1970";
+
+    private static final String INSTANT_MONTH = "12";
+
+    private static final String INSTANT_DAY = "27";
+
+    private static final String INSTANT_HOUR = "12";
+
+    private static final String INSTANT_MINUTE = "34";
+
+    private static final String INSTANT_SECOND = "56";
+
+    private static final String INSTANT_FRACTION = "789";
+
+    private static final Instant INSTANT = Instant.parse(INSTANT_YEAR
+            + '-'
+            + INSTANT_MONTH
+            + '-'
+            + INSTANT_DAY
+            + 'T'
+            + INSTANT_HOUR
+            + ':'
+            + INSTANT_MINUTE
+            + ':'
+            + INSTANT_SECOND
+            + '.'
+            + INSTANT_FRACTION
+            + 'Z');
+
+    private static final Supplier<Instant> CLOCK = () -> INSTANT;
+
+    @ParameterizedTest
+    @CsvSource({
+        "yyyy-MM-dd," + (INSTANT_YEAR + '-' + INSTANT_MONTH + '-' + INSTANT_DAY),
+        "HH:mm:ss," + (INSTANT_HOUR + ':' + INSTANT_MINUTE + ':' + INSTANT_SECOND),
+        "HH:mm:ss.SSS," + (INSTANT_HOUR + ':' + INSTANT_MINUTE + ':' + INSTANT_SECOND + '.' + INSTANT_FRACTION)
+    })
+    void common_date_patterns_should_work(final String instantPattern, final String formattedInstant) {
+
+        // Create a `StatusLogger` configuration
+        final Properties statusLoggerConfigProperties = new Properties();
+        statusLoggerConfigProperties.put(StatusLogger.STATUS_DATE_FORMAT, instantPattern);
+        statusLoggerConfigProperties.put(StatusLogger.STATUS_DATE_FORMAT_ZONE, "UTC");
+        final StatusLogger.Config statusLoggerConfig = new StatusLogger.Config(statusLoggerConfigProperties);
+
+        // Create a `StatusConsoleListener` recording `StatusData`
+        final StatusConsoleListener statusConsoleListener = mock(StatusConsoleListener.class);
+        when(statusConsoleListener.getStatusLevel()).thenReturn(Level.ALL);
+        final List<StatusData> loggedStatusData = new ArrayList<>();
+        doAnswer((Answer<Void>) invocation -> {
+                    final StatusData statusData = invocation.getArgument(0, StatusData.class);
+                    loggedStatusData.add(statusData);
+                    return null;
+                })
+                .when(statusConsoleListener)
+                .log(Mockito.any());
+
+        // Create the `StatusLogger`
+        final StatusLogger logger = new StatusLogger(
+                StatusLoggerDateTest.class.getSimpleName(),
+                ParameterizedNoReferenceMessageFactory.INSTANCE,
+                statusLoggerConfig,
+                CLOCK,
+                statusConsoleListener);
+
+        // Log a message
+        final String message = "test message";
+        final Level level = Level.ERROR;
+        final Throwable throwable = new RuntimeException("test failure");
+        logger.log(level, message, throwable);
+
+        // Verify the logging
+        assertThat(loggedStatusData).hasSize(1);
+        final StatusData statusData = loggedStatusData.get(0);
+        assertThat(statusData.getLevel()).isEqualTo(level);
+        assertThat(statusData.getThrowable()).isSameAs(throwable);
+        assertThat(statusData.getFormattedStatus())
+                .matches("(?s)^" + formattedInstant + " .+ " + level + ' ' + message + ".*" + throwable.getMessage()
+                        + ".*");
+    }
+}

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerFailingListenerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerFailingListenerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import uk.org.webcompere.systemstubs.SystemStubs;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+@ExtendWith(SystemStubsExtension.class)
+@ResourceLock("log4j2.StatusLogger")
+class StatusLoggerFailingListenerTest {
+
+    public static final StatusLogger STATUS_LOGGER = StatusLogger.getLogger();
+
+    private StatusListener listener;
+
+    @BeforeEach
+    void createAndRegisterListener() {
+        listener = mock(StatusListener.class);
+        STATUS_LOGGER.registerListener(listener);
+    }
+
+    @AfterEach
+    void unregisterListener() {
+        STATUS_LOGGER.removeListener(listener);
+    }
+
+    @Test
+    void logging_with_failing_listener_should_not_cause_stack_overflow() throws Exception {
+
+        // Set up a failing listener on `log(StatusData)`
+        when(listener.getStatusLevel()).thenReturn(Level.ALL);
+        final Exception listenerFailure = new RuntimeException("test failure " + Math.random());
+        doThrow(listenerFailure).when(listener).log(any());
+
+        // Log something and verify exception dump
+        final String stderr = SystemStubs.tapSystemErr(() -> STATUS_LOGGER.error("foo"));
+        final String listenerFailureClassName = listenerFailure.getClass().getCanonicalName();
+        assertThat(stderr).contains(listenerFailureClassName + ": " + listenerFailure.getMessage());
+    }
+}

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerLevelTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerLevelTest.java
@@ -22,16 +22,14 @@ import static org.mockito.Mockito.when;
 
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.ResourceLock;
 
 class StatusLoggerLevelTest {
 
     @Test
-    @ResourceLock("log4j2.StatusLogger")
     void effective_level_should_be_the_least_specific_one() {
 
         // Verify the initial level
-        final StatusLogger logger = StatusLogger.getLogger();
+        final StatusLogger logger = new StatusLogger();
         final Level fallbackListenerLevel = Level.ERROR;
         assertThat(logger.getLevel()).isEqualTo(fallbackListenerLevel);
 

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerLevelTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerLevelTest.java
@@ -22,10 +22,12 @@ import static org.mockito.Mockito.when;
 
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 class StatusLoggerLevelTest {
 
     @Test
+    @ResourceLock("log4j2.StatusLogger")
     void effective_level_should_be_the_least_specific_one() {
 
         // Verify the initial level

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerPropertiesUtilDoubleTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerPropertiesUtilDoubleTest.java
@@ -33,30 +33,16 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class StatusLoggerPropertiesUtilDoubleTest {
 
-    private static final String[] NOT_PREFIXED_MATCHING_PROPERTY_NAMES = new String[] {
-        // For system properties:
-        "StatusLogger.DateFormat",
-        "StatusLogger.dateFormat",
-        "StatusLogger.dateformat",
-        "StatusLogger.Dateformat",
-        "Status.Logger.Dateformat",
-        "Status.Logger.Date.Format",
-        "statusLoggerDateFormat",
-        "Status.Logger.Date.Format",
-        "status.logger.date.format",
-        // For environment variables:
-        "STATUSLOGGER_DATEFORMAT",
-        "STATUS_LOGGER_DATE_FORMAT"
+    private static final String[] MATCHING_PROPERTY_NAMES = new String[] {
+        // System properties for version range `[, 2.10)`
+        "log4j2.StatusLogger.DateFormat",
+        // System properties for version range `[2.10, 3)`
+        "log4j2.statusLoggerDateFormat",
+        // System properties for version range `[3,)`
+        "log4j2.StatusLogger.dateFormat",
+        // Environment variables
+        "LOG4J_STATUS_LOGGER_DATE_FORMAT"
     };
-
-    private static final String[] MATCHING_PROPERTY_NAMES = Stream.of(
-                    // For system properties:
-                    "log4j.", "log4j2.",
-                    // For environment variables:
-                    "LOG4J_", "LOG4J2_")
-            .flatMap(prefix -> Arrays.stream(NOT_PREFIXED_MATCHING_PROPERTY_NAMES)
-                    .map(notPrefixedPropertyName -> prefix + notPrefixedPropertyName))
-            .toArray(String[]::new);
 
     private static final String[] NOT_MATCHING_PROPERTY_NAMES =
             new String[] {"log4j2.StatusLogger$DateFormat", "log4j2.StàtusLögger.DateFormat"};

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerPropertiesUtilDoubleTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerPropertiesUtilDoubleTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.status;
+
+import static org.apache.logging.log4j.status.StatusLogger.PropertiesUtilsDouble.readAllAvailableProperties;
+import static org.apache.logging.log4j.status.StatusLogger.PropertiesUtilsDouble.readProperty;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.webcompere.systemstubs.SystemStubs.restoreSystemProperties;
+import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariable;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class StatusLoggerPropertiesUtilDoubleTest {
+
+    private static final String[] NOT_PREFIXED_MATCHING_PROPERTY_NAMES = new String[] {
+        // For system properties:
+        "StatusLogger.DateFormat",
+        "StatusLogger.dateFormat",
+        "StatusLogger.dateformat",
+        "StatusLogger.Dateformat",
+        "Status.Logger.Dateformat",
+        "Status.Logger.Date.Format",
+        "statusLoggerDateFormat",
+        "Status.Logger.Date.Format",
+        "status.logger.date.format",
+        // For environment variables:
+        "STATUSLOGGER_DATEFORMAT",
+        "STATUS_LOGGER_DATE_FORMAT"
+    };
+
+    private static final String[] MATCHING_PROPERTY_NAMES = Stream.of(
+                    // For system properties:
+                    "log4j.", "log4j2.",
+                    // For environment variables:
+                    "LOG4J_", "LOG4J2_")
+            .flatMap(prefix -> Arrays.stream(NOT_PREFIXED_MATCHING_PROPERTY_NAMES)
+                    .map(notPrefixedPropertyName -> prefix + notPrefixedPropertyName))
+            .toArray(String[]::new);
+
+    private static final String[] NOT_MATCHING_PROPERTY_NAMES =
+            new String[] {"log4j2.StatusLogger$DateFormat", "log4j2.StàtusLögger.DateFormat"};
+
+    private static final class TestCase {
+
+        private final boolean matching;
+
+        private final String propertyName;
+
+        private final String userProvidedPropertyName;
+
+        private TestCase(final boolean matching, final String propertyName, final String userProvidedPropertyName) {
+            this.matching = matching;
+            this.propertyName = propertyName;
+            this.userProvidedPropertyName = userProvidedPropertyName;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("`%s` %s `%s`", propertyName, matching ? "==" : "!=", userProvidedPropertyName);
+        }
+    }
+
+    static Stream<TestCase> testCases() {
+        return Stream.concat(
+                testCases(true, MATCHING_PROPERTY_NAMES, MATCHING_PROPERTY_NAMES),
+                testCases(false, MATCHING_PROPERTY_NAMES, NOT_MATCHING_PROPERTY_NAMES));
+    }
+
+    private static Stream<TestCase> testCases(
+            final boolean matching, final String[] propertyNames, final String[] userProvidedPropertyNames) {
+        return Arrays.stream(propertyNames).flatMap(propertyName -> Arrays.stream(userProvidedPropertyNames)
+                .map(userProvidedPropertyName -> new TestCase(matching, propertyName, userProvidedPropertyName)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    @ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ_WRITE)
+    void system_properties_should_work(final TestCase testCase) throws Exception {
+        restoreSystemProperties(() -> {
+            final String expectedValue = "foo";
+            System.setProperty(testCase.propertyName, expectedValue);
+            verifyProperty(testCase, expectedValue);
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    @ResourceLock(value = Resources.GLOBAL, mode = ResourceAccessMode.READ_WRITE)
+    void environment_variables_should_work(final TestCase testCase) throws Exception {
+        final String expectedValue = "bar";
+        withEnvironmentVariable(testCase.propertyName, expectedValue).execute(() -> {
+            verifyProperty(testCase, expectedValue);
+        });
+    }
+
+    private static void verifyProperty(final TestCase testCase, final String expectedValue) {
+        final Map<String, Object> normalizedProperties = readAllAvailableProperties();
+        final String actualValue = readProperty(normalizedProperties, testCase.userProvidedPropertyName);
+        if (testCase.matching) {
+            assertThat(actualValue).describedAs("" + testCase).isEqualTo(expectedValue);
+        } else {
+            assertThat(actualValue).describedAs("" + testCase).isNull();
+        }
+    }
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
@@ -68,7 +68,7 @@ public class StatusData implements Serializable {
             final Message message,
             @Nullable final Throwable throwable,
             @Nullable final String threadName) {
-        this(caller, level, message, throwable, threadName, null);
+        this(caller, level, message, throwable, threadName, null, Instant.now());
     }
 
     StatusData(
@@ -77,9 +77,10 @@ public class StatusData implements Serializable {
             final Message message,
             @Nullable final Throwable throwable,
             @Nullable final String threadName,
-            @Nullable final DateTimeFormatter instantFormatter) {
+            @Nullable final DateTimeFormatter instantFormatter,
+            final Instant instant) {
         this.instantFormatter = instantFormatter;
-        this.instant = Instant.now();
+        this.instant = instant;
         this.caller = caller;
         this.level = requireNonNull(level, "level");
         this.message = requireNonNull(message, "message");

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -189,7 +189,7 @@ public class StatusLogger extends AbstractLogger {
      * @see #STATUS_DATE_FORMAT_ZONE
      * @since 2.11.0
      */
-    public static final String STATUS_DATE_FORMAT = "log4j2.StatusLogger.DateFormat";
+    public static final String STATUS_DATE_FORMAT = "log4j2.StatusLogger.dateFormat";
 
     /**
      * The name of the system property that can be configured with a time-zone ID (e.g., {@code Europe/Amsterdam}, {@code UTC+01:00}) that will be used while formatting the created {@link StatusData}.
@@ -200,7 +200,7 @@ public class StatusLogger extends AbstractLogger {
      * @see #STATUS_DATE_FORMAT
      * @since 2.23.1
      */
-    static final String STATUS_DATE_FORMAT_ZONE = "log4j2.StatusLogger.DateFormatZone";
+    static final String STATUS_DATE_FORMAT_ZONE = "log4j2.StatusLogger.dateFormatZone";
 
     /**
      * The name of the file to be searched in the classpath to read properties from.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -19,6 +19,7 @@ package org.apache.logging.log4j.status;
 import static java.util.Objects.requireNonNull;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -36,8 +37,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Supplier;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.message.Message;
@@ -181,7 +180,7 @@ public class StatusLogger extends AbstractLogger {
      * @see #STATUS_DATE_FORMAT
      * @since 2.23.1
      */
-    public static final String STATUS_DATE_FORMAT_ZONE = "log4j2.StatusLogger.DateFormatZone";
+    static final String STATUS_DATE_FORMAT_ZONE = "log4j2.StatusLogger.DateFormatZone";
 
     /**
      * The name of the file to be searched in the classpath to read properties from.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/package-info.java
@@ -19,7 +19,7 @@
  * used by applications reporting on the status of the logging system
  */
 @Export
-@Version("2.23.0")
+@Version("2.23.1")
 package org.apache.logging.log4j.status;
 
 import org.osgi.annotation.bundle.Export;

--- a/src/changelog/.2.x.x/fix_StatusLogger_instant_formatting.xml
+++ b/src/changelog/.2.x.x/fix_StatusLogger_instant_formatting.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="fixed">
+  <description format="asciidoc">
+    Add `log4j2.StatusLogger.DateFormatZone` system property to set the time-zone `StatusLogger` uses to format `java.time.Instant`.
+    Without this formatting patterns accessing to time-zone-specific fields (e.g., year-of-era) cause failures.
+  </description>
+</entry>

--- a/src/changelog/.2.x.x/fix_StatusLogger_stack_overflow.xml
+++ b/src/changelog/.2.x.x/fix_StatusLogger_stack_overflow.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="fixed">
+  <description format="asciidoc">Fix stack overflow in `StatusLogger`</description>
+</entry>


### PR DESCRIPTION
This PR improves `StatusLogger` such that
1. A new `log4j2.StatusLogger.DateFormatZone` configuration property is introduced. This sets the time-zone `StatusLogger` uses to format `java.time.Instant`. Without this formatting patterns accessing to time-zone-specific fields (e.g., year-of-era) cause failures. The value defaults to `ZoneId.systemDefault()`.
2. `StatusLogger` is improved to avoid stack overflow caused by `StatusLogger#logMessage()` failures.

These issues are originally reported by @lauredogit here: https://github.com/apache/logging-log4j2/pull/2249#issuecomment-1960973519