### PR TITLE
Migrate `log4j-jakarta-smtp` to JUnit 5

### DIFF
--- a/log4j-jakarta-smtp/pom.xml
+++ b/log4j-jakarta-smtp/pom.xml
@@ -86,12 +86,6 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Test Dependencies -->
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
 </project>

--- a/log4j-jakarta-smtp/src/test/java/org/apache/logging/log4j/smtp/SmtpAppenderAsyncTest.java
+++ b/log4j-jakarta-smtp/src/test/java/org/apache/logging/log4j/smtp/SmtpAppenderAsyncTest.java
@@ -22,16 +22,16 @@ import static org.junit.Assert.fail;
 import java.util.Iterator;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.AvailablePortFinder;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.smtp.SimpleSmtpServer;
 import org.apache.logging.log4j.core.test.smtp.SmtpMessage;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SmtpAppenderAsyncTest {
 
@@ -39,34 +39,33 @@ public class SmtpAppenderAsyncTest {
 
     private SimpleSmtpServer smtpServer;
 
-    @BeforeClass
-    public static void setupClass() {
+    @BeforeAll
+    public static void setupAll() {
         PORT = AvailablePortFinder.getNextAvailable();
         System.setProperty("smtp.port", String.valueOf(PORT));
     }
 
-    @Before
+    @BeforeEach
     public void setup() {
         smtpServer = SimpleSmtpServer.start(PORT);
     }
 
-    @Rule
-    public LoggerContextRule ctx = new LoggerContextRule("SmtpAppenderAsyncTest.xml");
-
     @Test
-    public void testSync() {
-        testSmtpAppender(ctx.getLogger("sync"));
+    @LoggerContextSource("SmtpAppenderAsyncTest.xml")
+    public void testSync(final LoggerContext ctx) {
+        testSmtpAppender(ctx.getLogger("sync"), ctx);
     }
 
     @Test
-    public void testAsync() {
-        testSmtpAppender(ctx.getLogger("async"));
+    @LoggerContextSource("SmtpAppenderAsyncTest.xml")
+    public void testAsync(final LoggerContext ctx) {
+        testSmtpAppender(ctx.getLogger("async"), ctx);
     }
 
-    private void testSmtpAppender(final Logger logger) {
+    private void testSmtpAppender(final Logger logger, final LoggerContext ctx) {
         ThreadContext.put("MDC1", "mdc1");
         logger.error("the message");
-        ctx.getLoggerContext().stop();
+        ctx.stop();
         smtpServer.stop();
 
         assertEquals(1, smtpServer.getReceivedEmailSize());
@@ -83,15 +82,15 @@ public class SmtpAppenderAsyncTest {
         }
     }
 
-    @After
+    @AfterEach
     public void teardown() {
         if (smtpServer != null) {
             smtpServer.stop();
         }
     }
 
-    @AfterClass
-    public static void teardownClass() {
+    @AfterAll
+    public static void teardownAll() {
         System.clearProperty("smtp.port");
     }
 }

--- a/log4j-jakarta-smtp/src/test/java/org/apache/logging/log4j/smtp/SmtpAppenderTest.java
+++ b/log4j-jakarta-smtp/src/test/java/org/apache/logging/log4j/smtp/SmtpAppenderTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.logging.log4j.smtp;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.mail.Address;
 import jakarta.mail.Message;
@@ -34,13 +34,12 @@ import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.SmtpAppender;
 import org.apache.logging.log4j.core.test.AvailablePortFinder;
-import org.apache.logging.log4j.core.test.categories.Appenders;
 import org.apache.logging.log4j.core.test.smtp.SimpleSmtpServer;
 import org.apache.logging.log4j.core.test.smtp.SmtpMessage;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Smtp.class)
+@Tag("Appenders.Smtp")
 public class SmtpAppenderTest {
 
     private static final String HOST = "localhost";

--- a/log4j-jakarta-smtp/src/test/java/org/apache/logging/log4j/smtp/SmtpManagerTest.java
+++ b/log4j-jakarta-smtp/src/test/java/org/apache/logging/log4j/smtp/SmtpManagerTest.java
@@ -31,7 +31,7 @@ import org.apache.logging.log4j.core.util.ClockFactory;
 import org.apache.logging.log4j.core.util.DummyNanoClock;
 import org.apache.logging.log4j.message.ReusableMessage;
 import org.apache.logging.log4j.message.ReusableSimpleMessage;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SmtpManagerTest {
 


### PR DESCRIPTION
Hello 👋 

We are from Neighbourhoodie, the implementation partner of the [STF](https://www.sovereigntechfund.de/programs/bug-resilience) Bug Resilience Program. This work is part of our agreed `Milestone 1. Upgrade from JUnit 4 to JUnit 5`. This PR migrates the tests located in `log4j-jakarta-smtp` to JUnit5.

Thank you!

## Checklist

- [x] Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
- [x]  `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
