### PR TITLE
refactor log4j-jpa to use junit5

### DIFF
--- a/log4j-jpa/pom.xml
+++ b/log4j-jpa/pom.xml
@@ -87,11 +87,6 @@
     </dependency>
     <!-- Test Dependencies -->
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>org.eclipse.persistence.jpa</artifactId>
       <scope>test</scope>

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/AbstractJpaAppenderTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/AbstractJpaAppenderTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
@@ -34,12 +34,11 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
-import org.apache.logging.log4j.core.test.categories.Appenders;
 import org.apache.logging.log4j.status.StatusLogger;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Jpa.class)
+@Tag("Appenders.Jpa")
 public abstract class AbstractJpaAppenderTest {
     private final String databaseType;
     private Connection connection;
@@ -68,8 +67,8 @@ public abstract class AbstractJpaAppenderTest {
         try {
             final String appenderName = "databaseAppender";
             final Appender appender = context.getConfiguration().getAppender(appenderName);
-            assertNotNull("The appender '" + appenderName + "' should not be null.", appender);
-            assertTrue("The appender should be a JpaAppender.", appender instanceof JpaAppender);
+            assertNotNull(appender, "The appender '" + appenderName + "' should not be null.");
+            assertTrue(appender instanceof JpaAppender, "The appender should be a JpaAppender.");
             ((JpaAppender) appender).getManager().close();
         } finally {
             System.clearProperty(ConfigurationFactory.CONFIGURATION_FILE_PROPERTY);
@@ -108,44 +107,44 @@ public abstract class AbstractJpaAppenderTest {
             final Statement statement = this.connection.createStatement();
             final ResultSet resultSet = statement.executeQuery("SELECT * FROM jpaBaseLogEntry ORDER BY id");
 
-            assertTrue("There should be at least one row.", resultSet.next());
+            assertTrue(resultSet.next(), "There should be at least one row.");
 
             long date = resultSet.getTimestamp("eventDate").getTime();
-            assertTrue("The date should be later than pre-logging (1).", date >= millis);
-            assertTrue("The date should be earlier than now (1).", date <= System.currentTimeMillis());
-            assertEquals("The level column is not correct (1).", "INFO", resultSet.getString("level"));
-            assertEquals("The logger column is not correct (1).", logger1.getName(), resultSet.getString("logger"));
+            assertTrue(date >= millis, "The date should be later than pre-logging (1).");
+            assertTrue(date <= System.currentTimeMillis(), "The date should be earlier than now (1).");
+            assertEquals("INFO", resultSet.getString("level"), "The level column is not correct (1).");
+            assertEquals(logger1.getName(), resultSet.getString("logger"), "The logger column is not correct (1).");
             assertEquals(
-                    "The message column is not correct (1).", "Test my message 01.", resultSet.getString("message"));
-            assertNull("The exception column is not correct (1).", resultSet.getString("exception"));
+                    "Test my message 01.", resultSet.getString("message"), "The message column is not correct (1).");
+            assertNull(resultSet.getString("exception"), "The exception column is not correct (1).");
 
-            assertTrue("There should be at least two rows.", resultSet.next());
+            assertTrue(resultSet.next(), "There should be at least two rows.");
 
             date = resultSet.getTimestamp("eventDate").getTime();
-            assertTrue("The date should be later than pre-logging (2).", date >= millis);
-            assertTrue("The date should be earlier than now (2).", date <= System.currentTimeMillis());
-            assertEquals("The level column is not correct (2).", "ERROR", resultSet.getString("level"));
-            assertEquals("The logger column is not correct (2).", logger1.getName(), resultSet.getString("logger"));
+            assertTrue(date >= millis, "The date should be later than pre-logging (2).");
+            assertTrue(date <= System.currentTimeMillis(), "The date should be earlier than now (2).");
+            assertEquals("ERROR", resultSet.getString("level"), "The level column is not correct (2).");
+            assertEquals(logger1.getName(), resultSet.getString("logger"), "The logger column is not correct (2).");
             assertEquals(
-                    "The message column is not correct (2).",
                     "This is another message 02.",
-                    resultSet.getString("message"));
-            assertEquals("The exception column is not correct (2).", stackTrace, resultSet.getString("exception"));
+                    resultSet.getString("message"),
+                    "The message column is not correct (2).");
+            assertEquals(stackTrace, resultSet.getString("exception"), "The exception column is not correct (2).");
 
-            assertTrue("There should be three rows.", resultSet.next());
+            assertTrue(resultSet.next(), "There should be three rows.");
 
             date = resultSet.getTimestamp("eventDate").getTime();
-            assertTrue("The date should be later than pre-logging (3).", date >= millis);
-            assertTrue("The date should be earlier than now (3).", date <= System.currentTimeMillis());
-            assertEquals("The level column is not correct (3).", "WARN", resultSet.getString("level"));
-            assertEquals("The logger column is not correct (3).", logger2.getName(), resultSet.getString("logger"));
+            assertTrue(date >= millis, "The date should be later than pre-logging (3).");
+            assertTrue(date <= System.currentTimeMillis(), "The date should be earlier than now (3).");
+            assertEquals("WARN", resultSet.getString("level"), "The level column is not correct (3).");
+            assertEquals(logger2.getName(), resultSet.getString("logger"), "The logger column is not correct (3).");
             assertEquals(
-                    "The message column is not correct (3).",
                     "A final warning has been issued.",
-                    resultSet.getString("message"));
-            assertNull("The exception column is not correct (3).", resultSet.getString("exception"));
+                    resultSet.getString("message"),
+                    "The message column is not correct (3).");
+            assertNull(resultSet.getString("exception"), "The exception column is not correct (3).");
 
-            assertFalse("There should not be four rows.", resultSet.next());
+            assertFalse(resultSet.next(), "There should not be four rows.");
         } finally {
             this.tearDown();
         }
