### PR TITLE
Remove properties cache and token-based matching

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/PropertiesUtilTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/PropertiesUtilTest.java
@@ -212,15 +212,15 @@ class PropertiesUtilTest {
         {null, "org.apache.logging.log4j.level"},
         {null, "Log4jAnotherProperty"},
         {null, "log4j2.catalinaBase"},
-        {"ok", "log4j2.configurationFile"},
-        {"ok", "log4j2.defaultStatusLevel"},
-        {"ok", "log4j2.newLevel"},
-        {"ok", "log4j2.asyncLoggerTimeout"},
-        {"ok", "log4j2.asyncLoggerConfigRingBufferSize"},
-        {"ok", "log4j2.disableThreadContext"},
-        {"ok", "log4j2.disableThreadContextStack"},
-        {"ok", "log4j2.disableThreadContextMap"},
-        {"ok", "log4j2.isThreadContextMapInheritable"}
+        {"ok", "log4j.configurationFile"},
+        {"ok", "Log4jDefaultStatusLevel"},
+        {"ok", "org.apache.logging.log4j.newLevel"},
+        {"ok", "AsyncLogger.Timeout"},
+        {"ok", "AsyncLoggerConfig.RingBufferSize"},
+        {"ok", "disableThreadContext"},
+        {"ok", "disableThreadContextStack"},
+        {"ok", "disableThreadContextMap"},
+        {"ok", "isThreadContextMapInheritable"}
     };
 
     /**
@@ -232,7 +232,9 @@ class PropertiesUtilTest {
     void testResolvesOnlyLog4jProperties() {
         final PropertiesUtil util = new PropertiesUtil("Jira3413Test.properties");
         for (final String[] pair : data) {
-            assertEquals(pair[0], util.getStringProperty(pair[1]));
+            assertThat(util.getStringProperty(pair[1]))
+                    .as("Checking property %s", pair[1])
+                    .isEqualTo(pair[0]);
         }
     }
 

--- a/log4j-api-test/src/test/resources/Jira3413Test.properties
+++ b/log4j-api-test/src/test/resources/Jira3413Test.properties
@@ -21,14 +21,14 @@ another.property=fail
 catalina.base=fail
 
 # Some legacy properties with a characteristic prefix
-log4j.configurationFile=ok
-Log4jDefaultStatusLevel=ok
-org.apache.logging.log4j.newLevel=ok
+log4j2.configurationFile=ok
+log4j2.defaultStatusLevel=ok
+log4j2.newLevel=ok
 
 # No characteristic prefix
-AsyncLogger.Timeout=ok
-AsyncLoggerConfig.RingBufferSize=ok
-disableThreadContext=ok
-disableThreadContextStack=ok
-disableThreadContextMap=ok
-isThreadContextMapInheritable=ok
+log4j2.asyncLoggerTimeout=ok
+log4j2.asyncLoggerConfigRingBufferSize=ok
+log4j2.disableThreadContext=ok
+log4j2.disableThreadContextStack=ok
+log4j2.disableThreadContextMap=ok
+log4j2.isThreadContextMapInheritable=ok

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncQueueFullPolicyFactoryTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
-import org.apache.logging.log4j.util.PropertiesUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,7 +37,6 @@ public class AsyncQueueFullPolicyFactoryTest {
     public void resetProperties() throws Exception {
         System.clearProperty(AsyncQueueFullPolicyFactory.PROPERTY_NAME_ASYNC_EVENT_ROUTER);
         System.clearProperty(AsyncQueueFullPolicyFactory.PROPERTY_NAME_DISCARDING_THRESHOLD_LEVEL);
-        PropertiesUtil.getProperties().reload();
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/ThreadContextDataInjectorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/impl/ThreadContextDataInjectorTest.java
@@ -35,7 +35,6 @@ import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.ContextDataInjector;
 import org.apache.logging.log4j.spi.ReadOnlyThreadContextMap;
 import org.apache.logging.log4j.test.ThreadContextUtilityClass;
-import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
 import org.apache.logging.log4j.util.StringMap;
 import org.junit.After;
@@ -122,7 +121,6 @@ public class ThreadContextDataInjectorTest {
 
     private void prepareThreadContext(final boolean isThreadContextMapInheritable) {
         System.setProperty("log4j2.isThreadContextMapInheritable", Boolean.toString(isThreadContextMapInheritable));
-        PropertiesUtil.getProperties().reload();
         ThreadContextUtilityClass.reset();
         ThreadContext.remove("baz");
         ThreadContext.put("foo", "bar");

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/net/ssl/SslConfigurationFactoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/net/ssl/SslConfigurationFactoryTest.java
@@ -58,7 +58,6 @@ public class SslConfigurationFactoryTest {
         // Only keystore
         props.clear();
         addKeystoreConfiguration(props);
-        util.reload();
         sslConfiguration = SslConfigurationFactory.createSslConfiguration(util);
         assertNotNull(sslConfiguration);
         assertNotNull(sslConfiguration.getKeyStoreConfig());
@@ -66,7 +65,6 @@ public class SslConfigurationFactoryTest {
         // Only truststore
         props.clear();
         addTruststoreConfiguration(props);
-        util.reload();
         sslConfiguration = SslConfigurationFactory.createSslConfiguration(util);
         assertNotNull(sslConfiguration);
         assertNull(sslConfiguration.getKeyStoreConfig());
@@ -75,7 +73,6 @@ public class SslConfigurationFactoryTest {
         props.clear();
         addKeystoreConfiguration(props);
         addTruststoreConfiguration(props);
-        util.reload();
         sslConfiguration = SslConfigurationFactory.createSslConfiguration(util);
         assertNotNull(sslConfiguration);
         assertNotNull(sslConfiguration.getKeyStoreConfig());

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/AbstractJpaAppenderTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/AbstractJpaAppenderTest.java
@@ -36,7 +36,6 @@ import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.test.categories.Appenders;
 import org.apache.logging.log4j.status.StatusLogger;
-import org.apache.logging.log4j.util.PropertiesUtil;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -57,7 +56,6 @@ public abstract class AbstractJpaAppenderTest {
         System.setProperty(
                 ConfigurationFactory.CONFIGURATION_FILE_PROPERTY,
                 "org/apache/logging/log4j/core/appender/db/jpa/" + configFileName);
-        PropertiesUtil.getProperties().reload();
         final LoggerContext context = LoggerContext.getContext(false);
         if (context.getConfiguration() instanceof DefaultConfiguration) {
             context.reconfigure();
@@ -75,7 +73,6 @@ public abstract class AbstractJpaAppenderTest {
             ((JpaAppender) appender).getManager().close();
         } finally {
             System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
-            PropertiesUtil.getProperties().reload();
             context.reconfigure();
             StatusLogger.getLogger().reset();
 

--- a/src/changelog/.2.x.x/2849-remove-token-based-matching.xml
+++ b/src/changelog/.2.x.x/2849-remove-token-based-matching.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="2849" link="https://github.com/apache/logging-log4j2/pull/2849"/>
+  <description format="asciidoc">Remove configuration properties caching and (undocumented) fuzzy property name matching.</description>
+</entry>


### PR DESCRIPTION
The `PropertiesUtil` class preemptively caches lookups for all known keys from enumerable property sources.
On my Debian system a JVM has around 60 among environment variables and system properties, which causes `PropertiesUtil` to perform around 60 lookups for **each** of the 3 standard property sources. Most of these properties have nothing to do with Log4j.

On the other hand all Log4j artifacts use no more than 100 configuration properties and the results of most of those calls are cache in static fields.

This PR removes the property value caches used by `PropertiesUtil`.
The change should have no noticeable impact on the loading time of Log4j Core, while at the same time simplifies the system.

As remarkable side effect **token-based** matching of property names is no longer supported. This mean that, e.g. a system property like [`log4j2.asyncLoggerRingBufferSize`](https://logging.staged.apache.org/log4j/2.x/manual/systemproperties.html#log4j2.asyncLoggerRingBufferSize) can be written:

- as `AsyncLogger.RingBufferSize` (pre-2.10 legacy form),
- as `log4j2.asyncLoggerRingBufferSize` (2.10 canonical form).

No other forms (e.g. `log4j.async.logger.ringBuffer.size`) are accepted.

**Note**: We never documented that we support token-based matching. See [current Configuration Properties](https://logging.apache.org/log4j/2.x/manual/configuration.html#SystemProperties) documentation.
