### PR TITLE
Switch MongoDB tests to use Docker

### DIFF
--- a/BUILDING.adoc
+++ b/BUILDING.adoc
@@ -52,6 +52,13 @@ To remedy this, you can execute the following:
 printf '127.0.0.1 %s\n::1 %s\n' `hostname` `hostname` | sudo tee -a /etc/hosts
 ----
 
+[#docker]
+=== Docker tests
+
+Certain tests use Docker to spawn necessary external services.
+Docker tests are configured using the `docker` Maven profile, which is activated by default for the CI environment.
+You can locally enable this profile by passing a `-P docker` argument to your `./mvnw` commands.
+
 [#website]
 == Building the website
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/CoreDefaultBundle.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/CoreDefaultBundle.java
@@ -238,8 +238,10 @@ public final class CoreDefaultBundle {
     @SingletonFactory
     @Named("StatusLogger")
     @ConditionalOnMissingBinding
-    public Level defaultStatusLevel() {
-        return Level.ERROR;
+    public Level defaultStatusLevel(PropertyEnvironment environment) {
+        return environment
+                .getProperty(CoreProperties.StatusLoggerProperties.class)
+                .level();
     }
 
     @SingletonFactory

--- a/log4j-mongodb/pom.xml
+++ b/log4j-mongodb/pom.xml
@@ -35,29 +35,63 @@
       ~ OSGi and JPMS options
       -->
     <Fragment-Host>org.apache.logging.log4j.core</Fragment-Host>
+
+    <!-- Dependency properties -->
+    <mongodb.version>5.1.3</mongodb.version>
+    <slf4j2.version>2.0.15</slf4j2.version>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+
+      <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>bson</artifactId>
+        <version>${mongodb.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>mongodb-driver-core</artifactId>
+        <version>${mongodb.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mongodb</groupId>
+        <artifactId>mongodb-driver-sync</artifactId>
+        <version>${mongodb.version}</version>
+      </dependency>
+
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
+
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>bson</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongodb-driver-core</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongodb-driver-sync</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api-test</artifactId>
@@ -69,6 +103,7 @@
         </exclusion>
       </exclusions>
     </dependency>
+
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core-test</artifactId>
@@ -88,31 +123,19 @@
         </exclusion>
       </exclusions>
     </dependency>
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>de.flapdoodle.embed</groupId>
-      <artifactId>de.flapdoodle.embed.mongo</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>de.flapdoodle.embed</groupId>
-      <artifactId>de.flapdoodle.embed.process</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>de.flapdoodle.reverse</groupId>
-      <artifactId>de.flapdoodle.reverse</artifactId>
-      <scope>test</scope>
-    </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <build>
@@ -122,8 +145,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <!-- TODO: fix concurrent download of MongoDB distribution. -->
-          <forkCount>1</forkCount>
+          <skip>true</skip>
         </configuration>
         <dependencies>
           <dependency>
@@ -141,5 +163,111 @@
 
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+
+      <id>docker</id>
+
+      <!--
+        ~ Only the `ubuntu` CI runners have access to Docker
+        -->
+      <activation>
+        <os>
+          <family>linux</family>
+        </os>
+        <property>
+          <name>env.CI</name>
+          <value>true</value>
+        </property>
+      </activation>
+
+      <build>
+        <plugins>
+
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <verbose>all</verbose>
+              <startParallel>true</startParallel>
+              <autoCreateCustomNetworks>true</autoCreateCustomNetworks>
+              <images>
+                <image>
+                  <alias>mongo</alias>
+                  <name>mongo:latest</name>
+                  <run>
+                    <ports>
+                      <!--
+                        ~ Binds an ephemeral port on the host to port 27017 in the container.
+                        ~ Assigns the value of the port to the `mongo.port` property.
+                        -->
+                      <port>localhost:mongo.port:27017</port>
+                    </ports>
+                  </run>
+                </image>
+              </images>
+            </configuration>
+            <executions>
+              <execution>
+                <id>start-mongo</id>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>stop-mongo</id>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <dependencies>
+              <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit-jupiter.version}</version>
+              </dependency>
+              <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-nop</artifactId>
+                <version>${slf4j2.version}</version>
+              </dependency>
+            </dependencies>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <reuseForks>true</reuseForks>
+                  <includes>
+                    <include>**/*IT.java</include>
+                  </includes>
+                  <systemPropertyVariables>
+                    <!--
+                      ~ Silence the tests.
+                      ~ Annotate tests with `@UsingStatusListener` to see debug output on error
+                      -->
+                    <log4j.statusLogger.level>OFF</log4j.statusLogger.level>
+                    <!-- The `mongo.port` variable is created by `docker-maven-plugin` -->
+                    <log4j.mongo.port>${mongo.port}</log4j.mongo.port>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+        </plugins>
+      </build>
+
+    </profile>
+  </profiles>
 
 </project>

--- a/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/AbstractMongoDbCappedIT.java
+++ b/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/AbstractMongoDbCappedIT.java
@@ -23,17 +23,16 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.bson.Document;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
-public abstract class AbstractMongoDbCappedTest {
+abstract class AbstractMongoDbCappedIT {
 
-    @Test
-    public void test(final LoggerContext ctx, final MongoClient mongoClient) {
-        final Logger logger = ctx.getLogger(AbstractMongoDbCappedTest.class);
+    protected void test(final LoggerContext ctx, final MongoClient mongoClient) {
+        final Logger logger = ctx.getLogger(AbstractMongoDbCappedIT.class);
         logger.info("Hello log");
         final MongoDatabase database = mongoClient.getDatabase(MongoDbTestConstants.DATABASE_NAME);
         Assertions.assertNotNull(database);
-        final MongoCollection<Document> collection = database.getCollection(MongoDbTestConstants.COLLECTION_NAME);
+        final MongoCollection<Document> collection =
+                database.getCollection(getClass().getSimpleName());
         Assertions.assertNotNull(collection);
         final Document first = collection.find().first();
         Assertions.assertNotNull(first);

--- a/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbAdditionalFieldsIT.java
+++ b/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbAdditionalFieldsIT.java
@@ -26,21 +26,25 @@ import com.mongodb.client.MongoDatabase;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.test.junit.UsingStatusListener;
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
 
 @UsingMongoDb
-@LoggerContextSource("log4j2-mongodb-additional-fields.xml")
-public class MongoDbAdditionalFieldsTest {
+@LoggerContextSource("MongoDbAdditionalFields.xml")
+// Print debug status logger output upon failure
+@UsingStatusListener
+class MongoDbAdditionalFieldsIT {
 
     @Test
-    public void test(final LoggerContext ctx, final MongoClient mongoClient) {
-        final Logger logger = ctx.getLogger(MongoDbAdditionalFieldsTest.class);
+    void test(final LoggerContext ctx, final MongoClient mongoClient) {
+        final Logger logger = ctx.getLogger(MongoDbAdditionalFieldsIT.class);
         logger.info("Hello log 1");
         logger.info("Hello log 2", new RuntimeException("Hello ex 2"));
         final MongoDatabase database = mongoClient.getDatabase(MongoDbTestConstants.DATABASE_NAME);
         assertNotNull(database);
-        final MongoCollection<Document> collection = database.getCollection(MongoDbTestConstants.COLLECTION_NAME);
+        final MongoCollection<Document> collection =
+                database.getCollection(getClass().getSimpleName());
         assertNotNull(collection);
         final FindIterable<Document> found = collection.find();
         final Document first = found.first();

--- a/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbAuthFailureIT.java
+++ b/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbAuthFailureIT.java
@@ -16,36 +16,36 @@
  */
 package org.apache.logging.log4j.mongodb;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
-import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.test.junit.UsingStatusListener;
 import org.bson.Document;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @UsingMongoDb
-@LoggerContextSource("log4j2-mongodb-map-message.xml")
-public class MongoDbMapMessageTest {
+@LoggerContextSource("MongoDbAuthFailureIT.xml")
+// Print debug status logger output upon failure
+@UsingStatusListener
+class MongoDbAuthFailureIT {
 
     @Test
-    public void test(final LoggerContext ctx, final MongoClient mongoClient) {
-        final Logger logger = ctx.getLogger(MongoDbMapMessageTest.class);
-        final MapMessage<?, Object> mapMessage = new MapMessage<>();
-        mapMessage.with("SomeName", "SomeValue");
-        mapMessage.with("SomeInt", 1);
-        logger.info(mapMessage);
+    void test(final LoggerContext ctx, final MongoClient mongoClient) {
+        final Logger logger = ctx.getLogger(MongoDbAuthFailureIT.class);
+        logger.info("Hello log");
         final MongoDatabase database = mongoClient.getDatabase(MongoDbTestConstants.DATABASE_NAME);
-        Assertions.assertNotNull(database);
-        final MongoCollection<Document> collection = database.getCollection(MongoDbTestConstants.COLLECTION_NAME);
-        Assertions.assertNotNull(collection);
+        assertNotNull(database);
+        final MongoCollection<Document> collection =
+                database.getCollection(getClass().getSimpleName());
+        ;
+        assertNotNull(collection);
         final Document first = collection.find().first();
-        Assertions.assertNotNull(first);
-        final String firstJson = first.toJson();
-        Assertions.assertEquals("SomeValue", first.getString("SomeName"), firstJson);
-        Assertions.assertEquals(Integer.valueOf(1), first.getInteger("SomeInt"), firstJson);
+        assertNull(first);
     }
 }

--- a/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbCappedIntIT.java
+++ b/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbCappedIntIT.java
@@ -16,25 +16,21 @@
  */
 package org.apache.logging.log4j.mongodb;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoIterable;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.test.junit.UsingStatusListener;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests MongoDbRule.
- * <p>
- * The test framework {@code de.flapdoodle.embed.mongo} requires Java 8.
- * </p>
- */
 @UsingMongoDb
-public class MongoDbResolverTest {
+@LoggerContextSource("MongoDbCappedIntIT.xml")
+// Print debug status logger output upon failure
+@UsingStatusListener
+class MongoDbCappedIntIT extends AbstractMongoDbCappedIT {
 
     @Test
-    public void testAccess(final MongoClient mongoClient) {
-        final MongoIterable<String> databaseNames = mongoClient.listDatabaseNames();
-        assertNotNull(databaseNames);
-        assertNotNull(databaseNames.first());
+    @Override
+    protected void test(LoggerContext ctx, MongoClient mongoClient) {
+        super.test(ctx, mongoClient);
     }
 }

--- a/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbCappedLongIT.java
+++ b/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbCappedLongIT.java
@@ -16,11 +16,21 @@
  */
 package org.apache.logging.log4j.mongodb;
 
+import com.mongodb.client.MongoClient;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.test.junit.UsingStatusListener;
+import org.junit.jupiter.api.Test;
 
 @UsingMongoDb
-@LoggerContextSource("log4j2-mongodb-capped-long.xml")
-public class MongoDbCappedLongTest extends AbstractMongoDbCappedTest {
+@LoggerContextSource("MongoDbCappedLongIT.xml")
+// Print debug status logger output upon failure
+@UsingStatusListener
+class MongoDbCappedLongIT extends AbstractMongoDbCappedIT {
 
-    // test is in superclass
+    @Test
+    @Override
+    protected void test(LoggerContext ctx, MongoClient mongoClient) {
+        super.test(ctx, mongoClient);
+    }
 }

--- a/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbIT.java
+++ b/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbIT.java
@@ -26,21 +26,25 @@ import com.mongodb.client.MongoDatabase;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.test.junit.UsingStatusListener;
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
 
 @UsingMongoDb
-@LoggerContextSource("log4j2-mongodb.xml")
-public class MongoDbTest {
+@LoggerContextSource("MongoDbIT.xml")
+// Print debug status logger output upon failure
+@UsingStatusListener
+class MongoDbIT {
 
     @Test
-    public void test(final LoggerContext ctx, final MongoClient mongoClient) {
-        final Logger logger = ctx.getLogger(MongoDbTest.class);
+    void test(final LoggerContext ctx, final MongoClient mongoClient) {
+        final Logger logger = ctx.getLogger(MongoDbIT.class);
         logger.info("Hello log 1");
         logger.info("Hello log 2", new RuntimeException("Hello ex 2"));
         final MongoDatabase database = mongoClient.getDatabase(MongoDbTestConstants.DATABASE_NAME);
         assertNotNull(database);
-        final MongoCollection<Document> collection = database.getCollection(MongoDbTestConstants.COLLECTION_NAME);
+        final MongoCollection<Document> collection =
+                database.getCollection(getClass().getSimpleName());
         assertNotNull(collection);
         final FindIterable<Document> found = collection.find();
         final Document first = found.first();

--- a/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbResolver.java
+++ b/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbResolver.java
@@ -18,35 +18,9 @@ package org.apache.logging.log4j.mongodb;
 
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
-import de.flapdoodle.embed.mongo.commands.ServerAddress;
-import de.flapdoodle.embed.mongo.distribution.Version;
-import de.flapdoodle.embed.mongo.packageresolver.Command;
-import de.flapdoodle.embed.mongo.transitions.Mongod;
-import de.flapdoodle.embed.mongo.transitions.PackageOfCommandDistribution;
-import de.flapdoodle.embed.mongo.transitions.RunningMongodProcess;
-import de.flapdoodle.embed.mongo.types.DistributionBaseUrl;
-import de.flapdoodle.embed.process.config.store.FileSet;
-import de.flapdoodle.embed.process.config.store.FileType;
-import de.flapdoodle.embed.process.config.store.Package;
-import de.flapdoodle.embed.process.distribution.Distribution;
-import de.flapdoodle.embed.process.io.ProcessOutput;
-import de.flapdoodle.embed.process.io.Processors;
-import de.flapdoodle.embed.process.io.StreamProcessor;
-import de.flapdoodle.embed.process.types.Name;
-import de.flapdoodle.embed.process.types.ProcessConfig;
-import de.flapdoodle.os.OSType;
-import de.flapdoodle.reverse.TransitionWalker.ReachedState;
-import de.flapdoodle.reverse.transitions.Derive;
-import de.flapdoodle.reverse.transitions.Start;
-import java.util.Objects;
 import java.util.function.Supplier;
-import org.apache.commons.lang3.NotImplementedException;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.status.StatusLogger;
-import org.apache.logging.log4j.test.TestProperties;
 import org.apache.logging.log4j.test.junit.ExtensionContextAnchor;
-import org.apache.logging.log4j.test.junit.TestPropertySource;
+import org.apache.logging.log4j.util.PropertiesUtil;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
@@ -54,68 +28,13 @@ import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.support.TypeBasedParameterResolver;
 
-public class MongoDbResolver extends TypeBasedParameterResolver<MongoClient> implements BeforeAllCallback {
+class MongoDbResolver extends TypeBasedParameterResolver<MongoClient> implements BeforeAllCallback {
 
-    private static final Logger LOGGER = StatusLogger.getLogger();
-    private static final String LOGGING_TARGET_PROPERTY = "log4j2.mongoDbLoggingTarget";
-
-    private static final int BUILDER_TIMEOUT_MILLIS = 30000;
-
-    private static ProcessOutput getProcessOutput(final LoggingTarget loggingTarget, final String label) {
-        if (loggingTarget != null) {
-            switch (loggingTarget) {
-                case STATUS_LOGGER:
-                    return ProcessOutput.builder()
-                            .output(Processors.named(
-                                    "[" + label + " output]", new StatusLoggerStreamProcessor(Level.INFO)))
-                            .error(Processors.named(
-                                    "[" + label + " error]", new StatusLoggerStreamProcessor(Level.ERROR)))
-                            .commands(new StatusLoggerStreamProcessor(Level.DEBUG))
-                            .build();
-                case CONSOLE:
-                    return ProcessOutput.namedConsole(label);
-                default:
-            }
-        }
-        throw new NotImplementedException(Objects.toString(loggingTarget));
-    }
+    static final String PORT_PROPERTY = "log4j2.mongo.port";
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        final TestProperties props = TestPropertySource.createProperties(context);
-        final Mongod mongod = Mongod.builder()
-                .processOutput(Derive.given(Name.class)
-                        .state(ProcessOutput.class)
-                        .deriveBy(name -> getProcessOutput(
-                                LoggingTarget.getLoggingTarget(LoggingTarget.STATUS_LOGGER), name.value())))
-                .processConfig(Start.to(ProcessConfig.class)
-                        .initializedWith(ProcessConfig.defaults().withStopTimeoutInMillis(BUILDER_TIMEOUT_MILLIS))
-                        .withTransitionLabel("create default"))
-                // workaround for https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/309
-                .packageOfDistribution(new PackageOfCommandDistribution() {
-
-                    @Override
-                    protected Package packageOf(
-                            Command command, Distribution distribution, DistributionBaseUrl baseUrl) {
-                        if (distribution.platform().operatingSystem().type() == OSType.Windows) {
-                            final Package relativePackage =
-                                    commandPackageResolver().apply(command).packageFor(distribution);
-                            final FileSet.Builder fileSetBuilder = FileSet.builder()
-                                    .addEntry(FileType.Library, "ssleay32.dll")
-                                    .addEntry(FileType.Library, "libeay32.dll");
-                            relativePackage.fileSet().entries().forEach(fileSetBuilder::addEntries);
-                            return Package.builder()
-                                    .archiveType(relativePackage.archiveType())
-                                    .fileSet(fileSetBuilder.build())
-                                    .url(baseUrl.value() + relativePackage.url())
-                                    .hint(relativePackage.hint())
-                                    .build();
-                        }
-                        return super.packageOf(command, distribution, baseUrl);
-                    }
-                })
-                .build();
-        ExtensionContextAnchor.setAttribute(MongoClientHolder.class, new MongoClientHolder(mongod, props), context);
+        ExtensionContextAnchor.setAttribute(MongoClientHolder.class, new MongoClientHolder(), context);
     }
 
     @Override
@@ -125,25 +44,13 @@ public class MongoDbResolver extends TypeBasedParameterResolver<MongoClient> imp
                 .get();
     }
 
-    public enum LoggingTarget {
-        CONSOLE,
-        STATUS_LOGGER;
-
-        public static LoggingTarget getLoggingTarget(final LoggingTarget defaultValue) {
-            return LoggingTarget.valueOf(System.getProperty(LOGGING_TARGET_PROPERTY, defaultValue.name()));
-        }
-    }
-
     private static final class MongoClientHolder implements CloseableResource, Supplier<MongoClient> {
-        private final ReachedState<RunningMongodProcess> state;
         private final MongoClient mongoClient;
 
-        public MongoClientHolder(final Mongod mongod, final TestProperties props) {
-            state = mongod.start(Version.Main.V4_4);
-            final RunningMongodProcess mongodProcess = state.current();
-            final ServerAddress addr = mongodProcess.getServerAddress();
-            mongoClient = MongoClients.create(String.format("mongodb://%s:%d", addr.getHost(), addr.getPort()));
-            props.setProperty(MongoDbTestConstants.PROP_NAME_PORT, addr.getPort());
+        public MongoClientHolder() {
+            mongoClient = MongoClients.create(String.format(
+                    "mongodb://localhost:%d",
+                    PropertiesUtil.getProperties().getIntegerProperty(MongoDbTestConstants.PROP_NAME_PORT, 27017)));
         }
 
         @Override
@@ -154,30 +61,6 @@ public class MongoDbResolver extends TypeBasedParameterResolver<MongoClient> imp
         @Override
         public void close() throws Exception {
             mongoClient.close();
-            state.close();
-        }
-    }
-
-    private static final class StatusLoggerStreamProcessor implements StreamProcessor {
-
-        private final Level level;
-
-        public StatusLoggerStreamProcessor(Level level) {
-            this.level = level;
-        }
-
-        @Override
-        public void process(String line) {
-            LOGGER.log(level, () -> stripLineEndings(line));
-        }
-
-        @Override
-        public void onProcessed() {}
-
-        protected String stripLineEndings(String line) {
-            // we still need to remove line endings that are passed on by
-            // StreamToLineProcessor...
-            return line.replaceAll("[\n\r]+", "");
         }
     }
 }

--- a/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbResolverIT.java
+++ b/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbResolverIT.java
@@ -16,11 +16,28 @@
  */
 package org.apache.logging.log4j.mongodb;
 
-import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoIterable;
+import org.apache.logging.log4j.test.junit.UsingStatusListener;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests MongoDbRule.
+ * <p>
+ * The test framework {@code de.flapdoodle.embed.mongo} requires Java 8.
+ * </p>
+ */
 @UsingMongoDb
-@LoggerContextSource("log4j2-mongodb-capped-int.xml")
-public class MongoDbCappedIntTest extends AbstractMongoDbCappedTest {
+// Print debug status logger output upon failure
+@UsingStatusListener
+class MongoDbResolverIT {
 
-    // test is in superclass
+    @Test
+    void testAccess(final MongoClient mongoClient) {
+        final MongoIterable<String> databaseNames = mongoClient.listDatabaseNames();
+        assertNotNull(databaseNames);
+        assertNotNull(databaseNames.first());
+    }
 }

--- a/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbTestConstants.java
+++ b/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbTestConstants.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.mongodb;
 
 public class MongoDbTestConstants {
 
-    public static final String PROP_NAME_PORT = "MongoDBTestPort";
-    static final String COLLECTION_NAME = "testCollection";
+    public static final String PROP_NAME_PORT = "log4j.mongo.port";
     static final String DATABASE_NAME = "testDb";
 }

--- a/log4j-mongodb/src/test/resources/MongoDbAdditionalFields.xml
+++ b/log4j-mongodb/src/test/resources/MongoDbAdditionalFields.xml
@@ -15,15 +15,23 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="WARN">
+<Configuration xmlns="https://logging.apache.org/xml/ns"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="
+                   https://logging.apache.org/xml/ns
+                   https://logging.apache.org/xml/ns/log4j-config-3.xsd">
   <Appenders>
-    <NoSql name="MongoDbAppender">
-      <MongoDb connection="mongodb://localhost:${test:MongoDBTestPort:-27017}/testDb.testCollection" />
+    <NoSql name="MONGO">
+      <MongoDb connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}/testDb.MongoDbAdditionalFieldsIT"/>
+      <KeyValuePair key="A" value="1"/>
+      <KeyValuePair key="B" value="2"/>
+      <KeyValuePair key="env1" value="${env:PATH}"/>
+      <KeyValuePair key="env2" value="$${env:PATH}"/>
     </NoSql>
   </Appenders>
   <Loggers>
     <Root level="ALL">
-      <AppenderRef ref="MongoDbAppender" />
+      <AppenderRef ref="MONGO"/>
     </Root>
   </Loggers>
 </Configuration>

--- a/log4j-mongodb/src/test/resources/MongoDbAuthFailureIT.xml
+++ b/log4j-mongodb/src/test/resources/MongoDbAuthFailureIT.xml
@@ -15,19 +15,20 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="WARN">
+<Configuration xmlns="https://logging.apache.org/xml/ns"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="
+                   https://logging.apache.org/xml/ns
+                   https://logging.apache.org/xml/ns/log4j-config-3.xsd">
   <Appenders>
-    <NoSql name="MongoDbAppender">
-      <MongoDb connection="mongodb://localhost:${test:MongoDBTestPort:-27017}/testDb.testCollection" />
-      <KeyValuePair key="A" value="1" />
-      <KeyValuePair key="B" value="2" />
-      <KeyValuePair key="env1" value="${env:PATH}" />
-      <KeyValuePair key="env2" value="$${env:PATH}" />
+    <NoSql name="MONGO">
+      <MongoDb
+        connection="mongodb://log4jUser:12345678@localhost:${sys:log4j.mongo.port:-27017}/testDb.MongoDbAuthFailureIT" />
     </NoSql>
   </Appenders>
   <Loggers>
     <Root level="ALL">
-      <AppenderRef ref="MongoDbAppender" />
+      <AppenderRef ref="MONGO" />
     </Root>
   </Loggers>
 </Configuration>

--- a/log4j-mongodb/src/test/resources/MongoDbCappedIntIT.xml
+++ b/log4j-mongodb/src/test/resources/MongoDbCappedIntIT.xml
@@ -15,16 +15,22 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="WARN">
+<Configuration xmlns="https://logging.apache.org/xml/ns"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="
+                   https://logging.apache.org/xml/ns
+                   https://logging.apache.org/xml/ns/log4j-config-3.xsd">
   <Appenders>
-    <NoSql name="MongoDbAppender">
+    <NoSql name="MONGO">
       <MongoDb
-        connection="mongodb://log4jUser:12345678@localhost:${test:MongoDBTestPort:-27017}/testDb.testCollection" />
+        connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}/testDb.MongoDbCappedIntIT"
+        capped="true"
+        collectionSize="1073741824"/>
     </NoSql>
   </Appenders>
   <Loggers>
     <Root level="ALL">
-      <AppenderRef ref="MongoDbAppender" />
+      <AppenderRef ref="MONGO" />
     </Root>
   </Loggers>
 </Configuration>

--- a/log4j-mongodb/src/test/resources/MongoDbCappedLongIT.xml
+++ b/log4j-mongodb/src/test/resources/MongoDbCappedLongIT.xml
@@ -15,16 +15,23 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="WARN">
+<Configuration xmlns="https://logging.apache.org/xml/ns"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="
+                   https://logging.apache.org/xml/ns
+                   https://logging.apache.org/xml/ns/log4j-config-3.xsd">
   <Appenders>
-    <NoSql name="MongoDbAppender">
-      <MongoDb connection="mongodb://localhost:${test:MongoDBTestPort:-27017}/testDb.testCollection" />
-      <MessageLayout />
+    <NoSql name="MONGO">
+      <!-- collectionSize="2147483657" is max int + 10 -->
+      <MongoDb
+        connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}/testDb.MongoDbCappedLongIT"
+        capped="true"
+        collectionSize="2147483657"/>
     </NoSql>
   </Appenders>
   <Loggers>
     <Root level="ALL">
-      <AppenderRef ref="MongoDbAppender" />
+      <AppenderRef ref="MONGO" />
     </Root>
   </Loggers>
 </Configuration>

--- a/log4j-mongodb/src/test/resources/MongoDbIT.xml
+++ b/log4j-mongodb/src/test/resources/MongoDbIT.xml
@@ -15,19 +15,19 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="WARN">
+<Configuration xmlns="https://logging.apache.org/xml/ns"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="
+                   https://logging.apache.org/xml/ns
+                   https://logging.apache.org/xml/ns/log4j-config-3.xsd">
   <Appenders>
-    <NoSql name="MongoDbAppender">
-      <!-- collectionSize="2147483657" is max int + 10 -->
-      <MongoDb
-        connection="mongodb://localhost:${test:MongoDBTestPort:-27017}/testDb.testCollection"
-        capped="true"
-        collectionSize="2147483657"/>
+    <NoSql name="MONGO">
+      <MongoDb connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}/testDb.MongoDbIT" />
     </NoSql>
   </Appenders>
   <Loggers>
     <Root level="ALL">
-      <AppenderRef ref="MongoDbAppender" />
+      <AppenderRef ref="MONGO" />
     </Root>
   </Loggers>
 </Configuration>

--- a/log4j-mongodb/src/test/resources/MongoDbMapMessageIT.xml
+++ b/log4j-mongodb/src/test/resources/MongoDbMapMessageIT.xml
@@ -15,18 +15,20 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="WARN">
+<Configuration xmlns="https://logging.apache.org/xml/ns"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="
+                   https://logging.apache.org/xml/ns
+                   https://logging.apache.org/xml/ns/log4j-config-3.xsd">
   <Appenders>
-    <NoSql name="MongoDbAppender">
-      <MongoDb
-        connection="mongodb://localhost:${test:MongoDBTestPort:-27017}/testDb.testCollection"
-        capped="true"
-        collectionSize="1073741824"/>
+    <NoSql name="MONGO">
+      <MongoDb connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}/testDb.MongoDbMapMessageIT" />
+      <MessageLayout />
     </NoSql>
   </Appenders>
   <Loggers>
     <Root level="ALL">
-      <AppenderRef ref="MongoDbAppender" />
+      <AppenderRef ref="MONGO" />
     </Root>
   </Loggers>
 </Configuration>

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -108,8 +108,6 @@
     <elasticsearch.version>7.17.24</elasticsearch.version>
     <embedded-ldap.version>0.9.0</embedded-ldap.version>
     <felix.version>7.0.5</felix.version>
-    <flapdoodle-embed.version>4.13.1</flapdoodle-embed.version>
-    <flapdoodle-reverse.version>1.8.0</flapdoodle-reverse.version>
     <graalvm.version>24.0.2</graalvm.version>
     <groovy.version>4.0.23</groovy.version>
     <guava.version>33.3.0-jre</guava.version>
@@ -137,7 +135,6 @@
     <logback.version>1.4.14</logback.version>
     <maven.version>3.9.9</maven.version>
     <mockito.version>5.13.0</mockito.version>
-    <mongodb.version>5.1.3</mongodb.version>
     <nashorn.version>15.4</nashorn.version>
     <opentest4j.version>1.3.0</opentest4j.version>
     <org.eclipse.osgi.version>3.21.0</org.eclipse.osgi.version>
@@ -264,12 +261,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.mongodb</groupId>
-        <artifactId>bson</artifactId>
-        <version>${mongodb.version}</version>
-      </dependency>
-
-      <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
         <version>${byte-buddy.version}</version>
@@ -322,24 +313,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-pool2</artifactId>
         <version>${commons-pool2.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>de.flapdoodle.embed</groupId>
-        <artifactId>de.flapdoodle.embed.mongo</artifactId>
-        <version>${flapdoodle-embed.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>de.flapdoodle.embed</groupId>
-        <artifactId>de.flapdoodle.embed.process</artifactId>
-        <version>${flapdoodle-embed.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>de.flapdoodle.reverse</groupId>
-        <artifactId>de.flapdoodle.reverse</artifactId>
-        <version>${flapdoodle-reverse.version}</version>
       </dependency>
 
       <dependency>
@@ -551,18 +524,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.mongodb</groupId>
-        <artifactId>mongodb-driver-core</artifactId>
-        <version>${mongodb.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.mongodb</groupId>
-        <artifactId>mongodb-driver-sync</artifactId>
-        <version>${mongodb.version}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.openjdk.nashorn</groupId>
         <artifactId>nashorn-core</artifactId>
         <version>${nashorn.version}</version>
@@ -757,6 +718,12 @@
   <build>
     <pluginManagement>
       <plugins>
+
+        <plugin>
+          <groupId>io.fabric8</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>${docker-maven-plugin.version}</version>
+        </plugin>
 
         <plugin>
           <groupId>org.ops4j.pax.exam</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,8 @@
     <log4j.docgen.pluginDescriptorsDir.phase1>${maven.multiModuleProjectDirectory}/target/plugin-descriptors/phase1</log4j.docgen.pluginDescriptorsDir.phase1>
     <log4j.docgen.pluginDescriptorsDir.phase2>${maven.multiModuleProjectDirectory}/target/plugin-descriptors/phase2</log4j.docgen.pluginDescriptorsDir.phase2>
 
+    <!-- Downgrade temporarily Maven Surefire, since it breaks tests statistics on `ge.apache.org` -->
+    <version.maven-surefire>3.2.5</version.maven-surefire>
   </properties>
 
   <dependencyManagement>

--- a/src/changelog/.3.x.x/2229_mongodb_docker.xml
+++ b/src/changelog/.3.x.x/2229_mongodb_docker.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="2229" link="https://github.com/apache/logging-log4j2/issues/2229"/>
+  <description format="asciidoc">Switch MongoDB tests to use Docker.</description>
+</entry>


### PR DESCRIPTION
MongoDB is a binary server. The current `log4j-mongodb` tests download a **generic** binary MongoDB distribution and try to run it. The distribution is not self-contained and requires several libraries (e.g., OpenSSL) to be available on the target host.

Those libraries are not always available in the required version: e.g., currently MongoDB needs OpenSSL 1, but OpenSSL 3 is bundled in the most recent Debian.

This PR switches from the binary distribution to the usage of the **latest** Docker image available.

The advantages of this approach are:

- We always test against the newest server version available.
- The success of the tests does not depend on the libraries installed on the host.
- Tests can run in parallel. In the current approach, parallel tests failed since each one tried to download MongoDB separately.

The main disadvantage is that Docker will be required to test `log4j-mongodb`. This is the case for the CI, but individual developers might need to install it too.

Fixes #2229.