### PR TITLE
Use DateTimeFormatter.formatTo to directly append to StringBuilder

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -459,7 +459,7 @@ final class ParameterFormatter {
         if (!(o instanceof Date)) {
             return false;
         }
-        str.append(DATE_FORMATTER.format(((Date) o).toInstant()));
+        DATE_FORMATTER.formatTo(((Date) o).toInstant(), str);
         return true;
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
@@ -167,9 +167,9 @@ public class StatusData implements Serializable {
     @SuppressWarnings("DefaultCharset")
     public String getFormattedStatus() {
         final StringBuilder sb = new StringBuilder();
-        final String formattedInstant =
-                instantFormatter != null ? instantFormatter.format(instant) : instant.toString();
-        sb.append(formattedInstant);
+        // DateTimeFormatter.ISO_INSTANT is the default used in instant.toString()
+        DateTimeFormatter formatterToUse = instantFormatter != null ? instantFormatter : DateTimeFormatter.ISO_INSTANT;
+        formatterToUse.formatTo(instant, sb);
         sb.append(SPACE);
         sb.append(getThreadName());
         sb.append(SPACE);


### PR DESCRIPTION
In a few places in code, DateTimeFormatter.format(...) is called on an Instant, which creates a new String, when this is just appended to a StringBuilder. This can be improved by calling DateTimeFormatter.formatTo, passing in the StringBuilder, resulting in no intermediate String.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
