### PR TITLE
chore: use `computIfAbsent` in `MarkerManager

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/MarkerManager.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/MarkerManager.java
@@ -60,12 +60,7 @@ public final class MarkerManager {
      * @throws IllegalArgumentException if the argument is {@code null}
      */
     public static Marker getMarker(final String name) {
-        Marker result = MARKERS.get(name);
-        if (result == null) {
-            MARKERS.putIfAbsent(name, new Log4jMarker(name));
-            result = MARKERS.get(name);
-        }
-        return result;
+        return MARKERS.computeIfAbsent(name, Log4jMarker::new);
     }
 
     /**


### PR DESCRIPTION
This is a small change which utlizes a more domain-specific and potentially performant `computeIfAbsent` in `MarkerManager`.

## Checklist

* [x] Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* [x] `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* [x] Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* [x] ~~Tests for the changes are provided~~ There are no functional changes
* [x] [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
