### PR TITLE
Add trace context fields to GcpLayout.json

### DIFF
--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/GcpLayoutTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/GcpLayoutTest.java
@@ -28,6 +28,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.ContextDataFactory;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.util.StringMap;
 import org.junit.jupiter.api.Test;
 
 class GcpLayoutTest {
@@ -52,6 +55,29 @@ class GcpLayoutTest {
     @Test
     void test_full_log_events() {
         LogEventFixture.createFullLogEvents(LOG_EVENT_COUNT).forEach(GcpLayoutTest::verifySerialization);
+    }
+
+    @Test
+    void test_trace_context() {
+        final StringMap contextData = ContextDataFactory.createContextData();
+        contextData.putValue("trace_id", "4bf92f3577b34da6a3ce929d0e0e4736");
+        contextData.putValue("span_id", "00f067aa0ba902b7");
+
+        LogEvent logEvent =
+                Log4jLogEvent.newBuilder().setContextData(contextData).build();
+
+        usingSerializedLogEventAccessor(LAYOUT, logEvent, accessor -> {
+            // Verify trace id
+            assertThat(accessor.getString("logging.googleapis.com/trace"))
+                    .isEqualTo("4bf92f3577b34da6a3ce929d0e0e4736");
+
+            // Verify span ID
+            assertThat(accessor.getString("logging.googleapis.com/spanId")).isEqualTo("00f067aa0ba902b7");
+
+            // Verify trace sampled
+            assertThat(accessor.getBoolean("logging.googleapis.com/trace_sampled"))
+                    .isTrue();
+        });
     }
 
     private static void verifySerialization(final LogEvent logEvent) {

--- a/log4j-layout-template-json/src/main/resources/GcpLayout.json
+++ b/log4j-layout-template-json/src/main/resources/GcpLayout.json
@@ -40,6 +40,15 @@
     "$resolver": "counter",
     "stringified": true
   },
+  "logging.googleapis.com/trace": {
+    "$resolver": "mdc",
+    "key": "trace_id"
+  },
+  "logging.googleapis.com/spanId": {
+    "$resolver": "mdc",
+    "key": "span_id"
+  },
+  "logging.googleapis.com/trace_sampled": true,
   "_exception": {
     "class": {
       "$resolver": "exception",

--- a/src/changelog/.2.x.x/add_GcpLayout_tracing_support.xml
+++ b/src/changelog/.2.x.x/add_GcpLayout_tracing_support.xml
@@ -2,7 +2,7 @@
 <entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns="https://logging.apache.org/xml/ns"
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
-       type="changed">
+       type="added">
   <issue id="2498" link="https://github.com/apache/logging-log4j2/pull/2498"/>
-  <description format="asciidoc">Add trace context fields to GcpLayout.json</description>
+  <description format="asciidoc">Add trace context fields to `GcpLayout.json`</description>
 </entry>

--- a/src/changelog/.2.x.x/add_GcpLayout_tracing_support.xml
+++ b/src/changelog/.2.x.x/add_GcpLayout_tracing_support.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="2498" link="https://github.com/apache/logging-log4j2/pull/2498"/>
+  <description format="asciidoc">Add trace context fields to GcpLayout.json</description>
+</entry>


### PR DESCRIPTION
This PR adds a few tracing related JSON fields to the included `GcpLayout.json` event template which are documented in the [Cloud Logging docs](https://cloud.google.com/logging/docs/structured-logging#structured_logging_special_fields).

The intended source is [well known OpenTelemetry MDC keys](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/v2.3.0/docs/logger-mdc-instrumentation.md) encoded as a hex strings following the [W3C Trace Context standard](https://www.w3.org/TR/trace-context/#trace-id).

- MDC `trace_id` -> `logging.googleapis.com/trace`
- MDC `span_id` -> `logging.googleapis.com/spanId`
- `true` -> `logging.googleapis.com/trace_sampled`. This is unconditionally set to true because there is currently no way to derive it from W3C `trace_flags` with JTL (see https://github.com/apache/logging-log4j2/discussions/2482). I'm OK to remove this if needed, as it will affect existing users even if the MDC keys are not set. However it's absence does break some GCP UI features.
