### PR TITLE
Disable JMX bean creation by default

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/Server.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jmx/Server.java
@@ -127,7 +127,7 @@ public final class Server {
     }
 
     private static boolean isJmxDisabled() {
-        return PropertiesUtil.getProperties().getBooleanProperty(PROPERTY_DISABLE_JMX);
+        return PropertiesUtil.getProperties().getBooleanProperty(PROPERTY_DISABLE_JMX, true);
     }
 
     public static void reregisterMBeansAfterReconfigure() {

--- a/src/changelog/.2.x.x/.release-notes.adoc.ftl
+++ b/src/changelog/.2.x.x/.release-notes.adoc.ftl
@@ -22,4 +22,8 @@
 
 This releases contains ...
 
+=== JMX changes
+
+Starting in version 2.24.0, JMX support is disabled by default and can be re-enabled via the `log4j2.disableJmx=false` system property.
+
 <#include "../.changelog.adoc.ftl">

--- a/src/changelog/.2.x.x/2462_disable_jmx_by_default.xml
+++ b/src/changelog/.2.x.x/2462_disable_jmx_by_default.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="changed">
+    <issue id="2462" link="https://github.com/apache/logging-log4j2/issues/2462"/>
+    <description format="asciidoc">Disable JMX support by default. Require `log4j2.disableJmx` to be set to `false` to enable JMX support.</description>
+</entry>

--- a/src/site/antora/modules/ROOT/pages/log4j-jmx-gui.adoc
+++ b/src/site/antora/modules/ROOT/pages/log4j-jmx-gui.adoc
@@ -18,3 +18,10 @@ Licensed to the Apache Software Foundation (ASF) under one or more
 
 https://github.com/apache/logging-log4j-jmx-gui[The Apache Log4j JMX GUI] is a basic client GUI that can be used to monitor the `StatusLogger` output and to remotely modify the Log4j configuration.
 The client GUI can be run as a stand-alone application or as a JConsole plug-in.
+
+[NOTE]
+====
+The Java VM to be monitored has to enable Log4j JMX support, set the following system property when starting the Java VM:
+
+`log4j2.disableJmx=false`
+====

--- a/src/site/antora/modules/ROOT/pages/manual/configuration.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/configuration.adoc
@@ -2104,7 +2104,7 @@ The following is a list of available global configuration properties. Note that 
 | [[disableJmx]]log4j2.disableJmx
   ([[log4j2.disable.jmx]]log4j2.disable.jmx)
 | LOG4J_DISABLE_JMX
-| false
+| true
 |
     If `true`, Log4j configuration objects like LoggerContexts, Appenders, Loggers, etc.
     will not be instrumented with MBeans and cannot be remotely monitored and managed.

--- a/src/site/antora/modules/ROOT/pages/manual/jmx.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/jmx.adoc
@@ -18,9 +18,9 @@
 Remko Popma <remkop@yahoo.com>
 Volkan Yazıcı <vy@apache.org>
 
-Log4j 2 has built-in support for JMX. The StatusLogger, ContextSelector,
-and all LoggerContexts, LoggerConfigs and Appenders are instrumented
-with MBeans and can be remotely monitored and controlled.
+Log4j 2 has built-in support for JMX.
+
+When JMX support is enabled, the StatusLogger, ContextSelector, and all LoggerContexts, LoggerConfigs, and Appenders are instrumented with MBeans.
 
 Also included is a simple client GUI that can be used to monitor the
 StatusLogger output, as well as to remotely reconfigure Log4j with a
@@ -30,17 +30,19 @@ directly.
 [#Enabling_JMX]
 == Enabling JMX
 
-JMX support is enabled by default. When Log4j initializes, the
-StatusLogger, ContextSelector, and all LoggerContexts, LoggerConfigs and
-Appenders are instrumented with MBeans. To disable JMX completely, and
-prevent these MBeans from being created, specify system property
-`log4j2.disableJmx` to `true` when you start the Java VM.
+JMX support is disabled by default.
+
+NOTE: JMX support was enabled by default in Log4j 2 versions before 2.24.0.
+
+To enable JMX support, set the following system property when starting the Java VM:
+
+`log4j2.disableJmx=false`
 
 [#Local]
 == Local Monitoring and Management
 
-To perform local monitoring you don't need to specify any system
-properties. The JConsole tool that is included in the Java JDK can be
+To perform local monitoring you need to specify the `log4j2.disableJmx=false` system
+property. The JConsole tool that is included in the Java JDK can be
 used to monitor your application. Start JConsole by typing
 `$JAVA_HOME/bin/jconsole` in a command shell. For more details,
 see Oracle's documentation on
@@ -51,7 +53,11 @@ to use JConsole].
 == Remote Monitoring and Management
 
 To enable monitoring and management from remote systems, set the
-following system property when starting the Java VM.
+following two system properties when starting the Java VM:
+
+`log4j2.disableJmx=false`
+
+and
 
 `com.sun.management.jmxremote.port=portNum`
 


### PR DESCRIPTION
https://github.com/apache/logging-log4j2/issues/2462#issuecomment-2045821938

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
