### PR TITLE
[FOLLOWUP] Fix StatusLogger log level filtering when debug mode is enabled

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusConsoleListenerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusConsoleListenerTest.java
@@ -50,7 +50,7 @@ public class StatusConsoleListenerTest {
     }
 
     @Test
-    void level_and_stream_should_be_honored() throws Exception {
+    void stream_should_be_honored() throws Exception {
 
         // Create the listener.
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -58,7 +58,7 @@ public class StatusConsoleListenerTest {
         final PrintStream printStream = new PrintStream(outputStream, false, encoding);
         final StatusConsoleListener listener = new StatusConsoleListener(Level.WARN, printStream);
 
-        // First, log a message that is expected to be logged.
+        // log a message that is expected to be logged.
         final RuntimeException expectedThrowable = new RuntimeException("expectedThrowable");
         expectedThrowable.setStackTrace(new StackTraceElement[] {
             new StackTraceElement("expectedThrowableClass", "expectedThrowableMethod", "expectedThrowableFile", 1)
@@ -71,29 +71,12 @@ public class StatusConsoleListenerTest {
                 expectedThrowable,
                 null)); // as set by `StatusLogger` itself
 
-        // Second, log a message that is expected to be discarded due to its insufficient level.
-        final RuntimeException discardedThrowable = new RuntimeException("discardedThrowable");
-        discardedThrowable.setStackTrace(new StackTraceElement[] {
-            new StackTraceElement("discardedThrowableClass", "discardedThrowableMethod", "discardedThrowableFile", 2)
-        });
-        final Message discardedMessage = MESSAGE_FACTORY.newMessage("discardedMessage");
-        listener.log(new StatusData(
-                null, // since ignored by `SimpleLogger`
-                Level.INFO,
-                discardedMessage,
-                discardedThrowable,
-                null)); // as set by `StatusLogger` itself
-
         // Collect the output.
         printStream.flush();
         final String output = outputStream.toString(encoding);
 
         // Verify the output.
-        assertThat(output)
-                .contains(expectedThrowable.getMessage())
-                .contains(expectedMessage.getFormattedMessage())
-                .doesNotContain(discardedThrowable.getMessage())
-                .doesNotContain(discardedMessage.getFormattedMessage());
+        assertThat(output).contains(expectedThrowable.getMessage()).contains(expectedMessage.getFormattedMessage());
     }
 
     @Test

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
@@ -134,10 +134,8 @@ public class StatusConsoleListener implements StatusListener {
     @Override
     public void log(final StatusData data) {
         requireNonNull(data, "data");
-        if (level.isLessSpecificThan(data.getLevel())) {
-            final String formattedStatus = data.getFormattedStatus();
-            stream.println(formattedStatus);
-        }
+        final String formattedStatus = data.getFormattedStatus();
+        stream.println(formattedStatus);
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
@@ -44,9 +44,6 @@ public class StatusConsoleListener implements StatusListener {
     // `volatile` is necessary to correctly read the `stream` without holding the lock
     private volatile PrintStream stream;
 
-    // whether or not enables debug mode
-    private final boolean debugEnabled;
-
     /**
      * Constructs a {@link StatusConsoleListener} instance writing to {@link System#out} using the supplied level.
      *
@@ -54,18 +51,7 @@ public class StatusConsoleListener implements StatusListener {
      * @throws NullPointerException on null {@code level}
      */
     public StatusConsoleListener(final Level level) {
-        this(level, false);
-    }
-
-    /**
-     * Constructs a {@link StatusConsoleListener} instance writing to {@link System#out} using the supplied level.
-     *
-     * @param level the level of status messages that should appear on the console
-     * @param debugEnabled whether or not enables debug mode
-     * @throws NullPointerException on null {@code level}
-     */
-    public StatusConsoleListener(final Level level, final boolean debugEnabled) {
-        this(level, System.out, debugEnabled);
+        this(level, System.out);
     }
 
     /**
@@ -79,25 +65,8 @@ public class StatusConsoleListener implements StatusListener {
      * @throws NullPointerException on null {@code level} or {@code stream}
      */
     public StatusConsoleListener(final Level level, final PrintStream stream) {
-        this(level, stream, false);
-    }
-
-    /**
-     * Constructs a {@link StatusConsoleListener} instance using the supplied level and stream.
-     * <p>
-     * Make sure not to use a logger stream of some sort to avoid creating an infinite loop of indirection!
-     * </p>
-     *
-     * @param level the level of status messages that should appear on the console
-     * @param stream the stream to write to
-     * @param debugEnabled whether or not enables debug mode
-     * @throws NullPointerException on null {@code level} or {@code stream}
-     */
-    public StatusConsoleListener(final Level level, final PrintStream stream,
-        final boolean debugEnabled) {
         this.initialLevel = this.level = requireNonNull(level, "level");
         this.initialStream = this.stream = requireNonNull(stream, "stream");
-        this.debugEnabled = debugEnabled;
     }
 
     /**
@@ -165,7 +134,7 @@ public class StatusConsoleListener implements StatusListener {
     @Override
     public void log(final StatusData data) {
         requireNonNull(data, "data");
-        if (debugEnabled || level.isLessSpecificThan(data.getLevel())) {
+        if (level.isLessSpecificThan(data.getLevel())) {
             final String formattedStatus = data.getFormattedStatus();
             stream.println(formattedStatus);
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
@@ -44,6 +44,9 @@ public class StatusConsoleListener implements StatusListener {
     // `volatile` is necessary to correctly read the `stream` without holding the lock
     private volatile PrintStream stream;
 
+    // whether or not enables debug mode
+    private final boolean debugEnabled;
+
     /**
      * Constructs a {@link StatusConsoleListener} instance writing to {@link System#out} using the supplied level.
      *
@@ -51,7 +54,18 @@ public class StatusConsoleListener implements StatusListener {
      * @throws NullPointerException on null {@code level}
      */
     public StatusConsoleListener(final Level level) {
-        this(level, System.out);
+        this(level, false);
+    }
+
+    /**
+     * Constructs a {@link StatusConsoleListener} instance writing to {@link System#out} using the supplied level.
+     *
+     * @param level the level of status messages that should appear on the console
+     * @param debugEnabled whether or not enables debug mode
+     * @throws NullPointerException on null {@code level}
+     */
+    public StatusConsoleListener(final Level level, final boolean debugEnabled) {
+        this(level, System.out, debugEnabled);
     }
 
     /**
@@ -65,8 +79,25 @@ public class StatusConsoleListener implements StatusListener {
      * @throws NullPointerException on null {@code level} or {@code stream}
      */
     public StatusConsoleListener(final Level level, final PrintStream stream) {
+        this(level, stream, false);
+    }
+
+    /**
+     * Constructs a {@link StatusConsoleListener} instance using the supplied level and stream.
+     * <p>
+     * Make sure not to use a logger stream of some sort to avoid creating an infinite loop of indirection!
+     * </p>
+     *
+     * @param level the level of status messages that should appear on the console
+     * @param stream the stream to write to
+     * @param debugEnabled whether or not enables debug mode
+     * @throws NullPointerException on null {@code level} or {@code stream}
+     */
+    public StatusConsoleListener(final Level level, final PrintStream stream,
+        final boolean debugEnabled) {
         this.initialLevel = this.level = requireNonNull(level, "level");
         this.initialStream = this.stream = requireNonNull(stream, "stream");
+        this.debugEnabled = debugEnabled;
     }
 
     /**
@@ -134,7 +165,7 @@ public class StatusConsoleListener implements StatusListener {
     @Override
     public void log(final StatusData data) {
         requireNonNull(data, "data");
-        if (level.isLessSpecificThan(data.getLevel())) {
+        if (debugEnabled || level.isLessSpecificThan(data.getLevel())) {
             final String formattedStatus = data.getFormattedStatus();
             stream.println(formattedStatus);
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -526,8 +526,7 @@ public class StatusLogger extends AbstractLogger {
                 StatusLogger.class.getSimpleName(),
                 ParameterizedNoReferenceMessageFactory.INSTANCE,
                 Config.getInstance(),
-                new StatusConsoleListener(Config.getInstance().fallbackListenerLevel,
-                    Config.getInstance().debugEnabled));
+                new StatusConsoleListener(Config.getInstance().fallbackListenerLevel));
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -526,7 +526,8 @@ public class StatusLogger extends AbstractLogger {
                 StatusLogger.class.getSimpleName(),
                 ParameterizedNoReferenceMessageFactory.INSTANCE,
                 Config.getInstance(),
-                new StatusConsoleListener(Config.getInstance().fallbackListenerLevel));
+                new StatusConsoleListener(Config.getInstance().fallbackListenerLevel,
+                    Config.getInstance().debugEnabled));
     }
 
     /**


### PR DESCRIPTION
Follow up for https://github.com/apache/logging-log4j2/pull/2338, 
Fixes https://github.com/apache/logging-log4j2/issues/2337 and makes StatusLogger take debug mode into account.