### PR TITLE
Explicitly checking for `-Dlog4j.debug=false`

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerLevelTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerLevelTest.java
@@ -17,6 +17,7 @@
 package org.apache.logging.log4j.status;
 
 import static org.apache.logging.log4j.status.StatusLogger.DEFAULT_FALLBACK_LISTENER_LEVEL;
+import static org.apache.logging.log4j.util.Constants.LOG4J2_DEBUG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -185,5 +186,13 @@ class StatusLoggerLevelTest {
         // Verify the listener invocation
         assertThat(expectedMessageCount).isGreaterThan(0);
         verify(listener, times(expectedMessageCount)).log(any());
+    }
+
+    @Test
+    void check_debug_false() {
+        final Properties statusLoggerConfigProperties = new Properties();
+        statusLoggerConfigProperties.put(LOG4J2_DEBUG, "fAlsE");
+        StatusLogger.Config loggerConfig = new StatusLogger.Config(statusLoggerConfigProperties);
+        assertThat(loggerConfig.isDebugEnabled()).isFalse();
     }
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -381,6 +381,10 @@ public class StatusLogger extends AbstractLogger {
             }
             return formatter.withZone(zoneId);
         }
+
+        boolean isDebugEnabled() {
+            return debugEnabled;
+        }
     }
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -291,7 +291,7 @@ public class StatusLogger extends AbstractLogger {
 
         private static boolean readDebugEnabled(final Map<String, Object> normalizedProperties) {
             final String debug = PropertiesUtilsDouble.readProperty(normalizedProperties, DEBUG_PROPERTY_NAME);
-            return debug != null;
+            return debug != null && !"false".equalsIgnoreCase(debug);
         }
 
         private static int readBufferCapacity(final Map<String, Object> normalizedProperties) {

--- a/src/changelog/.2.x.x/2703_log4j_debug.xml
+++ b/src/changelog/.2.x.x/2703_log4j_debug.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="2703" link="https://github.com/apache/logging-log4j2/issue/2703"/>
+  <description format="asciidoc">Fix handling of `log4j2.debug`.</description>
+</entry>


### PR DESCRIPTION
As reported in:
https://github.com/apache/logging-log4j2/issues/2703