### PR TITLE
Set missing error-prone.version

### DIFF
--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -107,6 +107,7 @@
     <disruptor.version>4.0.0</disruptor.version>
     <elasticsearch.version>7.17.22</elasticsearch.version>
     <embedded-ldap.version>0.9.0</embedded-ldap.version>
+    <error-prone.version>2.28.0</error-prone.version>
     <felix.version>7.0.5</felix.version>
     <flapdoodle-embed.version>4.11.0</flapdoodle-embed.version>
     <flapdoodle-reverse.version>1.7.2</flapdoodle-reverse.version>


### PR DESCRIPTION
`${error-prone.version}` property was referenced in pom.xml but never set.

This should (also) fix https://github.com/apache/logging-log4j2/blob/main/BUILDING.adoc#compilation-in-intellij-idea-fails-with-java-plug-in-not-found-errorprone