@@ -174,43 +173,43 @@ public abstract class AbstractJpaAppenderTest {
             final Statement statement = this.connection.createStatement();
             final ResultSet resultSet = statement.executeQuery("SELECT * FROM jpaBasicLogEntry ORDER BY id");
 
-            assertTrue("There should be at least one row.", resultSet.next());
+            assertTrue(resultSet.next(), "There should be at least one row.");
 
             long date = resultSet.getLong("timemillis");
-            assertTrue("The date should be later than pre-logging (1).", date >= millis);
-            assertTrue("The date should be earlier than now (1).", date <= System.currentTimeMillis());
-            assertEquals("The level column is not correct (1).", "DEBUG", resultSet.getString("level"));
-            assertEquals("The logger column is not correct (1).", logger1.getName(), resultSet.getString("loggerName"));
-            assertEquals("The message column is not correct (1).", "Test my debug 01.", resultSet.getString("message"));
-            assertNull("The exception column is not correct (1).", resultSet.getString("thrown"));
+            assertTrue(date >= millis, "The date should be later than pre-logging (1).");
+            assertTrue(date <= System.currentTimeMillis(), "The date should be earlier than now (1).");
+            assertEquals("DEBUG", resultSet.getString("level"), "The level column is not correct (1).");
+            assertEquals(logger1.getName(), resultSet.getString("loggerName"), "The logger column is not correct (1).");
+            assertEquals("Test my debug 01.", resultSet.getString("message"), "The message column is not correct (1).");
+            assertNull(resultSet.getString("thrown"), "The exception column is not correct (1).");
 
-            assertTrue("There should be at least two rows.", resultSet.next());
+            assertTrue(resultSet.next(), "There should be at least two rows.");
 
             date = resultSet.getLong("timemillis");
-            assertTrue("The date should be later than pre-logging (2).", date >= millis);
-            assertTrue("The date should be earlier than now (2).", date <= System.currentTimeMillis());
-            assertEquals("The level column is not correct (2).", "WARN", resultSet.getString("level"));
-            assertEquals("The logger column is not correct (2).", logger1.getName(), resultSet.getString("loggerName"));
+            assertTrue(date >= millis, "The date should be later than pre-logging (2).");
+            assertTrue(date <= System.currentTimeMillis(), "The date should be earlier than now (2).");
+            assertEquals("WARN", resultSet.getString("level"), "The level column is not correct (2).");
+            assertEquals(logger1.getName(), resultSet.getString("loggerName"), "The logger column is not correct (2).");
             assertEquals(
-                    "The message column is not correct (2).",
                     "This is another warning 02.",
-                    resultSet.getString("message"));
-            assertEquals("The exception column is not correct (2).", stackTrace, resultSet.getString("thrown"));
+                    resultSet.getString("message"),
+                    "The message column is not correct (2).");
+            assertEquals(stackTrace, resultSet.getString("thrown"), "The exception column is not correct (2).");
 
-            assertTrue("There should be three rows.", resultSet.next());
+            assertTrue(resultSet.next(), "There should be three rows.");
 
             date = resultSet.getLong("timemillis");
-            assertTrue("The date should be later than pre-logging (3).", date >= millis);
-            assertTrue("The date should be earlier than now (3).", date <= System.currentTimeMillis());
-            assertEquals("The level column is not correct (3).", "FATAL", resultSet.getString("level"));
-            assertEquals("The logger column is not correct (3).", logger2.getName(), resultSet.getString("loggerName"));
+            assertTrue(date >= millis, "The date should be later than pre-logging (3).");
+            assertTrue(date <= System.currentTimeMillis(), "The date should be earlier than now (3).");
+            assertEquals("FATAL", resultSet.getString("level"), "The level column is not correct (3).");
+            assertEquals(logger2.getName(), resultSet.getString("loggerName"), "The logger column is not correct (3).");
             assertEquals(
-                    "The message column is not correct (3).",
                     "A fatal warning has been issued.",
-                    resultSet.getString("message"));
-            assertNull("The exception column is not correct (3).", resultSet.getString("thrown"));
+                    resultSet.getString("message"),
+                    "The message column is not correct (3).");
+            assertNull(resultSet.getString("thrown"), "The exception column is not correct (3).");
 
