### PR TITLE
Fix regex error in Log4j-config.xsd

### DIFF
--- a/log4j-core-test/src/main/resources/Log4j-config.xsd
+++ b/log4j-core-test/src/main/resources/Log4j-config.xsd
@@ -128,7 +128,7 @@
             </annotation>
             <simpleType>
                <restriction base="string">
-                  <pattern value="(|disable|\$\{[^{}]+\})" />
+                  <pattern value="(|disable|\\$\{[^{}]+\})" />
                </restriction>
             </simpleType>
          </attribute>
@@ -148,7 +148,7 @@
             <simpleType>
                <restriction base="string">
                   <pattern
-                     value="([Tt][Rr][Aa][Cc][Ee]|[Dd][Ee][Bb][Uu][Gg]|[Ii][Nn][Ff][Oo]|[Ww][Aa][Rr][Nn]|[Ee][Rr][Rr][Oo][Rr]|[Ff][Aa][Tt][Aa][Ll]|[Oo][Ff][Ff]|\$\{[^{}]+\})" />
+                     value="([Tt][Rr][Aa][Cc][Ee]|[Dd][Ee][Bb][Uu][Gg]|[Ii][Nn][Ff][Oo]|[Ww][Aa][Rr][Nn]|[Ee][Rr][Rr][Oo][Rr]|[Ff][Aa][Tt][Aa][Ll]|[Oo][Ff][Ff]|\\$\{[^{}]+\})" />
                </restriction>
             </simpleType>
          </attribute>
@@ -1389,7 +1389,7 @@
          <documentation>Allow boolean values or variable place holders in the form of ${variablename}</documentation>
       </annotation>
       <restriction base="string">
-         <pattern value="(true|false|\$\{[^{}]+\})" />
+         <pattern value="(true|false|\\$\{[^{}]+\})" />
       </restriction>
    </simpleType>
 
@@ -1398,7 +1398,7 @@
          <documentation>Allow long values or variable place holders in the form of ${variablename}</documentation>
       </annotation>
       <restriction base="string">
-         <pattern value="-?([0-9]+|\$\{[^{}]+\})" />
+         <pattern value="-?([0-9]+|\\$\{[^{}]+\})" />
       </restriction>
    </simpleType>
 

--- a/log4j-core/src/main/resources/Log4j-config.xsd
+++ b/log4j-core/src/main/resources/Log4j-config.xsd
@@ -128,7 +128,7 @@
             </annotation>
             <simpleType>
                <restriction base="string">
-                  <pattern value="(|disable|\$\{[^{}]+\})" />
+                  <pattern value="(|disable|\\$\{[^{}]+\})" />
                </restriction>
             </simpleType>
          </attribute>
@@ -148,7 +148,7 @@
             <simpleType>
                <restriction base="string">
                   <pattern
-                     value="([Tt][Rr][Aa][Cc][Ee]|[Dd][Ee][Bb][Uu][Gg]|[Ii][Nn][Ff][Oo]|[Ww][Aa][Rr][Nn]|[Ee][Rr][Rr][Oo][Rr]|[Ff][Aa][Tt][Aa][Ll]|[Oo][Ff][Ff]|\$\{[^{}]+\})" />
+                     value="([Tt][Rr][Aa][Cc][Ee]|[Dd][Ee][Bb][Uu][Gg]|[Ii][Nn][Ff][Oo]|[Ww][Aa][Rr][Nn]|[Ee][Rr][Rr][Oo][Rr]|[Ff][Aa][Tt][Aa][Ll]|[Oo][Ff][Ff]|\\$\{[^{}]+\})" />
                </restriction>
             </simpleType>
          </attribute>
@@ -1389,7 +1389,7 @@
          <documentation>Allow boolean values or variable place holders in the form of ${variablename}</documentation>
       </annotation>
       <restriction base="string">
-         <pattern value="(true|false|\$\{[^{}]+\})" />
+         <pattern value="(true|false|\\$\{[^{}]+\})" />
       </restriction>
    </simpleType>
 
@@ -1398,7 +1398,7 @@
          <documentation>Allow long values or variable place holders in the form of ${variablename}</documentation>
       </annotation>
       <restriction base="string">
-         <pattern value="-?([0-9]+|\$\{[^{}]+\})" />
+         <pattern value="-?([0-9]+|\\$\{[^{}]+\})" />
       </restriction>
    </simpleType>
 


### PR DESCRIPTION
Trivial fix of error "The value of the facet 'pattern' is not a valid regular expression"

Before:
```bash
$ xmllint --schema Log4j-config.xsd /tmp/log4j2.xml --noout
regexp error : failed to compile: Wrong escape sequence, misuse of character '\'
regexp error : failed to compile: internal: no atom generated
regexp error : failed to compile: generate transition: atom == NULL
regexp error : failed to compile: xmlFAParseAtom: expecting ')'
regexp error : failed to compile: xmlFAParseRegExp: extra characters
Log4j-config.xsd:131: element pattern: Schemas parser error : Element '{[http://www.w3.org/2001/XMLSchema}pattern':](http://www.w3.org/2001/XMLSchema%7Dpattern':) The value '(|disable|\$\{[^{}]+\})' of the facet 'pattern' is not a valid regular expression.
...
```
And few same messages

After:
```bash
$ xmllint --schema log4j-core/src/main/resources/Log4j-config.xsd /tmp/log4j2.xml --noout
/tmp/log4j2.xml validates
```