### PR TITLE
Fix `ClassCastException` in LMAX Disruptor 3 initialization

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
@@ -55,6 +55,7 @@ class AsyncLoggerDisruptor extends AbstractLifeCycle {
         if (DisruptorUtil.DISRUPTOR_MAJOR_VERSION == 3) {
             try {
                 return (EventHandler<RingBufferLogEvent>)
+                    // Avoid using `LoaderUtil`, which might choose an incorrect class loader – see #2768.
                     Class.forName("org.apache.logging.log4j.core.async.RingBufferLogEventHandler")
                         .getConstructor()
                         .newInstance();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
@@ -54,8 +54,11 @@ class AsyncLoggerDisruptor extends AbstractLifeCycle {
     private static EventHandler<RingBufferLogEvent> createEventHandler() {
         if (DisruptorUtil.DISRUPTOR_MAJOR_VERSION == 3) {
             try {
-                return LoaderUtil.newInstanceOf("org.apache.logging.log4j.core.async.RingBufferLogEventHandler");
-            } catch (final ClassCastException | ReflectiveOperationException | LinkageError e) {
+                return (EventHandler<RingBufferLogEvent>)
+                    Class.forName("org.apache.logging.log4j.core.async.RingBufferLogEventHandler")
+                        .getConstructor()
+                        .newInstance();
+            } catch (final ReflectiveOperationException | LinkageError e) {
                 LOGGER.warn("Failed to create event handler for LMAX Disruptor 3.x, trying version 4.x.", e);
             }
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
@@ -56,8 +56,8 @@ class AsyncLoggerDisruptor extends AbstractLifeCycle {
                 return (EventHandler<RingBufferLogEvent>)
                         // Avoid using `LoaderUtil`, which might choose an incorrect class loader – see #2768.
                         Class.forName("org.apache.logging.log4j.core.async.RingBufferLogEventHandler")
-                            .getConstructor()
-                            .newInstance();
+                                .getConstructor()
+                                .newInstance();
             } catch (final ReflectiveOperationException | LinkageError e) {
                 LOGGER.warn("Failed to create event handler for LMAX Disruptor 3.x, trying version 4.x.", e);
             }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
@@ -55,7 +55,7 @@ class AsyncLoggerDisruptor extends AbstractLifeCycle {
         if (DisruptorUtil.DISRUPTOR_MAJOR_VERSION == 3) {
             try {
                 return LoaderUtil.newInstanceOf("org.apache.logging.log4j.core.async.RingBufferLogEventHandler");
-            } catch (final ReflectiveOperationException | LinkageError e) {
+            } catch (final ClassCastException | ReflectiveOperationException | LinkageError e) {
                 LOGGER.warn("Failed to create event handler for LMAX Disruptor 3.x, trying version 4.x.", e);
             }
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerDisruptor.java
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.core.util.Log4jThread;
 import org.apache.logging.log4j.core.util.Log4jThreadFactory;
 import org.apache.logging.log4j.core.util.Throwables;
 import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.util.LoaderUtil;
 
 /**
  * Helper class for async loggers: AsyncLoggerDisruptor handles the mechanics of working with the LMAX Disruptor, and
@@ -55,10 +54,10 @@ class AsyncLoggerDisruptor extends AbstractLifeCycle {
         if (DisruptorUtil.DISRUPTOR_MAJOR_VERSION == 3) {
             try {
                 return (EventHandler<RingBufferLogEvent>)
-                    // Avoid using `LoaderUtil`, which might choose an incorrect class loader – see #2768.
-                    Class.forName("org.apache.logging.log4j.core.async.RingBufferLogEventHandler")
-                        .getConstructor()
-                        .newInstance();
+                        // Avoid using `LoaderUtil`, which might choose an incorrect class loader – see #2768.
+                        Class.forName("org.apache.logging.log4j.core.async.RingBufferLogEventHandler")
+                            .getConstructor()
+                            .newInstance();
             } catch (final ReflectiveOperationException | LinkageError e) {
                 LOGGER.warn("Failed to create event handler for LMAX Disruptor 3.x, trying version 4.x.", e);
             }

--- a/src/changelog/.2.x.x/fix_disruptor3_cce.xml
+++ b/src/changelog/.2.x.x/fix_disruptor3_cce.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="2768" link="https://github.com/apache/logging-log4j2/pull/2768"/>
+  <description format="asciidoc">Fix `ClassCastException` in LMAX Disruptor 3 initialization</description>
+</entry>


### PR DESCRIPTION
During startup with an agent, the resulting object can be in the wrong classloader leading to a ClassCastException. Catching that falls back to the old behaviour which works fine

The new behaviour was introduced in 2.23.0 with apache#2112

