### PR TITLE
Fix `StatusLogger` log level filtering when debug mode is enabled (#2337)

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -768,7 +768,8 @@ public class StatusLogger extends AbstractLogger {
     }
 
     private void notifyListener(final StatusListener listener, final StatusData statusData) {
-        if (config.debugEnabled || listener.getStatusLevel().isLessSpecificThan(statusData.getLevel())) {
+        final boolean levelEnabled = isLevelEnabled(listener.getStatusLevel(), statusData.getLevel());
+        if (levelEnabled) {
             listener.log(statusData);
         }
     }
@@ -963,8 +964,20 @@ public class StatusLogger extends AbstractLogger {
     }
 
     @Override
-    public boolean isEnabled(final Level level, final Marker marker) {
-        requireNonNull(level, "level");
-        return getLevel().isLessSpecificThan(level);
+    public boolean isEnabled(final Level messageLevel, final Marker marker) {
+        requireNonNull(messageLevel, "messageLevel");
+        final Level loggerLevel = getLevel();
+        return isLevelEnabled(loggerLevel, messageLevel);
+    }
+
+    /**
+     * Checks if the message level is allowed for the filtering level (e.g., of logger, of listener) by taking debug mode into account.
+     *
+     * @param filteringLevel the level (e.g., of logger, of listener) to filter messages
+     * @param messageLevel the level of the message
+     * @return {@code true}, if the sink level is less specific than the message level; {@code false}, otherwise
+     */
+    private boolean isLevelEnabled(final Level filteringLevel, final Level messageLevel) {
+        return config.debugEnabled || filteringLevel.isLessSpecificThan(messageLevel);
     }
 }

--- a/src/changelog/.2.x.x/fix_StatusLogger_debug_mode.xml
+++ b/src/changelog/.2.x.x/fix_StatusLogger_debug_mode.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="fixed">
+  <issue id="2337" link="https://github.com/apache/logging-log4j2/issues/2337"/>
+  <description format="asciidoc">Fix `StatusLogger` log level filtering when debug mode is enabled</description>
+</entry>


### PR DESCRIPTION
Fixes #2337 and makes `StatusLogger` take debug mode into account.