### PR TITLE
Deprecate `log4j2.defaultStatusLevel` property

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/xml/XmlConfigurationPropsTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/xml/XmlConfigurationPropsTest.java
@@ -72,9 +72,17 @@ class XmlConfigurationPropsTest {
     }
 
     @Test
+    @SetTestProperty(key = StatusLogger.DEFAULT_STATUS_LISTENER_LEVEL, value = "INFO")
     @SetTestProperty(key = Constants.LOG4J_DEFAULT_STATUS_LEVEL, value = "WARN")
     @LoggerContextSource(value = CONFIG1)
     void testDefaultStatus(final Configuration config) {
+        testConfiguration(config, CONFIG1_NAME, Level.INFO, null);
+    }
+
+    @Test
+    @SetTestProperty(key = Constants.LOG4J_DEFAULT_STATUS_LEVEL, value = "WARN")
+    @LoggerContextSource(value = CONFIG1)
+    void testDeprecatedDefaultStatus(final Configuration config) {
         testConfiguration(config, CONFIG1_NAME, Level.WARN, null);
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
@@ -76,6 +76,7 @@ import org.apache.logging.log4j.core.util.Source;
 import org.apache.logging.log4j.core.util.WatchManager;
 import org.apache.logging.log4j.core.util.Watcher;
 import org.apache.logging.log4j.core.util.WatcherFactory;
+import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.PropertiesUtil;
 
@@ -479,8 +480,11 @@ public abstract class AbstractConfiguration extends AbstractFilterable implement
     }
 
     protected Level getDefaultStatus() {
-        final String statusLevel = PropertiesUtil.getProperties()
-                .getStringProperty(Constants.LOG4J_DEFAULT_STATUS_LEVEL, Level.ERROR.name());
+        final PropertiesUtil properties = PropertiesUtil.getProperties();
+        String statusLevel = properties.getStringProperty(StatusLogger.DEFAULT_STATUS_LISTENER_LEVEL);
+        if (statusLevel == null) {
+            statusLevel = properties.getStringProperty(Constants.LOG4J_DEFAULT_STATUS_LEVEL, Level.ERROR.name());
+        }
         try {
             return Level.toLevel(statusLevel);
         } catch (final Exception ex) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/Constants.java
@@ -35,7 +35,10 @@ public final class Constants {
 
     /**
      * Property name for the default status (internal log4j logging) level to use if not specified in configuration.
+     * @deprecated since 2.24.0 use
+     * {@link org.apache.logging.log4j.status.StatusLogger#DEFAULT_STATUS_LISTENER_LEVEL} instead.
      */
+    @Deprecated
     public static final String LOG4J_DEFAULT_STATUS_LEVEL = "Log4jDefaultStatusLevel";
 
     /**

--- a/src/changelog/.2.x.x/deprecate_log4j2_default_status_level.xml
+++ b/src/changelog/.2.x.x/deprecate_log4j2_default_status_level.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <description format="asciidoc">Deprecate `log4j2.defaultStatusLevel` property in Log4j Core in favor of `log4j2.statusLoggerLevel`.</description>
+</entry>

--- a/src/site/antora/modules/ROOT/pages/manual/configuration.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/configuration.adoc
@@ -2219,7 +2219,7 @@ The following is a list of available global configuration properties. Note that 
 | [[statusLoggerLevel]]log4j2.statusLoggerLevel
   ([[log4j2.StatusLogger.level]]log4j2.StatusLogger.level)
 | LOG4J_STATUS_LOGGER_LEVEL
-| WARN
+| ERROR
 |
   The initial "listenersLevel" of the StatusLogger. If StatusLogger listeners are added, the "listenerLevel"
   is changed to that of the most verbose listener. If any listeners are registered, the listenerLevel is

--- a/src/site/antora/modules/ROOT/pages/manual/configuration.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/configuration.adoc
@@ -1715,13 +1715,10 @@ protected final static Logger logger = StatusLogger.getLogger();
 Since StatusLogger implements the Log4j 2 API's Logger interface, all
 the normal Logger methods may be used.
 
-When configuring Log4j it is sometimes necessary to view the generated
-status events. This can be accomplished by adding the status attribute
-to the configuration element or a default value can be provided by
-setting the "Log4jDefaultStatusLevel" system property. Valid values of
-the status attribute are "trace", "debug", "info", "warn", "error" and
-"fatal". The following configuration has the status attribute set to
-debug.
+When configuring Log4j it is sometimes necessary to view the generated status events.
+This can be accomplished by adding the status attribute to the configuration element or a default value can be provided by setting the xref:statusLoggerLevel["log4j2.statusLoggerLevel"] system property.
+Valid values of the status attribute are "trace", "debug", "info", "warn", "error" and "fatal".
+The following configuration has the status attribute set to debug.
 
 [source,xml]
 ----
@@ -2218,18 +2215,6 @@ The following is a list of available global configuration properties. Note that 
   Note that the StatusLogger level is only used to determine the status log output level
   until a listener is registered. In practice, a listener is registered when a configuration is found,
   and from that point onwards, status messages are only sent to the listeners (depending on their statusLevel).
-
-| [[defaultStatusLevel]]log4j2.defaultStatusLevel
-  ([[Log4jDefaultStatusLevel]]Log4jDefaultStatusLevel)
-| LOG4J_DEFAULT_STATUS_LEVEL
-| ERROR
-|
-  The StatusLogger logs events that occur in the logging system to the console.
-  During configuration, AbstractConfiguration registers a StatusConsoleListener with the StatusLogger that may
-  redirect status log events from the default console output to a file.
-  The listener also supports fine-grained filtering.
-  This system property specifies the default status log level for the listener to use if the configuration does not specify a status level.
-  Note: this property is used by the log4j-core implementation only after a configuration file has been found.
 
 | [[statusLoggerLevel]]log4j2.statusLoggerLevel
   ([[log4j2.StatusLogger.level]]log4j2.StatusLogger.level)


### PR DESCRIPTION
The Log4j system property `log4j2.defaultStatusLevel` has almost the same purpose as the `log4j2.statusLoggerLevel`:

* the `log4j2.statusLoggerLevel` property sets the level of the fallback status logger listener **before** a configuration is parsed,
* the `log4j2.defaultStatusLevel` property sets the level of the fallback status logger listener **after** a configuration is parsed (unless the configuration has a `status` attribute).

Removing one of them makes `-Dlog4j2.statusLoggerLevel=WARN` a viable less verbose alternative to `-Dlog4j2.debug`.
