### PR TITLE
Backport part of #2062 to `2.x` branch.

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/PropertiesUtilTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/PropertiesUtilTest.java
@@ -23,10 +23,12 @@ import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.NANOS;
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -36,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Stream;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
@@ -45,19 +46,20 @@ import org.junit.jupiter.api.parallel.Resources;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.Issue;
 import org.junitpioneer.jupiter.ReadsSystemProperty;
 
-public class PropertiesUtilTest {
+class PropertiesUtilTest {
 
     private final Properties properties = new Properties();
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         properties.load(ClassLoader.getSystemResourceAsStream("PropertiesUtilTest.properties"));
     }
 
     @Test
-    public void testExtractSubset() {
+    void testExtractSubset() {
         assertHasAllProperties(PropertiesUtil.extractSubset(properties, "a"));
         assertHasAllProperties(PropertiesUtil.extractSubset(properties, "b."));
         assertHasAllProperties(PropertiesUtil.extractSubset(properties, "c.1"));
@@ -67,7 +69,7 @@ public class PropertiesUtilTest {
     }
 
     @Test
-    public void testPartitionOnCommonPrefix() {
+    void testPartitionOnCommonPrefix() {
         final Map<String, Properties> parts = PropertiesUtil.partitionOnCommonPrefixes(properties);
         assertEquals(4, parts.size());
         assertHasAllProperties(parts.get("a"));
@@ -85,7 +87,7 @@ public class PropertiesUtilTest {
     }
 
     @Test
-    public void testGetCharsetProperty() {
+    void testGetCharsetProperty() {
         final Properties p = new Properties();
         p.setProperty("e.1", StandardCharsets.US_ASCII.name());
         p.setProperty("e.2", "wrong-charset-name");
@@ -130,8 +132,8 @@ public class PropertiesUtilTest {
 
     @ParameterizedTest
     @MethodSource
-    void should_properly_parse_duration(final Duration expected, final String value) {
-        Assertions.assertThat(PropertiesUtil.parseDuration(value)).isEqualTo(expected);
+    void should_properly_parse_duration(final Duration expected, final CharSequence value) {
+        assertThat(PropertiesUtil.parseDuration(value)).isEqualTo(expected);
     }
 
     static List<String> should_throw_on_invalid_duration() {
@@ -142,13 +144,13 @@ public class PropertiesUtilTest {
 
     @ParameterizedTest
     @MethodSource
-    void should_throw_on_invalid_duration(final String value) {
+    void should_throw_on_invalid_duration(final CharSequence value) {
         assertThrows(IllegalArgumentException.class, () -> PropertiesUtil.parseDuration(value));
     }
 
     @Test
     @ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ)
-    public void testGetMappedProperty_sun_stdout_encoding() {
+    void testGetMappedProperty_sun_stdout_encoding() {
         final PropertiesUtil pu = new PropertiesUtil(System.getProperties());
         final Charset expected = System.console() == null ? Charset.defaultCharset() : StandardCharsets.UTF_8;
         assertEquals(expected, pu.getCharsetProperty("sun.stdout.encoding"));
@@ -156,7 +158,7 @@ public class PropertiesUtilTest {
 
     @Test
     @ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ)
-    public void testGetMappedProperty_sun_stderr_encoding() {
+    void testGetMappedProperty_sun_stderr_encoding() {
         final PropertiesUtil pu = new PropertiesUtil(System.getProperties());
         final Charset expected = System.console() == null ? Charset.defaultCharset() : StandardCharsets.UTF_8;
         assertEquals(expected, pu.getCharsetProperty("sun.err.encoding"));
@@ -164,7 +166,7 @@ public class PropertiesUtilTest {
 
     @Test
     @ResourceLock(Resources.SYSTEM_PROPERTIES)
-    public void testNonStringSystemProperties() {
+    void testNonStringSystemProperties() {
         final Object key1 = "1";
         final Object key2 = new Object();
         System.getProperties().put(key1, new Object());
@@ -180,12 +182,30 @@ public class PropertiesUtilTest {
 
     @Test
     @ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ)
-    public void testPublish() {
+    void testPublish() {
         final Properties props = new Properties();
-        final PropertiesUtil util = new PropertiesUtil(props);
+        new PropertiesUtil(props);
         final String value = System.getProperty("Application");
         assertNotNull(value, "System property was not published");
         assertEquals("Log4j", value);
+    }
+
+    @Test
+    @ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ)
+    @Issue("https://github.com/spring-projects/spring-boot/issues/33450")
+    void testBadPropertySource() {
+        final String key = "testKey";
+        final Properties props = new Properties();
+        props.put(key, "test");
+        final PropertiesUtil util = new PropertiesUtil(props);
+        final ErrorPropertySource source = new ErrorPropertySource();
+        util.addPropertySource(source);
+        try {
+            assertEquals("test", util.getStringProperty(key));
+            assertTrue(source.exceptionThrown);
+        } finally {
+            util.removePropertySource(source);
+        }
     }
 
     private static final String[][] data = {
@@ -209,7 +229,7 @@ public class PropertiesUtilTest {
      */
     @Test
     @ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ)
-    public void testResolvesOnlyLog4jProperties() {
+    void testResolvesOnlyLog4jProperties() {
         final PropertiesUtil util = new PropertiesUtil("Jira3413Test.properties");
         for (final String[] pair : data) {
             assertEquals(pair[0], util.getStringProperty(pair[1]));
@@ -222,7 +242,7 @@ public class PropertiesUtilTest {
      */
     @Test
     @ReadsSystemProperty
-    public void testLog4jProperty() {
+    void testLog4jProperty() {
         final Properties props = new Properties();
         final String incorrect = "log4j2.";
         final String correct = "not.starting.with.log4j";
@@ -230,5 +250,41 @@ public class PropertiesUtilTest {
         props.setProperty(correct, correct);
         final PropertiesUtil util = new PropertiesUtil(props);
         assertEquals(correct, util.getStringProperty(correct));
+    }
+
+    @Test
+    void should_support_multiple_sources_with_same_priority() {
+        final int priority = 2003;
+        final String key1 = "propertySource1";
+        final Properties props1 = new Properties();
+        props1.put(key1, "props1");
+        final String key2 = "propertySource2";
+        final Properties props2 = new Properties();
+        props2.put(key2, "props2");
+        final PropertiesUtil util = new PropertiesUtil(new PropertiesPropertySource(props1, priority));
+        util.addPropertySource(new PropertiesPropertySource(props2, priority));
+        assertThat(util.getStringProperty(key1)).isEqualTo("props1");
+        assertThat(util.getStringProperty(key2)).isEqualTo("props2");
+    }
+
+    private static class ErrorPropertySource implements PropertySource {
+        public boolean exceptionThrown = false;
+
+        @Override
+        public int getPriority() {
+            return Integer.MIN_VALUE;
+        }
+
+        @Override
+        public String getProperty(final String key) {
+            exceptionThrown = true;
+            throw new IllegalStateException("Test");
+        }
+
+        @Override
+        public boolean containsProperty(final String key) {
+            exceptionThrown = true;
+            throw new IllegalStateException("Test");
+        }
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
@@ -50,7 +50,7 @@ public interface PropertySource {
      *
      * @param action action to perform on each key/value pair
      */
-    default void forEach(BiConsumer<String, String> action) {}
+    default void forEach(final BiConsumer<String, String> action) {}
 
     /**
      * Returns the list of all property names.
@@ -68,7 +68,7 @@ public interface PropertySource {
      * @param tokens list of property name tokens
      * @return a normalized property name using the given tokens
      */
-    default CharSequence getNormalForm(Iterable<? extends CharSequence> tokens) {
+    default CharSequence getNormalForm(final Iterable<? extends CharSequence> tokens) {
         return null;
     }
 
@@ -78,7 +78,7 @@ public interface PropertySource {
      * @return The value or null;
      * @since 2.13.0
      */
-    default String getProperty(String key) {
+    default String getProperty(final String key) {
         return null;
     }
 
@@ -88,7 +88,7 @@ public interface PropertySource {
      * @return The value or null;
      * @since 2.13.0
      */
-    default boolean containsProperty(String key) {
+    default boolean containsProperty(final String key) {
         return false;
     }
 
@@ -99,6 +99,8 @@ public interface PropertySource {
      */
     class Comparator implements java.util.Comparator<PropertySource>, Serializable {
         private static final long serialVersionUID = 1L;
+
+        static final Comparator INSTANCE = new Comparator();
 
         @Override
         public int compare(final PropertySource o1, final PropertySource o2) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/Server.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/Server.java
@@ -237,12 +237,14 @@ public final class Server {
      * @param loggerContextName name of the logger context to unregister
      */
     public static void unregisterLoggerContext(final String loggerContextName) {
-        if (isJmxDisabled()) {
-            LOGGER.debug("JMX disabled for Log4j2. Not unregistering MBeans.");
-            return;
+        if (loggerContextName != null) {
+            if (isJmxDisabled()) {
+                LOGGER.debug("JMX disabled for Log4j2. Not unregistering MBeans.");
+                return;
+            }
+            final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+            unregisterLoggerContext(loggerContextName, mbs);
         }
-        final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-        unregisterLoggerContext(loggerContextName, mbs);
     }
 
     /**

--- a/src/changelog/.2.x.x/1799_ignore_propertysource_errors.xml
+++ b/src/changelog/.2.x.x/1799_ignore_propertysource_errors.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="Spring-33450" link="https://github.com/spring-projects/spring-boot/issues/33450"/>
+  <description format="asciidoc">Ignore exceptions thrown by PropertySources.</description>
+</entry>

--- a/src/changelog/.2.x.x/LOG4J2-3618_propertysource_comparator.xml
+++ b/src/changelog/.2.x.x/LOG4J2-3618_propertysource_comparator.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="LOG4J2-3618" link="https://issues.apache.org/jira/browse/LOG4J2-3618"/>
+  <description format="asciidoc">Fixes property source ordering to account for same priority of different sources.</description>
+</entry>


### PR DESCRIPTION
This backports the part of PR #2062 that concerns spring-projects/spring-boot#33450 to the `2.x` branch.

It contains two sets of changes:

- it catches exceptions thrown by property sources and logs them as warnings,
- it adds a `PropertiesUtil#removePropertySource` to allow Spring Boot to remove its custom property source, when the Spring `Environment` becomes unavailable at shutdown.

Note that the second change will not be effective **until** Spring Boot starts using it, which can happen only after a `2.24.0` release of Log4j API.

**Remark**: the part of PR #2062 that concerns #1799 was not backported, since I believe it to be a Spring Boot problem:

1. Spring Boot should not perform an unchecked cast of `o.a.l.l.spi.LoggerContext`,
2. Spring Boot should not call `LogManager.getContext` multiple times, but cache the `LoggerContext` it received at startup.

Fixes #2453