-            assertFalse("There should not be four rows.", resultSet.next());
+            assertFalse(resultSet.next(), "There should not be four rows.");
         } finally {
             this.tearDown();
         }

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/JpaHsqldbAppenderTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/JpaHsqldbAppenderTest.java
@@ -16,18 +16,17 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.test.categories.Appenders;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Jpa.class)
+@Tag("Appenders.Jpa")
 public class JpaHsqldbAppenderTest extends AbstractJpaAppenderTest {
     private static final String USER_ID = "sa";
     private static final String PASSWORD = "123";
@@ -62,7 +61,7 @@ public class JpaHsqldbAppenderTest extends AbstractJpaAppenderTest {
     public void testNoEntityClassName() {
         final JpaAppender appender = JpaAppender.createAppender("name", null, null, null, null, "jpaAppenderTestUnit");
 
-        assertNull("The appender should be null.", appender);
+        assertNull(appender, "The appender should be null.");
     }
 
     @Test
@@ -70,7 +69,7 @@ public class JpaHsqldbAppenderTest extends AbstractJpaAppenderTest {
         final JpaAppender appender =
                 JpaAppender.createAppender("name", null, null, null, TestBaseEntity.class.getName(), null);
 
-        assertNull("The appender should be null.", appender);
+        assertNull(appender, "The appender should be null.");
     }
 
     @Test
@@ -78,7 +77,7 @@ public class JpaHsqldbAppenderTest extends AbstractJpaAppenderTest {
         final JpaAppender appender =
                 JpaAppender.createAppender("name", null, null, null, "com.foo.Bar", "jpaAppenderTestUnit");
 
-        assertNull("The appender should be null.", appender);
+        assertNull(appender, "The appender should be null.");
     }
 
     @Test
@@ -86,7 +85,7 @@ public class JpaHsqldbAppenderTest extends AbstractJpaAppenderTest {
         final JpaAppender appender =
                 JpaAppender.createAppender("name", null, null, null, Object.class.getName(), "jpaAppenderTestUnit");
 
-        assertNull("The appender should be null.", appender);
+        assertNull(appender, "The appender should be null.");
     }
 
     @Test
@@ -94,7 +93,7 @@ public class JpaHsqldbAppenderTest extends AbstractJpaAppenderTest {
         final JpaAppender appender = JpaAppender.createAppender(
                 "name", null, null, null, BadConstructorEntity1.class.getName(), "jpaAppenderTestUnit");
 
-        assertNull("The appender should be null.", appender);
+        assertNull(appender, "The appender should be null.");
     }
 
     @Test
@@ -102,7 +101,7 @@ public class JpaHsqldbAppenderTest extends AbstractJpaAppenderTest {
         final JpaAppender appender = JpaAppender.createAppender(
                 "name", null, null, null, BadConstructorEntity2.class.getName(), "jpaAppenderTestUnit");
 
-        assertNull("The appender should be null.", appender);
+        assertNull(appender, "The appender should be null.");
     }
 
     @SuppressWarnings("unused")

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/LogEventEntityTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/LogEventEntityTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa;
 
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
 import java.util.Map;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
@@ -25,8 +27,7 @@ import org.apache.logging.log4j.core.impl.ThrowableProxy;
 import org.apache.logging.log4j.core.time.Instant;
 import org.apache.logging.log4j.core.time.MutableInstant;
 import org.apache.logging.log4j.message.Message;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LogEventEntityTest {
 
@@ -116,12 +117,12 @@ public class LogEventEntityTest {
                 return 0;
             }
         };
-        Assert.assertNotSame(logEvent, logEvent.toImmutable());
+        assertNotSame(logEvent, logEvent.toImmutable());
     }
 
     @Test
     public void testToImmutable_TestBaseEntity() {
         final LogEvent logEvent = new TestBaseEntity();
-        Assert.assertNotSame(logEvent, logEvent.toImmutable());
+        assertNotSame(logEvent, logEvent.toImmutable());
     }
 }

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ContextDataAttributeConverterTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ContextDataAttributeConverterTest.java
@@ -16,21 +16,21 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.apache.logging.log4j.core.test.categories.Appenders;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
 import org.apache.logging.log4j.util.StringMap;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Jpa.class)
+@Tag("Appenders.Jpa")
 public class ContextDataAttributeConverterTest {
     private ContextDataAttributeConverter converter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.converter = new ContextDataAttributeConverter();
     }
@@ -42,7 +42,7 @@ public class ContextDataAttributeConverterTest {
         map.putValue("key2", "value2");
 
         assertEquals(
-                "The converted value is not correct.", map.toString(), this.converter.convertToDatabaseColumn(map));
+                map.toString(), this.converter.convertToDatabaseColumn(map), "The converted value is not correct.");
     }
 
     @Test
