### PR TITLE
Synchronize `JeroMqAppender` test methods

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/mom/jeromq/JeroMqAppender.java
@@ -224,22 +224,30 @@ public final class JeroMqAppender extends AbstractAppender {
         return stopped;
     }
 
-    // not public, handy for testing
-    int getSendRcFalse() {
+    /**
+     * Used in tests
+     */
+    synchronized int getSendRcFalse() {
         return sendRcFalse;
     }
 
-    // not public, handy for testing
-    int getSendRcTrue() {
+    /**
+     * Used in tests
+     */
+    synchronized int getSendRcTrue() {
         return sendRcTrue;
     }
 
-    // not public, handy for testing
-    void resetSendRcs() {
+    /**
+     * Used in tests
+     */
+    synchronized void resetSendRcs() {
         sendRcTrue = sendRcFalse = 0;
     }
 
-    // not public, handy for testing
+    /**
+     * Used in tests
+     */
     JeroMqManager getManager() {
         return manager;
     }


### PR DESCRIPTION
The `sendRcFalse` and `sendRcTrue` fields of `JeroMqAppender` are accessed without the necessary synchronization, which causes some test failures.

Closes #3002 
