### PR TITLE
Deprecate `Message#getFormat()`

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/AbstractLoggerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/AbstractLoggerTest.java
@@ -1447,11 +1447,6 @@ public class AbstractLoggerTest {
         }
 
         @Override
-        public String getFormat() {
-            return null;
-        }
-
-        @Override
         public Object[] getParameters() {
             return Constants.EMPTY_OBJECT_ARRAY;
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/Message.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/Message.java
@@ -69,17 +69,15 @@ public interface Message extends Serializable {
     String getFormattedMessage();
 
     /**
-     * Gets the format portion of the Message.
+     * This method has unclear semantics and inconsistent implementations – its usage is strongly discouraged.
      *
-     * @return The message format. Some implementations, such as ParameterizedMessage, will use this as
-     * the message "pattern". Other Messages may simply return an empty String.
-     * TODO Do all messages have a format?  What syntax?  Using a Formatter object could be cleaner.
-     * (RG) In SimpleMessage the format is identical to the formatted message. In ParameterizedMessage and
-     * StructuredDataMessage it is not. It is up to the Message implementer to determine what this
-     * method will return. A Formatter is inappropriate as this is very specific to the Message
-     * implementation so it isn't clear to me how having a Formatter separate from the Message would be cleaner.
+     * @deprecated Deprecated since version {@code 2.24.0}.
+     * Use {@link MultiformatMessage} instead to implement messages that can format themselves in one or more encodings.
      */
-    String getFormat();
+    @Deprecated
+    default String getFormat() {
+        return null;
+    }
 
     /**
      * Gets parameter values, if any.

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerArgumentFreedOnErrorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerArgumentFreedOnErrorTest.java
@@ -84,11 +84,6 @@ public class AsyncLoggerArgumentFreedOnErrorTest {
         }
 
         @Override
-        public String getFormat() {
-            return Strings.EMPTY;
-        }
-
-        @Override
         public Object[] getParameters() {
             return org.apache.logging.log4j.util.Constants.EMPTY_OBJECT_ARRAY;
         }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigErrorOnFormat.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncLoggerConfigErrorOnFormat.java
@@ -84,11 +84,6 @@ public class AsyncLoggerConfigErrorOnFormat {
         }
 
         @Override
-        public String getFormat() {
-            return null;
-        }
-
-        @Override
         public Object[] getParameters() {
             return null;
         }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLogger3Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/QueueFullAsyncLogger3Test.java
@@ -94,11 +94,6 @@ public class QueueFullAsyncLogger3Test extends QueueFullAbstractTest {
         }
 
         @Override
-        public String getFormat() {
-            return null;
-        }
-
-        @Override
         public Object[] getParameters() {
             return org.apache.logging.log4j.util.Constants.EMPTY_OBJECT_ARRAY;
         }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/JndiRestrictedLookupTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/lookup/JndiRestrictedLookupTest.java
@@ -25,7 +25,6 @@ import javax.naming.Reference;
 import javax.naming.Referenceable;
 import javax.naming.StringRefAddr;
 import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.util.Strings;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -149,11 +148,6 @@ public class JndiRestrictedLookupTest {
         @Override
         public String getFormattedMessage() {
             return message;
-        }
-
-        @Override
-        public String getFormat() {
-            return Strings.EMPTY;
         }
 
         @Override

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/MessageResolverTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/resolver/MessageResolverTest.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.core.test.junit.Named;
 import org.apache.logging.log4j.layout.template.json.JsonTemplateLayout;
 import org.apache.logging.log4j.layout.template.json.util.JsonReader;
 import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.MultiformatMessage;
 import org.apache.logging.log4j.message.ObjectMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.message.StringMapMessage;
@@ -203,7 +204,7 @@ class MessageResolverTest {
     }
 
     @Test
-    void test_custom_Message() {
+    void test_MultiformatMessage() {
 
         // Create the event template
         final String eventTemplate = writeJson(asMap("$resolver", "message"));
@@ -216,7 +217,7 @@ class MessageResolverTest {
 
         // Create the log event with a `TestMessage`
         final LogEvent logEvent = Log4jLogEvent.newBuilder()
-                .setMessage(new TestMessage())
+                .setMessage(new TestMultiformatMessage())
                 .setTimeMillis(System.currentTimeMillis())
                 .build();
 
@@ -225,7 +226,7 @@ class MessageResolverTest {
                 .isEqualTo("bar"));
     }
 
-    private static final class TestMessage implements Message {
+    private static final class TestMultiformatMessage implements MultiformatMessage {
 
         @Override
         public String getFormattedMessage() {
@@ -233,8 +234,16 @@ class MessageResolverTest {
         }
 
         @Override
-        public String getFormat() {
-            return "JSON";
+        public String[] getFormats() {
+            return new String[] {"JSON"};
+        }
+
+        @Override
+        public String getFormattedMessage(final String[] formats) {
+            if (formats.length != 1 || !"JSON".equals(formats[0])) {
+                throw new UnsupportedOperationException();
+            }
+            return getFormattedMessage();
         }
 
         @Override

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/MessageResolver.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/MessageResolver.java
@@ -137,22 +137,17 @@ public final class MessageResolver implements EventResolver {
     private static EventResolver createObjectResolver(final String fallbackKey) {
         return (final LogEvent logEvent, final JsonWriter jsonWriter) -> {
 
-            // Skip custom serializers for `SimpleMessage`
+            // Skip custom serializers for SimpleMessage.
             final Message message = logEvent.getMessage();
             final boolean simple = message instanceof SimpleMessage;
             if (!simple) {
 
-                // Try `Message` serializer
-                if (writeMessage(jsonWriter, message)) {
-                    return;
-                }
-
-                // Try `MultiformatMessage` serializer
+                // Try MultiformatMessage serializer.
                 if (writeMultiformatMessage(jsonWriter, message)) {
                     return;
                 }
 
-                // Try `ObjectMessage` serializer
+                // Try ObjectMessage serializer.
                 if (writeObjectMessage(jsonWriter, message)) {
                     return;
                 }
@@ -161,20 +156,6 @@ public final class MessageResolver implements EventResolver {
             // Fallback to plain String serializer.
             resolveString(fallbackKey, logEvent, jsonWriter);
         };
-    }
-
-    private static boolean writeMessage(final JsonWriter jsonWriter, final Message message) {
-
-        // Check the format
-        final String format = message.getFormat();
-        if (!FORMATS[0].equalsIgnoreCase(format)) {
-            return false;
-        }
-
-        // Write the formatted message
-        final String messageJson = message.getFormattedMessage();
-        jsonWriter.writeRawString(messageJson);
-        return true;
     }
 
     private static boolean writeMultiformatMessage(final JsonWriter jsonWriter, final Message message) {

--- a/log4j-perf-test/src/main/java/org/apache/logging/log4j/perf/nogc/NoGcMessage.java
+++ b/log4j-perf-test/src/main/java/org/apache/logging/log4j/perf/nogc/NoGcMessage.java
@@ -88,11 +88,6 @@ public class NoGcMessage implements Message {
     }
 
     @Override
-    public String getFormat() {
-        return null;
-    }
-
-    @Override
     public Object[] getParameters() {
         return getState().getParamsCopy();
     }

--- a/src/changelog/.2.x.x/deprecate-Message-getFormat.xml
+++ b/src/changelog/.2.x.x/deprecate-Message-getFormat.xml
@@ -2,6 +2,6 @@
 <entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns="https://logging.apache.org/xml/ns"
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
-       type="fixed">
-  <description format="asciidoc">Fix handling of `Message#getFormat()` in `MessageResolver` of `JsonTemplateLayout`</description>
+       type="deprecated">
+  <description format="asciidoc">Deprecate `Message#getFormat()` due to unclear semantics and inconsistent implementations</description>
 </entry>

--- a/src/site/antora/modules/ROOT/pages/manual/filters.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/filters.adoc
@@ -746,19 +746,16 @@ include::partial$manual/log-event.adoc[]
 [#RegexFilter]
 ==== `RegexFilter`
 
-The `RegexFilter` matches a regular expression against either the result of
-link:../javadoc/log4j-api/org/apache/logging/log4j/message/Message.html#getFormat()[`Message.getFormat()`]
-or
-link:../javadoc/log4j-api/org/apache/logging/log4j/message/Message.html#getFormat()[`Message.getFormattedMessage()`].
-It can be used with all kinds of `Message` implementations.
+The `RegexFilter` matches a regular expression against messages.
+Besides the <<common-configuration-attributes,common configuration attributes>>, the `RegexFilter` supports the following parameters:
 
-Besides the <<common-configuration-attributes,common configuration attributes>>,
-the `RegexFilter` supports the following parameters:
-
-.`RegexFilter` -- configuration attributes
-[cols="1m,1,1,4"]
+.`RegexFilter` configuration attributes
+[%header,cols="1m,1,1,4"]
 |===
-|Attribute | Type | Default value | Description
+|Attribute
+| Type
+| Default value
+| Description
 
 | regex
 | https://docs.oracle.com/javase/{java-target-version}/docs/api/java/util/regex/Pattern.html[`Pattern`]
@@ -770,13 +767,7 @@ the `RegexFilter` supports the following parameters:
 | useRawMsg
 | `boolean`
 | `false`
-| If `true` the result of
-link:../javadoc/log4j-api/org/apache/logging/log4j/message/Message.html#getFormat()[`Message.getFormat()`]
-will be used.
-Otherwise,
-link:../javadoc/log4j-api/org/apache/logging/log4j/message/Message.html#getFormat()[`Message.getFormattedMessage()`]
-is used.
-
+| If `true`, for xref:manual/messages.adoc#ParameterizedMessage[`ParameterizedMessage`], xref:manual/messages.adoc#StringFormattedMessage[`StringFormattedMessage`], and xref:manual/messages.adoc#MessageFormatMessage[`MessageFormatMessage`], the message format pattern; for xref:manual/messages.adoc#StructuredDataMessage[`StructuredDataMessage`], the message field will be used as the match target.
 |===
 
 [WARNING]

--- a/src/site/antora/modules/ROOT/pages/manual/messages.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/messages.adoc
@@ -288,11 +288,9 @@ include::example$manual/messages/CustomMessageExample.java[tag=loginFailure]
 [#format-type]
 === Format type
 
-The link:../javadoc/log4j-api/org/apache/logging/log4j/message/Message.html[`Message`] interface supports the notion of _format_ (e.g., JSON, XML) through its `getFormat()` method of return type `String`.
+You can extend from <<MultiformatMessage>> (and optionally from <<MultiFormatStringBuilderFormattable>>) to implement messages that can format themselves in one or more encodings; JSON, XML, etc.
 Layouts leverage this mechanism to encode a message in a particular format.
-For instance, when xref:manual/json-template-layout.adoc[] figures out that `getFormat()` of a `Message` returns `JSON`, it injects the `Message#getFormattedMessage()` output as is without quoting it.
-This way a message implementation can communicate its support for a particular encoding.
-If you want to support multiple formats, extend from <<MultiformatMessage>>, and optionally from <<MultiFormatStringBuilderFormattable>>, instead.
+For instance, when xref:manual/json-template-layout.adoc[] figures out that the array returned by `getFormats()` of a `MultiformatMessage` contains `JSON`, it injects the `MultiformatMessage#getFormattedMessage({"JSON"})` output as is without quoting it.
 
 [#marker-interfaces]
 === Marker interfaces


### PR DESCRIPTION
`Message#getFormat()` doesn't only have unclear semantics, it is also implemented very inconsistently. One might think it should return `JSON` by messages that want to format themselves in JSON, yet, thanks to many implementations forwarding `getFormat()` to `message` (yes, the arbitrary user-provided message!), this is not the case.

In short, it is an incomplete and failed attempt to allow messages to format themselves in one or more encodings. Good news is, we already have a working solution for that: `MultiformatMessage`.

This PR
1. deprecates `Message#getFormat()`
2. advocates `MultiformatMessage`