### PR TITLE
refactor: Migrate log4j-to-slf4j to JUnit5

### DIFF
--- a/log4j-to-slf4j/pom.xml
+++ b/log4j-to-slf4j/pom.xml
@@ -103,11 +103,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>

--- a/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/CallerInformationTest.java
+++ b/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/CallerInformationTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.testUtil.StringListAppender;
@@ -37,9 +37,9 @@ public class CallerInformationTest {
         logger.warn("Verifying the caller class is still correct.");
         logger.error("Hopefully nobody breaks me!");
         final List<String> messages = app.strList;
-        assertEquals("Incorrect number of messages.", 3, messages.size());
+        assertEquals(3, messages.size(), "Incorrect number of messages.");
         for (final String message : messages) {
-            assertEquals("Incorrect caller class name.", this.getClass().getName(), message);
+            assertEquals(this.getClass().getName(), message, "Incorrect caller class name.");
         }
     }
 
@@ -53,9 +53,9 @@ public class CallerInformationTest {
         logger.warn("brains~~~");
         logger.info("Itchy. Tasty.");
         final List<String> messages = app.strList;
-        assertEquals("Incorrect number of messages.", 5, messages.size());
+        assertEquals(5, messages.size(), "Incorrect number of messages.");
         for (final String message : messages) {
-            assertEquals("Incorrect caller method name.", "testMethodLogger", message);
+            assertEquals("testMethodLogger", message, "Incorrect caller method name.");
         }
     }
 }

--- a/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/LoggerTest.java
+++ b/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/LoggerTest.java
@@ -16,18 +16,18 @@
  */
 package org.apache.logging.slf4j;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.theInstance;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -213,7 +213,7 @@ public class LoggerTest {
         final List<String> msgs = list.strList;
         assertThat(msgs, hasSize(1));
         final String expected = "java.lang.Throwable: Testing";
-        assertTrue("Incorrect message data", msgs.get(0).contains(expected));
+        assertTrue(msgs.get(0).contains(expected), "Incorrect message data");
     }
 
     @SuppressWarnings("unchecked")
@@ -224,24 +224,24 @@ public class LoggerTest {
         ThreadContext.clearMap();
         logger.debug("Debug message");
         assertThat(list.strList, hasSize(2));
-        assertTrue("Incorrect year", list.strList.get(0).startsWith("2010"));
+        assertTrue(list.strList.get(0).startsWith("2010"), "Incorrect year");
     }
 
     @Test
     public void mdcNullBackedIsEmpty() {
-        assertNull("Setup wrong", MDC.getCopyOfContextMap());
+        assertNull(MDC.getCopyOfContextMap(), "Setup wrong");
         assertTrue(ThreadContext.isEmpty());
     }
 
     @Test
     public void mdcNullBackedContainsKey() {
-        assertNull("Setup wrong", MDC.getCopyOfContextMap());
+        assertNull(MDC.getCopyOfContextMap(), "Setup wrong");
         assertFalse(ThreadContext.containsKey("something"));
     }
 
     @Test
     public void mdcNullBackedContainsNullKey() {
-        assertNull("Setup wrong", MDC.getCopyOfContextMap());
+        assertNull(MDC.getCopyOfContextMap(), "Setup wrong");
         assertFalse(ThreadContext.containsKey(null));
     }
 
@@ -249,7 +249,7 @@ public class LoggerTest {
     public void mdcContainsNullKey() {
         try {
             ThreadContext.put("some", "thing");
-            assertNotNull("Setup wrong", MDC.getCopyOfContextMap());
+            assertNotNull(MDC.getCopyOfContextMap(), "Setup wrong");
             assertFalse(ThreadContext.containsKey(null));
         } finally {
             ThreadContext.clearMap();


### PR DESCRIPTION
## Introduction

We are from Neighbourhoodie, the implementation partner of the [STF](https://www.sovereigntechfund.de/programs/bug-resilience) Bug Resilience Program. This work is part of our agreed Milestone 1. Upgrade from JUnit 4 to JUnit 5. This PR migrates the tests located in log4j-to-slf4j to JUnit5.

## Checklist

* [x] Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* [x] `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [x] [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
