### PR TITLE
Improve Develocity Build Scan support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,13 +33,14 @@ jobs:
     # Temporary use `develocity` branch
     uses: apache/logging-parent/.github/workflows/build-reusable.yaml@develocity
     secrets:
-      GE_ACCESS_TOKEN: ${{ ! startsWith(github.refname, 'release/') && secrets.GE_ACCESS_TOKEN }}
+      DV_ACCESS_TOKEN: ${{ ! startsWith(github.refname, 'release/') && secrets.GE_ACCESS_TOKEN }}
     with:
       java-version: |
         8
         17
       site-enabled: true
       reproducibility-check-enabled: false
+      develocity-enabled: true
 
   deploy-snapshot:
     needs: build

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -57,7 +57,6 @@ jobs:
     # Secrets for committing the generated site
     secrets:
       GPG_SECRET_KEY: ${{ secrets.LOGGING_GPG_SECRET_KEY }}
-      GE_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
     # Write permissions for committing the generated site
     permissions:
       contents: write
@@ -88,7 +87,6 @@ jobs:
     # Secrets for committing the generated site
     secrets:
       GPG_SECRET_KEY: ${{ secrets.LOGGING_GPG_SECRET_KEY }}
-      GE_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
     # Write permissions for committing the generated site
     permissions:
       contents: write

--- a/.github/workflows/develocity-publish-build-scans.yaml
+++ b/.github/workflows/develocity-publish-build-scans.yaml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Develocity - Publish Maven Build Scans
+
+on:
+  workflow_run:
+    workflows: [ "build" ]
+    types: [ completed ]
+
+jobs:
+
+  publish-build-scans:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: write
+    steps:
+      - name: Setup Build Scan link capture
+        uses: gradle/develocity-actions/maven-setup@v1
+      - name: Publish Build Scans
+        uses: gradle/develocity-actions/maven-publish-build-scan@v1
+        with:
+          develocity-url: 'https://ge.apache.org'
+          develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}


### PR DESCRIPTION
In order to improve the [Develocity](https://ge.apache.org/) Build Scan support on the Log4j2 project, this PR provides:
- Build Scan publication for PR issued from forked repositories following [this approach](https://github.com/gradle/develocity-actions?tab=readme-ov-file#publish-build-scans-for-pull-requests-issued-from-forked-repositories) (ie. [without access to GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow))
- Build Scan publication only for `build` job

The new `develocity-enabled` flag requires [this PR](https://github.com/apache/logging-parent/pull/207) to be merged first

Note:
It would be ideal to rename the secret `GE_ACCESS_TOKEN` to `DV_ACCESS_TOKEN` and apply the change in this PR

## Checklist

[X] Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
[X] `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
[ ] Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
[ ] Tests for the changes are provided
[X] [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
