### PR TITLE
Add `reachability-metadata.json` to all Log4j modules

### DIFF
--- a/log4j-api/src/main/resources/META-INF/native-image/org.apache.logging.log4j/log4j-api/resource-config.json
+++ b/log4j-api/src/main/resources/META-INF/native-image/org.apache.logging.log4j/log4j-api/resource-config.json
@@ -1,0 +1,9 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "log4j2\\.(component|simplelog|StatusLogger)\\.properties"
+      }
+    ]
+  }
+}

--- a/log4j-core-test/pom.xml
+++ b/log4j-core-test/pom.xml
@@ -63,6 +63,7 @@
 
     <!-- Additional version of LMAX Disruptor to test -->
     <disruptor4.version>4.0.0</disruptor4.version>
+    <json-unit.version>2.40.1</json-unit.version>
   </properties>
 
   <dependencies>
@@ -292,12 +293,14 @@
     <dependency>
       <groupId>net.javacrumbs.json-unit</groupId>
       <artifactId>json-unit-assertj</artifactId>
+      <version>${json-unit.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>net.javacrumbs.json-unit</groupId>
       <artifactId>json-unit</artifactId>
+      <version>${json-unit.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/log4j-core-test/pom.xml
+++ b/log4j-core-test/pom.xml
@@ -66,57 +66,69 @@
   </properties>
 
   <dependencies>
-    <!-- Pull in useful test classes from API -->
+
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api-test</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
     </dependency>
+
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
     </dependency>
+
     <!-- GC-free -->
     <dependency>
       <groupId>com.google.code.java-allocation-instrumenter</groupId>
       <artifactId>java-allocation-instrumenter</artifactId>
     </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-commons</artifactId>
     </dependency>
+
     <!-- Needed for JNDI mocks using `org.springframework.mock.jndi` -->
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
     </dependency>
+
     <!-- JNDI and JMS tests -->
     <dependency>
       <groupId>org.apache.activemq</groupId>
@@ -129,65 +141,77 @@
         </exclusion>
       </exclusions>
     </dependency>
+
     <dependency>
       <groupId>org.apache-extras.beanshell</groupId>
       <artifactId>bsh</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Other -->
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Used for compressing to formats other than zip and gz -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Alternative implementation of BlockingQueue using Conversant Disruptor for AsyncAppender -->
     <dependency>
       <groupId>com.conversantmedia</groupId>
       <artifactId>disruptor</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Required for AsyncLoggers -->
     <dependency>
       <groupId>com.lmax</groupId>
       <artifactId>disruptor</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.zapodot</groupId>
       <artifactId>embedded-ldap-junit</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-dateutil</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-jsr223</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Embedded JDBC drivers for database appender tests -->
     <dependency>
       <groupId>org.hsqldb</groupId>
@@ -195,145 +219,177 @@
       <classifier>jdk8</classifier>
       <scope>test</scope>
     </dependency>
+
     <!-- Required for JSON support -->
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Required for XML layout and receiver support -->
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-xml</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Required for YAML support (including JSON requirements) -->
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Required for console color support in Windows -->
     <dependency>
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Used for JMS appenders (needs an implementation of course) -->
     <dependency>
       <groupId>javax.jms</groupId>
       <artifactId>javax.jms-api</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>com.sun.mail</groupId>
       <artifactId>javax.mail</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>javax.mail</groupId>
       <artifactId>javax.mail-api</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Alternative implementation of BlockingQueue using JCTools for AsyncAppender -->
     <dependency>
       <groupId>org.jctools</groupId>
       <artifactId>jctools-core</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Used for ZeroMQ JeroMQ appender -->
     <dependency>
       <groupId>org.zeromq</groupId>
       <artifactId>jeromq</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Zeroconf advertiser tests -->
     <dependency>
       <groupId>org.jmdns</groupId>
       <artifactId>jmdns</artifactId>
       <scope>test</scope>
     </dependency>
-    <!--  GELF -->
+
+    <!--  GELF and other tests that use JSON -->
+    <dependency>
+      <groupId>net.javacrumbs.json-unit</groupId>
+      <artifactId>json-unit-assertj</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>net.javacrumbs.json-unit</groupId>
       <artifactId>json-unit</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.junit-pioneer</groupId>
       <artifactId>junit-pioneer</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- JUnit, naturally -->
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Used for Kafka appender -->
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Mocking framework for use with JUnit -->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- Used for testing HttpAppender -->
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-core</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-matchers</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!--  Apache Commons Compress -->
     <dependency>
       <groupId>org.tukaani</groupId>
       <artifactId>xz</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>com.github.luben</groupId>
       <artifactId>zstd-jni</artifactId>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/FakeAnnotations.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/FakeAnnotations.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.config.plugins.processor;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Member;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.PluginVisitorStrategy;
+import org.apache.logging.log4j.core.config.plugins.validation.Constraint;
+import org.apache.logging.log4j.core.config.plugins.validation.ConstraintValidator;
+import org.apache.logging.log4j.core.config.plugins.visitors.PluginVisitor;
+import org.apache.logging.log4j.core.lookup.StrSubstitutor;
+
+/**
+ * Fake constraint and plugin visitor that are accessed through reflection.
+ */
+public class FakeAnnotations {
+
+    @Constraint(FakeConstraintValidator.class)
+    public @interface FakeConstraint {}
+
+    public static class FakeConstraintValidator implements ConstraintValidator<FakeConstraint> {
+        @Override
+        public void initialize(FakeConstraint annotation) {}
+
+        @Override
+        public boolean isValid(String name, Object value) {
+            return false;
+        }
+    }
+
+    @PluginVisitorStrategy(FakePluginVisitor.class)
+    public @interface FakeAnnotation {}
+
+    public static class FakePluginVisitor implements PluginVisitor<FakeAnnotation> {
+
+        @Override
+        public PluginVisitor<FakeAnnotation> setAnnotation(Annotation annotation) {
+            return null;
+        }
+
+        @Override
+        public PluginVisitor<FakeAnnotation> setAliases(String... aliases) {
+            return null;
+        }
+
+        @Override
+        public PluginVisitor<FakeAnnotation> setStrSubstitutor(StrSubstitutor substitutor) {
+            return null;
+        }
+
+        @Override
+        public PluginVisitor<FakeAnnotation> setMember(Member member) {
+            return null;
+        }
+
+        @Override
+        public Object visit(Configuration configuration, Node node, LogEvent event, StringBuilder log) {
+            return null;
+        }
+
+        @Override
+        public PluginVisitor<FakeAnnotation> setConversionType(Class<?> conversionType) {
+            return null;
+        }
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/FakePlugin.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/FakePlugin.java
@@ -16,8 +16,21 @@
  */
 package org.apache.logging.log4j.core.config.plugins.processor;
 
+import java.io.Serializable;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Node;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAliases;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.config.plugins.PluginLoggerContext;
+import org.apache.logging.log4j.core.config.plugins.PluginNode;
+import org.apache.logging.log4j.core.config.plugins.PluginValue;
 
 /**
  * Test plugin class for unit tests.
@@ -28,4 +41,45 @@ public class FakePlugin {
 
     @Plugin(name = "Nested", category = "Test")
     public static class Nested {}
+
+    @PluginFactory
+    public static FakePlugin newPlugin(
+            @PluginAttribute("attribute") int attribute,
+            @PluginElement("layout") Layout<? extends Serializable> layout,
+            @PluginConfiguration Configuration config,
+            @PluginNode Node node,
+            @PluginLoggerContext LoggerContext loggerContext,
+            @PluginValue("value") String value) {
+        return null;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder implements org.apache.logging.log4j.core.util.Builder<FakePlugin> {
+
+        @PluginBuilderAttribute
+        private int attribute;
+
+        @PluginElement("layout")
+        private Layout<? extends Serializable> layout;
+
+        @PluginConfiguration
+        private Configuration config;
+
+        @PluginNode
+        private Node node;
+
+        @PluginLoggerContext
+        private LoggerContext loggerContext;
+
+        @PluginValue("value")
+        private String value;
+
+        @Override
+        public FakePlugin build() {
+            return null;
+        }
+    }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessorTest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.config.plugins.processor;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.apache.commons.io.IOUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class GraalVmProcessorTest {
+
+    private static final String FAKE_PLUGIN = String.join(
+            "",
+            "  {",
+            "    \"name\": \"org.apache.logging.log4j.core.config.plugins.processor.FakePlugin\",",
+            "    \"methods\": [",
+            "      {",
+            "        \"name\": \"<init>\",",
+            "        \"parameterTypes\": []",
+            "      },",
+            "      {",
+            "        \"name\": \"newPlugin\",",
+            "        \"parameterTypes\": [",
+            "          \"int\",",
+            "          \"org.apache.logging.log4j.core.Layout\",",
+            "          \"org.apache.logging.log4j.core.config.Configuration\",",
+            "          \"org.apache.logging.log4j.core.config.Node\",",
+            "          \"org.apache.logging.log4j.core.LoggerContext\",",
+            "          \"java.lang.String\"",
+            "        ]",
+            "      }",
+            "    ],",
+            "    \"fields\": []",
+            "  }");
+    private static final String FAKE_PLUGIN_BUILDER = String.join(
+            "\n",
+            "{",
+            "    \"name\": \"org.apache.logging.log4j.core.config.plugins.processor.FakePlugin$Builder\",",
+            "    \"methods\": [],",
+            "    \"fields\": [",
+            "      {",
+            "        \"name\": \"attribute\"",
+            "      },",
+            "      {",
+            "        \"name\": \"config\"",
+            "      },",
+            "      {",
+            "        \"name\": \"layout\"",
+            "      },",
+            "      {",
+            "        \"name\": \"loggerContext\"",
+            "      },",
+            "      {",
+            "        \"name\": \"node\"",
+            "      },",
+            "      {",
+            "        \"name\": \"value\"",
+            "      }",
+            "    ]",
+            "  }");
+    private static final String FAKE_PLUGIN_NESTED = String.join(
+            "\n",
+            "  {",
+            "    \"name\": \"org.apache.logging.log4j.core.config.plugins.processor.FakePlugin$Nested\",",
+            "    \"methods\": [",
+            "      {",
+            "        \"name\": \"<init>\",",
+            "        \"parameterTypes\": []",
+            "      }",
+            "    ],",
+            "    \"fields\": []",
+            "  }");
+    private static final String FAKE_CONSTRAINT_VALIDATOR = String.join(
+            "\n",
+            "  {",
+            "    \"name\": \"org.apache.logging.log4j.core.config.plugins.processor.FakeAnnotations$FakeConstraintValidator\",",
+            "    \"methods\": [",
+            "      {",
+            "        \"name\": \"<init>\",",
+            "        \"parameterTypes\": []",
+            "      }",
+            "    ],",
+            "    \"fields\": []",
+            "  }");
+    private static final String FAKE_PLUGIN_VISITOR = String.join(
+            "\n",
+            "  {",
+            "    \"name\": \"org.apache.logging.log4j.core.config.plugins.processor.FakeAnnotations$FakePluginVisitor\",",
+            "    \"methods\": [",
+            "      {",
+            "        \"name\": \"<init>\",",
+            "        \"parameterTypes\": []",
+            "      }",
+            "    ],",
+            "    \"fields\": []",
+            "  }");
+
+    private static String reachabilityMetadata;
+
+    @BeforeAll
+    static void setup() throws IOException {
+        // There are two descriptors, choose the one in `test-classes`
+        URL reachabilityMetadataUrl = null;
+        for (URL url : Collections.list(GraalVmProcessor.class
+                .getClassLoader()
+                .getResources("META-INF/native-image/org.apache.logging.log4j/log4j-core-test/reflect-config.json"))) {
+            if (url.getPath().contains("test-classes")) {
+                reachabilityMetadataUrl = url;
+                break;
+            }
+        }
+        Assertions.assertThat(reachabilityMetadataUrl).isNotNull();
+        reachabilityMetadata =
+                IOUtils.toString(Objects.requireNonNull(reachabilityMetadataUrl), StandardCharsets.UTF_8);
+    }
+
+    static Stream<Arguments> containsSpecificEntries() {
+        return Stream.of(
+                Arguments.of(FakePlugin.class, FAKE_PLUGIN),
+                Arguments.of(FakePlugin.Builder.class, FAKE_PLUGIN_BUILDER),
+                Arguments.of(FakePlugin.Nested.class, FAKE_PLUGIN_NESTED),
+                Arguments.of(FakeAnnotations.FakeConstraintValidator.class, FAKE_CONSTRAINT_VALIDATOR),
+                Arguments.of(FakeAnnotations.FakePluginVisitor.class, FAKE_PLUGIN_VISITOR));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void containsSpecificEntries(Class<?> clazz, String expectedJson) {
+        assertThatJson(reachabilityMetadata)
+                .inPath(filterByName(clazz))
+                .isArray()
+                .contains(json(expectedJson));
+    }
+
+    private String filterByName(Class<?> clazz) {
+        return String.format("$[?(@.name == '%s')]", clazz.getName());
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessorTest.java
@@ -21,6 +21,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.URL;
@@ -28,10 +29,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Stream;
 import org.apache.commons.io.IOUtils;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -117,9 +116,8 @@ class GraalVmProcessorTest {
                 break;
             }
         }
-        Assertions.assertThat(reachabilityMetadataUrl).isNotNull();
-        reachabilityMetadata =
-                IOUtils.toString(Objects.requireNonNull(reachabilityMetadataUrl), StandardCharsets.UTF_8);
+        assertThat(reachabilityMetadataUrl).isNotNull();
+        reachabilityMetadata = IOUtils.toString(reachabilityMetadataUrl, StandardCharsets.UTF_8);
     }
 
     static Stream<Arguments> containsSpecificEntries() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessor.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.config.plugins.processor;
+
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceProvider;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.SimpleElementVisitor8;
+import javax.lang.model.util.SimpleTypeVisitor8;
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+import org.apache.logging.log4j.core.config.plugins.processor.internal.Annotations;
+import org.apache.logging.log4j.core.config.plugins.processor.internal.ReachabilityMetadata;
+import org.apache.logging.log4j.util.Strings;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Java annotation processor that generates GraalVM metadata.
+ * <p>
+ *     <strong>Note:</strong> The annotations listed here must also be classified by the {@link Annotations} helper.
+ * </p>
+ */
+@ServiceProvider(value = Processor.class, resolution = Resolution.OPTIONAL)
+@SupportedAnnotationTypes({
+    "org.apache.logging.log4j.core.config.plugins.validation.Constraint",
+    "org.apache.logging.log4j.core.config.plugins.Plugin",
+    "org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute",
+    "org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory",
+    "org.apache.logging.log4j.core.config.plugins.PluginConfiguration",
+    "org.apache.logging.log4j.core.config.plugins.PluginElement",
+    "org.apache.logging.log4j.core.config.plugins.PluginFactory",
+    "org.apache.logging.log4j.core.config.plugins.PluginLoggerContext",
+    "org.apache.logging.log4j.core.config.plugins.PluginNode",
+    "org.apache.logging.log4j.core.config.plugins.PluginValue",
+    "org.apache.logging.log4j.core.config.plugins.PluginVisitorStrategy"
+})
+@SupportedOptions({"log4j.graalvm.groupId", "log4j.graalvm.artifactId"})
+public class GraalVmProcessor extends AbstractProcessor {
+
+    private final Map<String, ReachabilityMetadata.Type> reachableTypes = new HashMap<>();
+    private final List<Element> processedElements = new ArrayList<>();
+    private Annotations annotationUtil;
+
+    @Override
+    public synchronized void init(ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        this.annotationUtil = new Annotations(processingEnv.getElementUtils());
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        Messager messager = processingEnv.getMessager();
+        for (TypeElement annotation : annotations) {
+            Annotations.Type annotationType = annotationUtil.classifyAnnotation(annotation);
+            for (Element element : roundEnv.getElementsAnnotatedWith(annotation)) {
+                switch (annotationType) {
+                    case PLUGIN:
+                        processPlugin(element);
+                        break;
+                    case CONSTRAINT_OR_VISITOR:
+                        processConstraintOrVisitor(element, annotation);
+                        break;
+                    case PARAMETER:
+                        processParameter(element);
+                        break;
+                    case FACTORY:
+                        processFactory(element);
+                        break;
+                    case UNKNOWN:
+                        messager.printMessage(
+                                Diagnostic.Kind.WARNING,
+                                "The annotation type `" + annotation + "` is not handled by "
+                                        + GraalVmProcessor.class.getSimpleName(),
+                                annotation);
+                }
+                processedElements.add(element);
+            }
+        }
+        // Write the result file
+        if (roundEnv.processingOver() && !reachableTypes.isEmpty()) {
+            //
+            // Many users will have `log4j-core` on the annotation processor path, but do not have Log4j Plugins.
+            // Therefore, we check for the annotation processor required options only if some elements were processed.
+            //
+            String groupId = processingEnv.getOptions().get("log4j.graalvm.groupId");
+            String artifactId = processingEnv.getOptions().get("log4j.graalvm.artifactId");
+            if (groupId == null || artifactId == null) {
+                messager.printMessage(
+                        Diagnostic.Kind.ERROR,
+                        "The `" + GraalVmProcessor.class.getName()
+                                + "` annotation processor is missing the required `maven.groupId` and `maven.artifactId` options.\n"
+                                + "The generation of GraalVM reflection metadata for your Log4j Plugins will be disabled.");
+                return false;
+            }
+            String reachabilityMetadataPath =
+                    String.format("META-INF/native-image/%s/%s/reflect-config.json", groupId, artifactId);
+            try {
+                messager.printMessage(
+                        Diagnostic.Kind.NOTE,
+                        String.format(
+                                "%s: writing GraalVM metadata for %d Java classes to `%s`.",
+                                GraalVmProcessor.class.getSimpleName(),
+                                reachableTypes.size(),
+                                reachabilityMetadataPath));
+                writeReachabilityMetadata(reachabilityMetadataPath, processedElements.toArray(new Element[0]));
+            } catch (IOException e) {
+                StringWriter sw = new StringWriter();
+                sw.append(GraalVmProcessor.class.getSimpleName())
+                        .append(": unable to write reachability metadata to file ")
+                        .append(reachabilityMetadataPath)
+                        .append("\n");
+                e.printStackTrace(new PrintWriter(sw));
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, sw.toString());
+            }
+        }
+        // Do not claim the annotations to allow other annotation processors to run
+        return false;
+    }
+
+    private void processPlugin(Element element) {
+        TypeElement typeElement = safeCast(element, TypeElement.class);
+        if (typeElement != null) {
+            for (Element child : typeElement.getEnclosedElements()) {
+                if (child instanceof ExecutableElement) {
+                    ExecutableElement executableChild = (ExecutableElement) child;
+                    if (executableChild.getModifiers().contains(Modifier.PUBLIC)) {
+                        switch (executableChild.getSimpleName().toString()) {
+                                // 1. All public constructors.
+                            case "<init>":
+                                addMethod(typeElement, executableChild);
+                                break;
+                                // 2. Static `newInstance` method used in, e.g. `PatternConverter` classes.
+                            case "newInstance":
+                                if (executableChild.getModifiers().contains(Modifier.STATIC)) {
+                                    addMethod(typeElement, executableChild);
+                                }
+                                break;
+                                // 3. Other factory methods are annotated, so we don't deal with them here.
+                            default:
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void processConstraintOrVisitor(Element element, TypeElement annotation) {
+        // Add the metadata for the public constructors
+        processPlugin(annotationUtil.getAnnotationClassValue(element, annotation));
+    }
+
+    private void processParameter(Element element) {
+        switch (element.getKind()) {
+            case FIELD:
+                {
+                    VariableElement field = safeCast(element, VariableElement.class);
+                    TypeElement typeElement = safeCast(element.getEnclosingElement(), TypeElement.class);
+                    if (typeElement != null && field != null) {
+                        addField(typeElement, field);
+                    }
+                }
+                break;
+            case PARAMETER:
+                // Do nothing, the containing method must be annotated with a factory annotation.
+                break;
+            default:
+                processingEnv
+                        .getMessager()
+                        .printMessage(Diagnostic.Kind.ERROR, "Invalid Log4j Attribute element.", element);
+        }
+    }
+
+    private void processFactory(Element element) {
+        ExecutableElement method = safeCast(element, ExecutableElement.class);
+        TypeElement typeElement = safeCast(element.getEnclosingElement(), TypeElement.class);
+        if (typeElement != null && method != null) {
+            addMethod(typeElement, method);
+        }
+    }
+
+    private void writeReachabilityMetadata(String reachabilityMetadataPath, Element... elements) throws IOException {
+        FileObject resource = processingEnv
+                .getFiler()
+                .createResource(StandardLocation.CLASS_OUTPUT, Strings.EMPTY, reachabilityMetadataPath, elements);
+        try (OutputStream os = resource.openOutputStream();
+                Writer writer = new OutputStreamWriter(os, StandardCharsets.UTF_8)) {
+            ReachabilityMetadata.Reflection reflection = new ReachabilityMetadata.Reflection();
+            reachableTypes.values().forEach(reflection::addType);
+            ReachabilityMetadata.writeReflectConfig(reflection, writer);
+        }
+    }
+
+    private void addField(TypeElement parent, VariableElement element) {
+        ReachabilityMetadata.Type reachableType =
+                reachableTypes.computeIfAbsent(toString(parent), ReachabilityMetadata.Type::new);
+        reachableType.addField(
+                new ReachabilityMetadata.Field(element.getSimpleName().toString()));
+    }
+
+    private void addMethod(TypeElement parent, ExecutableElement element) {
+        ReachabilityMetadata.Type reachableType =
+                reachableTypes.computeIfAbsent(toString(parent), ReachabilityMetadata.Type::new);
+        ReachabilityMetadata.Method method =
+                new ReachabilityMetadata.Method(element.getSimpleName().toString());
+        element.getParameters().stream().map(v -> toString(v.asType())).forEach(method::addParameterType);
+        reachableType.addMethod(method);
+    }
+
+    private <T extends Element> @Nullable T safeCast(Element element, Class<T> type) {
+        if (type.isInstance(element)) {
+            return type.cast(element);
+        }
+        processingEnv
+                .getMessager()
+                .printMessage(
+                        Diagnostic.Kind.ERROR,
+                        "Unexpected type of element `" + element + "`: expecting `" + type.getName() + "` but found `"
+                                + element.getClass().getName() + "`",
+                        element);
+        return null;
+    }
+
+    /**
+     * Returns the fully qualified name of a type.
+     *
+     * @param type A Java type.
+     */
+    private String toString(TypeMirror type) {
+        return type.accept(
+                new SimpleTypeVisitor8<String, @Nullable Void>() {
+                    @Override
+                    protected String defaultAction(final TypeMirror e, @Nullable Void unused) {
+                        return e.toString();
+                    }
+
+                    @Override
+                    public String visitArray(final ArrayType t, @Nullable Void unused) {
+                        return visit(t.getComponentType(), unused) + "[]";
+                    }
+
+                    @Override
+                    public @Nullable String visitDeclared(final DeclaredType t, final Void unused) {
+                        return processingEnv.getTypeUtils().erasure(t).toString();
+                    }
+                },
+                null);
+    }
+
+    /**
+     * Returns the fully qualified name of the element corresponding to a {@link DeclaredType}.
+     *
+     * @param element A Java language element.
+     */
+    private String toString(Element element) {
+        return element.accept(
+                new SimpleElementVisitor8<String, @Nullable Void>() {
+                    @Override
+                    public String visitPackage(PackageElement e, @Nullable Void unused) {
+                        return e.getQualifiedName().toString();
+                    }
+
+                    @Override
+                    public String visitType(TypeElement e, @Nullable Void unused) {
+                        Element parent = e.getEnclosingElement();
+                        String separator = parent.getKind() == ElementKind.PACKAGE ? "." : "$";
+                        return visit(parent, unused)
+                                + separator
+                                + e.getSimpleName().toString();
+                    }
+
+                    @Override
+                    protected String defaultAction(Element e, @Nullable Void unused) {
+                        return "";
+                    }
+                },
+                null);
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessor.java
@@ -20,11 +20,6 @@ import aQute.bnd.annotation.Resolution;
 import aQute.bnd.annotation.spi.ServiceProvider;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -51,7 +46,6 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.SimpleElementVisitor8;
 import javax.lang.model.util.SimpleTypeVisitor8;
 import javax.tools.Diagnostic;
-import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 import org.apache.logging.log4j.core.config.plugins.processor.internal.Annotations;
 import org.apache.logging.log4j.core.config.plugins.processor.internal.ReachabilityMetadata;
@@ -80,6 +74,10 @@ import org.jspecify.annotations.Nullable;
 })
 @SupportedOptions({"log4j.graalvm.groupId", "log4j.graalvm.artifactId"})
 public class GraalVmProcessor extends AbstractProcessor {
+
+    private static final String GROUP_ID = "log4j.graalvm.groupId";
+    private static final String ARTIFACT_ID = "log4j.graalvm.artifactId";
+    private static final String PROCESSOR_NAME = GraalVmProcessor.class.getName();
 
     private final Map<String, ReachabilityMetadata.Type> reachableTypes = new HashMap<>();
     private final List<Element> processedElements = new ArrayList<>();
@@ -118,8 +116,8 @@ public class GraalVmProcessor extends AbstractProcessor {
                     case UNKNOWN:
                         messager.printMessage(
                                 Diagnostic.Kind.WARNING,
-                                "The annotation type `" + annotation + "` is not handled by "
-                                        + GraalVmProcessor.class.getSimpleName(),
+                                String.format(
+                                        "The annotation type `%s` is not handled by %s", annotation, PROCESSOR_NAME),
                                 annotation);
                 }
                 processedElements.add(element);
@@ -127,40 +125,7 @@ public class GraalVmProcessor extends AbstractProcessor {
         }
         // Write the result file
         if (roundEnv.processingOver() && !reachableTypes.isEmpty()) {
-            //
-            // Many users will have `log4j-core` on the annotation processor path, but do not have Log4j Plugins.
-            // Therefore, we check for the annotation processor required options only if some elements were processed.
-            //
-            String groupId = processingEnv.getOptions().get("log4j.graalvm.groupId");
-            String artifactId = processingEnv.getOptions().get("log4j.graalvm.artifactId");
-            if (groupId == null || artifactId == null) {
-                messager.printMessage(
-                        Diagnostic.Kind.ERROR,
-                        "The `" + GraalVmProcessor.class.getName()
-                                + "` annotation processor is missing the required `maven.groupId` and `maven.artifactId` options.\n"
-                                + "The generation of GraalVM reflection metadata for your Log4j Plugins will be disabled.");
-                return false;
-            }
-            String reachabilityMetadataPath =
-                    String.format("META-INF/native-image/%s/%s/reflect-config.json", groupId, artifactId);
-            try {
-                messager.printMessage(
-                        Diagnostic.Kind.NOTE,
-                        String.format(
-                                "%s: writing GraalVM metadata for %d Java classes to `%s`.",
-                                GraalVmProcessor.class.getSimpleName(),
-                                reachableTypes.size(),
-                                reachabilityMetadataPath));
-                writeReachabilityMetadata(reachabilityMetadataPath, processedElements.toArray(new Element[0]));
-            } catch (IOException e) {
-                StringWriter sw = new StringWriter();
-                sw.append(GraalVmProcessor.class.getSimpleName())
-                        .append(": unable to write reachability metadata to file ")
-                        .append(reachabilityMetadataPath)
-                        .append("\n");
-                e.printStackTrace(new PrintWriter(sw));
-                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, sw.toString());
-            }
+            writeReachabilityMetadata();
         }
         // Do not claim the annotations to allow other annotation processors to run
         return false;
@@ -168,25 +133,23 @@ public class GraalVmProcessor extends AbstractProcessor {
 
     private void processPlugin(Element element) {
         TypeElement typeElement = safeCast(element, TypeElement.class);
-        if (typeElement != null) {
-            for (Element child : typeElement.getEnclosedElements()) {
-                if (child instanceof ExecutableElement) {
-                    ExecutableElement executableChild = (ExecutableElement) child;
-                    if (executableChild.getModifiers().contains(Modifier.PUBLIC)) {
-                        switch (executableChild.getSimpleName().toString()) {
-                                // 1. All public constructors.
-                            case "<init>":
+        for (Element child : typeElement.getEnclosedElements()) {
+            if (child instanceof ExecutableElement) {
+                ExecutableElement executableChild = (ExecutableElement) child;
+                if (executableChild.getModifiers().contains(Modifier.PUBLIC)) {
+                    switch (executableChild.getSimpleName().toString()) {
+                            // 1. All public constructors.
+                        case "<init>":
+                            addMethod(typeElement, executableChild);
+                            break;
+                            // 2. Static `newInstance` method used in, e.g. `PatternConverter` classes.
+                        case "newInstance":
+                            if (executableChild.getModifiers().contains(Modifier.STATIC)) {
                                 addMethod(typeElement, executableChild);
-                                break;
-                                // 2. Static `newInstance` method used in, e.g. `PatternConverter` classes.
-                            case "newInstance":
-                                if (executableChild.getModifiers().contains(Modifier.STATIC)) {
-                                    addMethod(typeElement, executableChild);
-                                }
-                                break;
-                                // 3. Other factory methods are annotated, so we don't deal with them here.
-                            default:
-                        }
+                            }
+                            break;
+                            // 3. Other factory methods are annotated, so we don't deal with them here.
+                        default:
                     }
                 }
             }
@@ -201,42 +164,68 @@ public class GraalVmProcessor extends AbstractProcessor {
     private void processParameter(Element element) {
         switch (element.getKind()) {
             case FIELD:
-                {
-                    VariableElement field = safeCast(element, VariableElement.class);
-                    TypeElement typeElement = safeCast(element.getEnclosingElement(), TypeElement.class);
-                    if (typeElement != null && field != null) {
-                        addField(typeElement, field);
-                    }
-                }
+                addField(
+                        safeCast(element.getEnclosingElement(), TypeElement.class),
+                        safeCast(element, VariableElement.class));
                 break;
             case PARAMETER:
                 // Do nothing, the containing method must be annotated with a factory annotation.
                 break;
             default:
-                processingEnv
-                        .getMessager()
-                        .printMessage(Diagnostic.Kind.ERROR, "Invalid Log4j Attribute element.", element);
+                String msg = String.format("Invalid Log4j parameter element `%s`.", element);
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg, element);
+                throw new IllegalStateException(msg);
         }
     }
 
     private void processFactory(Element element) {
-        ExecutableElement method = safeCast(element, ExecutableElement.class);
-        TypeElement typeElement = safeCast(element.getEnclosingElement(), TypeElement.class);
-        if (typeElement != null && method != null) {
-            addMethod(typeElement, method);
+        addMethod(
+                safeCast(element.getEnclosingElement(), TypeElement.class), safeCast(element, ExecutableElement.class));
+    }
+
+    private void writeReachabilityMetadata() {
+        //
+        // Many users will have `log4j-core` on the annotation processor path, but do not have Log4j Plugins.
+        // Therefore, we check for the annotation processor required options only if some elements were processed.
+        //
+        Messager messager = processingEnv.getMessager();
+        String reachabilityMetadataPath = getReachabilityMetadataPath();
+        try {
+            messager.printMessage(
+                    Diagnostic.Kind.NOTE,
+                    String.format(
+                            "%s: writing GraalVM metadata for %d Java classes to `%s`.",
+                            PROCESSOR_NAME, reachableTypes.size(), reachabilityMetadataPath));
+            try (OutputStream output = processingEnv
+                    .getFiler()
+                    .createResource(
+                            StandardLocation.CLASS_OUTPUT,
+                            Strings.EMPTY,
+                            reachabilityMetadataPath,
+                            processedElements.toArray(new Element[0]))
+                    .openOutputStream()) {
+                ReachabilityMetadata.writeReflectConfig(reachableTypes.values(), output);
+            }
+        } catch (IOException e) {
+            String message = String.format(
+                    "%s: unable to write reachability metadata to file `%s`", PROCESSOR_NAME, reachabilityMetadataPath);
+            messager.printMessage(Diagnostic.Kind.ERROR, message);
+            throw new IllegalArgumentException(message, e);
         }
     }
 
-    private void writeReachabilityMetadata(String reachabilityMetadataPath, Element... elements) throws IOException {
-        FileObject resource = processingEnv
-                .getFiler()
-                .createResource(StandardLocation.CLASS_OUTPUT, Strings.EMPTY, reachabilityMetadataPath, elements);
-        try (OutputStream os = resource.openOutputStream();
-                Writer writer = new OutputStreamWriter(os, StandardCharsets.UTF_8)) {
-            ReachabilityMetadata.Reflection reflection = new ReachabilityMetadata.Reflection();
-            reachableTypes.values().forEach(reflection::addType);
-            ReachabilityMetadata.writeReflectConfig(reflection, writer);
+    private String getReachabilityMetadataPath() {
+        String groupId = processingEnv.getOptions().get(GROUP_ID);
+        String artifactId = processingEnv.getOptions().get(ARTIFACT_ID);
+        if (groupId == null || artifactId == null) {
+            String message = String.format(
+                    "The `%s` annotation processor is missing the required `%s` and `%s` options.%n"
+                            + "The generation of GraalVM reflection metadata for your Log4j Plugins will be disabled.",
+                    PROCESSOR_NAME, GROUP_ID, ARTIFACT_ID);
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message);
+            throw new IllegalArgumentException(message);
         }
+        return String.format("META-INF/native-image/%s/%s/reflect-config.json", groupId, artifactId);
     }
 
     private void addField(TypeElement parent, VariableElement element) {
@@ -255,18 +244,16 @@ public class GraalVmProcessor extends AbstractProcessor {
         reachableType.addMethod(method);
     }
 
-    private <T extends Element> @Nullable T safeCast(Element element, Class<T> type) {
+    private <T extends Element> T safeCast(Element element, Class<T> type) {
         if (type.isInstance(element)) {
             return type.cast(element);
         }
-        processingEnv
-                .getMessager()
-                .printMessage(
-                        Diagnostic.Kind.ERROR,
-                        "Unexpected type of element `" + element + "`: expecting `" + type.getName() + "` but found `"
-                                + element.getClass().getName() + "`",
-                        element);
-        return null;
+        // This should never happen, unless annotations start appearing on unexpected elements.
+        String msg = String.format(
+                "Unexpected type of element `%s`: expecting `%s` but found `%s`",
+                element, type.getName(), element.getClass().getName());
+        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, msg, element);
+        throw new IllegalStateException(msg);
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessor.java
@@ -77,7 +77,7 @@ public class GraalVmProcessor extends AbstractProcessor {
 
     private static final String GROUP_ID = "log4j.graalvm.groupId";
     private static final String ARTIFACT_ID = "log4j.graalvm.artifactId";
-    private static final String PROCESSOR_NAME = GraalVmProcessor.class.getName();
+    private static final String PROCESSOR_NAME = GraalVmProcessor.class.getSimpleName();
 
     private final Map<String, ReachabilityMetadata.Type> reachableTypes = new HashMap<>();
     private final List<Element> processedElements = new ArrayList<>();
@@ -188,24 +188,22 @@ public class GraalVmProcessor extends AbstractProcessor {
         // Many users will have `log4j-core` on the annotation processor path, but do not have Log4j Plugins.
         // Therefore, we check for the annotation processor required options only if some elements were processed.
         //
-        Messager messager = processingEnv.getMessager();
         String reachabilityMetadataPath = getReachabilityMetadataPath();
-        try {
-            messager.printMessage(
-                    Diagnostic.Kind.NOTE,
-                    String.format(
-                            "%s: writing GraalVM metadata for %d Java classes to `%s`.",
-                            PROCESSOR_NAME, reachableTypes.size(), reachabilityMetadataPath));
-            try (OutputStream output = processingEnv
-                    .getFiler()
-                    .createResource(
-                            StandardLocation.CLASS_OUTPUT,
-                            Strings.EMPTY,
-                            reachabilityMetadataPath,
-                            processedElements.toArray(new Element[0]))
-                    .openOutputStream()) {
-                ReachabilityMetadata.writeReflectConfig(reachableTypes.values(), output);
-            }
+        Messager messager = processingEnv.getMessager();
+        messager.printMessage(
+                Diagnostic.Kind.NOTE,
+                String.format(
+                        "%s: writing GraalVM metadata for %d Java classes to `%s`.",
+                        PROCESSOR_NAME, reachableTypes.size(), reachabilityMetadataPath));
+        try (OutputStream output = processingEnv
+                .getFiler()
+                .createResource(
+                        StandardLocation.CLASS_OUTPUT,
+                        Strings.EMPTY,
+                        reachabilityMetadataPath,
+                        processedElements.toArray(new Element[0]))
+                .openOutputStream()) {
+            ReachabilityMetadata.writeReflectConfig(reachableTypes.values(), output);
         } catch (IOException e) {
             String message = String.format(
                     "%s: unable to write reachability metadata to file `%s`", PROCESSOR_NAME, reachabilityMetadataPath);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/internal/Annotations.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/internal/Annotations.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.config.plugins.processor.internal;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.util.Elements;
+
+public final class Annotations {
+
+    /**
+     * These are fields, methods or parameters that correspond to Log4j configuration attributes, elements, and other
+     * injected elements.
+     * <p>
+     *     <strong>Note:</strong> The annotations listed here must also be declared in
+     *     {@link org.apache.logging.log4j.core.config.plugins.processor.GraalVmProcessor}.
+     * </p>
+     */
+    private static final Collection<String> PARAMETER_ANNOTATION_NAMES = Arrays.asList(
+            "org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute",
+            "org.apache.logging.log4j.core.config.plugins.PluginConfiguration",
+            "org.apache.logging.log4j.core.config.plugins.PluginElement",
+            "org.apache.logging.log4j.core.config.plugins.PluginLoggerContext",
+            "org.apache.logging.log4j.core.config.plugins.PluginNode",
+            "org.apache.logging.log4j.core.config.plugins.PluginValue");
+    /**
+     * These are static methods that must be reachable through reflection.
+     * <p>
+     *     <strong>Note:</strong> The annotations listed here must also be declared in
+     *     {@link org.apache.logging.log4j.core.config.plugins.processor.GraalVmProcessor}.
+     * </p>
+     */
+    private static final Collection<String> FACTORY_ANNOTATION_NAMES = Arrays.asList(
+            "org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory",
+            "org.apache.logging.log4j.core.config.plugins.PluginFactory");
+    /**
+     * These must be public types with either:
+     * <ul>
+     *     <li>A factory method.</li>
+     *     <li>A static method called {@code newInstance}.</li>
+     *     <li>A public no-argument constructor.</li>
+     * </ul>
+     * <p>
+     *     <strong>Note:</strong> The annotations listed here must also be declared in
+     *     {@link org.apache.logging.log4j.core.config.plugins.processor.GraalVmProcessor}.
+     * </p>
+     */
+    private static final Collection<String> PLUGIN_ANNOTATION_NAMES =
+            Collections.singletonList("org.apache.logging.log4j.core.config.plugins.Plugin");
+
+    /**
+     * Reflection is also used to create constraint validators and plugin visitors.
+     * <p>
+     *     <strong>Note:</strong> The annotations listed here must also be declared in
+     *     {@link org.apache.logging.log4j.core.config.plugins.processor.GraalVmProcessor}.
+     * </p>
+     */
+    private static final Collection<String> CONSTRAINT_OR_VISITOR_ANNOTATION_NAMES = Arrays.asList(
+            "org.apache.logging.log4j.core.config.plugins.validation.Constraint",
+            "org.apache.logging.log4j.core.config.plugins.PluginVisitorStrategy");
+
+    public enum Type {
+        /**
+         * Annotation used to mark a configuration attribute, element or other injected parameters.
+         */
+        PARAMETER,
+        /**
+         * Annotation used to mark a Log4j Plugin factory method.
+         */
+        FACTORY,
+        /**
+         * Annotation used to mark a Log4j Plugin class.
+         */
+        PLUGIN,
+        /**
+         * Annotation containing the name of a
+         * {@link org.apache.logging.log4j.core.config.plugins.validation.ConstraintValidator}
+         * or
+         * {@link org.apache.logging.log4j.core.config.plugins.visitors.PluginVisitor}.
+         */
+        CONSTRAINT_OR_VISITOR,
+        /**
+         * Unknown
+         */
+        UNKNOWN
+    }
+
+    private final Map<TypeElement, Type> typeElementToTypeMap = new HashMap<>();
+
+    public Annotations(final Elements elements) {
+        PARAMETER_ANNOTATION_NAMES.forEach(className -> addTypeElementIfExists(elements, className, Type.PARAMETER));
+        FACTORY_ANNOTATION_NAMES.forEach(className -> addTypeElementIfExists(elements, className, Type.FACTORY));
+        PLUGIN_ANNOTATION_NAMES.forEach(className -> addTypeElementIfExists(elements, className, Type.PLUGIN));
+        CONSTRAINT_OR_VISITOR_ANNOTATION_NAMES.forEach(
+                className -> addTypeElementIfExists(elements, className, Type.CONSTRAINT_OR_VISITOR));
+    }
+
+    private void addTypeElementIfExists(Elements elements, CharSequence className, Type type) {
+        final TypeElement element = elements.getTypeElement(className);
+        if (element != null) {
+            typeElementToTypeMap.put(element, type);
+        }
+    }
+
+    public Annotations.Type classifyAnnotation(TypeElement element) {
+        return typeElementToTypeMap.getOrDefault(element, Type.UNKNOWN);
+    }
+
+    public Element getAnnotationClassValue(Element element, TypeElement annotation) {
+        // This prevents getting an "Attempt to access Class object for TypeMirror" exception
+        AnnotationMirror annotationMirror = element.getAnnotationMirrors().stream()
+                .filter(am -> am.getAnnotationType().asElement().equals(annotation))
+                .findFirst()
+                .orElseThrow(
+                        () -> new IllegalStateException("No `@" + annotation + "` annotation found on " + element));
+        AnnotationValue annotationValue = annotationMirror.getElementValues().entrySet().stream()
+                .filter(e -> "value".equals(e.getKey().getSimpleName().toString()))
+                .map(Map.Entry::getValue)
+                .findFirst()
+                .orElseThrow(() ->
+                        new IllegalStateException("No `value` found `@" + annotation + "` annotation on " + element));
+        DeclaredType value = (DeclaredType) annotationValue.getValue();
+        return value.asElement();
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/internal/ReachabilityMetadata.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/internal/ReachabilityMetadata.java
@@ -17,6 +17,9 @@
 package org.apache.logging.log4j.core.config.plugins.processor.internal;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
@@ -281,8 +284,8 @@ public final class ReachabilityMetadata {
 
         private final Collection<Type> types = new TreeSet<>(Comparator.comparing(Type::getType));
 
-        public void addType(Type type) {
-            types.add(type);
+        public Reflection(Collection<Type> types) {
+            this.types.addAll(types);
         }
 
         void toJson(MinimalJsonWriter jsonWriter) throws IOException {
@@ -302,11 +305,12 @@ public final class ReachabilityMetadata {
     /**
      * Writes the contents of a {@code reflect-config.json} file.
      *
-     * @param reflection The reflection metadata.
+     * @param types The reflection metadata for types.
      * @param output The object to use as output.
      */
-    public static void writeReflectConfig(Reflection reflection, Appendable output) throws IOException {
-        MinimalJsonWriter jsonWriter = new MinimalJsonWriter(output);
+    public static void writeReflectConfig(Collection<Type> types, OutputStream output) throws IOException {
+        Reflection reflection = new Reflection(types);
+        MinimalJsonWriter jsonWriter = new MinimalJsonWriter(new OutputStreamWriter(output, StandardCharsets.UTF_8));
         reflection.toJson(jsonWriter);
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/internal/ReachabilityMetadata.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/internal/ReachabilityMetadata.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.config.plugins.processor.internal;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.IntStream;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Provides support for the
+ * <a href="https://www.graalvm.org/latest/reference-manual/native-image/metadata/#specifying-metadata-with-json">{@code reachability-metadata.json}</a>
+ * file format.
+ */
+@NullMarked
+public final class ReachabilityMetadata {
+
+    /**
+     * Key used to specify the name of a field or method
+     */
+    public static final String FIELD_OR_METHOD_NAME = "name";
+    /**
+     * Key used to list the method parameter types.
+     */
+    public static final String PARAMETER_TYPES = "parameterTypes";
+    /**
+     * Key used to specify the name of a type.
+     * <p>
+     *     Since GraalVM for JDK 23 it will be called "type".
+     * </p>
+     */
+    public static final String TYPE_NAME = "name";
+    /**
+     * Key used to specify the list of fields available for reflection.
+     */
+    public static final String FIELDS = "fields";
+    /**
+     * Key used to specify the list of methods available for reflection.
+     */
+    public static final String METHODS = "methods";
+
+    private static class MinimalJsonWriter {
+
+        private static final int ESCAPED_CHARS_LENGHT = 128;
+
+        /**
+         * BitSet of 7-bit ASCII characters that would require quoting in JSON.
+         */
+        private static final BitSet ESCAPED_CHARS;
+
+        static {
+            BitSet requiresLookup = new BitSet(ESCAPED_CHARS_LENGHT);
+            // Control chars need generic escape sequence
+            for (int i = 0; i < 32; ++i) {
+                requiresLookup.set(i);
+            }
+            // Others (and some within that range too) have explicit shorter sequences
+            requiresLookup.set('"');
+            requiresLookup.set('\\');
+            requiresLookup.set(0x08);
+            requiresLookup.set(0x09);
+            requiresLookup.set(0x0C);
+            requiresLookup.set(0x0A);
+            requiresLookup.set(0x0D);
+            ESCAPED_CHARS = requiresLookup;
+        }
+
+        private final Appendable output;
+
+        public MinimalJsonWriter(Appendable output) {
+            this.output = output;
+        }
+
+        /**
+         * Writes a JSON String ignoring characters that need quoting.
+         */
+        public void writeString(CharSequence input) throws IOException {
+            output.append('"');
+            int limit = input.length();
+            for (int i = 0; i < limit; ++i) {
+                char c = input.charAt(i);
+                if (c >= ESCAPED_CHARS_LENGHT || !ESCAPED_CHARS.get(c)) {
+                    output.append(c);
+                }
+            }
+            output.append('"');
+        }
+
+        public void writeObjectStart() throws IOException {
+            output.append('{');
+        }
+
+        public void writeObjectEnd() throws IOException {
+            output.append('}');
+        }
+
+        public void writeObjectKey(CharSequence key) throws IOException {
+            writeString(key);
+            output.append(':');
+        }
+
+        public void writeArrayStart() throws IOException {
+            output.append('[');
+        }
+
+        public void writeSeparator() throws IOException {
+            output.append(',');
+        }
+
+        public void writeArrayEnd() throws IOException {
+            output.append(']');
+        }
+    }
+
+    /**
+     * Specifies a field that needs to be accessed through reflection.
+     */
+    public static class Field implements Comparable<Field> {
+
+        private final String name;
+
+        public Field(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        void toJson(MinimalJsonWriter jsonWriter) throws IOException {
+            jsonWriter.writeObjectStart();
+            jsonWriter.writeObjectKey(FIELD_OR_METHOD_NAME);
+            jsonWriter.writeString(name);
+            jsonWriter.writeObjectEnd();
+        }
+
+        @Override
+        public int compareTo(Field other) {
+            return name.compareTo(other.name);
+        }
+    }
+
+    /**
+     * Specifies a method that needs to be accessed through reflection.
+     */
+    public static class Method implements Comparable<Method> {
+
+        private final String name;
+        private final List<String> parameterTypes = new ArrayList<>();
+
+        public Method(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void addParameterType(final String parameterType) {
+            parameterTypes.add(parameterType);
+        }
+
+        void toJson(MinimalJsonWriter jsonWriter) throws IOException {
+            jsonWriter.writeObjectStart();
+            jsonWriter.writeObjectKey(FIELD_OR_METHOD_NAME);
+            jsonWriter.writeString(name);
+            jsonWriter.writeSeparator();
+            jsonWriter.writeObjectKey(PARAMETER_TYPES);
+            jsonWriter.writeArrayStart();
+            boolean first = true;
+            for (String parameterType : parameterTypes) {
+                if (!first) {
+                    jsonWriter.writeSeparator();
+                }
+                first = false;
+                jsonWriter.writeString(parameterType);
+            }
+            jsonWriter.writeArrayEnd();
+            jsonWriter.writeObjectEnd();
+        }
+
+        @Override
+        public int compareTo(Method other) {
+            int result = name.compareTo(other.name);
+            if (result == 0) {
+                result = parameterTypes.size() - other.parameterTypes.size();
+            }
+            if (result == 0) {
+                result = IntStream.range(0, parameterTypes.size())
+                        .map(idx -> parameterTypes.get(idx).compareTo(other.parameterTypes.get(idx)))
+                        .filter(r -> r != 0)
+                        .findFirst()
+                        .orElse(0);
+            }
+            return result;
+        }
+    }
+
+    /**
+     * Specifies a Java type that needs to be accessed through reflection.
+     */
+    public static class Type {
+
+        private final String type;
+        private final Collection<Method> methods = new TreeSet<>();
+        private final Collection<Field> fields = new TreeSet<>();
+
+        public Type(String type) {
+            this.type = type;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void addMethod(Method method) {
+            methods.add(method);
+        }
+
+        public void addField(Field field) {
+            fields.add(field);
+        }
+
+        void toJson(MinimalJsonWriter jsonWriter) throws IOException {
+            jsonWriter.writeObjectStart();
+            jsonWriter.writeObjectKey(TYPE_NAME);
+            jsonWriter.writeString(type);
+            jsonWriter.writeSeparator();
+
+            boolean first = true;
+            jsonWriter.writeObjectKey(METHODS);
+            jsonWriter.writeArrayStart();
+            for (Method method : methods) {
+                if (!first) {
+                    jsonWriter.writeSeparator();
+                }
+                first = false;
+                method.toJson(jsonWriter);
+            }
+            jsonWriter.writeArrayEnd();
+            jsonWriter.writeSeparator();
+
+            first = true;
+            jsonWriter.writeObjectKey(FIELDS);
+            jsonWriter.writeArrayStart();
+            for (Field field : fields) {
+                if (!first) {
+                    jsonWriter.writeSeparator();
+                }
+                first = false;
+                field.toJson(jsonWriter);
+            }
+            jsonWriter.writeArrayEnd();
+            jsonWriter.writeObjectEnd();
+        }
+    }
+
+    /**
+     * Collection of reflection metadata.
+     */
+    public static class Reflection {
+
+        private final Collection<Type> types = new TreeSet<>(Comparator.comparing(Type::getType));
+
+        public void addType(Type type) {
+            types.add(type);
+        }
+
+        void toJson(MinimalJsonWriter jsonWriter) throws IOException {
+            boolean first = true;
+            jsonWriter.writeArrayStart();
+            for (Type type : types) {
+                if (!first) {
+                    jsonWriter.writeSeparator();
+                }
+                first = false;
+                type.toJson(jsonWriter);
+            }
+            jsonWriter.writeArrayEnd();
+        }
+    }
+
+    /**
+     * Writes the contents of a {@code reflect-config.json} file.
+     *
+     * @param reflection The reflection metadata.
+     * @param output The object to use as output.
+     */
+    public static void writeReflectConfig(Reflection reflection, Appendable output) throws IOException {
+        MinimalJsonWriter jsonWriter = new MinimalJsonWriter(output);
+        reflection.toJson(jsonWriter);
+    }
+
+    private ReachabilityMetadata() {}
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/package-info.java
@@ -20,7 +20,7 @@
  * executable {@link org.apache.logging.log4j.core.config.plugins.util.PluginManager} class in your build process.
  */
 @Export
-@Version("2.20.1")
+@Version("2.25.0")
 package org.apache.logging.log4j.core.config.plugins.processor;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/resources/META-INF/native-image/org.apache.logging.log4j/log4j-core/resource-config.json
+++ b/log4j-core/src/main/resources/META-INF/native-image/org.apache.logging.log4j/log4j-core/resource-config.json
@@ -1,0 +1,12 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "log4j2.*"
+      },
+      {
+        "pattern": "META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat"
+      }
+    ]
+  }
+}

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -578,6 +578,12 @@
 
       <dependency>
         <groupId>net.javacrumbs.json-unit</groupId>
+        <artifactId>json-unit-assertj</artifactId>
+        <version>${json-unit.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>net.javacrumbs.json-unit</groupId>
         <artifactId>json-unit</artifactId>
         <version>${json-unit.version}</version>
       </dependency>
@@ -1189,6 +1195,8 @@
                     <processor>org.apache.logging.log4j.docgen.processor.DescriptorGenerator</processor>
                     <!-- Process sources using `org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor` to generate `Log4j2Plugins.dat` -->
                     <processor>org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor</processor>
+                    <!-- Generates GraalVM reachability metadata -->
+                    <processor>org.apache.logging.log4j.core.config.plugins.processor.GraalVmProcessor</processor>
                   </annotationProcessors>
                   <compilerArgs>
                     <!-- Provide `org.apache.logging.log4j.docgen.processor.DescriptorGenerator` arguments: -->
@@ -1198,6 +1206,9 @@
                     <arg>-Alog4j.docgen.version=${project.version}</arg>
                     <arg>-Alog4j.docgen.description=${project.description}</arg>
                     <arg>-Alog4j.docgen.typeFilter.excludePattern=${log4j.docgen.typeFilter.excludePattern}</arg>
+                    <!-- Provide arguments for the GraalVM processor -->
+                    <arg>-Alog4j.graalvm.groupId=${project.groupId}</arg>
+                    <arg>-Alog4j.graalvm.artifactId=${project.artifactId}</arg>
                   </compilerArgs>
                   <proc>only</proc>
                 </configuration>

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -108,7 +108,6 @@
     <jeromq.version>0.6.0</jeromq.version>
     <jmdns.version>3.5.12</jmdns.version>
     <jmh.version>1.37</jmh.version>
-    <json-unit.version>2.40.1</json-unit.version>
     <junit.version>4.13.2</junit.version>
     <junit-jupiter.version>5.10.3</junit-jupiter.version>
     <junit-pioneer.version>1.9.1</junit-pioneer.version>
@@ -574,18 +573,6 @@
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
         <version>${jna.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>net.javacrumbs.json-unit</groupId>
-        <artifactId>json-unit-assertj</artifactId>
-        <version>${json-unit.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>net.javacrumbs.json-unit</groupId>
-        <artifactId>json-unit</artifactId>
-        <version>${json-unit.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This PR adds a plugin processor that generates a GraalVM reachability metadata file and bundles it with each Log4j module.

After this change, GraalVM will be able to handle Log4j Core without any user intervention.

**Note**: I also added a static `resource-config.json` file that specifies that all resources starting with `log4j2` and the plugin descriptor must be included in the GraalVM image.

Part of #2831.