### PR TITLE
Close stale issues

### DIFF
--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -30,6 +30,7 @@ jobs:
     steps:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e    # v9.0.0
         with:
+          # Labels need to match with the ones in `labeler.yaml`!
           only-labels: waiting-for-user
           stale-issue-message: >
             This issue is stale because it has been waiting for your feedback for more than 60 days.

--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          only-labels: waiting-for-user
+          stale-issue-message: >
+            This issue is stale because it has been waiting for your feedback for more than 60 days.
+            The Apache Logging Services community values every submitted issue, but without additional information from you,
+            we are unable to provide a solution to your problem.
+
+            Please comment on this issue or it will be closed in 7 days.

--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -32,6 +32,7 @@ jobs:
         with:
           # Labels need to match with the ones in `labeler.yaml`!
           only-labels: waiting-for-user
+          days-before-stale: 7
           stale-issue-message: >
             This issue is stale because it has been waiting for your feedback for more than 60 days.
             The Apache Logging Services community values every submitted issue, but without additional information from you,

--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -28,7 +28,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e    # v9.0.0
         with:
           only-labels: waiting-for-user
           stale-issue-message: >

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -42,4 +42,3 @@ jobs:
          GH_TOKEN: ${{ github.token }}
        run: |
          gh issue edit $ISSUE --add-label 'waiting-for-maintainer' --remove-label 'waiting-for-user'
-

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: 'Check labels'
+on:
+  issue_comment:
+    types: [created]
+  issues:
+    types: [opened]
+env:
+  # If this workflow is triggered by an `opened` event, the user type is always 'user'.
+  user_type: ${{ contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.comment.author_association) && 'maintainer' || 'user' }}
+
+permissions:
+  issues: write
+
+jobs:
+  check-labels:
+    # Prevents the job from running on pull requests
+    if: ${{ ! github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+
+    steps:
+     - name: Add `waiting-for-maintainer` label
+       if: env.user_type == 'user'
+       env:
+         ISSUE: ${{ github.event.issue.html_url }}
+         GH_TOKEN: ${{ github.token }}
+       run: |
+         gh issue edit $ISSUE --add-label 'waiting-for-maintainer' --remove-label 'waiting-for-user'
+

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -35,6 +35,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+     # The `waiting-for-maintainer` label needs to match with the one in `close-stale.yaml`!
      - name: Add `waiting-for-maintainer` label
        if: env.user_type == 'user'
        env:


### PR DESCRIPTION
We add a GitHub action to automatically close GitHub issues that:

- are marked as `waiting-for-user`,
- have been inactive for more than 60 days.
