### PR TITLE
Add Develocity integration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,9 @@ on:
 
 permissions: read-all
 
+env:
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+
 jobs:
 
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,8 +42,7 @@ jobs:
   build:
     if: github.actor != 'dependabot[bot]'
     # Temporary switch to `@fix/macos-java-8` to see how the situation evolves with macOS runners
-    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@fix/macos-java-8
-    # uses: apache/logging-parent/.github/workflows/build-reusable.yaml@rel/11.0.0
+    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@develocity
     with:
       java-version: |
         8

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -29,6 +29,9 @@ on:
 
 permissions: read-all
 
+env:
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+
 jobs:
 
   deploy-site-stg:

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .vscode
 /.metadata/
 /.mvn/wrapper/maven-wrapper.jar
+/.mvn/.develocity
 .flattened-pom.xml
 .project
 .settings

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<develocity>
+    <server>
+        <url>https://ge.apache.org</url>
+    </server>
+    <buildScan>
+        <obfuscation>
+            <ipAddresses>0.0.0.0</ipAddresses>
+        </obfuscation>
+        <publishing>
+            <onlyIf>
+                <![CDATA[authenticated]]>
+            </onlyIf>
+        </publishing>
+        <backgroundBuildScanUpload>#{isFalse(env['GITHUB_ACTIONS'])}</backgroundBuildScanUpload>
+    </buildScan>
+    <buildCache>
+        <local>
+            <enabled>#{isFalse(env['GITHUB_ACTIONS'])}</enabled>
+        </local>
+        <remote>
+            <enabled>false</enabled>
+        </remote>
+    </buildCache>
+</develocity>

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -9,7 +9,7 @@
         </obfuscation>
         <publishing>
             <onlyIf>
-                <![CDATA[authenticated]]>
+                <![CDATA[authenticated || env['CI'] != null]]>
             </onlyIf>
         </publishing>
         <backgroundBuildScanUpload>#{isFalse(env['GITHUB_ACTIONS'])}</backgroundBuildScanUpload>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <extension>
+        <groupId>com.gradle</groupId>
+        <artifactId>develocity-maven-extension</artifactId>
+        <version>1.21.3</version>
+    </extension>
+    <extension>
+        <groupId>com.gradle</groupId>
+        <artifactId>common-custom-user-data-maven-extension</artifactId>
+        <version>2.0</version>
+    </extension>
+</extensions>


### PR DESCRIPTION
This PR will enable you to publish Build Scans to [ge.apache.org](https://ge.apache.org/) as discussed with @ppkarwasz

## Description
This PR publishes a build scan for CI builds from the build and deploy-site GH workflows and for every local build from an authenticated Apache committer. 
The build will not fail if publishing fails. 
Local cache is enabled on local builds but not on CI builds.

The build scans of the Apache Log4j2 project are published to the Develocity instance at [ge.apache.org](https://ge.apache.org/), hosted by the Apache Software Foundation and run in partnership between the ASF and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Apache Log4j2 project and all other Apache projects.

On this Develocity instance, Apache Log4j2 will have access not only to all of the published build scans but other aggregate data features such as:
- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.