@@ -53,16 +53,16 @@ public class ContextDataAttributeConverterTest {
         map.putValue("myKey", "yourValue");
 
         assertEquals(
-                "The converted value is not correct.", map.toString(), this.converter.convertToDatabaseColumn(map));
+                map.toString(), this.converter.convertToDatabaseColumn(map), "The converted value is not correct.");
     }
 
     @Test
     public void testConvertNullToDatabaseColumn() {
-        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+        assertNull(this.converter.convertToDatabaseColumn(null), "The converted value should be null.");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testConvertToEntityAttribute() {
-        this.converter.convertToEntityAttribute(null);
+        assertThrows(UnsupportedOperationException.class, () -> this.converter.convertToEntityAttribute(null));
     }
 }

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ContextDataJsonAttributeConverterTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ContextDataJsonAttributeConverterTest.java
@@ -16,23 +16,22 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.apache.logging.log4j.core.test.categories.Appenders;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
 import org.apache.logging.log4j.util.StringMap;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Jpa.class)
+@Tag("Appenders.Jpa")
 public class ContextDataJsonAttributeConverterTest {
     private ContextDataJsonAttributeConverter converter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.converter = new ContextDataJsonAttributeConverter();
     }
@@ -45,12 +44,12 @@ public class ContextDataJsonAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(map);
 
-        assertNotNull("The converted value should not be null.", converted);
+        assertNotNull(converted, "The converted value should not be null.");
 
         final ReadOnlyStringMap reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The reversed value is not correct.", map, reversed);
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals(map, reversed, "The reversed value is not correct.");
     }
 
     @Test
@@ -62,22 +61,22 @@ public class ContextDataJsonAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(map);
 
-        assertNotNull("The converted value should not be null.", converted);
+        assertNotNull(converted, "The converted value should not be null.");
 
         final ReadOnlyStringMap reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The reversed value is not correct.", map, reversed);
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals(reversed, map, "The reversed value is not correct.");
     }
 
     @Test
     public void testConvertNullToDatabaseColumn() {
-        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+        assertNull(this.converter.convertToDatabaseColumn(null), "The converted value should be null.");
     }
 
     @Test
     public void testConvertNullOrBlankToEntityAttribute() {
-        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
-        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+        assertNull(this.converter.convertToEntityAttribute(null), "The converted attribute should be null (1).");
+        assertNull(this.converter.convertToEntityAttribute(""), "The converted attribute should be null (2).");
     }
 }

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ContextMapAttributeConverterTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ContextMapAttributeConverterTest.java
@@ -16,21 +16,21 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.logging.log4j.core.test.categories.Appenders;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Jpa.class)
+@Tag("Appenders.Jpa")
 public class ContextMapAttributeConverterTest {
     private ContextMapAttributeConverter converter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.converter = new ContextMapAttributeConverter();
     }
@@ -42,7 +42,7 @@ public class ContextMapAttributeConverterTest {
         map.put("key2", "value2");
 
         assertEquals(
-                "The converted value is not correct.", map.toString(), this.converter.convertToDatabaseColumn(map));
+                map.toString(), this.converter.convertToDatabaseColumn(map), "The converted value is not correct.");
     }
 
     @Test
@@ -53,16 +53,16 @@ public class ContextMapAttributeConverterTest {
         map.put("myKey", "yourValue");
 
         assertEquals(
-                "The converted value is not correct.", map.toString(), this.converter.convertToDatabaseColumn(map));
+                map.toString(), this.converter.convertToDatabaseColumn(map), "The converted value is not correct.");
     }
 
     @Test
     public void testConvertNullToDatabaseColumn() {
-        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+        assertNull(this.converter.convertToDatabaseColumn(null), "The converted value should be null.");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testConvertToEntityAttribute() {
-        this.converter.convertToEntityAttribute(null);
+        assertThrows(UnsupportedOperationException.class, () -> this.converter.convertToEntityAttribute(null));
     }
 }

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ContextMapJsonAttributeConverterTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ContextMapJsonAttributeConverterTest.java
@@ -16,22 +16,21 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.logging.log4j.core.test.categories.Appenders;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Jpa.class)
+@Tag("Appenders.Jpa")
 public class ContextMapJsonAttributeConverterTest {
     private ContextMapJsonAttributeConverter converter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.converter = new ContextMapJsonAttributeConverter();
     }
@@ -44,12 +43,12 @@ public class ContextMapJsonAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(map);
 
-        assertNotNull("The converted value should not be null.", converted);
+        assertNotNull(converted, "The converted value should not be null.");
 
         final Map<String, String> reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The reversed value is not correct.", map, reversed);
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals(map, reversed, "The reversed value is not correct.");
     }
 
     @Test
@@ -61,22 +60,22 @@ public class ContextMapJsonAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(map);
 
