### PR TITLE
Update `newMap.numEntries` after copying the old map in `UnmodifiableArrayBackedMap#copyAndPutAll`

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/internal/map/UnmodifiableArrayBackedMapTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/internal/map/UnmodifiableArrayBackedMapTest.java
@@ -55,18 +55,19 @@ public class UnmodifiableArrayBackedMapTest {
     @Test
     public void testCopyAndPut() {
         UnmodifiableArrayBackedMap testMap = UnmodifiableArrayBackedMap.EMPTY_MAP;
-        testMap = testMap.copyAndPut("1", "value1");
-        assertTrue(testMap.containsKey("1"));
-        assertEquals(testMap.get("1"), "value1");
+        testMap = testMap.copyAndPut("6", "value6");
+        assertTrue(testMap.containsKey("6"));
+        assertEquals(testMap.get("6"), "value6");
 
-        testMap = testMap.copyAndPut("1", "another value");
-        assertTrue(testMap.containsKey("1"));
-        assertEquals(testMap.get("1"), "another value");
+        testMap = testMap.copyAndPut("6", "another value");
+        assertTrue(testMap.containsKey("6"));
+        assertEquals(testMap.get("6"), "another value");
 
         HashMap<String, String> newValues = getTestParameters();
         testMap = testMap.copyAndPutAll(newValues);
         assertEquals(testMap.get("1"), "value1");
         assertEquals(testMap.get("4"), "value4");
+        assertEquals(testMap.get("6"), "another value");
     }
 
     @Test

--- a/log4j-api/src/main/java/org/apache/logging/log4j/internal/map/UnmodifiableArrayBackedMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/internal/map/UnmodifiableArrayBackedMap.java
@@ -282,6 +282,7 @@ public class UnmodifiableArrayBackedMap extends AbstractMap<String, String> impl
         // copy the contents of the current map (if any)
         if (numEntries > 0) {
             System.arraycopy(backingArray, 0, newMap.backingArray, 0, numEntries * 2 + 1);
+            newMap.numEntries = numEntries;
         }
 
         for (Map.Entry<String, String> entry : entriesToAdd.entrySet()) {

--- a/src/changelog/.2.x.x/2942_fix_ThreadContext_putAll.xml
+++ b/src/changelog/.2.x.x/2942_fix_ThreadContext_putAll.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="2942" link="https://github.com/apache/logging-log4j2/pull/2942"/>
+  <description format="asciidoc">Fix `putAll()` in the default thread context map implementation</description>
+</entry>


### PR DESCRIPTION
This pr fixes a bug in the `UnmodifiableArrayBackedMap#copyAndPutAll` method by adding an update to `newMap's` `numEntries` after copying the contents of the old map.

To reproduce this issue, this pr refactors the test case `UnmodifiableArrayBackedMapTest#testCopyAndPut`:

run 

```
mvn clean install -pl log4j-api-test -am -DskipTests
mvn test -pl log4j-api-test -Dtest=org.apache.logging.log4j.internal.map.UnmodifiableArrayBackedMapTest
```

**before:**
 
```
[INFO] Running org.apache.logging.log4j.internal.map.UnmodifiableArrayBackedMapTest
[ERROR] Tests run: 20, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.032 s <<< FAILURE! -- in org.apache.logging.log4j.internal.map.UnmodifiableArrayBackedMapTest
[ERROR] org.apache.logging.log4j.internal.map.UnmodifiableArrayBackedMapTest.testCopyAndPut -- Time elapsed: 0.012 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <null> but was: <another value>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
	at org.apache.logging.log4j.internal.map.UnmodifiableArrayBackedMapTest.testCopyAndPut(UnmodifiableArrayBackedMapTest.java:70)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   UnmodifiableArrayBackedMapTest.testCopyAndPut:70 expected: <null> but was: <another value>
[INFO] 
[ERROR] Tests run: 20, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
```

**after:**

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.logging.log4j.internal.map.UnmodifiableArrayBackedMapTest
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 s -- in org.apache.logging.log4j.internal.map.UnmodifiableArrayBackedMapTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0
```


## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
