### PR TITLE
Make location computation and message formatting more lazy

### DIFF
--- a/log4j-1.2-api/pom.xml
+++ b/log4j-1.2-api/pom.xml
@@ -35,10 +35,11 @@
       -->
     <bnd-module-name>org.apache.log4j</bnd-module-name>
     <bnd-extra-package-options>
+      <!-- External optional dependencies -->
+      javax.jms;substitute="javax.jms-api";version="[1.1,3)";resolution:=optional,
+      org.jspecify.annotations.*;resolution:=optional,
       <!-- JMX support -->
       com.sun.jdmk.comm;resolution:=optional,
-      <!-- JMS is optional -->
-      javax.jms;substitute="javax.jms-api";version="[1.1,3)";resolution:=optional,
       <!-- Log4j Core is optional -->
       org.apache.logging.log4j.core.*;resolution:=optional
     </bnd-extra-package-options>

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/LogEventWrapper.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/LogEventWrapper.java
@@ -117,7 +117,7 @@ public class LogEventWrapper implements LogEvent {
     }
 
     @Override
-    public StackTraceElement getSource() {
+    public @Nullable StackTraceElement getSource() {
         return peekSource();
     }
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/LogEventWrapper.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/LogEventWrapper.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.spi.MutableThreadContextStack;
 import org.apache.logging.log4j.util.BiConsumer;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.TriConsumer;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Exposes a Log4j 1 logging event as a Log4j 2 LogEvent.
@@ -109,10 +110,15 @@ public class LogEventWrapper implements LogEvent {
     }
 
     @Override
-    public StackTraceElement getSource() {
+    public @Nullable StackTraceElement peekSource() {
         final LocationInfo info = event.getLocationInformation();
         return new StackTraceElement(
                 info.getClassName(), info.getMethodName(), info.getFileName(), Integer.parseInt(info.getLineNumber()));
+    }
+
+    @Override
+    public StackTraceElement getSource() {
+        return peekSource();
     }
 
     @Override

--- a/log4j-async-logger/src/main/java/org/apache/logging/log4j/async/logger/AsyncLoggerConfig.java
+++ b/log4j-async-logger/src/main/java/org/apache/logging/log4j/async/logger/AsyncLoggerConfig.java
@@ -165,7 +165,6 @@ public class AsyncLoggerConfig extends LoggerConfig {
     private void logToAsyncDelegate(final LogEvent event) {
         // Passes on the event to a separate thread that will call
         // asyncCallAppenders(LogEvent).
-        populateLazilyInitializedFields(event);
         if (!delegate.tryEnqueue(event, this)) {
             handleQueueFull(event);
         }
@@ -191,11 +190,6 @@ public class AsyncLoggerConfig extends LoggerConfig {
                 default:
             }
         }
-    }
-
-    private void populateLazilyInitializedFields(final LogEvent event) {
-        event.getSource();
-        event.getThreadName();
     }
 
     void logInBackgroundThread(final LogEvent event) {

--- a/log4j-async-logger/src/main/java/org/apache/logging/log4j/async/logger/RingBufferLogEvent.java
+++ b/log4j-async-logger/src/main/java/org/apache/logging/log4j/async/logger/RingBufferLogEvent.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.message.TimestampMessage;
 import org.apache.logging.log4j.util.StringBuilders;
 import org.apache.logging.log4j.util.StringMap;
 import org.apache.logging.log4j.util.Strings;
+import org.jspecify.annotations.Nullable;
 
 /**
  * When the Disruptor is started, the RingBuffer is populated with event objects. These objects are then re-used during
@@ -430,6 +431,11 @@ public class RingBufferLogEvent implements ReusableLogEvent, ReusableMessage, Ch
 
     @Override
     public StackTraceElement getSource() {
+        return peekSource();
+    }
+
+    @Override
+    public @Nullable StackTraceElement peekSource() {
         return location;
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/MutableLogEventTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/MutableLogEventTest.java
@@ -96,7 +96,7 @@ public class MutableLogEventTest {
                 .setTimeMillis(987654321)
                 .build();
         final MutableLogEvent mutable = new MutableLogEvent();
-        mutable.initFrom(source);
+        mutable.moveValuesFrom(source);
         assertEquals(CONTEXT_DATA, mutable.getContextData(), "contextMap");
         assertEquals(STACK, mutable.getContextStack(), "stack");
         assertTrue(mutable.isEndOfBatch(), "endOfBatch");
@@ -138,7 +138,7 @@ public class MutableLogEventTest {
                 .setTimeMillis(987654321)
                 .build();
         final MutableLogEvent mutable = new MutableLogEvent();
-        mutable.initFrom(source);
+        mutable.moveValuesFrom(source);
         assertEquals("msg in a {}", mutable.getFormat(), "format");
         assertEquals("msg in a bottle", mutable.getFormattedMessage(), "formatted");
         assertArrayEquals(new String[] {"bottle"}, mutable.getParameters(), "parameters");
@@ -182,7 +182,7 @@ public class MutableLogEventTest {
                 .setTimeMillis(987654321)
                 .build();
         final MutableLogEvent mutable = new MutableLogEvent();
-        mutable.initFrom(source);
+        mutable.moveValuesFrom(source);
         assertNull(mutable.getFormat(), "format");
         assertEquals(param.toString(), mutable.getFormattedMessage(), "formatted");
         assertArrayEquals(new Object[] {param}, mutable.getParameters(), "parameters");

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/AbstractLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/AbstractLogEvent.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.core.time.Instant;
 import org.apache.logging.log4j.core.time.MutableInstant;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.jspecify.annotations.Nullable;
 
 /**
  * An abstract log event implementation with default values for all methods. The setters are no-ops.
@@ -78,6 +79,11 @@ public abstract class AbstractLogEvent implements LogEvent {
 
     @Override
     public StackTraceElement getSource() {
+        return null;
+    }
+
+    @Override
+    public @Nullable StackTraceElement peekSource() {
         return null;
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/LogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/LogEvent.java
@@ -139,17 +139,19 @@ public interface LogEvent {
 
     /**
      * Gets the source of the logging call or computes it.
-     *
+     * <p>
+     *     The implementation must be idempotent: multiple calls to this method must always return the same value.
+     * </p>
      * @return source of logging request, may be {@code null} if {@link #isIncludeLocation()} is {@code false}.
-     * @implNote The implementation must be idempotent: multiple calls to this method must always return the same value.
      */
     StackTraceElement getSource();
 
     /**
      * Gets the source of the logging call.
-     *
+     * <p>
+     *     This method must be side effect free.
+     * </p>
      * @return source of logging request or {@code  null} if currently unknown.
-     * @implNote This method must be side effect free.
      */
     @Nullable
     StackTraceElement peekSource();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/LogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/LogEvent.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.core.impl.ThrowableProxy;
 import org.apache.logging.log4j.core.time.Instant;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Provides contextual information about a logged message. Besides containing a
@@ -48,16 +49,12 @@ public interface LogEvent {
 
     /**
      * Returns a copy of this log event.
+     * <p>
+     *     Location information for both events might be computed by this method.
+     * </p>
      */
     default LogEvent toMemento() {
         return new MementoLogEvent(this);
-    }
-
-    /**
-     * Returns a copy of this log event and overrides the {@code includeLocation} option.
-     */
-    default LogEvent toMemento(final boolean includeLocation) {
-        return new MementoLogEvent(this, includeLocation);
     }
 
     /**
@@ -141,11 +138,21 @@ public interface LogEvent {
     Instant getInstant();
 
     /**
-     * Gets the source of logging request.
+     * Gets the source of the logging call or computes it.
      *
-     * @return source of logging request, may be null.
+     * @return source of logging request, may be {@code null} if {@link #isIncludeLocation()} is {@code false}.
+     * @implNote The implementation must be idempotent: multiple calls to this method must always return the same value.
      */
     StackTraceElement getSource();
+
+    /**
+     * Gets the source of the logging call.
+     *
+     * @return source of logging request or {@code  null} if currently unknown.
+     * @implNote This method must be side effect free.
+     */
+    @Nullable
+    StackTraceElement peekSource();
 
     /**
      * Gets the thread name.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/Logger.java
@@ -140,7 +140,6 @@ public class Logger extends AbstractLogger implements Supplier<LoggerConfig> {
         return privateConfig.loggerConfig;
     }
 
-    @Override
     protected boolean requiresLocation() {
         return privateConfig.requiresLocation;
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
@@ -162,8 +162,12 @@ public final class AsyncAppender extends AbstractAppender {
         if (!isStarted()) {
             throw new IllegalStateException("AsyncAppender " + getName() + " is not active");
         }
-        final LogEvent memento = logEvent.toMemento(includeLocation);
+        // Modifications to the original `logEvent`:
+        // 1. Format message, if it is not thread-safe.
         InternalAsyncUtil.makeMessageImmutable(logEvent.getMessage());
+        // 2. Compute location, unless disabled.
+        InternalAsyncUtil.makeLocationImmutable(this, logEvent);
+        final LogEvent memento = logEvent.toMemento();
         if (!transfer(memento)) {
             if (blocking) {
                 if (AbstractLogger.getRecursionDepth() > 1) { // LOG4J2-1518, LOG4J2-2031

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/RewriteAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/RewriteAppender.java
@@ -117,8 +117,7 @@ public final class RewriteAppender extends AbstractAppender {
     @Override
     public boolean requiresLocation() {
         for (final AppenderControl control : appenders.values()) {
-            final Appender appender = control.getAppender();
-            if (appender.requiresLocation()) {
+            if (control.getAppender().requiresLocation()) {
                 return true;
             }
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/MutableLogEvent.java
@@ -22,7 +22,6 @@ import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.ReusableLogEvent;
-import org.apache.logging.log4j.core.async.InternalAsyncUtil;
 import org.apache.logging.log4j.core.time.Clock;
 import org.apache.logging.log4j.core.time.Instant;
 import org.apache.logging.log4j.core.time.MutableInstant;
@@ -39,6 +38,7 @@ import org.apache.logging.log4j.util.StackLocatorUtil;
 import org.apache.logging.log4j.util.StringBuilders;
 import org.apache.logging.log4j.util.StringMap;
 import org.apache.logging.log4j.util.Strings;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Mutable implementation of the {@code ReusableLogEvent} interface.
@@ -53,7 +53,6 @@ public class MutableLogEvent implements ReusableLogEvent, ReusableMessage, Param
     private final MutableInstant instant = new MutableInstant();
     private long nanoTime;
     private short parameterCount;
-    private boolean includeLocation;
     private boolean endOfBatch = false;
     private Level level;
     private String threadName;
@@ -66,9 +65,11 @@ public class MutableLogEvent implements ReusableLogEvent, ReusableMessage, Param
     private ThrowableProxy thrownProxy;
     private StringMap contextData = ContextDataFactory.createContextData();
     private Marker marker;
-    private String loggerFqcn;
-    private StackTraceElement source;
     private ThreadContext.ContextStack contextStack;
+    // Location information
+    private String loggerFqcn;
+    private @Nullable StackTraceElement source;
+    private boolean includeLocation;
 
     public MutableLogEvent() {
         // messageText and the parameter array are lazily initialized
@@ -93,8 +94,7 @@ public class MutableLogEvent implements ReusableLogEvent, ReusableMessage, Param
      *
      * @param event the event to copy data from
      */
-    public void initFrom(final LogEvent event) {
-        this.loggerFqcn = event.getLoggerFqcn();
+    public void moveValuesFrom(final LogEvent event) {
         this.marker = event.getMarker();
         this.level = event.getLevel();
         this.loggerName = event.getLoggerName();
@@ -109,19 +109,21 @@ public class MutableLogEvent implements ReusableLogEvent, ReusableMessage, Param
         this.contextData.putAll(event.getContextData());
 
         this.contextStack = event.getContextStack();
-        this.source = event.isIncludeLocation() ? event.getSource() : null;
         this.threadId = event.getThreadId();
         this.threadName = event.getThreadName();
         this.threadPriority = event.getThreadPriority();
         this.endOfBatch = event.isEndOfBatch();
         this.includeLocation = event.isIncludeLocation();
         this.nanoTime = event.getNanoTime();
+        // Location data
+        this.loggerFqcn = event.getLoggerFqcn();
+        this.source = event.peekSource();
+        this.includeLocation = event.isIncludeLocation();
         setMessage(event.getMessage());
     }
 
     @Override
     public void clear() {
-        loggerFqcn = null;
         marker = null;
         level = null;
         loggerName = null;
@@ -129,7 +131,6 @@ public class MutableLogEvent implements ReusableLogEvent, ReusableMessage, Param
         messageFormat = null;
         thrown = null;
         thrownProxy = null;
-        source = null;
         if (contextData != null) {
             if (contextData.isFrozen()) { // came from CopyOnWrite thread context
                 contextData = null;
@@ -138,6 +139,9 @@ public class MutableLogEvent implements ReusableLogEvent, ReusableMessage, Param
             }
         }
         contextStack = null;
+        // Location information
+        loggerFqcn = null;
+        source = null;
 
         // ThreadName should not be cleared: this field is set in the ReusableLogEventFactory
         // where this instance is kept in a ThreadLocal, so it usually does not change.
@@ -211,15 +215,14 @@ public class MutableLogEvent implements ReusableLogEvent, ReusableMessage, Param
     }
 
     @Override
-    public void setMessage(final Message msg) {
-        if (msg instanceof ReusableMessage) {
-            final ReusableMessage reusable = (ReusableMessage) msg;
+    public void setMessage(final Message message) {
+        if (message instanceof final ReusableMessage reusable) {
             reusable.formatTo(getMessageTextForWriting());
-            this.messageFormat = msg.getFormat();
+            messageFormat = message.getFormat();
             parameters = reusable.swapParameters(parameters == null ? new Object[10] : parameters);
             parameterCount = reusable.getParameterCount();
         } else {
-            this.message = InternalAsyncUtil.makeMessageImmutable(msg);
+            this.message = message;
         }
     }
 
@@ -373,13 +376,14 @@ public class MutableLogEvent implements ReusableLogEvent, ReusableMessage, Param
      */
     @Override
     public StackTraceElement getSource() {
-        if (source != null) {
-            return source;
+        if (source == null && loggerFqcn != null) {
+            return source = includeLocation ? StackLocatorUtil.calcLocation(loggerFqcn) : null;
         }
-        if (loggerFqcn == null || !includeLocation) {
-            return null;
-        }
-        source = StackLocatorUtil.calcLocation(loggerFqcn);
+        return peekSource();
+    }
+
+    @Override
+    public @Nullable StackTraceElement peekSource() {
         return source;
     }
 

--- a/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeEvent.java
+++ b/log4j-flume-ng/src/main/java/org/apache/logging/log4j/flume/appender/FlumeEvent.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.message.StructuredDataId;
 import org.apache.logging.log4j.message.StructuredDataMessage;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.Strings;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Class that is both a Flume and Log4j Event.
@@ -237,6 +238,11 @@ public class FlumeEvent extends SimpleEvent implements LogEvent {
     @Override
     public StackTraceElement getSource() {
         return event.getSource();
+    }
+
+    @Override
+    public @Nullable StackTraceElement peekSource() {
+        return event.peekSource();
     }
 
     /**

--- a/log4j-kit/src/main/java/org/apache/logging/log4j/kit/env/internal/PropertiesUtilPropertyEnvironment.java
+++ b/log4j-kit/src/main/java/org/apache/logging/log4j/kit/env/internal/PropertiesUtilPropertyEnvironment.java
@@ -24,9 +24,10 @@ import org.apache.logging.log4j.util.PropertiesUtil;
 
 /**
  * An adapter of the {@link PropertiesUtil} from Log4j API 2.x.
- *
- * @implNote Since {@link PropertiesUtil} requires all properties to start with {@code log4j2.}, we must add the prefix
- * before querying for the property.
+ * <p>
+ *     Since {@link PropertiesUtil} requires all properties to start with {@code log4j2.}, we must add the prefix
+ *     before querying for the property.
+ * </p>
  */
 public class PropertiesUtilPropertyEnvironment extends BasicPropertyEnvironment {
 

--- a/log4j-kit/src/main/java/org/apache/logging/log4j/kit/logger/AbstractLogger.java
+++ b/log4j-kit/src/main/java/org/apache/logging/log4j/kit/logger/AbstractLogger.java
@@ -143,7 +143,7 @@ public abstract class AbstractLogger implements ExtendedLogger {
     }
 
     /**
-     * @implNote This method is used by all the other filtering methods.
+     * This method is used by all the other filtering methods and is the only that needs an implementation.
      */
     @Override
     public abstract boolean isEnabled(Level level, @Nullable Marker marker);

--- a/log4j-kit/src/test/java/org/apache/logging/log4j/kit/logger/AbstractLoggerTest.java
+++ b/log4j-kit/src/test/java/org/apache/logging/log4j/kit/logger/AbstractLoggerTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 class AbstractLoggerTest {
 
     private static final int MAX_INLINE_SIZE = 35;
+    private static final String OBJECT = "Ljava/lang/Object;";
     /**
      * List of methods that currently don't fit into 35 bytes.
      */
@@ -36,13 +37,12 @@ class AbstractLoggerTest {
             "<clinit>()V",
             "<init>(",
             "handleLogMessageException(Ljava/lang/Throwable;Ljava/lang/String;Lorg/apache/logging/log4j/message/Message;)V",
-            // logging methods with Supplier, MessageSupplier or more than 2 parameters
-            "logMessage(Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Marker;Lorg/apache/logging/log4j/util/MessageSupplier;Ljava/lang/Throwable;)V",
-            "logMessage(Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Marker;Lorg/apache/logging/log4j/util/Supplier;Ljava/lang/Throwable;)V",
-            "logMessage(Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Marker;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;",
-            "logMessage(Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Marker;Ljava/lang/String;[Lorg/apache/logging/log4j/util/Supplier;)V",
-            // logging methods with more than 3 parameters
-            "logIfEnabled(Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Marker;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;");
+            // unconditional logging methods with more than 7 parameters
+            "logMessage(Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Marker;Ljava/lang/String;"
+                    + OBJECT.repeat(8),
+            // conditional logging methods with more than 3 parameters
+            "logIfEnabled(Ljava/lang/String;Lorg/apache/logging/log4j/Level;Lorg/apache/logging/log4j/Marker;Ljava/lang/String;"
+                    + OBJECT.repeat(4));
 
     @Test
     void does_not_exceed_MaxInlineSize() throws Exception {


### PR DESCRIPTION
We move the computation of location and message formatting to the last method call executed before a message leaves the current thread.

This has several consequences:

 - the refactoring of location computations should solve #1458,
 - since `AbstractLogger` no longer needs to compute the location of the caller, many messages were refactored to fit in the 35 bytes of bytecode limit. Only `logIfEnabled` methods with 4 or more `Object` parameters are over the limit and `logMessage` methods with 8 or more `Object` parameters, `handleMessageException` and the constructors,
 - messages that are filtered out by e.g. the filter of `AsyncAppender` do not include location information.

Part of #2290.