-        assertNotNull("The converted value should not be null.", converted);
+        assertNotNull(converted, "The converted value should not be null.");
 
         final Map<String, String> reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The reversed value is not correct.", map, reversed);
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals(map, reversed, "The reversed value is not correct.");
     }
 
     @Test
     public void testConvertNullToDatabaseColumn() {
-        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+        assertNull(this.converter.convertToDatabaseColumn(null), "The converted value should be null.");
     }
 
     @Test
     public void testConvertNullOrBlankToEntityAttribute() {
-        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
-        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+        assertNull(this.converter.convertToEntityAttribute(null), "The converted attribute should be null (1).");
+        assertNull(this.converter.convertToEntityAttribute(""), "The converted attribute should be null (2).");
     }
 }

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ContextStackAttributeConverterTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ContextStackAttributeConverterTest.java
@@ -16,22 +16,22 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import org.apache.logging.log4j.ThreadContext;
-import org.apache.logging.log4j.core.test.categories.Appenders;
 import org.apache.logging.log4j.spi.MutableThreadContextStack;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Jpa.class)
+@Tag("Appenders.Jpa")
 public class ContextStackAttributeConverterTest {
     private ContextStackAttributeConverter converter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.converter = new ContextStackAttributeConverter();
     }
@@ -41,9 +41,9 @@ public class ContextStackAttributeConverterTest {
         final ThreadContext.ContextStack stack = new MutableThreadContextStack(Arrays.asList("value1", "another2"));
 
         assertEquals(
-                "The converted value is not correct.",
                 "value1\nanother2",
-                this.converter.convertToDatabaseColumn(stack));
+                this.converter.convertToDatabaseColumn(stack),
+                "The converted value is not correct.");
     }
 
     @Test
@@ -51,18 +51,18 @@ public class ContextStackAttributeConverterTest {
         final ThreadContext.ContextStack stack = new MutableThreadContextStack(Arrays.asList("key1", "value2", "my3"));
 
         assertEquals(
-                "The converted value is not correct.",
                 "key1\nvalue2\nmy3",
-                this.converter.convertToDatabaseColumn(stack));
+                this.converter.convertToDatabaseColumn(stack),
+                "The converted value is not correct.");
     }
 
     @Test
     public void testConvertNullToDatabaseColumn() {
-        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+        assertNull(this.converter.convertToDatabaseColumn(null), "The converted value should be null.");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testConvertToEntityAttribute() {
-        this.converter.convertToEntityAttribute(null);
+        assertThrows(UnsupportedOperationException.class, () -> this.converter.convertToEntityAttribute(null));
     }
 }

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ContextStackJsonAttributeConverterTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ContextStackJsonAttributeConverterTest.java
@@ -16,28 +16,24 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
 import org.apache.logging.log4j.ThreadContext;
-import org.apache.logging.log4j.core.test.categories.Appenders;
 import org.apache.logging.log4j.spi.MutableThreadContextStack;
-import org.apache.logging.log4j.test.junit.ThreadContextStackRule;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.apache.logging.log4j.test.junit.UsingThreadContextStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Jpa.class)
+@UsingThreadContextStack
+@Tag("Appenders.Jpa")
 public class ContextStackJsonAttributeConverterTest {
     private ContextStackJsonAttributeConverter converter;
 
-    @Rule
-    public final ThreadContextStackRule threadContextRule = new ThreadContextStackRule();
-
-    @Before
+    @BeforeEach
     public void setUp() {
         this.converter = new ContextStackJsonAttributeConverter();
     }
@@ -48,12 +44,12 @@ public class ContextStackJsonAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(stack);
 
-        assertNotNull("The converted value should not be null.", converted);
+        assertNotNull(converted, "The converted value should not be null.");
 
         final ThreadContext.ContextStack reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The reversed value is not correct.", stack.asList(), reversed.asList());
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals(stack.asList(), reversed.asList(), "The reversed value is not correct.");
     }
 
     @Test
@@ -62,22 +58,22 @@ public class ContextStackJsonAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(stack);
 
-        assertNotNull("The converted value should not be null.", converted);
+        assertNotNull(converted, "The converted value should not be null.");
 
         final ThreadContext.ContextStack reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The reversed value is not correct.", stack.asList(), reversed.asList());
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals(stack.asList(), reversed.asList(), "The reversed value is not correct.");
     }
 
     @Test
     public void testConvertNullToDatabaseColumn() {
-        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+        assertNull(this.converter.convertToDatabaseColumn(null), "The converted value should be null.");
     }
 
     @Test
     public void testConvertNullOrBlankToEntityAttribute() {
-        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
-        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+        assertNull(this.converter.convertToEntityAttribute(null), "The converted attribute should be null (1).");
+        assertNull(this.converter.convertToEntityAttribute(""), "The converted attribute should be null (2).");
     }
 }

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/InstantAttributeConverterTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/InstantAttributeConverterTest.java
@@ -16,25 +16,24 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.apache.logging.log4j.core.test.categories.Appenders;
 import org.apache.logging.log4j.core.time.Instant;
 import org.apache.logging.log4j.core.time.MutableInstant;
 import org.apache.logging.log4j.status.StatusLogger;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Jpa.class)
+@Tag("Appenders.Jpa")
 public class InstantAttributeConverterTest {
     private static final StatusLogger LOGGER = StatusLogger.getLogger();
 
     private InstantAttributeConverter converter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.converter = new InstantAttributeConverter();
     }
