### PR TITLE
Fix `StatusLogger` to correctly read `log4j2.StatusLogger.properties`

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerPropertiesUtilDoubleTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerPropertiesUtilDoubleTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.status;
 
+import static java.util.Collections.singletonMap;
 import static org.apache.logging.log4j.status.StatusLogger.PropertiesUtilsDouble.readAllAvailableProperties;
 import static org.apache.logging.log4j.status.StatusLogger.PropertiesUtilsDouble.readProperty;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,7 +25,9 @@ import static uk.org.webcompere.systemstubs.SystemStubs.withEnvironmentVariable;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
@@ -108,5 +111,12 @@ class StatusLoggerPropertiesUtilDoubleTest {
         } else {
             assertThat(actualValue).describedAs("" + testCase).isNull();
         }
+    }
+
+    @Test
+    void properties_file_in_class_path_should_be_read() {
+        final String propertiesFileName = StatusLoggerPropertiesUtilDoubleTest.class.getSimpleName() + ".properties";
+        final Properties actualProperties = StatusLogger.PropertiesUtilsDouble.readPropertiesFile(propertiesFileName);
+        assertThat(actualProperties).containsExactlyEntriesOf(singletonMap("foo", "bar"));
     }
 }

--- a/log4j-api-test/src/test/resources/StatusLoggerPropertiesUtilDoubleTest.properties
+++ b/log4j-api-test/src/test/resources/StatusLoggerPropertiesUtilDoubleTest.properties
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# This file only exists to test if `StatusLogger.PropertiesUtilDouble` indeed loads the resource at the root directory.
+# Hence, don't place this file under a subdirectory!
+#
+foo=bar

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -404,7 +404,7 @@ public class StatusLogger extends AbstractLogger {
         static Map<String, Object> readAllAvailableProperties() {
             final Properties systemProperties = System.getProperties();
             final Properties environmentProperties = readEnvironmentProperties();
-            final Properties fileProvidedProperties = readPropertiesFile();
+            final Properties fileProvidedProperties = readPropertiesFile(PROPERTIES_FILE_NAME);
             return normalizeProperties(systemProperties, environmentProperties, fileProvidedProperties);
         }
 
@@ -419,12 +419,12 @@ public class StatusLogger extends AbstractLogger {
         // Consequently, they would delegate to `LoaderUtil`, etc.
         // All these mechanisms expect a working `StatusLogger`.
         // Hence, in order to be self-sufficient, we cannot rely on them.
-        private static Properties readPropertiesFile() {
+        static Properties readPropertiesFile(final String propertiesFileName) {
             final Properties properties = new Properties();
             // Unlike `ClassLoader#getResource()`, which takes absolute resource paths, `Class#getResource()` supports
             // relative resource paths. Without a `/` prefix, the resource must be placed into JAR resources as
             // `org/apache/logging/log4j/status/log4j2.StatusLogger.properties`. Hence, the `/` prefix.
-            final String resourceName = '/' + PROPERTIES_FILE_NAME;
+            final String resourceName = '/' + propertiesFileName;
             final URL url = StatusLogger.class.getResource(resourceName);
             if (url == null) {
                 return properties;
@@ -432,7 +432,7 @@ public class StatusLogger extends AbstractLogger {
             try (final InputStream stream = url.openStream()) {
                 properties.load(stream);
             } catch (final IOException error) {
-                final String message = String.format("failed reading properties from `%s`", PROPERTIES_FILE_NAME);
+                final String message = String.format("failed reading properties from `%s`", propertiesFileName);
                 final RuntimeException extendedError = new RuntimeException(message, error);
                 // There is no logging system at this stage.
                 // There is nothing we can do but simply dumping the failure.

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -421,7 +421,11 @@ public class StatusLogger extends AbstractLogger {
         // Hence, in order to be self-sufficient, we cannot rely on them.
         private static Properties readPropertiesFile() {
             final Properties properties = new Properties();
-            final URL url = StatusLogger.class.getResource(PROPERTIES_FILE_NAME);
+            // Unlike `ClassLoader#getResource()`, which takes absolute resource paths, `Class#getResource()` supports
+            // relative resource paths. Without a `/` prefix, the resource must be placed into JAR resources as
+            // `org/apache/logging/log4j/status/log4j2.StatusLogger.properties`. Hence, the `/` prefix.
+            final String resourceName = '/' + PROPERTIES_FILE_NAME;
+            final URL url = StatusLogger.class.getResource(resourceName);
             if (url == null) {
                 return properties;
             }

--- a/src/changelog/.2.x.x/fix_StatusLogger_properties_read.xml
+++ b/src/changelog/.2.x.x/fix_StatusLogger_properties_read.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="fixed">
+  <description format="asciidoc">Fix `StatusLogger` to correctly read `log4j2.StatusLogger.properties` resource</description>
+</entry>

--- a/src/changelog/.2.x.x/fix_StatusLogger_properties_read.xml
+++ b/src/changelog/.2.x.x/fix_StatusLogger_properties_read.xml
@@ -3,5 +3,6 @@
        xmlns="http://logging.apache.org/log4j/changelog"
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
        type="fixed">
+  <issue id="2354" link="https://github.com/apache/logging-log4j2/pull/2354"/>
   <description format="asciidoc">Fix `StatusLogger` to correctly read `log4j2.StatusLogger.properties` resource</description>
 </entry>


### PR DESCRIPTION
As reported [here](/apache/logging-log4j2/pull/2249#discussion_r1513116254) by @carterkozak, `StatusLogger` logic to read the `log4j2.StatusLogger.properties` resource is broken. This PR addresses that.
