### PR TITLE
Disable level modification via JUL by default

### DIFF
--- a/log4j-jul/src/main/java/org/apache/logging/log4j/jul/LogManager.java
+++ b/log4j-jul/src/main/java/org/apache/logging/log4j/jul/LogManager.java
@@ -21,7 +21,6 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Logger;
-import org.apache.logging.log4j.LoggingException;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
 import org.apache.logging.log4j.util.PropertiesUtil;
@@ -58,21 +57,9 @@ public class LogManager extends java.util.logging.LogManager {
             }
         }
         if (adapter == null) {
-            // default adapter
-            String adapterClassName;
-            try {
-                // find out if log4j-core is available
-                LoaderUtil.loadClass(Constants.CORE_LOGGER_CLASS_NAME);
-                adapterClassName = Constants.CORE_LOGGER_ADAPTER_CLASS_NAME;
-            } catch (final ClassNotFoundException ignored) {
-                adapterClassName = Constants.API_LOGGER_ADAPTER_CLASS_NAME;
-            }
-            LOGGER.debug("Attempting to use {}", adapterClassName);
-            try {
-                adapter = LoaderUtil.newCheckedInstanceOf(adapterClassName, AbstractLoggerAdapter.class);
-            } catch (final Exception e) {
-                throw LOGGER.throwing(new LoggingException(e));
-            }
+            // Use API by default
+            // See https://github.com/apache/logging-log4j2/issues/2353
+            adapter = new ApiLoggerAdapter();
         }
         loggerAdapter = adapter;
         LOGGER.info("Registered Log4j as the java.util.logging.LogManager.");

--- a/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/ApiLoggerTest.java
+++ b/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/ApiLoggerTest.java
@@ -16,15 +16,13 @@
  */
 package org.apache.logging.log4j.jul.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 import java.util.logging.Logger;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.jul.ApiLoggerAdapter;
-import org.apache.logging.log4j.jul.Constants;
 import org.apache.logging.log4j.jul.LogManager;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -37,17 +35,15 @@ public class ApiLoggerTest extends AbstractLoggerTest {
     @BeforeClass
     public static void setUpClass() {
         System.setProperty("java.util.logging.manager", LogManager.class.getName());
-        System.setProperty(Constants.LOGGER_ADAPTOR_PROPERTY, ApiLoggerAdapter.class.getName());
     }
 
     @AfterClass
     public static void tearDownClass() {
         System.clearProperty("java.util.logging.manager");
-        System.clearProperty(Constants.LOGGER_ADAPTOR_PROPERTY);
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         logger = Logger.getLogger(LOGGER_NAME);
         logger.setFilter(null);
         assertThat(logger.getLevel(), equalTo(java.util.logging.Level.FINE));
@@ -60,7 +56,7 @@ public class ApiLoggerTest extends AbstractLoggerTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         if (eventAppender != null) {
             eventAppender.clear();
         }
@@ -73,18 +69,18 @@ public class ApiLoggerTest extends AbstractLoggerTest {
     }
 
     @Test
-    public void testGetParent() throws Exception {
+    public void testGetParent() {
         final Logger parent = logger.getParent();
         assertNull("No parent logger should be automatically set up using log4j-api", parent);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testSetParentFails() throws Exception {
+    public void testSetParentFails() {
         logger.setParent(null);
     }
 
     @Test
-    public void testSetLevelFails() throws Exception {
+    public void testSetLevelFails() {
         logger.setLevel(null);
     }
 }

--- a/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/CoreLoggerTest.java
+++ b/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/CoreLoggerTest.java
@@ -22,6 +22,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.jul.Constants;
+import org.apache.logging.log4j.jul.CoreLoggerAdapter;
 import org.apache.logging.log4j.jul.LogManager;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.After;
@@ -56,11 +58,13 @@ public class CoreLoggerTest extends AbstractLoggerTest {
     @BeforeClass
     public static void setUpClass() {
         System.setProperty("java.util.logging.manager", LogManager.class.getName());
+        System.setProperty(Constants.LOGGER_ADAPTOR_PROPERTY, CoreLoggerAdapter.class.getName());
     }
 
     @AfterClass
     public static void tearDownClass() {
         System.clearProperty("java.util.logging.manager");
+        System.clearProperty(Constants.LOGGER_ADAPTOR_PROPERTY);
     }
 
     @Before

--- a/src/changelog/.2.x.x/2353_set_level_no-op.xml
+++ b/src/changelog/.2.x.x/2353_set_level_no-op.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="2353" link="https://github.com/apache/logging-log4j2/issues/2353"/>
+  <description format="asciidoc">Disable level modification via JUL by default.</description>
+</entry>

--- a/src/site/antora/modules/ROOT/partials/manual/systemproperties/properties-log4j-jul.adoc
+++ b/src/site/antora/modules/ROOT/partials/manual/systemproperties/properties-log4j-jul.adoc
@@ -69,17 +69,24 @@ Fully qualified name of an alternative `org.apache.logging.log4j.jul.LevelConver
 |===
 | Env. variable | `LOG4J_JUL_LOGGER_ADAPTER`
 | Type          | `Class<? extends AbstractLoggerAdapter>`
-| Default value | _depends on classpath_
+| Default value | `org.apache.logging.log4j.jul.ApiLoggerAdapter`
 |===
 
 Fully qualified class name of the `org.apache.logging.log4j.jul.AbstractLoggerAdapter` implementation to use.
 
-This property allows users to choose between two implementation of the logging bridge:
+This property allows users to choose between two implementations of the logging bridge:
 
-org.apache.logging.log4j.jul.CoreLoggerAdapter::
-The default if `log4j-core` is found in the class path.
+`org.apache.logging.log4j.jul.CoreLoggerAdapter`::
 It allows users to modify the Log4j Core configuration through the JUL https://docs.oracle.com/javase/{java-target-version}/docs/api/java/util/logging/Logger.html[`Logger`] interface.
+It requires the usage of the
+xref:manual/implementation.adoc[Log4j Core]
+implementation.
 
-org.apache.logging.log4j.jul.ApiLoggerAdapter::
-The default if `log4j-core` cannot be found in the class path.
+`org.apache.logging.log4j.jul.ApiLoggerAdapter`::
 It disables the level mutators in the JUL `Logger` interface.
+
+[NOTE]
+====
+Since version 2.24.0 the default value changed to `ApiLoggerAdapter`.
+If you need to modify log levels via JUL, you need to select `CoreLoggerAdapter` explicitly.
+====


### PR DESCRIPTION
This PR switches the default JUL `LoggerAdapter` from `CoreLoggerAdapter` to `ApiLoggerAdapter`.
Level mutators in the `java.util.logging.Logger` interface will be disabled by default, unless users reenable them explicitly.

Closes #2353.