@@ -46,24 +45,24 @@ public class InstantAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(instant);
 
-        assertNotNull("The converted value should not be null.", converted);
-        assertEquals("The converted value is not correct.", "1234567,89012", converted);
+        assertNotNull(converted, "The converted value should not be null.");
+        assertEquals("1234567,89012", converted, "The converted value is not correct.");
 
         final Instant reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("epoch sec", 1234567, reversed.getEpochSecond());
-        assertEquals("nanoOfSecond", 89012, reversed.getNanoOfSecond());
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals(1234567, reversed.getEpochSecond(), "epoch sec");
+        assertEquals(89012, reversed.getNanoOfSecond(), "nanoOfSecond");
     }
 
     @Test
     public void testConvertNullToDatabaseColumn() {
-        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+        assertNull(this.converter.convertToDatabaseColumn(null), "The converted value should be null.");
     }
 
     @Test
     public void testConvertNullOrBlankToEntityAttribute() {
-        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
-        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+        assertNull(this.converter.convertToEntityAttribute(null), "The converted attribute should be null (1).");
+        assertNull(this.converter.convertToEntityAttribute(""), "The converted attribute should be null (2).");
     }
 }

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/MarkerAttributeConverterTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/MarkerAttributeConverterTest.java
@@ -16,22 +16,21 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
-import org.apache.logging.log4j.core.test.categories.Appenders;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Jpa.class)
+@Tag("Appenders.Jpa")
 public class MarkerAttributeConverterTest {
     private MarkerAttributeConverter converter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.converter = new MarkerAttributeConverter();
     }
@@ -42,13 +41,13 @@ public class MarkerAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(marker);
 
-        assertNotNull("The converted value should not be null.", converted);
-        assertEquals("The converted value is not correct.", "testConvert01", converted);
+        assertNotNull(converted, "The converted value should not be null.");
+        assertEquals("testConvert01", converted, "The converted value is not correct.");
 
         final Marker reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The reversed value is not correct.", "testConvert01", marker.getName());
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals("testConvert01", marker.getName(), "The reversed value is not correct.");
     }
 
     @Test
@@ -59,33 +58,33 @@ public class MarkerAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(marker);
 
-        assertNotNull("The converted value should not be null.", converted);
+        assertNotNull(converted, "The converted value should not be null.");
         assertEquals(
-                "The converted value is not correct.",
                 "testConvert02[ anotherConvert02[ finalConvert03 ] ]",
-                converted);
+                converted,
+                "The converted value is not correct.");
 
         final Marker reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The reversed value is not correct.", "testConvert02", marker.getName());
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals("testConvert02", marker.getName(), "The reversed value is not correct.");
         final Marker[] parents = marker.getParents();
-        assertNotNull("The first parent should not be null.", parents);
-        assertNotNull("The first parent should not be null.", parents[0]);
-        assertEquals("The first parent is not correct.", "anotherConvert02", parents[0].getName());
-        assertNotNull("The second parent should not be null.", parents[0].getParents());
-        assertNotNull("The second parent should not be null.", parents[0].getParents()[0]);
-        assertEquals("The second parent is not correct.", "finalConvert03", parents[0].getParents()[0].getName());
+        assertNotNull(parents, "The first parent should not be null.");
+        assertNotNull(parents[0], "The first parent should not be null.");
+        assertEquals("anotherConvert02", parents[0].getName(), "The first parent is not correct.");
+        assertNotNull(parents[0].getParents(), "The second parent should not be null.");
+        assertNotNull(parents[0].getParents()[0], "The second parent should not be null.");
+        assertEquals("finalConvert03", parents[0].getParents()[0].getName(), "The second parent is not correct.");
     }
 
     @Test
     public void testConvertNullToDatabaseColumn() {
-        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+        assertNull(this.converter.convertToDatabaseColumn(null), "The converted value should be null.");
     }
 
     @Test
     public void testConvertNullOrBlankToEntityAttribute() {
-        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
-        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+        assertNull(this.converter.convertToEntityAttribute(null), "The converted attribute should be null (1).");
+        assertNull(this.converter.convertToEntityAttribute(""), "The converted attribute should be null (2).");
     }
 }

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/MessageAttributeConverterTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/MessageAttributeConverterTest.java
@@ -16,24 +16,23 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.apache.logging.log4j.core.test.categories.Appenders;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.status.StatusLogger;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Jpa.class)
+@Tag("Appenders.Jpa")
 public class MessageAttributeConverterTest {
     private static final StatusLogger LOGGER = StatusLogger.getLogger();
 
     private MessageAttributeConverter converter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.converter = new MessageAttributeConverter();
     }
@@ -44,23 +43,23 @@ public class MessageAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(message);
 
