### PR TITLE
Fix empty string handling for `TruncatingBufferedWriter`

### DIFF
--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/util/TruncatingBufferedWriterTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/util/TruncatingBufferedWriterTest.java
@@ -49,7 +49,6 @@ class TruncatingBufferedWriterTest {
         writer.append("yo");
         writer.append(null);
         writer.append("yo dog", 3, 6);
-        writer.append("nothing", 3, 0);
         writer.append(null, -1, -1);
         writer.append("", -1, -1);
         writer.append("");

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/util/TruncatingBufferedWriterTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/util/TruncatingBufferedWriterTest.java
@@ -38,12 +38,21 @@ class TruncatingBufferedWriterTest {
         writer.write(new char[] {Character.MIN_VALUE, Character.MAX_VALUE});
         writer.write("foo");
         writer.write("foobar", 3, 3);
+        writer.write("empty", 3, 0);
         writer.write(new char[] {'f', 'o', 'o', 'b', 'a', 'r', 'b', 'u', 'z', 'z'}, 6, 4);
+        writer.write(new char[] {'a', 'b', 'c'}, 0, 0);
+        writer.write(new char[] {}, 0, 0);
+        writer.write(new char[] {});
+        writer.write("", 0, 0);
+        writer.write("");
         writer.append('!');
         writer.append("yo");
         writer.append(null);
         writer.append("yo dog", 3, 6);
+        writer.append("nothing", 3, 0);
         writer.append(null, -1, -1);
+        writer.append("", -1, -1);
+        writer.append("");
 
         // Verify accessors.
         final char[] expectedBuffer = new char[capacity];

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/TruncatingBufferedWriter.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/TruncatingBufferedWriter.java
@@ -178,11 +178,8 @@ final class TruncatingBufferedWriter extends Writer implements CharSequence {
             return this;
         }
 
+        // Short-circuit on empty sequence
         if (seq.length() == 0) {
-            return this;
-        }
-
-        if (end == 0) {
             return this;
         }
 

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/TruncatingBufferedWriter.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/TruncatingBufferedWriter.java
@@ -77,6 +77,11 @@ final class TruncatingBufferedWriter extends Writer implements CharSequence {
 
         // Check arguments.
         Objects.requireNonNull(source, "source");
+
+        if (source.length == 0) {
+            return;
+        }
+
         if (offset < 0 || offset >= source.length) {
             throw new IndexOutOfBoundsException("invalid offset: " + offset);
         }
@@ -126,6 +131,11 @@ final class TruncatingBufferedWriter extends Writer implements CharSequence {
 
         // Check arguments.
         Objects.requireNonNull(string, "string");
+
+        if (string.isEmpty()) {
+            return;
+        }
+
         if (offset < 0 || offset >= string.length()) {
             throw new IndexOutOfBoundsException("invalid offset: " + offset);
         }
@@ -165,6 +175,14 @@ final class TruncatingBufferedWriter extends Writer implements CharSequence {
         // Short-circuit on null sequence.
         if (seq == null) {
             write("null");
+            return this;
+        }
+
+        if (seq.length() == 0) {
+            return this;
+        }
+
+        if (end == 0) {
             return this;
         }
 

--- a/src/changelog/.2.x.x/fix-TruncatingBufferedWriter-empty-input-handling.xml
+++ b/src/changelog/.2.x.x/fix-TruncatingBufferedWriter-empty-input-handling.xml
@@ -4,8 +4,5 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <issue id="2609" link="https://github.com/apache/logging-log4j2/pull/2609"/>
-  <description format="asciidoc">
-    Fix empty string handling for TruncatingBufferedWriter
-    The expected behavior is to handle empty strings as a no-op. The actual behavior was an IndexOutOfBoundException being thrown.
-  </description>
+  <description format="asciidoc">Fix empty string handling for `TruncatingBufferedWriter`</description>
 </entry>

--- a/src/changelog/.2.x.x/fix-TruncatingBufferedWriter-empty-input-handling.xml
+++ b/src/changelog/.2.x.x/fix-TruncatingBufferedWriter-empty-input-handling.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="2609" link="https://github.com/apache/logging-log4j2/pull/2609"/>
+  <description format="asciidoc">
+    Fix empty string handling for TruncatingBufferedWriter
+    The expected behavior is to handle empty strings as a no-op. The actual behavior was an IndexOutOfBoundException being thrown.
+  </description>
+</entry>


### PR DESCRIPTION
```
ERROR StatusConsoleListener An exception occurred processing Appender console
 java.lang.IndexOutOfBoundsException: invalid offset: 0
	at org.apache.logging.log4j.layout.template.json.util.TruncatingBufferedWriter.write(TruncatingBufferedWriter.java:131)
	at java.base/java.io.PrintWriter.write(PrintWriter.java:541)
	at java.base/java.io.PrintWriter.write(PrintWriter.java:558)
	at java.base/java.io.PrintWriter.print(PrintWriter.java:685)
	at com.lowagie.text.ExceptionConverter.printStackTrace(ExceptionConverter.java:162)
	at org.apache.logging.log4j.layout.template.json.resolver.StackTraceStringResolver.resolve(StackTraceStringResolver.java:80)
	at org.apache.logging.log4j.layout.template.json.resolver.ExceptionResolver.lambda$createStackTraceStringResolver$3(ExceptionResolver.java:302)
	at org.apache.logging.log4j.layout.template.json.resolver.ExceptionResolver.resolve(ExceptionResolver.java:445)
	at org.apache.logging.log4j.layout.template.json.resolver.ExceptionResolver.resolve(ExceptionResolver.java:188)
	at org.apache.logging.log4j.layout.template.json.resolver.TemplateResolver.resolve(TemplateResolver.java:66)
	at org.apache.logging.log4j.layout.template.json.resolver.TemplateResolvers$4.resolve(TemplateResolvers.java:284)
...
```

The client code assumes empty strings will not result in an exception being thrown

## Checklist

- [x] Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
- [x] `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
- [x] Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
- [x] Tests for the changes are provided
- [x] [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
