### PR TITLE
Deprecate `o.a.l.l.c.a.r.a.Duration` class for removal

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModifiedTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModifiedTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.attribute.FileTime;
+import java.time.Duration;
 import java.util.List;
 import org.apache.logging.log4j.core.config.Node;
 import org.apache.logging.log4j.core.config.NullConfiguration;
@@ -42,12 +43,6 @@ import org.junitpioneer.jupiter.SetSystemProperty;
  */
 @SetSystemProperty(key = "log4j2.status.entries", value = "10")
 class IfLastModifiedTest {
-
-    @Test
-    public void testGetDurationReturnsConstructorValue() {
-        final IfLastModified filter = IfLastModified.createAgeCondition(Duration.parse("P7D"));
-        assertEquals(0, filter.getAge().compareTo(Duration.parse("P7D")));
-    }
 
     @Test
     public void testAcceptsIfFileAgeEqualToDuration() {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModifiedTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModifiedTest.java
@@ -46,7 +46,8 @@ class IfLastModifiedTest {
 
     @Test
     public void testAcceptsIfFileAgeEqualToDuration() {
-        final IfLastModified filter = IfLastModified.createAgeCondition(Duration.parse("PT33S"));
+        final IfLastModified filter =
+                IfLastModified.newBuilder().setAge(Duration.parse("PT33S")).build();
         final DummyFileAttributes attrs = new DummyFileAttributes();
         final long age = 33 * 1000;
         attrs.lastModified = FileTime.fromMillis(System.currentTimeMillis() - age);
@@ -55,7 +56,8 @@ class IfLastModifiedTest {
 
     @Test
     public void testAcceptsIfFileAgeExceedsDuration() {
-        final IfLastModified filter = IfLastModified.createAgeCondition(Duration.parse("PT33S"));
+        final IfLastModified filter =
+                IfLastModified.newBuilder().setAge(Duration.parse("PT33S")).build();
         final DummyFileAttributes attrs = new DummyFileAttributes();
         final long age = 33 * 1000 + 5;
         attrs.lastModified = FileTime.fromMillis(System.currentTimeMillis() - age);
@@ -64,7 +66,8 @@ class IfLastModifiedTest {
 
     @Test
     public void testDoesNotAcceptIfFileAgeLessThanDuration() {
-        final IfLastModified filter = IfLastModified.createAgeCondition(Duration.parse("PT33S"));
+        final IfLastModified filter =
+                IfLastModified.newBuilder().setAge(Duration.parse("PT33S")).build();
         final DummyFileAttributes attrs = new DummyFileAttributes();
         final long age = 33 * 1000 - 5;
         attrs.lastModified = FileTime.fromMillis(System.currentTimeMillis() - age);
@@ -74,7 +77,10 @@ class IfLastModifiedTest {
     @Test
     public void testAcceptCallsNestedConditionsOnlyIfPathAccepted() {
         final CountingCondition counter = new CountingCondition(true);
-        final IfLastModified filter = IfLastModified.createAgeCondition(Duration.parse("PT33S"), counter);
+        final IfLastModified filter = IfLastModified.newBuilder()
+                .setAge(Duration.parse("PT33S"))
+                .setNestedConditions(counter)
+                .build();
         final DummyFileAttributes attrs = new DummyFileAttributes();
         final long oldEnough = 33 * 1000 + 5;
         attrs.lastModified = FileTime.fromMillis(System.currentTimeMillis() - oldEnough);
@@ -99,8 +105,10 @@ class IfLastModifiedTest {
     @Test
     public void testBeforeTreeWalk() {
         final CountingCondition counter = new CountingCondition(true);
-        final IfLastModified filter =
-                IfLastModified.createAgeCondition(Duration.parse("PT33S"), counter, counter, counter);
+        final IfLastModified filter = IfLastModified.newBuilder()
+                .setAge(Duration.parse("PT33S"))
+                .setNestedConditions(counter, counter, counter)
+                .build();
         filter.beforeFileTreeWalk();
         assertEquals(3, counter.getBeforeFileTreeWalkCount());
     }
@@ -108,7 +116,8 @@ class IfLastModifiedTest {
     @Test
     public void testCreateAgeConditionCalledProgrammaticallyThrowsNPEWhenAgeIsNotSpecified() {
         Duration age = null;
-        assertThrows(NullPointerException.class, () -> IfLastModified.createAgeCondition(age));
+        assertThrows(
+                NullPointerException.class, () -> IfLastModified.newBuilder().setAge(age));
     }
 
     @ParameterizedTest

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/Duration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/Duration.java
@@ -30,7 +30,9 @@ import java.util.regex.Pattern;
  * This implementation does not support fractions or negative values.
  *
  * @see #parse(CharSequence)
+ * @deprecated since 2.24.0 use {@link java.time.Duration} instead.
  */
+@Deprecated
 public class Duration implements Serializable, Comparable<Duration> {
     private static final long serialVersionUID = -3756810052716342061L;
 
@@ -65,6 +67,13 @@ public class Duration implements Serializable, Comparable<Duration> {
      */
     private static final Pattern PATTERN = Pattern.compile(
             "P?(?:([0-9]+)D)?" + "(T?(?:([0-9]+)H)?(?:([0-9]+)M)?(?:([0-9]+)?S)?)?", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * @since 2.24.0
+     */
+    public static Duration ofMillis(final long millis) {
+        return new Duration(millis / 1000L);
+    }
 
     /**
      * The number of seconds in the duration.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModified.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModified.java
@@ -117,13 +117,13 @@ public final class IfLastModified implements PathCondition {
     public static final class Builder implements org.apache.logging.log4j.core.util.Builder<IfLastModified> {
         @PluginBuilderAttribute
         @Required(message = "No age provided for IfLastModified")
-        private Duration age;
+        private org.apache.logging.log4j.core.appender.rolling.action.Duration age;
 
         @PluginElement("nestedConditions")
         private PathCondition[] nestedConditions;
 
         public Builder setAge(final Duration age) {
-            this.age = age;
+            this.age = org.apache.logging.log4j.core.appender.rolling.action.Duration.ofMillis(age.toMillis());
             return this;
         }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModified.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModified.java
@@ -28,8 +28,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
-import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
 import org.apache.logging.log4j.core.util.Clock;
 import org.apache.logging.log4j.core.util.ClockFactory;
@@ -106,7 +106,7 @@ public final class IfLastModified implements PathCondition {
     /**
      * @since 2.24.0
      */
-    @PluginFactory
+    @PluginBuilderFactory
     public static Builder newBuilder() {
         return new Builder();
     }
@@ -134,7 +134,7 @@ public final class IfLastModified implements PathCondition {
 
         @Override
         public IfLastModified build() {
-            return isValid() ? new IfLastModified(age, nestedConditions) : null;
+            return isValid() ? new IfLastModified(Duration.ofMillis(age.toMillis()), nestedConditions) : null;
         }
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModified.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModified.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.status.StatusLogger;
 
 /**
  * PathCondition that accepts paths that are older than the specified duration.
+ * @since 2.5
  */
 @Plugin(name = "IfLastModified", category = Core.CATEGORY_NAME, printObject = true)
 public final class IfLastModified implements PathCondition {
@@ -52,7 +53,7 @@ public final class IfLastModified implements PathCondition {
     }
 
     /**
-     * @deprecated since 2.24.0 without a replacement.
+     * @deprecated since 2.24.0. In 3.0.0 the signature will change.
      */
     @Deprecated
     public org.apache.logging.log4j.core.appender.rolling.action.Duration getAge() {
@@ -102,11 +103,17 @@ public final class IfLastModified implements PathCondition {
         return "IfLastModified(age=" + age + nested + ")";
     }
 
+    /**
+     * @since 2.24.0
+     */
     @PluginFactory
     public static Builder newBuilder() {
         return new Builder();
     }
 
+    /**
+     * @since 2.24.0
+     */
     public static final class Builder implements org.apache.logging.log4j.core.util.Builder<IfLastModified> {
         @PluginBuilderAttribute
         @Required(message = "No age provided for IfLastModified")

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModified.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/IfLastModified.java
@@ -19,6 +19,7 @@ package org.apache.logging.log4j.core.appender.rolling.action;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -50,8 +51,12 @@ public final class IfLastModified implements PathCondition {
         this.nestedConditions = PathCondition.copy(nestedConditions);
     }
 
-    public Duration getAge() {
-        return age;
+    /**
+     * @deprecated since 2.24.0 without a replacement.
+     */
+    @Deprecated
+    public org.apache.logging.log4j.core.appender.rolling.action.Duration getAge() {
+        return org.apache.logging.log4j.core.appender.rolling.action.Duration.ofMillis(age.toMillis());
     }
 
     public List<PathCondition> getNestedConditions() {
@@ -90,19 +95,28 @@ public final class IfLastModified implements PathCondition {
     }
 
     /**
+     * @deprecated since 2.24.0 use {@link #createAgeCondition(Duration, PathCondition...)} instead.
+     */
+    @Deprecated
+    public static IfLastModified createAgeCondition(
+            final org.apache.logging.log4j.core.appender.rolling.action.Duration age,
+            final PathCondition... pathConditions) {
+        return createAgeCondition(Duration.ofMillis(age.toMillis()), pathConditions);
+    }
+
+    /**
      * Create an IfLastModified condition.
      *
      * @param age The path age that is accepted by this condition. Must be a valid Duration.
-     * @param nestedConditions nested conditions to evaluate if this condition accepts a path
+     * @param pathConditions Nested conditions to evaluate if this condition accepts a path.
      * @return An IfLastModified condition.
+     * @since 2.24.0
      */
     @PluginFactory
     public static IfLastModified createAgeCondition(
-            // @formatter:off
             @PluginAttribute("age") @Required(message = "No age provided for IfLastModified") final Duration age,
-            @PluginElement("PathConditions") final PathCondition... nestedConditions) {
-        // @formatter:on
-        return new IfLastModified(age, nestedConditions);
+            @PluginElement("pathConditions") final PathCondition... pathConditions) {
+        return new IfLastModified(age, Objects.requireNonNull(pathConditions));
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/package-info.java
@@ -18,7 +18,7 @@
  * Support classes for the Rolling File Appender.
  */
 @Export
-@Version("2.20.2")
+@Version("2.24.0")
 package org.apache.logging.log4j.core.appender.rolling.action;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverters.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverters.java
@@ -32,7 +32,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Provider;
 import java.security.Security;
-import java.time.Duration;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import org.apache.logging.log4j.Level;
@@ -226,7 +225,7 @@ public final class TypeConverters {
     /**
      * Converts a {@link String} into a {@link org.apache.logging.log4j.core.appender.rolling.action.Duration}.
      * @since 2.5
-     * @deprecated since 2.24.0 use {@link JavaDurationConverter}
+     * @deprecated since 2.24.0. A {@link java.time.Duration} converter will be available in 3.0.0.
      */
     @Plugin(name = "Duration", category = CATEGORY)
     @Deprecated
@@ -235,18 +234,6 @@ public final class TypeConverters {
         @Override
         public org.apache.logging.log4j.core.appender.rolling.action.Duration convert(final String s) {
             return org.apache.logging.log4j.core.appender.rolling.action.Duration.parse(s);
-        }
-    }
-
-    /**
-     * Converts a {@link String} into a {@link Duration}.
-     * @since 2.24.0
-     */
-    @Plugin(name = "JavaDuration", category = CATEGORY)
-    public static class JavaDurationConverter implements TypeConverter<Duration> {
-        @Override
-        public Duration convert(final String s) {
-            return Duration.parse(s);
         }
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverters.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/TypeConverters.java
@@ -32,11 +32,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Provider;
 import java.security.Security;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.regex.Pattern;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.appender.rolling.action.Duration;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.util.CronExpression;
 import org.apache.logging.log4j.status.StatusLogger;
@@ -224,11 +224,26 @@ public final class TypeConverters {
     }
 
     /**
-     * Converts a {@link String} into a {@link Duration}.
+     * Converts a {@link String} into a {@link org.apache.logging.log4j.core.appender.rolling.action.Duration}.
      * @since 2.5
+     * @deprecated since 2.24.0 use {@link JavaDurationConverter}
      */
     @Plugin(name = "Duration", category = CATEGORY)
-    public static class DurationConverter implements TypeConverter<Duration> {
+    @Deprecated
+    public static class DurationConverter
+            implements TypeConverter<org.apache.logging.log4j.core.appender.rolling.action.Duration> {
+        @Override
+        public org.apache.logging.log4j.core.appender.rolling.action.Duration convert(final String s) {
+            return org.apache.logging.log4j.core.appender.rolling.action.Duration.parse(s);
+        }
+    }
+
+    /**
+     * Converts a {@link String} into a {@link Duration}.
+     * @since 2.24.0
+     */
+    @Plugin(name = "JavaDuration", category = CATEGORY)
+    public static class JavaDurationConverter implements TypeConverter<Duration> {
         @Override
         public Duration convert(final String s) {
             return Duration.parse(s);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/convert/package-info.java
@@ -20,7 +20,7 @@
  * attributes in plugin factory methods.
  */
 @Export
-@Version("2.20.2")
+@Version("2.24.0")
 package org.apache.logging.log4j.core.config.plugins.convert;
 
 import org.osgi.annotation.bundle.Export;

--- a/src/changelog/.2.x.x/deprecate_duration.xml
+++ b/src/changelog/.2.x.x/deprecate_duration.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="changed">
+  <description format="asciidoc">Deprecate `org.apache.logging.log4j.core.appender.rolling.action.Duration` class for removal.</description>
+</entry>


### PR DESCRIPTION
We deprecate the [`o.a.l.l.c.a.r.a.Duration`](https://logging.apache.org/log4j/2.x/javadoc/log4j-core/org/apache/logging/log4j/core/appender/rolling/action/Duration) and replace it with `java.time.Duration`.