-        assertNotNull("The converted value should not be null.", converted);
-        assertEquals("The converted value is not correct.", "Message #3 said [Hello].", converted);
+        assertNotNull(converted, "The converted value should not be null.");
+        assertEquals("Message #3 said [Hello].", converted, "The converted value is not correct.");
 
         final Message reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The reversed value is not correct.", "Message #3 said [Hello].", reversed.getFormattedMessage());
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals("Message #3 said [Hello].", reversed.getFormattedMessage(), "The reversed value is not correct.");
     }
 
     @Test
     public void testConvertNullToDatabaseColumn() {
-        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+        assertNull(this.converter.convertToDatabaseColumn(null), "The converted value should be null.");
     }
 
     @Test
     public void testConvertNullOrBlankToEntityAttribute() {
-        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
-        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+        assertNull(this.converter.convertToEntityAttribute(null), "The converted attribute should be null (1).");
+        assertNull(this.converter.convertToEntityAttribute(""), "The converted attribute should be null (2).");
     }
 }

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/StackTraceElementAttributeConverterTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/StackTraceElementAttributeConverterTest.java
@@ -16,22 +16,21 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.logging.log4j.core.test.categories.Appenders;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Jpa.class)
+@Tag("Appenders.Jpa")
 public class StackTraceElementAttributeConverterTest {
     private StackTraceElementAttributeConverter converter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.converter = new StackTraceElementAttributeConverter();
     }
@@ -43,20 +42,20 @@ public class StackTraceElementAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(element);
 
-        assertNotNull("The converted value should not be null.", converted);
+        assertNotNull(converted, "The converted value should not be null.");
         assertEquals(
-                "The converted value is not correct.",
                 "TestNoPackage.testConvert01(TestNoPackage.java:1234)",
-                converted);
+                converted,
+                "The converted value is not correct.");
 
         final StackTraceElement reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The class name is not correct.", "TestNoPackage", reversed.getClassName());
-        assertEquals("The method name is not correct.", "testConvert01", reversed.getMethodName());
-        assertEquals("The file name is not correct.", "TestNoPackage.java", reversed.getFileName());
-        assertEquals("The line number is not correct.", 1234, reversed.getLineNumber());
-        assertFalse("The native flag should be false.", reversed.isNativeMethod());
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals("TestNoPackage", reversed.getClassName(), "The class name is not correct.");
+        assertEquals("testConvert01", reversed.getMethodName(), "The method name is not correct.");
+        assertEquals("TestNoPackage.java", reversed.getFileName(), "The file name is not correct.");
+        assertEquals(1234, reversed.getLineNumber(), "The line number is not correct.");
+        assertFalse(reversed.isNativeMethod(), "The native flag should be false.");
     }
 
     @Test
@@ -66,20 +65,20 @@ public class StackTraceElementAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(element);
 
-        assertNotNull("The converted value should not be null.", converted);
+        assertNotNull(converted, "The converted value should not be null.");
         assertEquals(
-                "The converted value is not correct.",
                 "org.apache.logging.TestWithPackage.testConvert02(TestWithPackage.java)",
-                converted);
+                converted,
+                "The converted value is not correct.");
 
         final StackTraceElement reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The class name is not correct.", "org.apache.logging.TestWithPackage", reversed.getClassName());
-        assertEquals("The method name is not correct.", "testConvert02", reversed.getMethodName());
-        assertEquals("The file name is not correct.", "TestWithPackage.java", reversed.getFileName());
-        assertEquals("The line number is not correct.", -1, reversed.getLineNumber());
-        assertFalse("The native flag should be false.", reversed.isNativeMethod());
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals("org.apache.logging.TestWithPackage", reversed.getClassName(), "The class name is not correct.");
+        assertEquals("testConvert02", reversed.getMethodName(), "The method name is not correct.");
+        assertEquals("TestWithPackage.java", reversed.getFileName(), "The file name is not correct.");
+        assertEquals(-1, reversed.getLineNumber(), "The line number is not correct.");
+        assertFalse(reversed.isNativeMethod(), "The native flag should be false.");
     }
 
     @Test
@@ -89,20 +88,20 @@ public class StackTraceElementAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(element);
 
-        assertNotNull("The converted value should not be null.", converted);
+        assertNotNull(converted, "The converted value should not be null.");
         assertEquals(
-                "The converted value is not correct.",
                 "org.apache.logging.TestNoSource.testConvert03(Unknown Source)",
-                converted);
+                converted,
+                "The converted value is not correct.");
 
         final StackTraceElement reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The class name is not correct.", "org.apache.logging.TestNoSource", reversed.getClassName());
-        assertEquals("The method name is not correct.", "testConvert03", reversed.getMethodName());
-        assertEquals("The file name is not correct.", null, reversed.getFileName());
-        assertEquals("The line number is not correct.", -1, reversed.getLineNumber());
-        assertFalse("The native flag should be false.", reversed.isNativeMethod());
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals("org.apache.logging.TestNoSource", reversed.getClassName(), "The class name is not correct.");
+        assertEquals("testConvert03", reversed.getMethodName(), "The method name is not correct.");
+        assertEquals(null, reversed.getFileName(), "The file name is not correct.");
+        assertEquals(-1, reversed.getLineNumber(), "The line number is not correct.");
+        assertFalse(reversed.isNativeMethod(), "The native flag should be false.");
     }
 
     @Test
