### PR TITLE
Add service to attach metrics to Log4j Core

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
@@ -41,12 +41,14 @@ import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.config.NullConfiguration;
 import org.apache.logging.log4j.core.config.Reconfigurable;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.core.instrumentation.InstrumentationService;
 import org.apache.logging.log4j.core.jmx.Server;
 import org.apache.logging.log4j.core.util.Cancellable;
 import org.apache.logging.log4j.core.util.ExecutorServices;
 import org.apache.logging.log4j.core.util.NetUtils;
 import org.apache.logging.log4j.core.util.ShutdownCallbackRegistry;
 import org.apache.logging.log4j.message.MessageFactory;
+import org.apache.logging.log4j.message.ParameterizedMessageFactory;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.spi.LoggerContextFactory;
 import org.apache.logging.log4j.spi.LoggerContextShutdownAware;
@@ -800,6 +802,12 @@ public class LoggerContext extends AbstractLifeCycle
 
     // LOG4J2-151: changed visibility from private to protected
     protected Logger newInstance(final LoggerContext ctx, final String name, final MessageFactory messageFactory) {
-        return new Logger(ctx, name, messageFactory);
+        // TODO: Adapt after
+        //           https://github.com/apache/logging-log4j2/issues/2379
+        //       is fixed.
+        final MessageFactory actualMessageFactory = InstrumentationService.getInstance()
+                .instrumentMessageFactory(
+                        name, messageFactory != null ? messageFactory : ParameterizedMessageFactory.INSTANCE);
+        return new Logger(ctx, name, actualMessageFactory);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
@@ -48,6 +48,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
 import org.apache.logging.log4j.core.filter.AbstractFilterable;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.core.instrumentation.InstrumentationService;
 import org.apache.logging.log4j.spi.AbstractLogger;
 
 /**
@@ -121,7 +122,9 @@ public final class AsyncAppender extends AbstractAppender {
         } else if (errorRef == null) {
             throw new ConfigurationException("No appenders are available for AsyncAppender " + getName());
         }
-        asyncQueueFullPolicy = AsyncQueueFullPolicyFactory.create();
+        asyncQueueFullPolicy = InstrumentationService.getInstance()
+                .instrumentQueueFullPolicy(
+                        InstrumentationService.ASYNC_APPENDER, getName(), AsyncQueueFullPolicyFactory.create());
 
         dispatcher.start();
         super.start();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -47,6 +47,7 @@ import org.apache.logging.log4j.core.impl.LocationAware;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.impl.LogEventFactory;
 import org.apache.logging.log4j.core.impl.ReusableLogEventFactory;
+import org.apache.logging.log4j.core.instrumentation.InstrumentationService;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 import org.apache.logging.log4j.core.util.Booleans;
 import org.apache.logging.log4j.core.util.Constants;
@@ -237,9 +238,9 @@ public class LoggerConfig extends AbstractFilterable implements LocationAware {
      * Default constructor.
      */
     public LoggerConfig() {
-        this.logEventFactory = LOG_EVENT_FACTORY;
-        this.level = Level.ERROR;
         this.name = Strings.EMPTY;
+        this.logEventFactory = InstrumentationService.getInstance().instrumentLogEventFactory(name, LOG_EVENT_FACTORY);
+        this.level = Level.ERROR;
         this.properties = null;
         this.propertiesRequireLookup = false;
         this.config = null;
@@ -254,8 +255,8 @@ public class LoggerConfig extends AbstractFilterable implements LocationAware {
      * @param additive true if the Logger is additive, false otherwise.
      */
     public LoggerConfig(final String name, final Level level, final boolean additive) {
-        this.logEventFactory = LOG_EVENT_FACTORY;
         this.name = name;
+        this.logEventFactory = InstrumentationService.getInstance().instrumentLogEventFactory(name, LOG_EVENT_FACTORY);
         this.level = level;
         this.additive = additive;
         this.properties = null;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ReliabilityStrategyFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ReliabilityStrategyFactory.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.core.config;
 
+import org.apache.logging.log4j.core.instrumentation.InstrumentationService;
 import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.PropertiesUtil;
@@ -43,9 +44,14 @@ public final class ReliabilityStrategyFactory {
      *         configuration change
      */
     public static ReliabilityStrategy getReliabilityStrategy(final LoggerConfig loggerConfig) {
+        return InstrumentationService.getInstance()
+                .instrumentReliabilityStrategy(
+                        loggerConfig.getName(), createFromProperties(loggerConfig, PropertiesUtil.getProperties()));
+    }
 
-        final String strategy =
-                PropertiesUtil.getProperties().getStringProperty("log4j.ReliabilityStrategy", "AwaitCompletion");
+    private static ReliabilityStrategy createFromProperties(
+            final LoggerConfig loggerConfig, final PropertiesUtil properties) {
+        final String strategy = properties.getStringProperty("log4j.ReliabilityStrategy", "AwaitCompletion");
         if ("AwaitCompletion".equals(strategy)) {
             return new AwaitCompletionReliabilityStrategy(loggerConfig);
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/instrumentation/InstrumentationService.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/instrumentation/InstrumentationService.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.instrumentation;
+
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.async.AsyncQueueFullPolicy;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.ReliabilityStrategy;
+import org.apache.logging.log4j.core.impl.LogEventFactory;
+import org.apache.logging.log4j.core.instrumentation.internal.CompositeInstrumentationService;
+import org.apache.logging.log4j.core.jmx.RingBufferAdminMBean;
+import org.apache.logging.log4j.message.MessageFactory;
+
+/**
+ * Service class to influence the way Log4j components are created
+ * <p>
+ *     Integrators that wish to instrument Log4j Core to provide metrics and other services, should implement this
+ *     class and register it with {@link java.util.ServiceLoader}.
+ * </p>
+ * @since 2.24.0
+ */
+public interface InstrumentationService {
+
+    /**
+     * Indicates that the component is used by an {@link org.apache.logging.log4j.core.appender.AsyncAppender}.
+     */
+    String ASYNC_APPENDER = "ASYNC_APPENDER";
+    /**
+     * Indicates that the component is used by an {@link org.apache.logging.log4j.core.async.AsyncLogger}.
+     */
+    String ASYNC_LOGGER = "ASYNC_LOGGER";
+    /**
+     * Indicates that the component is used by an {@link org.apache.logging.log4j.core.async.AsyncLoggerConfig}.
+     */
+    String ASYNC_LOGGER_CONFIG = "ASYNC_LOGGER_CONFIG";
+
+    /**
+     * @return The default instance of {@code InstrumentationService}
+     */
+    static InstrumentationService getInstance() {
+        return CompositeInstrumentationService.getInstance();
+    }
+
+    /**
+     * Allows to instrument the creation of {@link org.apache.logging.log4j.message.Message}s by the logger.
+     * <p>
+     *     This callback is called each time a new {@link org.apache.logging.log4j.core.Logger} is created by Log4j
+     *     Core.
+     * </p>
+     * @param loggerName The name of the logger to be created.
+     * @param messageFactory The message factory provided by the user or the default one.
+     * @return The actual message factory to use.
+     */
+    default MessageFactory instrumentMessageFactory(final String loggerName, final MessageFactory messageFactory) {
+        return messageFactory;
+    }
+
+    /**
+     * Allows to instrument the delivery process of log events during a reconfiguration.
+     * <p>
+     *     This callback is called each time a new {@link LoggerConfig} is created by Log4j Core.
+     * </p>
+     * @param loggerName The name of the logger configuration to be created.
+     * @param strategy The reliability strategy configured by the user.
+     * @return The actual reliability strategy to use.
+     */
+    default ReliabilityStrategy instrumentReliabilityStrategy(
+            final String loggerName, final ReliabilityStrategy strategy) {
+        return strategy;
+    }
+
+    /**
+     * Allows to instrument the creation of {@link org.apache.logging.log4j.core.LogEvent}s.
+     * <p>
+     *     This callback is called each time a new {@link LoggerConfig} is created by Log4j Core.
+     * </p>
+     * @param loggerName The name of the logger configuration to be created.
+     * @param logEventFactory The log event factory configured by the user.
+     * @return The actual log event factory to use.
+     */
+    default LogEventFactory instrumentLogEventFactory(final String loggerName, final LogEventFactory logEventFactory) {
+        return logEventFactory;
+    }
+
+    /**
+     * Allows to instrument the handling of queue full events.
+     * <p>
+     *     This event is called, when as new queue full policy is created.
+     * </p>
+     * @param parentType The type of the component that will use the queue full policy.
+     *                   <p>
+     *                   Currently the following constants are supported:
+     *                   </p>
+     *                   <ol>
+     *                       <li>{@link #ASYNC_APPENDER},</li>
+     *                       <li>{@link #ASYNC_LOGGER},</li>
+     *                       <li>{@link #ASYNC_LOGGER_CONFIG}.</li>
+     *                   </ol>
+     * @param parentName The name of
+     * @param queueFullPolicy The reliability strategy configured by the user.
+     * @return The actual policy to use.
+     */
+    default AsyncQueueFullPolicy instrumentQueueFullPolicy(
+            final String parentType, final String parentName, final AsyncQueueFullPolicy queueFullPolicy) {
+        return queueFullPolicy;
+    }
+
+    /**
+     * Allows to instrument the ring buffer of a disruptor.
+     * <p>
+     *     Whenever a new {@link com.lmax.disruptor.RingBuffer} is created, this method is called.
+     * </p>
+     * @param ringBufferAdmin An object that gives access to the characteristics of a ring buffer,
+     */
+    default void instrumentRingBuffer(final RingBufferAdminMBean ringBufferAdmin) {}
+
+    /**
+     * Allows to instrument a {@link LoggerConfig}.
+     * <p>
+     *
+     * </p>
+     * @param loggerConfig The logger configuration to instrument.
+     * @return The same logger configuration or a wrapper.
+     */
+    default LoggerConfig instrumentLoggerConfig(final LoggerConfig loggerConfig) {
+        return loggerConfig;
+    }
+
+    /**
+     * Allows to instrument an {@link Appender}.
+     * @param appender The appender to instrument.
+     * @return The same appender or a wrapper.
+     */
+    default Appender instrumentAppender(final Appender appender) {
+        return appender;
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/instrumentation/internal/CompositeInstrumentationService.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/instrumentation/internal/CompositeInstrumentationService.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.instrumentation.internal;
+
+import java.util.ServiceLoader;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.async.AsyncQueueFullPolicy;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.config.ReliabilityStrategy;
+import org.apache.logging.log4j.core.impl.LogEventFactory;
+import org.apache.logging.log4j.core.instrumentation.InstrumentationService;
+import org.apache.logging.log4j.core.jmx.RingBufferAdminMBean;
+import org.apache.logging.log4j.core.util.Loader;
+import org.apache.logging.log4j.message.MessageFactory;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Lazy;
+import org.apache.logging.log4j.util.ServiceLoaderUtil;
+
+public final class CompositeInstrumentationService implements InstrumentationService {
+
+    private static final Lazy<InstrumentationService> INSTANCE =
+            Lazy.lazy(CompositeInstrumentationService::createInstance);
+
+    private static InstrumentationService createInstance() {
+        final InstrumentationService[] services = ServiceLoaderUtil.safeStream(
+                        InstrumentationService.class,
+                        ServiceLoader.load(InstrumentationService.class, Loader.getClassLoader()),
+                        StatusLogger.getLogger())
+                .toArray(InstrumentationService[]::new);
+        return new CompositeInstrumentationService(services);
+    }
+
+    public static InstrumentationService getInstance() {
+        return INSTANCE.get();
+    }
+
+    private final InstrumentationService[] services;
+
+    private CompositeInstrumentationService(final InstrumentationService[] services) {
+        this.services = services;
+    }
+
+    @Override
+    public MessageFactory instrumentMessageFactory(final String loggerName, final MessageFactory messageFactory) {
+        MessageFactory result = messageFactory;
+        for (final InstrumentationService service : services) {
+            result = service.instrumentMessageFactory(loggerName, result);
+        }
+        return result;
+    }
+
+    @Override
+    public ReliabilityStrategy instrumentReliabilityStrategy(
+            final String loggerName, final ReliabilityStrategy strategy) {
+        ReliabilityStrategy result = strategy;
+        for (final InstrumentationService service : services) {
+            result = service.instrumentReliabilityStrategy(loggerName, result);
+        }
+        return result;
+    }
+
+    @Override
+    public LogEventFactory instrumentLogEventFactory(final String loggerName, final LogEventFactory logEventFactory) {
+        LogEventFactory result = logEventFactory;
+        for (final InstrumentationService service : services) {
+            result = service.instrumentLogEventFactory(loggerName, result);
+        }
+        return result;
+    }
+
+    @Override
+    public AsyncQueueFullPolicy instrumentQueueFullPolicy(
+            final String parentType, final String parentName, final AsyncQueueFullPolicy queueFullPolicy) {
+        AsyncQueueFullPolicy result = queueFullPolicy;
+        for (final InstrumentationService service : services) {
+            result = service.instrumentQueueFullPolicy(parentType, parentName, result);
+        }
+        return result;
+    }
+
+    @Override
+    public void instrumentRingBuffer(final RingBufferAdminMBean ringBufferAdmin) {
+        for (final InstrumentationService service : services) {
+            service.instrumentRingBuffer(ringBufferAdmin);
+        }
+    }
+
+    @Override
+    public LoggerConfig instrumentLoggerConfig(final LoggerConfig loggerConfig) {
+        LoggerConfig result = loggerConfig;
+        for (final InstrumentationService service : services) {
+            result = service.instrumentLoggerConfig(result);
+        }
+        return result;
+    }
+
+    @Override
+    public Appender instrumentAppender(final Appender appender) {
+        Appender result = appender;
+        for (final InstrumentationService service : services) {
+            result = service.instrumentAppender(result);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
This PR is an evolution of #1943, that adds an easy to use way to add metrics and other instrumentation to Log4j Core.

It introduces an `InstrumentationService` class that is used each time a component on the "logging path" is created or added to the `Configuration`. Most notably:

- `instrumentMessageFactory` is called each time a logger is created,
- each time a logger configuration is added `instrumentLogEventFactory`, `instrumentReliabilityStrategy` and `instrumentLoggerConfig` are called,
- each time an asynchronous element is created (`AsyncLoggerDisruptor`, `AsyncLoggerConfigDisruptor` or `AsyncAppender) the `instrumentQueueFullPolicy` method is called,
- the startup of a disruptor-based element additionally causes an `instrumentRingBuffer` call,
- finally each time an appender is added to the configuration an `instrumentAppender` call happens.

Most of these methods can be use twofold:

- they can return a wrapped component, so that "push" metrics can be implemented,
- they can return the parameter of the method itself.

What do you think? cc/ @adamthom-amzn, @jvz 

Looking at the currently existing solutions, `micrometer-metrics` (cf. [`Log4j2Metrics`](https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/logging/Log4j2Metrics.java)) could replace their filter-based solution to one based on `instrumentLogEventFactory`.

Which of the other method's could be useful? Are the additional parameters enough to define all the dimensions of the metrics?

**Note**: this PR is a draft for now, since it lacks documentation and tests.