### PR TITLE
Fix MacOS build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,8 +38,8 @@ jobs:
 
   build:
     if: github.actor != 'dependabot[bot]'
-    # Temporary switch to `@main` waiting for 11.0.1 release
-    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@main
+    # Temporary switch to `@fix/macos-java-8` to see how the situation evolves with macOS runners
+    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@fix/macos-java-8
     # uses: apache/logging-parent/.github/workflows/build-reusable.yaml@rel/11.0.0
     with:
       java-version: |


### PR DESCRIPTION
This PR tries to fix the MacOS 14 build, which uses `arm64` instead of `x64` as architecture:

- <s>it refactors the `java8-tests` profile to use the Github and architecture specific `JAVA_HOME_8_X64` variable,</s>
- <s>it uses the new `install-java8` reusable build property that installs JDK 8 on all architectures except MacOS.</s>
- it switches the build to the `fix/macos-java-8` reusable build branch (see apache/logging-parent#169).