@@ -112,31 +111,31 @@ public class StackTraceElementAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(element);
 
-        assertNotNull("The converted value should not be null.", converted);
+        assertNotNull(converted, "The converted value should not be null.");
         assertEquals(
-                "The converted value is not correct.",
                 "org.apache.logging.TestIsNativeMethod.testConvert04(Native Method)",
-                converted);
+                converted,
+                "The converted value is not correct.");
 
         final StackTraceElement reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
+        assertNotNull(reversed, "The reversed value should not be null.");
         assertEquals(
-                "The class name is not correct.", "org.apache.logging.TestIsNativeMethod", reversed.getClassName());
-        assertEquals("The method name is not correct.", "testConvert04", reversed.getMethodName());
-        assertEquals("The file name is not correct.", null, reversed.getFileName());
-        assertEquals("The line number is not correct.", -2, reversed.getLineNumber());
-        assertTrue("The native flag should be true.", reversed.isNativeMethod());
+                "org.apache.logging.TestIsNativeMethod", reversed.getClassName(), "The class name is not correct.");
+        assertEquals("testConvert04", reversed.getMethodName(), "The method name is not correct.");
+        assertEquals(null, reversed.getFileName(), "The file name is not correct.");
+        assertEquals(-2, reversed.getLineNumber(), "The line number is not correct.");
+        assertTrue(reversed.isNativeMethod(), "The native flag should be true.");
     }
 
     @Test
     public void testConvertNullToDatabaseColumn() {
-        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+        assertNull(this.converter.convertToDatabaseColumn(null), "The converted value should be null.");
     }
 
     @Test
     public void testConvertNullOrBlankToEntityAttribute() {
-        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
-        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+        assertNull(this.converter.convertToEntityAttribute(null), "The converted attribute should be null (1).");
+        assertNull(this.converter.convertToEntityAttribute(""), "The converted attribute should be null (2).");
     }
 }

--- a/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ThrowableAttributeConverterTest.java
+++ b/log4j-jpa/src/test/java/org/apache/logging/log4j/core/appender/db/jpa/converter/ThrowableAttributeConverterTest.java
@@ -16,21 +16,20 @@
  */
 package org.apache.logging.log4j.core.appender.db.jpa.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.sql.SQLException;
-import org.apache.logging.log4j.core.test.categories.Appenders;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(Appenders.Jpa.class)
+@Tag("Appenders.Jpa")
 public class ThrowableAttributeConverterTest {
     private ThrowableAttributeConverter converter;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.converter = new ThrowableAttributeConverter();
     }
@@ -43,13 +42,13 @@ public class ThrowableAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(exception);
 
-        assertNotNull("The converted value is not correct.", converted);
-        assertEquals("The converted value is not correct.", stackTrace, converted);
+        assertNotNull(converted, "The converted value is not correct.");
+        assertEquals(stackTrace, converted, "The converted value is not correct.");
 
         final Throwable reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The reversed value is not correct.", stackTrace, getStackTrace(reversed));
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals(stackTrace, getStackTrace(reversed), "The reversed value is not correct.");
     }
 
     @Test
@@ -62,24 +61,24 @@ public class ThrowableAttributeConverterTest {
 
         final String converted = this.converter.convertToDatabaseColumn(exception);
 
-        assertNotNull("The converted value is not correct.", converted);
-        assertEquals("The converted value is not correct.", stackTrace, converted);
+        assertNotNull(converted, "The converted value is not correct.");
+        assertEquals(stackTrace, converted, "The converted value is not correct.");
 
         final Throwable reversed = this.converter.convertToEntityAttribute(converted);
 
-        assertNotNull("The reversed value should not be null.", reversed);
-        assertEquals("The reversed value is not correct.", stackTrace, getStackTrace(reversed));
+        assertNotNull(reversed, "The reversed value should not be null.");
+        assertEquals(stackTrace, getStackTrace(reversed), "The reversed value is not correct.");
     }
 
     @Test
     public void testConvertNullToDatabaseColumn() {
-        assertNull("The converted value should be null.", this.converter.convertToDatabaseColumn(null));
+        assertNull(this.converter.convertToDatabaseColumn(null), "The converted value should be null.");
     }
 
     @Test
     public void testConvertNullOrBlankToEntityAttribute() {
-        assertNull("The converted attribute should be null (1).", this.converter.convertToEntityAttribute(null));
-        assertNull("The converted attribute should be null (2).", this.converter.convertToEntityAttribute(""));
+        assertNull(this.converter.convertToEntityAttribute(null), "The converted attribute should be null (1).");
+        assertNull(this.converter.convertToEntityAttribute(""), "The converted attribute should be null (2).");
     }
 
     private static String getStackTrace(final Throwable throwable) {


### PR DESCRIPTION
Hello :wave: 

This PR migrates the tests located in log4j-jpa to JUnit5.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
