### PR TITLE
Improve GraalVM support of `SimpleLoggerContext`

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContext.java
@@ -17,11 +17,10 @@
 package org.apache.logging.log4j.simple;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.PrintStream;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.message.MessageFactory;
+import org.apache.logging.log4j.simple.internal.SimpleProvider;
 import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.spi.ExtendedLogger;
 import org.apache.logging.log4j.spi.LoggerContext;
@@ -35,10 +34,6 @@ public class SimpleLoggerContext implements LoggerContext {
 
     /** Singleton instance. */
     static final SimpleLoggerContext INSTANCE = new SimpleLoggerContext();
-
-    private static final String SYSTEM_OUT = "system.out";
-
-    private static final String SYSTEM_ERR = "system.err";
 
     /** The default format to use when formatting dates */
     protected static final String DEFAULT_DATE_TIME_FORMAT = "yyyy/MM/dd HH:mm:ss:SSS zzz";
@@ -79,34 +74,15 @@ public class SimpleLoggerContext implements LoggerContext {
             value = "PATH_TRAVERSAL_OUT",
             justification = "Opens a file retrieved from configuration (Log4j properties)")
     public SimpleLoggerContext() {
-        props = new PropertiesUtil("log4j2.simplelog.properties");
-
-        showContextMap = props.getBooleanProperty(SYSTEM_PREFIX + "showContextMap", false);
-        showLogName = props.getBooleanProperty(SYSTEM_PREFIX + "showlogname", false);
-        showShortName = props.getBooleanProperty(SYSTEM_PREFIX + "showShortLogname", true);
-        showDateTime = props.getBooleanProperty(SYSTEM_PREFIX + "showdatetime", false);
-        final String lvl = props.getStringProperty(SYSTEM_PREFIX + "level");
-        defaultLevel = Level.toLevel(lvl, Level.ERROR);
-
-        dateTimeFormat = showDateTime
-                ? props.getStringProperty(
-                        SimpleLoggerContext.SYSTEM_PREFIX + "dateTimeFormat", DEFAULT_DATE_TIME_FORMAT)
-                : null;
-
-        final String fileName = props.getStringProperty(SYSTEM_PREFIX + "logFile", SYSTEM_ERR);
-        PrintStream ps;
-        if (SYSTEM_ERR.equalsIgnoreCase(fileName)) {
-            ps = System.err;
-        } else if (SYSTEM_OUT.equalsIgnoreCase(fileName)) {
-            ps = System.out;
-        } else {
-            try {
-                ps = new PrintStream(new FileOutputStream(fileName));
-            } catch (final FileNotFoundException fnfe) {
-                ps = System.err;
-            }
-        }
-        this.stream = ps;
+        final SimpleProvider.Config config = SimpleProvider.Config.INSTANCE;
+        props = config.props;
+        showContextMap = config.showContextMap;
+        showLogName = config.showLogName;
+        showShortName = config.showShortName;
+        showDateTime = config.showDateTime;
+        defaultLevel = config.defaultLevel;
+        dateTimeFormat = config.dateTimeFormat;
+        stream = config.stream;
     }
 
     @Override

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/internal/SimpleProvider.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/internal/SimpleProvider.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.simple.internal;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.simple.SimpleLoggerContext;
+import org.apache.logging.log4j.simple.SimpleLoggerContextFactory;
+import org.apache.logging.log4j.spi.LoggerContextFactory;
+import org.apache.logging.log4j.spi.NoOpThreadContextMap;
+import org.apache.logging.log4j.spi.Provider;
+import org.apache.logging.log4j.spi.ThreadContextMap;
+import org.apache.logging.log4j.util.PropertiesUtil;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A {@link Provider} implementation to use {@link SimpleLoggerContext}.
+ *
+ * @since 2.24.0
+ */
+@NullMarked
+public final class SimpleProvider extends Provider {
+
+    private final ThreadContextMap threadContextMap;
+
+    public SimpleProvider() {
+        super(null, CURRENT_VERSION);
+        this.threadContextMap =
+                Config.INSTANCE.showContextMap ? super.getThreadContextMapInstance() : NoOpThreadContextMap.INSTANCE;
+    }
+
+    @Override
+    public LoggerContextFactory getLoggerContextFactory() {
+        return SimpleLoggerContextFactory.INSTANCE;
+    }
+
+    @Override
+    public ThreadContextMap getThreadContextMapInstance() {
+        return threadContextMap;
+    }
+
+    public static final class Config {
+
+        /** The default format to use when formatting dates */
+        private static final String DEFAULT_DATE_TIME_FORMAT = "yyyy/MM/dd HH:mm:ss:SSS zzz";
+
+        /** All system properties used by <code>SimpleLog</code> start with this */
+        private static final String SYSTEM_PREFIX = "org.apache.logging.log4j.simplelog.";
+
+        private static final String SYSTEM_OUT = "system.out";
+
+        private static final String SYSTEM_ERR = "system.err";
+
+        public static final Config INSTANCE = new Config();
+
+        public final PropertiesUtil props;
+
+        public final boolean showContextMap;
+
+        public final boolean showLogName;
+
+        public final boolean showShortName;
+
+        public final boolean showDateTime;
+
+        public final Level defaultLevel;
+
+        public final @Nullable String dateTimeFormat;
+
+        public final PrintStream stream;
+
+        private Config() {
+            props = new PropertiesUtil("log4j2.simplelog.properties");
+
+            showContextMap = props.getBooleanProperty(SYSTEM_PREFIX + "showContextMap", false);
+            showLogName = props.getBooleanProperty(SYSTEM_PREFIX + "showlogname", false);
+            showShortName = props.getBooleanProperty(SYSTEM_PREFIX + "showShortLogname", true);
+            showDateTime = props.getBooleanProperty(SYSTEM_PREFIX + "showdatetime", false);
+            final String lvl = props.getStringProperty(SYSTEM_PREFIX + "level");
+            defaultLevel = Level.toLevel(lvl, Level.ERROR);
+
+            dateTimeFormat = showDateTime
+                    ? props.getStringProperty(SYSTEM_PREFIX + "dateTimeFormat", DEFAULT_DATE_TIME_FORMAT)
+                    : null;
+
+            final String fileName = props.getStringProperty(SYSTEM_PREFIX + "logFile", SYSTEM_ERR);
+            PrintStream ps;
+            if (SYSTEM_ERR.equalsIgnoreCase(fileName)) {
+                ps = System.err;
+            } else if (SYSTEM_OUT.equalsIgnoreCase(fileName)) {
+                ps = System.out;
+            } else {
+                try {
+                    ps = new PrintStream(new FileOutputStream(fileName));
+                } catch (final FileNotFoundException fnfe) {
+                    ps = System.err;
+                }
+            }
+            this.stream = ps;
+        }
+    }
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/package-info.java
@@ -20,7 +20,7 @@
  * Providers are able to be loaded at runtime.
  */
 @Export
-@Version("2.20.2")
+@Version("2.24.0")
 package org.apache.logging.log4j.simple;
 
 import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
This PR allows to create GraalVM applications that only use this `SimpleLoggerContext`.

For this purpose we create a `SimpleProvider` implementation of `Provider`, which is **not** instantiated by reflection.

Part of #2830

