### PR TITLE
Document module deprecation in 2.x

### DIFF
--- a/src/site/antora/modules/ROOT/pages/jakarta.adoc
+++ b/src/site/antora/modules/ROOT/pages/jakarta.adoc
@@ -267,6 +267,12 @@ include::example$manual/webapp/AsyncServlet.java[tag=manual]
 [#log4j-taglib]
 === Logging in JavaServer Pages
 
+[WARNING]
+====
+*The Log4j Tag library is planned to be removed in the next major release!*
+If you are using this library, please get in touch with the Log4j maintainers using link:{logging-services-url}/support.html[the official support channels].
+====
+
 To help users add logging statements to JavaServer Pages, Log4j provides a JSP tag library modeled after the
 https://web.archive.org/web/20140215182415/http://jakarta.apache.org/taglibs/log/[Jakarta Commons Log Tag library].
 To use it, you need to add the following runtime dependency to your web application project:

--- a/src/site/antora/modules/ROOT/pages/manual/appenders/database.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/appenders/database.adoc
@@ -190,6 +190,8 @@ The `uuid` column is additionally converted into a `java.util.UUID` before being
 [#CassandraAppender]
 == Cassandra Appender
 
+include::partial$manual/appender-deprecation.adoc[]
+
 The Cassandra Appender writes its output to an
 https://cassandra.apache.org/_/index.html[Apache Cassandra]
 database.
@@ -806,6 +808,8 @@ include::example$manual/appenders/database/jdbc.sql[lines=17..-1]
 [#JpaAppender]
 == JPA Appender
 
+include::partial$manual/appender-deprecation.adoc[]
+
 The JPA Appender writes log events to a relational database table using the
 https://jakarta.ee/specifications/persistence/2.2/[Jakarta Persistence API 2.2].
 To use the appender, you need to:
@@ -1241,6 +1245,12 @@ xref:plugin-reference.adoc#org-apache-logging-log4j_log4j-mongodb4_org-apache-lo
 
 [#CouchDbProvider]
 === Apache CouchDB provider
+
+[WARNING]
+====
+*This provider is planned to be removed in the next major release!*
+If you are using this library, please get in touch with the Log4j maintainers using link:{logging-services-url}/support.html[the official support channels].
+====
 
 The `CouchDb` Provider allows using the <<NoSqlAppender>> with an
 https://couchdb.apache.org/[Apache CouchDB database].

--- a/src/site/antora/modules/ROOT/pages/manual/appenders/message-queue.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/appenders/message-queue.adoc
@@ -679,6 +679,8 @@ include::example$manual/appenders/message-queue/jms-message.properties[tag=appen
 [[KafkaAppender]]
 == Kafka Appender
 
+include::partial$manual/appender-deprecation.adoc[]
+
 The KafkaAppender logs events to an https://kafka.apache.org/[Apache Kafka] topic.
 Each log event is sent as a
 https://kafka.apache.org/30/javadoc/org/apache/kafka/clients/producer/ProducerRecord.html[`ProducerRecord<byte[\], byte[\]>`], where:
@@ -902,6 +904,13 @@ include::example$manual/appenders/message-queue/kafka.properties[tag=loggers]
 
 [[JeroMqAppender]]
 == ZeroMQ/JeroMQ Appender
+
+[WARNING]
+====
+*This appender is planned to be removed in the next major release!*
+Users should consider switching to
+https://github.com/fbacchella/loghublog4j2#zmqappender[a third-party `ZMQ` appender].
+====
 
 The ZeroMQ appender uses the https://github.com/zeromq/jeromq[JeroMQ] library to send log events to one or more ZeroMQ endpoints.
 

--- a/src/site/antora/modules/ROOT/partials/manual/appender-deprecation.adoc
+++ b/src/site/antora/modules/ROOT/partials/manual/appender-deprecation.adoc
@@ -1,0 +1,22 @@
+////
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+////
+
+[WARNING]
+====
+*This appender is planned to be removed in the next major release!*
+If you are using this library, please get in touch with the Log4j maintainers using link:{logging-services-url}/support.html[the official support channels].
+====


### PR DESCRIPTION
Since layout deprecation was already done in #2527, we document:

* The deprecation of some appenders, pointing to third-party alternatives, when possible.
* The deprecation of the Log4j Tag library.

The Spring Boot Lookup and Java EE SMTP Appender will disappear in version 3.x, but will be replaced with the Spring Boot 3 Lookup (in Spring Boot) and Jakarta EE SMTP Appender.

Closes #1950.
