### PR TITLE
Switch to parallel testing by default

### DIFF
--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -995,40 +995,12 @@
         </executions>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
-          <runOrder>alphabetical</runOrder>
-          <systemPropertyVariables>
-            <java.awt.headless>true</java.awt.headless>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-
     </plugins>
-
   </build>
 
   <profiles>
 
-    <profile>
-      <id>parallel-tests</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <forkCount>1C</forkCount>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
+    <!-- `plugin-processing` profile containing configuration specific to `@Plugin`-annotated members -->
     <profile>
 
       <id>plugin-processing</id>
@@ -1112,7 +1084,6 @@
                   ]]></source>
                 </configuration>
               </execution>
-
             </executions>
           </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -924,6 +924,22 @@
   </build>
 
   <profiles>
+
+    <profile>
+      <id>sequential-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <forkCount>1</forkCount>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>rewrite</id>
 


### PR DESCRIPTION
Since `main` tests were more fragile, we kept the tests in `main` to run sequentially, while those in `2.x` run in parallel.

This PR switches `main` testing back to parallel mode (1 test per JVM).
