### PR TITLE
refactor(1.2-api): migrate to junit5

### DIFF
--- a/log4j-1.2-api/pom.xml
+++ b/log4j-1.2-api/pom.xml
@@ -112,6 +112,7 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- JUnit -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
@@ -123,10 +124,9 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/CallerInformationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/CallerInformationTest.java
@@ -16,39 +16,36 @@
  */
 package org.apache.log4j;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.Test;
 
+// config from log4j-core test-jar
+@LoggerContextSource(value = "log4j2-calling-class.xml")
 public class CallerInformationTest {
 
-    // config from log4j-core test-jar
-    private static final String CONFIG = "log4j2-calling-class.xml";
-
-    @ClassRule
-    public static final LoggerContextRule ctx = new LoggerContextRule(CONFIG);
-
     @Test
-    public void testClassLogger() {
-        final ListAppender app = ctx.getListAppender("Class").clear();
+    public void testClassLogger(@Named("Class") final ListAppender app) {
+        app.clear();
         final Logger logger = Logger.getLogger("ClassLogger");
         logger.info("Ignored message contents.");
         logger.warn("Verifying the caller class is still correct.");
         logger.error("Hopefully nobody breaks me!");
         final List<String> messages = app.getMessages();
-        assertEquals("Incorrect number of messages.", 3, messages.size());
+
+        assertEquals(3, messages.size(), "Incorrect number of messages.");
         for (final String message : messages) {
-            assertEquals("Incorrect caller class name.", this.getClass().getName(), message);
+            assertEquals(this.getClass().getName(), message, "Incorrect caller class name.");
         }
     }
 
     @Test
-    public void testMethodLogger() {
-        final ListAppender app = ctx.getListAppender("Method").clear();
+    public void testMethodLogger(@Named("Method") final ListAppender app) {
+        app.clear();
         final Logger logger = Logger.getLogger("MethodLogger");
         logger.info("More messages.");
         logger.warn("CATASTROPHE INCOMING!");
@@ -56,9 +53,9 @@ public class CallerInformationTest {
         logger.warn("brains~~~");
         logger.info("Itchy. Tasty.");
         final List<String> messages = app.getMessages();
-        assertEquals("Incorrect number of messages.", 5, messages.size());
+        assertEquals(5, messages.size(), "Incorrect number of messages.");
         for (final String message : messages) {
-            assertEquals("Incorrect caller method name.", "testMethodLogger", message);
+            assertEquals("testMethodLogger", message, "Incorrect caller method name.");
         }
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/CategoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/CategoryTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.log4j;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -43,10 +43,10 @@ import org.apache.logging.log4j.message.ObjectMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests of Category.
@@ -60,21 +60,21 @@ public class CategoryTest {
     private static final ListAppender appender = new ListAppender(VERSION2_APPENDER_NAME);
     private static final org.apache.log4j.ListAppender version1Appender = new org.apache.log4j.ListAppender();
 
-    @BeforeClass
-    public static void setupClass() {
+    @BeforeAll
+    public static void setupAll() {
         appender.start();
         version1Appender.setName(VERSION1_APPENDER_NAME);
         ConfigurationFactory.setConfigurationFactory(cf);
         LoggerContext.getContext().reconfigure();
     }
 
-    @AfterClass
-    public static void cleanupClass() {
+    @AfterAll
+    public static void cleanupAll() {
         ConfigurationFactory.removeConfigurationFactory(cf);
         appender.stop();
     }
 
-    @Before
+    @BeforeEach
     public void before() {
         appender.clear();
     }
@@ -98,23 +98,23 @@ public class CategoryTest {
         category.info("Hello, World");
         List<LogEvent> list = appender.getEvents();
         int events = list.size();
-        assertTrue("Number of events should be 1, was " + events, events == 1);
+        assertTrue(events == 1, "Number of events should be 1, was " + events);
         LogEvent event = list.get(0);
         Message msg = event.getMessage();
-        assertNotNull("No message", msg);
+        assertNotNull(msg, "No message");
         // LOG4J2-3080: use message type consistently
-        assertTrue("Incorrect Message type", msg instanceof SimpleMessage);
+        assertTrue(msg instanceof SimpleMessage, "Incorrect Message type");
         assertEquals("Hello, World", msg.getFormat());
         appender.clear();
         // Logging a String map
         category.info(Collections.singletonMap("hello", "world"));
         list = appender.getEvents();
         events = list.size();
-        assertTrue("Number of events should be 1, was " + events, events == 1);
+        assertTrue(events == 1, "Number of events should be 1, was " + events);
         event = list.get(0);
         msg = event.getMessage();
-        assertNotNull("No message", msg);
-        assertTrue("Incorrect Message type", msg instanceof MapMessage);
+        assertNotNull(msg, "No message");
+        assertTrue(msg instanceof MapMessage, "Incorrect Message type");
         Object[] objects = msg.getParameters();
         assertEquals("world", objects[0]);
         appender.clear();
@@ -122,11 +122,11 @@ public class CategoryTest {
         category.info(Collections.singletonMap(1234L, "world"));
         list = appender.getEvents();
         events = list.size();
-        assertTrue("Number of events should be 1, was " + events, events == 1);
+        assertTrue(events == 1, "Number of events should be 1, was " + events);
         event = list.get(0);
         msg = event.getMessage();
-        assertNotNull("No message", msg);
-        assertTrue("Incorrect Message type", msg instanceof MapMessage);
+        assertNotNull(msg, "No message");
+        assertTrue(msg instanceof MapMessage, "Incorrect Message type");
         objects = msg.getParameters();
         assertEquals("world", objects[0]);
         appender.clear();
@@ -135,11 +135,11 @@ public class CategoryTest {
         category.info(obj);
         list = appender.getEvents();
         events = list.size();
-        assertTrue("Number of events should be 1, was " + events, events == 1);
+        assertTrue(events == 1, "Number of events should be 1, was " + events);
         event = list.get(0);
         msg = event.getMessage();
-        assertNotNull("No message", msg);
-        assertTrue("Incorrect Message type", msg instanceof ObjectMessage);
+        assertNotNull(msg, "No message");
+        assertTrue(msg instanceof ObjectMessage, "Incorrect Message type");
         objects = msg.getParameters();
         assertEquals(obj, objects[0]);
         appender.clear();
@@ -147,11 +147,11 @@ public class CategoryTest {
         category.log(Priority.INFO, "Hello, World");
         list = appender.getEvents();
         events = list.size();
-        assertTrue("Number of events should be 1, was " + events, events == 1);
+        assertTrue(events == 1, "Number of events should be 1, was " + events);
         event = list.get(0);
         msg = event.getMessage();
-        assertNotNull("No message", msg);
-        assertTrue("Incorrect Message type", msg instanceof SimpleMessage);
+        assertNotNull(msg, "No message");
+        assertTrue(msg instanceof SimpleMessage, "Incorrect Message type");
         assertEquals("Hello, World", msg.getFormat());
         appender.clear();
     }
@@ -245,14 +245,14 @@ public class CategoryTest {
         ((org.apache.logging.log4j.core.Logger) category.getLogger()).addAppender(appender);
         category.error("Test Message");
         final List<String> msgs = appender.getMessages();
-        assertTrue("Incorrect number of messages. Expected 1 got " + msgs.size(), msgs.size() == 1);
+        assertTrue(msgs.size() == 1, "Incorrect number of messages. Expected 1 got " + msgs.size());
         final String msg = msgs.get(0);
         appender.clear();
         final String threadName = Thread.currentThread().getName();
         final String expected = "ERROR o.a.l.CategoryTest [" + threadName + "] Test Message" + Strings.LINE_SEPARATOR;
         assertTrue(
-                "Incorrect message " + Strings.dquote(msg) + " expected " + Strings.dquote(expected),
-                msg.endsWith(expected));
+                msg.endsWith(expected),
+                "Incorrect message " + Strings.dquote(msg) + " expected " + Strings.dquote(expected));
     }
 
     @Test
@@ -320,15 +320,15 @@ public class CategoryTest {
 
         // Verify collected log events.
         final List<LogEvent> events = appender.getEvents();
-        assertEquals("was expecting a single event", 1, events.size());
+        assertEquals(1, events.size(), "was expecting a single event");
         final LogEvent logEvent = events.get(0);
 
         // Verify the collected message.
         final Message message = logEvent.getMessage();
         final Class<? extends Message> actualMessageClass = message.getClass();
         assertTrue(
-                "was expecting message to be instance of " + expectedMessageClass + ", found: " + actualMessageClass,
-                expectedMessageClass.isAssignableFrom(actualMessageClass));
+                expectedMessageClass.isAssignableFrom(actualMessageClass),
+                "was expecting message to be instance of " + expectedMessageClass + ", found: " + actualMessageClass);
         @SuppressWarnings("unchecked")
         final M typedMessage = (M) message;
         messageTester.accept(typedMessage);
@@ -346,23 +346,17 @@ public class CategoryTest {
             logger.addAppender(appender);
             // Root logger
             rootLogger.info("testAddLogger");
-            assertEquals(
-                    "adding at root works",
-                    ++count,
-                    version1Appender.getEvents().size());
-            assertEquals("adding at child works", 0, appender.getEvents().size());
+            assertEquals(++count, version1Appender.getEvents().size(), "adding at root works");
+            assertEquals(0, appender.getEvents().size(), "adding at child works");
             // Another logger
             logger.info("testAddLogger2");
-            assertEquals(
-                    "adding at root works",
-                    ++count,
-                    version1Appender.getEvents().size());
-            assertEquals("adding at child works", 1, appender.getEvents().size());
+            assertEquals(++count, version1Appender.getEvents().size(), "adding at root works");
+            assertEquals(1, appender.getEvents().size(), "adding at child works");
             // Call appenders
             final LoggingEvent event = new LoggingEvent();
             logger.callAppenders(event);
-            assertEquals("callAppenders", ++count, version1Appender.getEvents().size());
-            assertEquals("callAppenders", 2, appender.getEvents().size());
+            assertEquals(++count, version1Appender.getEvents().size(), "callAppenders");
+            assertEquals(2, appender.getEvents().size(), "callAppenders");
         } finally {
             LogManager.resetConfiguration();
         }
@@ -377,17 +371,17 @@ public class CategoryTest {
             v2RootLogger.addAppender(AppenderAdapter.adapt(version1Appender));
             v2RootLogger.addAppender(appender);
             final List<Appender> rootAppenders = Collections.list(rootLogger.getAllAppenders());
-            assertEquals("only v1 appenders", 1, rootAppenders.size());
-            assertTrue("appender is a v1 ListAppender", rootAppenders.get(0) instanceof org.apache.log4j.ListAppender);
+            assertEquals(1, rootAppenders.size(), "only v1 appenders");
+            assertTrue(rootAppenders.get(0) instanceof org.apache.log4j.ListAppender, "appender is a v1 ListAppender");
             assertEquals(
-                    "explicitly named appender",
                     VERSION1_APPENDER_NAME,
-                    rootLogger.getAppender(VERSION1_APPENDER_NAME).getName());
+                    rootLogger.getAppender(VERSION1_APPENDER_NAME).getName(),
+                    "explicitly named appender");
             final Appender v2ListAppender = rootLogger.getAppender(VERSION2_APPENDER_NAME);
-            assertTrue("explicitly named appender", v2ListAppender instanceof AppenderWrapper);
+            assertTrue(v2ListAppender instanceof AppenderWrapper, "explicitly named appender");
             assertTrue(
-                    "appender is a v2 ListAppender",
-                    ((AppenderWrapper) v2ListAppender).getAppender() instanceof ListAppender);
+                    ((AppenderWrapper) v2ListAppender).getAppender() instanceof ListAppender,
+                    "appender is a v2 ListAppender");
 
             final Logger logger = LogManager.getLogger(CategoryTest.class);
             final org.apache.logging.log4j.core.Logger v2Logger =
@@ -396,17 +390,17 @@ public class CategoryTest {
             loggerAppender.setName("appender2");
             v2Logger.addAppender(AppenderAdapter.adapt(loggerAppender));
             final List<Appender> appenders = Collections.list(logger.getAllAppenders());
-            assertEquals("no parent appenders", 1, appenders.size());
+            assertEquals(1, appenders.size(), "no parent appenders");
             assertEquals(loggerAppender, appenders.get(0));
-            assertNull("no parent appenders", logger.getAppender(VERSION1_APPENDER_NAME));
-            assertNull("no parent appenders", logger.getAppender(VERSION2_APPENDER_NAME));
+            assertNull(logger.getAppender(VERSION1_APPENDER_NAME), "no parent appenders");
+            assertNull(logger.getAppender(VERSION2_APPENDER_NAME), "no parent appenders");
 
             final Logger childLogger = LogManager.getLogger(CategoryTest.class.getName() + ".child");
             final Enumeration<Appender> childAppenders = childLogger.getAllAppenders();
-            assertFalse("no parent appenders", childAppenders.hasMoreElements());
-            assertNull("no parent appenders", childLogger.getAppender("appender2"));
-            assertNull("no parent appenders", childLogger.getAppender(VERSION1_APPENDER_NAME));
-            assertNull("no parent appenders", childLogger.getAppender(VERSION2_APPENDER_NAME));
+            assertFalse(childAppenders.hasMoreElements(), "no parent appenders");
+            assertNull(childLogger.getAppender("appender2"), "no parent appenders");
+            assertNull(childLogger.getAppender(VERSION1_APPENDER_NAME), "no parent appenders");
+            assertNull(childLogger.getAppender(VERSION2_APPENDER_NAME), "no parent appenders");
         } finally {
             LogManager.resetConfiguration();
         }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/CategoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/CategoryTest.java
@@ -98,7 +98,7 @@ public class CategoryTest {
         category.info("Hello, World");
         List<LogEvent> list = appender.getEvents();
         int events = list.size();
-        assertTrue(events == 1, "Number of events should be 1, was " + events);
+        assertEquals(events, 1, "Number of events");
         LogEvent event = list.get(0);
         Message msg = event.getMessage();
         assertNotNull(msg, "No message");
@@ -110,7 +110,7 @@ public class CategoryTest {
         category.info(Collections.singletonMap("hello", "world"));
         list = appender.getEvents();
         events = list.size();
-        assertTrue(events == 1, "Number of events should be 1, was " + events);
+        assertEquals(events, 1, "Number of events");
         event = list.get(0);
         msg = event.getMessage();
         assertNotNull(msg, "No message");
@@ -122,7 +122,7 @@ public class CategoryTest {
         category.info(Collections.singletonMap(1234L, "world"));
         list = appender.getEvents();
         events = list.size();
-        assertTrue(events == 1, "Number of events should be 1, was " + events);
+        assertEquals(events, 1, "Number of events");
         event = list.get(0);
         msg = event.getMessage();
         assertNotNull(msg, "No message");
@@ -135,7 +135,7 @@ public class CategoryTest {
         category.info(obj);
         list = appender.getEvents();
         events = list.size();
-        assertTrue(events == 1, "Number of events should be 1, was " + events);
+        assertEquals(events, 1, "Number of events");
         event = list.get(0);
         msg = event.getMessage();
         assertNotNull(msg, "No message");
@@ -147,7 +147,7 @@ public class CategoryTest {
         category.log(Priority.INFO, "Hello, World");
         list = appender.getEvents();
         events = list.size();
-        assertTrue(events == 1, "Number of events should be 1, was " + events);
+        assertEquals(events, 1, "Number of events");
         event = list.get(0);
         msg = event.getMessage();
         assertNotNull(msg, "No message");
@@ -164,7 +164,7 @@ public class CategoryTest {
     @Test
     public void testGetChainedPriorityReturnType() throws Exception {
         final Method method = Category.class.getMethod("getChainedPriority", (Class[]) null);
-        assertTrue(method.getReturnType() == Priority.class);
+        assertEquals(method.getReturnType(), Priority.class);
     }
 
     /**
@@ -245,7 +245,7 @@ public class CategoryTest {
         ((org.apache.logging.log4j.core.Logger) category.getLogger()).addAppender(appender);
         category.error("Test Message");
         final List<String> msgs = appender.getMessages();
-        assertTrue(msgs.size() == 1, "Incorrect number of messages. Expected 1 got " + msgs.size());
+        assertEquals(msgs.size(), 1, "Incorrect number of messages. Expected 1 got " + msgs.size());
         final String msg = msgs.get(0);
         appender.clear();
         final String threadName = Thread.currentThread().getName();

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LevelTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LevelTest.java
@@ -60,7 +60,7 @@ public class LevelTest {
         //
         //  JDK 1.1 doesn't support readResolve necessary for the assertion
         if (!System.getProperty("java.version").startsWith("1.1.")) {
-            assertTrue(obj == Level.INFO);
+            assertEquals(obj, Level.INFO);
         }
     }
 

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LogManagerTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LogManagerTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.log4j;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link LogManager}.

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LogWithMDCTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LogWithMDCTest.java
@@ -16,39 +16,34 @@
  */
 package org.apache.log4j;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test logging with MDC values.
  */
+@LoggerContextSource("logWithMDC.xml")
 public class LogWithMDCTest {
 
-    private static final String CONFIG = "logWithMDC.xml";
-
-    @ClassRule
-    public static final LoggerContextRule CTX = new LoggerContextRule(CONFIG);
-
     @Test
-    public void testMDC() {
+    public void testMDC(@Named("List") final ListAppender listApp) {
         MDC.put("Key1", "John");
         MDC.put("Key2", "Smith");
         try {
             final Logger logger = Logger.getLogger("org.apache.test.logging");
             logger.debug("This is a test");
-            final ListAppender listApp = (ListAppender) CTX.getAppender("List");
             assertNotNull(listApp);
             final List<String> msgs = listApp.getMessages();
-            assertNotNull("No messages received", msgs);
+            assertNotNull(msgs, "No messages received");
             assertTrue(msgs.size() == 1);
-            assertTrue("Key1 is missing", msgs.get(0).contains("Key1=John"));
-            assertTrue("Key2 is missing", msgs.get(0).contains("Key2=Smith"));
+            assertTrue(msgs.get(0).contains("Key1=John"), "Key1 is missing");
+            assertTrue(msgs.get(0).contains("Key2=Smith"), "Key2 is missing");
         } finally {
             MDC.remove("Key1");
             MDC.remove("Key2");

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LogWithMDCTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LogWithMDCTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.log4j;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -41,7 +42,7 @@ public class LogWithMDCTest {
             assertNotNull(listApp);
             final List<String> msgs = listApp.getMessages();
             assertNotNull(msgs, "No messages received");
-            assertTrue(msgs.size() == 1);
+            assertEquals(msgs.size(), 1);
             assertTrue(msgs.get(0).contains("Key1=John"), "Key1 is missing");
             assertTrue(msgs.get(0).contains("Key2=Smith"), "Key2 is missing");
         } finally {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LogWithRouteTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LogWithRouteTest.java
@@ -16,39 +16,34 @@
  */
 package org.apache.log4j;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test passing MDC values to the Routing appender.
  */
+@LoggerContextSource("log-RouteWithMDC.xml")
 public class LogWithRouteTest {
 
-    private static final String CONFIG = "log-RouteWithMDC.xml";
-
-    @ClassRule
-    public static final LoggerContextRule CTX = new LoggerContextRule(CONFIG);
-
     @Test
-    public void testMDC() {
+    public void testMDC(@Named("List") final ListAppender listApp) {
         MDC.put("Type", "Service");
         MDC.put("Name", "John Smith");
         try {
             final Logger logger = Logger.getLogger("org.apache.test.logging");
             logger.debug("This is a test");
-            final ListAppender listApp = (ListAppender) CTX.getAppender("List");
             assertNotNull(listApp);
             final List<String> msgs = listApp.getMessages();
-            assertNotNull("No messages received", msgs);
+            assertNotNull(msgs, "No messages received");
             assertTrue(msgs.size() == 1);
-            assertTrue("Type is missing", msgs.get(0).contains("Type=Service"));
-            assertTrue("Name is missing", msgs.get(0).contains("Name=John Smith"));
+            assertTrue(msgs.get(0).contains("Type=Service"), "Type is missing");
+            assertTrue(msgs.get(0).contains("Name=John Smith"), "Name is missing");
         } finally {
             MDC.remove("Type");
             MDC.remove("Name");

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LogWithRouteTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LogWithRouteTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.log4j;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -41,7 +42,7 @@ public class LogWithRouteTest {
             assertNotNull(listApp);
             final List<String> msgs = listApp.getMessages();
             assertNotNull(msgs, "No messages received");
-            assertTrue(msgs.size() == 1);
+            assertEquals(msgs.size(), 1);
             assertTrue(msgs.get(0).contains("Type=Service"), "Type is missing");
             assertTrue(msgs.get(0).contains("Name=John Smith"), "Name is missing");
         } finally {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LoggerJira3410Test.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LoggerJira3410Test.java
@@ -16,8 +16,8 @@
  */
 package org.apache.log4j;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.List;
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests Jira3410.
@@ -58,23 +58,23 @@ public class LoggerJira3410Test {
                     listAppender = (ListAppender) ((AppenderAdapter.Adapter) entry.getValue()).getAppender();
                 }
             }
-            assertNotNull("No Message Appender", listAppender);
+            assertNotNull(listAppender, "No Message Appender");
             final List<String> messages = listAppender.getMessages();
-            assertTrue("No messages", messages != null && !messages.isEmpty());
+            assertTrue(messages != null && !messages.isEmpty(), "No messages");
             final String msg0 = messages.get(0);
             final String msg1 = messages.get(1);
             final String msg2 = messages.get(2);
             // TODO Should be 1, not "1".
             // TODO Where are the {} characters?
-            assertTrue(msg0, msg0.trim().endsWith(Long.MAX_VALUE + "=\"1\""));
+            assertTrue(msg0.trim().endsWith(Long.MAX_VALUE + "=\"1\""), msg0);
             //
             // TODO Should be 1, not "1".
             // TODO Should be null, not "null".
             // TODO Where are the {} characters?
             // TODO Where is the , characters?
-            assertTrue(msg1, msg1.trim().endsWith("null=\"null\" " + Long.MAX_VALUE + "=\"1\""));
+            assertTrue(msg1.trim().endsWith("null=\"null\" " + Long.MAX_VALUE + "=\"1\""), msg1);
             //
-            assertTrue(msg2, msg2.trim().endsWith("{null=null, " + Long.MAX_VALUE + "=1}"));
+            assertTrue(msg2.trim().endsWith("{null=null, " + Long.MAX_VALUE + "=1}"), msg2);
         }
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LoggerTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LoggerTest.java
@@ -16,13 +16,16 @@
  */
 package org.apache.log4j;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Locale;
@@ -35,10 +38,10 @@ import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Used for internal unit testing the Logger class.
@@ -57,26 +60,26 @@ public class LoggerTest {
 
     static ConfigurationFactory configurationFactory = new BasicConfigurationFactory();
 
-    @BeforeClass
-    public static void setUpClass() {
+    @BeforeAll
+    public static void setUpAll() {
         rbUS = ResourceBundle.getBundle("L7D", new Locale("en", "US"));
         assertNotNull(rbUS);
 
         rbFR = ResourceBundle.getBundle("L7D", new Locale("fr", "FR"));
-        assertNotNull("Got a null resource bundle.", rbFR);
+        assertNotNull(rbFR, "Got a null resource bundle.");
 
         rbCH = ResourceBundle.getBundle("L7D", new Locale("fr", "CH"));
-        assertNotNull("Got a null resource bundle.", rbCH);
+        assertNotNull(rbCH, "Got a null resource bundle.");
 
         ConfigurationFactory.setConfigurationFactory(configurationFactory);
     }
 
-    @AfterClass
-    public static void tearDownClass() {
+    @AfterAll
+    public static void tearDownAll() {
         ConfigurationFactory.removeConfigurationFactory(configurationFactory);
     }
 
-    @Before
+    @BeforeEach
     public void resetTest() {
         Objects.requireNonNull(LogManager.getHierarchy()).resetConfiguration();
         a1 = null;
@@ -485,9 +488,9 @@ public class LoggerTest {
             root.log(Priority.INFO, "Test msg2", null);
             root.log(Priority.INFO, "Test msg3");
             final List<String> msgs = appender.getMessages();
-            assertTrue("Incorrect number of messages", msgs.size() == 3);
+            assertTrue(msgs.size() == 3, "Incorrect number of messages");
             final String msg = msgs.get(0);
-            assertTrue("Message contains incorrect class name: " + msg, msg.contains(LoggerTest.class.getName()));
+            assertTrue(msg.contains(LoggerTest.class.getName()), "Message contains incorrect class name: " + msg);
             appender.stop();
         } finally {
             ((org.apache.logging.log4j.core.Logger) root.getLogger()).removeAppender(appender);
@@ -500,21 +503,22 @@ public class LoggerTest {
         final Logger a_b = Logger.getLogger("a.b");
         final Logger a_b_c = Logger.getLogger("a.b.c");
         // test default for this test
-        assertThat(a.getLevel()).isNull();
-        assertThat(a_b.getLevel()).isNull();
-        assertThat(a_b_c.getLevel()).isNull();
-        assertThat(a.getEffectiveLevel()).isEqualTo(Level.DEBUG);
-        assertThat(a_b.getEffectiveLevel()).isEqualTo(Level.DEBUG);
-        assertThat(a_b_c.getEffectiveLevel()).isEqualTo(Level.DEBUG);
+        assertThat(a.getLevel(), nullValue());
+        assertThat(a_b.getLevel(), nullValue());
+        assertThat(a_b_c.getLevel(), nullValue());
+        assertThat(a.getEffectiveLevel(), is(equalTo(Level.DEBUG)));
+        assertThat(a_b.getEffectiveLevel(), is(equalTo(Level.DEBUG)));
+        assertThat(a_b_c.getEffectiveLevel(), is(equalTo(Level.DEBUG)));
+
         // all
         for (final Level level :
                 new Level[] {Level.DEBUG, Level.ERROR, Level.FATAL, Level.INFO, Level.TRACE, Level.WARN}) {
             a.setLevel(level);
-            assertThat(a.getLevel()).isEqualTo(level);
-            assertThat(a_b.getLevel()).isNull();
-            assertThat(a_b.getEffectiveLevel()).isEqualTo(level);
-            assertThat(a_b.getLevel()).isNull();
-            assertThat(a_b_c.getEffectiveLevel()).isEqualTo(level);
+            assertThat(a.getLevel(), is(equalTo(level)));
+            assertThat(a_b.getLevel(), nullValue());
+            assertThat(a_b.getEffectiveLevel(), is(equalTo(level)));
+            assertThat(a_b_c.getLevel(), nullValue());
+            assertThat(a_b_c.getEffectiveLevel(), is(equalTo(level)));
         }
     }
 
@@ -524,20 +528,22 @@ public class LoggerTest {
         final Logger a_b = Logger.getLogger("a.b");
         final Logger a_b_c = Logger.getLogger("a.b.c");
         // test default for this test
-        assertThat(a.getPriority()).isNull();
-        assertThat(a_b.getPriority()).isNull();
-        assertThat(a_b_c.getPriority()).isNull();
-        assertThat(a.getEffectiveLevel()).isEqualTo(Level.DEBUG);
-        assertThat(a_b.getEffectiveLevel()).isEqualTo(Level.DEBUG);
-        assertThat(a_b_c.getEffectiveLevel()).isEqualTo(Level.DEBUG);
+        assertThat(a.getPriority(), nullValue());
+        assertThat(a_b.getPriority(), nullValue());
+        assertThat(a_b_c.getPriority(), nullValue());
+
+        assertThat(a.getEffectiveLevel(), is(equalTo(Level.DEBUG)));
+        assertThat(a_b.getEffectiveLevel(), is(equalTo(Level.DEBUG)));
+        assertThat(a_b_c.getEffectiveLevel(), is(equalTo(Level.DEBUG)));
+
         // all
         for (final Priority level : Level.getAllPossiblePriorities()) {
             a.setPriority(level);
-            assertThat(a.getPriority()).isEqualTo(level);
-            assertThat(a_b.getPriority()).isNull();
-            assertThat(a_b.getEffectiveLevel()).isEqualTo(level);
-            assertThat(a_b.getPriority()).isNull();
-            assertThat(a_b_c.getEffectiveLevel()).isEqualTo(level);
+            assertThat(a.getPriority(), is(equalTo(level)));
+            assertThat(a_b.getPriority(), nullValue());
+            assertThat(a_b.getEffectiveLevel(), is(equalTo(level)));
+            assertThat(a_b.getPriority(), nullValue());
+            assertThat(a_b_c.getEffectiveLevel(), is(equalTo(level)));
         }
     }
 

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LoggerTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LoggerTest.java
@@ -327,7 +327,7 @@ public class LoggerTest {
         final Logger root = Logger.getRootLogger();
         root.setResourceBundle(rbUS);
         ResourceBundle t = root.getResourceBundle();
-        assertTrue(t == rbUS);
+        assertEquals(t, rbUS);
 
         final Logger x = Logger.getLogger("x");
         final Logger x_y = Logger.getLogger("x.y");
@@ -347,7 +347,7 @@ public class LoggerTest {
         final Logger root = Logger.getRootLogger();
         root.setResourceBundle(rbUS);
         ResourceBundle t = root.getResourceBundle();
-        assertTrue(t == rbUS);
+        assertEquals(t, rbUS);
 
         final Logger x = Logger.getLogger("x");
         final Logger x_y = Logger.getLogger("x.y");
@@ -488,7 +488,7 @@ public class LoggerTest {
             root.log(Priority.INFO, "Test msg2", null);
             root.log(Priority.INFO, "Test msg3");
             final List<String> msgs = appender.getMessages();
-            assertTrue(msgs.size() == 3, "Incorrect number of messages");
+            assertEquals(msgs.size(), 3, "Incorrect number of messages");
             final String msg = msgs.get(0);
             assertTrue(msg.contains(LoggerTest.class.getName()), "Message contains incorrect class name: " + msg);
             appender.stop();

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LoggingTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LoggingTest.java
@@ -16,28 +16,23 @@
  */
 package org.apache.log4j;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  */
+@LoggerContextSource("log4j2-config.xml")
 public class LoggingTest {
-
-    private static final String CONFIG = "log4j2-config.xml";
-
-    @ClassRule
-    public static final LoggerContextRule CTX = new LoggerContextRule(CONFIG);
 
     @Test
     public void testParent() {
         final Logger logger = Logger.getLogger("org.apache.test.logging.Test");
         final Category parent = logger.getParent();
-        assertNotNull("No parent Logger", parent);
-        assertEquals("Incorrect parent logger", "org.apache.test.logging", parent.getName());
+        assertNotNull(parent, "No parent Logger");
+        assertEquals("org.apache.test.logging", parent.getName(), "Incorrect parent logger");
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/MDCTestCase.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/MDCTestCase.java
@@ -16,19 +16,20 @@
  */
 package org.apache.log4j;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class MDCTestCase {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         MDC.clear();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         MDC.clear();
     }
@@ -36,8 +37,8 @@ public class MDCTestCase {
     @Test
     public void testPut() {
         MDC.put("key", "some value");
-        Assert.assertEquals("some value", MDC.get("key"));
-        Assert.assertEquals(1, MDC.getContext().size());
+        assertEquals("some value", MDC.get("key"));
+        assertEquals(1, MDC.getContext().size());
     }
 
     @Test

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/NDCTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/NDCTest.java
@@ -16,23 +16,24 @@
  */
 package org.apache.log4j;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Stack;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NDCTest {
 
     @Test
     public void testPopEmpty() {
         NDC.clear();
-        Assert.assertEquals(Strings.EMPTY, NDC.pop());
+        assertEquals(Strings.EMPTY, NDC.pop());
     }
 
     @Test
     public void testPeekEmpty() {
         NDC.clear();
-        Assert.assertEquals(Strings.EMPTY, NDC.peek());
+        assertEquals(Strings.EMPTY, NDC.peek());
     }
 
     @SuppressWarnings({"rawtypes"})

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/PriorityTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/PriorityTest.java
@@ -190,7 +190,7 @@ public class PriorityTest {
     @Test
     @SuppressWarnings("deprecation")
     public void testToPriorityString() {
-        assertTrue(Priority.toPriority("DEBUG") == Level.DEBUG);
+        assertEquals(Priority.toPriority("DEBUG"), Level.DEBUG);
     }
 
     /**
@@ -199,7 +199,7 @@ public class PriorityTest {
     @Test
     @SuppressWarnings("deprecation")
     public void testToPriorityInt() {
-        assertTrue(Priority.toPriority(Priority.DEBUG_INT) == Level.DEBUG);
+        assertEquals(Priority.toPriority(Priority.DEBUG_INT), Level.DEBUG);
     }
 
     /**
@@ -208,7 +208,7 @@ public class PriorityTest {
     @Test
     @SuppressWarnings("deprecation")
     public void testToPriorityStringPriority() {
-        assertTrue(Priority.toPriority("foo", Priority.DEBUG) == Priority.DEBUG);
+        assertEquals(Priority.toPriority("foo", Priority.DEBUG), Priority.DEBUG);
     }
 
     /**
@@ -217,7 +217,7 @@ public class PriorityTest {
     @Test
     @SuppressWarnings("deprecation")
     public void testToPriorityIntPriority() {
-        assertTrue(Priority.toPriority(17, Priority.DEBUG) == Priority.DEBUG);
+        assertEquals(Priority.toPriority(17, Priority.DEBUG), Priority.DEBUG);
     }
 
     /**

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/PropertyConfiguratorTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/PropertyConfiguratorTest.java
@@ -16,7 +16,12 @@
  */
 package org.apache.log4j;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -252,11 +257,11 @@ class PropertyConfiguratorTest {
             PropertyConfigurator.configure(inputStream);
 
             final Logger rootLogger = Logger.getRootLogger();
-            assertThat(rootLogger.getLevel()).isEqualTo(Level.INFO);
-            assertThat(rootLogger.getAppender("CONSOLE")).isNotNull();
+            assertThat(rootLogger.getLevel(), is(equalTo(Level.INFO)));
+            assertThat(rootLogger.getAppender("CONSOLE"), notNullValue());
             final Logger logger = Logger.getLogger("org.apache.log4j.PropertyConfiguratorTest");
-            assertThat(logger.getLevel()).isEqualTo(Level.DEBUG);
-            assertThat(logger.getAppender("ROLLING")).isNotNull();
+            assertThat(logger.getLevel(), is(equalTo(Level.DEBUG)));
+            assertThat(logger.getAppender("ROLLING"), notNullValue());
         }
     }
 
@@ -368,15 +373,15 @@ class PropertyConfiguratorTest {
     void when_compatibility_disabled_configurator_is_no_op() throws IOException {
         final Logger rootLogger = Logger.getRootLogger();
         final Logger logger = Logger.getLogger("org.apache.log4j.PropertyConfiguratorTest");
-        assertThat(logger.getLevel()).isNull();
+        assertThat(logger.getLevel(), nullValue());
         try (final InputStream inputStream = PropertyConfiguratorTest.class.getResourceAsStream(FILTER_PROPERTIES)) {
             PropertyConfigurator.configure(inputStream);
 
-            assertThat(rootLogger.getAppender("CONSOLE")).isNull();
-            assertThat(rootLogger.getLevel()).isNotEqualTo(Level.INFO);
+            assertThat(rootLogger.getAppender("CONSOLE"), nullValue());
+            assertThat(rootLogger.getLevel(), is(not(equalTo(Level.INFO))));
 
-            assertThat(logger.getAppender("ROLLING")).isNull();
-            assertThat(logger.getLevel()).isNull();
+            assertThat(logger.getAppender("ROLLING"), nullValue());
+            assertThat(logger.getLevel(), nullValue());
         }
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/bridge/LogEventWrapperTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/bridge/LogEventWrapperTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.log4j.bridge;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.logging.log4j.core.LogEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LogEventWrapperTest {
 

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationConverterTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationConverterTest.java
@@ -29,12 +29,9 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
-@RunWith(Parameterized.class)
 public abstract class AbstractLog4j1ConfigurationConverterTest {
 
     protected static List<Path> getPaths(final String root) throws IOException {
@@ -49,19 +46,15 @@ public abstract class AbstractLog4j1ConfigurationConverterTest {
         return paths;
     }
 
-    private final Path pathIn;
-
-    public AbstractLog4j1ConfigurationConverterTest(final Path path) {
-        this.pathIn = path;
-    }
+    public AbstractLog4j1ConfigurationConverterTest() {}
 
     @Test
-    public void test() throws Exception {
+    public void test(Path path) throws Exception {
         final Path tempFile = Files.createTempFile("log4j2", ".xml");
         try {
             final Log4j1ConfigurationConverter.CommandLineArguments cla =
                     new Log4j1ConfigurationConverter.CommandLineArguments();
-            cla.setPathIn(pathIn);
+            cla.setPathIn(path);
             cla.setPathOut(tempFile);
             Log4j1ConfigurationConverter.run(cla);
             checkWellFormedXml(tempFile);

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AbstractLog4j1ConfigurationTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileDescriptor;
@@ -65,14 +65,12 @@ import org.apache.logging.log4j.core.filter.Filterable;
 import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.core.layout.HtmlLayout;
 import org.apache.logging.log4j.core.layout.PatternLayout;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public abstract class AbstractLog4j1ConfigurationTest {
 
-    @Rule
-    public TemporaryFolder tempFolder =
-            TemporaryFolder.builder().assureDeletion().build();
+    @TempDir
+    File tempDir;
 
     abstract Configuration getConfiguration(String configResourcePrefix) throws URISyntaxException, IOException;
 
@@ -99,12 +97,9 @@ public abstract class AbstractLog4j1ConfigurationTest {
     }
 
     private void testConsoleAppender(final ConsoleAppender expected, final ConsoleAppender actual) {
-        assertEquals("immediateFlush", expected.getImmediateFlush(), actual.getImmediateFlush());
-        assertEquals("target", expected.getTarget(), actual.getTarget());
-        assertEquals(
-                "layoutClass",
-                expected.getLayout().getClass(),
-                actual.getLayout().getClass());
+        assertEquals(expected.getImmediateFlush(), actual.getImmediateFlush(), "immediateFlush");
+        assertEquals(expected.getTarget(), actual.getTarget(), "target");
+        assertEquals(expected.getLayout().getClass(), actual.getLayout().getClass(), "layoutClass");
         if (expected.getLayout() instanceof PatternLayout) {
             patternLayoutEquals((PatternLayout) expected.getLayout(), (PatternLayout) actual.getLayout());
         }
@@ -120,8 +115,8 @@ public abstract class AbstractLog4j1ConfigurationTest {
         final String name = "Console";
         final ConsoleAppender appender = configuration.getAppender(name);
         assertNotNull(
-                "Missing appender '" + name + "' in configuration " + configResource + " → " + configuration, appender);
-        assertTrue("follow", getFollowProperty(appender));
+                appender, "Missing appender '" + name + "' in configuration " + configResource + " → " + configuration);
+        assertEquals(true, getFollowProperty(appender), "follow");
         assertEquals(Target.SYSTEM_ERR, appender.getTarget());
         //
         final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
@@ -157,9 +152,9 @@ public abstract class AbstractLog4j1ConfigurationTest {
         final Configuration configuration = getConfiguration("config-1.2/log4j-system-properties-1");
         try {
             final RollingFileAppender appender = configuration.getAppender("RFA");
-            assertFalse("append", getAppendProperty(appender));
-            assertEquals("bufferSize", 1000, appender.getManager().getBufferSize());
-            assertFalse("immediateFlush", appender.getImmediateFlush());
+            assertFalse(getAppendProperty(appender), "append");
+            assertEquals(1000, appender.getManager().getBufferSize(), "bufferSize");
+            assertFalse(appender.getImmediateFlush(), "immediateFlush");
             final DefaultRolloverStrategy rolloverStrategy =
                     (DefaultRolloverStrategy) appender.getManager().getRolloverStrategy();
             assertEquals(16, rolloverStrategy.getMaxIndex());
@@ -167,7 +162,7 @@ public abstract class AbstractLog4j1ConfigurationTest {
             final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
             assertEquals(1, triggeringPolicies.length);
             final TriggeringPolicy tp = triggeringPolicies[0];
-            assertTrue(tp.getClass().getName(), tp instanceof SizeBasedTriggeringPolicy);
+            assertTrue(tp instanceof SizeBasedTriggeringPolicy, tp.getClass().getName());
             final SizeBasedTriggeringPolicy sbtp = (SizeBasedTriggeringPolicy) tp;
             assertEquals(20 * 1024 * 1024, sbtp.getMaxFileSize());
             appender.stop(10, TimeUnit.SECONDS);
@@ -197,30 +192,33 @@ public abstract class AbstractLog4j1ConfigurationTest {
         final Appender appender = configuration.getAppender("RFA");
         assertNotNull(appender);
         assertEquals("RFA", appender.getName());
-        assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
+        assertTrue(appender instanceof RollingFileAppender, appender.getClass().getName());
         final RollingFileAppender rfa = (RollingFileAppender) appender;
 
         assertTrue(
-                "defaultRolloverStrategy", rfa.getManager().getRolloverStrategy() instanceof DefaultRolloverStrategy);
-        assertFalse(
-                "rolloverStrategy", ((DefaultRolloverStrategy) rfa.getManager().getRolloverStrategy()).isUseMax());
-        assertFalse("append", getAppendProperty(rfa));
-        assertEquals("bufferSize", 1000, rfa.getManager().getBufferSize());
-        assertFalse("immediateFlush", rfa.getImmediateFlush());
+                rfa.getManager().getRolloverStrategy() instanceof DefaultRolloverStrategy, "defaultRolloverStrategy");
+        assertFalse(((DefaultRolloverStrategy) rfa.getManager().getRolloverStrategy()).isUseMax(), "rolloverStrategy");
+        assertFalse(getAppendProperty(rfa), "append");
+        assertEquals(1000, rfa.getManager().getBufferSize(), "bufferSize");
+        assertFalse(rfa.getImmediateFlush(), "immediateFlush");
         assertEquals("target/hadoop.log", rfa.getFileName());
         assertEquals("target/hadoop.log.%i", rfa.getFilePattern());
         final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
         assertNotNull(triggeringPolicy);
-        assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
+        assertTrue(
+                triggeringPolicy instanceof CompositeTriggeringPolicy,
+                triggeringPolicy.getClass().getName());
         final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
         final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
         assertEquals(1, triggeringPolicies.length);
         final TriggeringPolicy tp = triggeringPolicies[0];
-        assertTrue(tp.getClass().getName(), tp instanceof SizeBasedTriggeringPolicy);
+        assertTrue(tp instanceof SizeBasedTriggeringPolicy, tp.getClass().getName());
         final SizeBasedTriggeringPolicy sbtp = (SizeBasedTriggeringPolicy) tp;
         assertEquals(256 * 1024 * 1024, sbtp.getMaxFileSize());
         final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
-        assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
+        assertTrue(
+                rolloverStrategy instanceof DefaultRolloverStrategy,
+                rolloverStrategy.getClass().getName());
         final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
         assertEquals(20, drs.getMaxIndex());
         configuration.start();
@@ -233,25 +231,30 @@ public abstract class AbstractLog4j1ConfigurationTest {
             final Appender appender = configuration.getAppender("DRFA");
             assertNotNull(appender);
             assertEquals("DRFA", appender.getName());
-            assertTrue(appender.getClass().getName(), appender instanceof RollingFileAppender);
+            assertTrue(
+                    appender instanceof RollingFileAppender, appender.getClass().getName());
             final RollingFileAppender rfa = (RollingFileAppender) appender;
-            assertFalse("append", getAppendProperty(rfa));
-            assertEquals("bufferSize", 1000, rfa.getManager().getBufferSize());
-            assertFalse("immediateFlush", rfa.getImmediateFlush());
+            assertFalse(getAppendProperty(rfa), "append");
+            assertEquals(1000, rfa.getManager().getBufferSize(), "bufferSize");
+            assertFalse(rfa.getImmediateFlush(), "immediateFlush");
             assertEquals("target/hadoop.log", rfa.getFileName());
             assertEquals("target/hadoop.log%d{.dd-MM-yyyy}", rfa.getFilePattern());
             final TriggeringPolicy triggeringPolicy = rfa.getTriggeringPolicy();
             assertNotNull(triggeringPolicy);
-            assertTrue(triggeringPolicy.getClass().getName(), triggeringPolicy instanceof CompositeTriggeringPolicy);
+            assertTrue(
+                    triggeringPolicy instanceof CompositeTriggeringPolicy,
+                    triggeringPolicy.getClass().getName());
             final CompositeTriggeringPolicy ctp = (CompositeTriggeringPolicy) triggeringPolicy;
             final TriggeringPolicy[] triggeringPolicies = ctp.getTriggeringPolicies();
             assertEquals(1, triggeringPolicies.length);
             final TriggeringPolicy tp = triggeringPolicies[0];
-            assertTrue(tp.getClass().getName(), tp instanceof TimeBasedTriggeringPolicy);
+            assertTrue(tp instanceof TimeBasedTriggeringPolicy, tp.getClass().getName());
             final TimeBasedTriggeringPolicy tbtp = (TimeBasedTriggeringPolicy) tp;
             assertEquals(1, tbtp.getInterval());
             final RolloverStrategy rolloverStrategy = rfa.getManager().getRolloverStrategy();
-            assertTrue(rolloverStrategy.getClass().getName(), rolloverStrategy instanceof DefaultRolloverStrategy);
+            assertTrue(
+                    rolloverStrategy instanceof DefaultRolloverStrategy,
+                    rolloverStrategy.getClass().getName());
             final DefaultRolloverStrategy drs = (DefaultRolloverStrategy) rolloverStrategy;
             assertEquals(Integer.MAX_VALUE, drs.getMaxIndex());
         } finally {
@@ -269,9 +272,9 @@ public abstract class AbstractLog4j1ConfigurationTest {
         final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");
         assertNotNull(loggerConfig);
         assertEquals(Level.DEBUG, loggerConfig.getLevel());
-        assertFalse("append", getAppendProperty(appender));
-        assertEquals("bufferSize", 1000, appender.getManager().getBufferSize());
-        assertFalse("immediateFlush", appender.getImmediateFlush());
+        assertFalse(getAppendProperty(appender), "append");
+        assertEquals(1000, appender.getManager().getBufferSize(), "bufferSize");
+        assertFalse(appender.getImmediateFlush(), "immediateFlush");
         configuration.start();
         configuration.stop();
         return appender.getLayout();
@@ -310,7 +313,7 @@ public abstract class AbstractLog4j1ConfigurationTest {
         final Appender appender = configuration.getAppender("NullAppender");
         assertNotNull(appender);
         assertEquals("NullAppender", appender.getName());
-        assertTrue(appender.getClass().getName(), appender instanceof NullAppender);
+        assertTrue(appender instanceof NullAppender, appender.getClass().getName());
     }
 
     private boolean getFollowProperty(final ConsoleAppender consoleAppender) throws Exception {
@@ -351,8 +354,8 @@ public abstract class AbstractLog4j1ConfigurationTest {
     private Layout<?> testLayout(final Configuration config, final String appenderName) {
         final ConsoleAppender appender = config.getAppender(appenderName);
         assertNotNull(
-                "Missing appender '" + appenderName + "' in configuration " + config.getConfigurationSource(),
-                appender);
+                appender,
+                "Missing appender '" + appenderName + "' in configuration " + config.getConfigurationSource());
         return appender.getLayout();
     }
 
@@ -364,60 +367,58 @@ public abstract class AbstractLog4j1ConfigurationTest {
         // HtmlLayout
         final HtmlLayout htmlLayout = (HtmlLayout) testLayout(config, "HTMLLayout");
         assertNotNull(htmlLayout);
-        assertEquals("title", "Log4J Log Messages", htmlLayout.getTitle());
-        assertFalse("locationInfo", htmlLayout.isLocationInfo());
+        assertEquals("Log4J Log Messages", htmlLayout.getTitle(), "title");
+        assertFalse(htmlLayout.isLocationInfo(), "locationInfo");
         // PatternLayout
         final PatternLayout patternLayout = (PatternLayout) testLayout(config, "PatternLayout");
         assertNotNull(patternLayout);
-        assertEquals("conversionPattern", "%m%n", patternLayout.getConversionPattern());
+        assertEquals("%m%n", patternLayout.getConversionPattern(), "conversionPattern");
         // TTCCLayout
         final PatternLayout ttccLayout = (PatternLayout) testLayout(config, "TTCCLayout");
         assertNotNull(ttccLayout);
         assertEquals(
-                "equivalent conversion pattern",
                 "%r [%t] %p %c %notEmpty{%ndc }- %m%n",
-                ttccLayout.getConversionPattern());
+                ttccLayout.getConversionPattern(), "equivalent conversion pattern");
         // TODO: XMLLayout
         // final XmlLayout xmlLayout = (XmlLayout) testLayout(config, "XMLLayout");
         // assertNotNull(xmlLayout);
         // ConsoleAppender
         final ConsoleAppender consoleAppender = config.getAppender("ConsoleAppender");
         assertNotNull(consoleAppender);
-        assertEquals("target", Target.SYSTEM_OUT, consoleAppender.getTarget());
+        assertEquals(Target.SYSTEM_OUT, consoleAppender.getTarget(), "target");
         final boolean follow = getFollowProperty(consoleAppender);
-        assertFalse("follow", follow);
+        assertFalse(follow, "follow");
         // DailyRollingFileAppender
         final RollingFileAppender dailyRollingFileAppender = config.getAppender("DailyRollingFileAppender");
         assertNotNull(dailyRollingFileAppender);
         assertEquals(
-                "equivalent file pattern",
                 "target/dailyRollingFileAppender%d{.yyyy-MM-dd}",
-                dailyRollingFileAppender.getFilePattern());
-        assertTrue("append", getAppendProperty(dailyRollingFileAppender));
-        assertEquals("bufferSize", 8192, dailyRollingFileAppender.getManager().getBufferSize());
-        assertTrue("immediateFlush", dailyRollingFileAppender.getImmediateFlush());
+                dailyRollingFileAppender.getFilePattern(), "equivalent file pattern");
+        assertEquals(true, getAppendProperty(dailyRollingFileAppender), "append");
+        assertEquals(8192, dailyRollingFileAppender.getManager().getBufferSize(), "bufferSize");
+        assertTrue(dailyRollingFileAppender.getImmediateFlush(), "immediateFlush");
         // FileAppender
         final FileAppender fileAppender = config.getAppender("FileAppender");
         assertNotNull(fileAppender);
-        assertTrue("append", getAppendProperty(fileAppender));
-        assertEquals("bufferSize", 8192, fileAppender.getManager().getBufferSize());
-        assertTrue("immediateFlush", fileAppender.getImmediateFlush());
+        assertTrue(getAppendProperty(fileAppender), "append");
+        assertEquals(8192, fileAppender.getManager().getBufferSize(), "bufferSize");
+        assertTrue(fileAppender.getImmediateFlush(), "immediateFlush");
         // RollingFileAppender
         final RollingFileAppender rollingFileAppender = config.getAppender("RollingFileAppender");
         assertNotNull(rollingFileAppender);
-        assertEquals("equivalent file pattern", "target/rollingFileAppender.%i", rollingFileAppender.getFilePattern());
+        assertEquals("target/rollingFileAppender.%i", rollingFileAppender.getFilePattern(), "equivalent file pattern");
         final CompositeTriggeringPolicy compositePolicy =
                 rollingFileAppender.getManager().getTriggeringPolicy();
         assertEquals(1, compositePolicy.getTriggeringPolicies().length);
         final SizeBasedTriggeringPolicy sizePolicy =
                 (SizeBasedTriggeringPolicy) compositePolicy.getTriggeringPolicies()[0];
-        assertEquals("maxFileSize", 10 * 1024 * 1024L, sizePolicy.getMaxFileSize());
+        assertEquals(10 * 1024 * 1024L, sizePolicy.getMaxFileSize(), "maxFileSize");
         final DefaultRolloverStrategy strategy =
                 (DefaultRolloverStrategy) rollingFileAppender.getManager().getRolloverStrategy();
-        assertEquals("maxBackupIndex", 1, strategy.getMaxIndex());
-        assertTrue("append", getAppendProperty(rollingFileAppender));
-        assertEquals("bufferSize", 8192, rollingFileAppender.getManager().getBufferSize());
-        assertTrue("immediateFlush", rollingFileAppender.getImmediateFlush());
+        assertEquals(1, strategy.getMaxIndex(), "maxBackupIndex");
+        assertTrue(getAppendProperty(rollingFileAppender), "append");
+        assertEquals(8192, rollingFileAppender.getManager().getBufferSize(), "bufferSize");
+        assertTrue(rollingFileAppender.getImmediateFlush(), "immediateFlush");
         config.start();
         config.stop();
     }
@@ -437,8 +438,8 @@ public abstract class AbstractLog4j1ConfigurationTest {
         } else if (filter instanceof FilterAdapter) {
             // Don't create adapters from wrappers
             assertFalse(
-                    "found FilterAdapter of a FilterWrapper",
-                    ((FilterAdapter) filter).getFilter() instanceof FilterWrapper);
+                    ((FilterAdapter) filter).getFilter() instanceof FilterWrapper,
+                    "found FilterAdapter of a FilterWrapper");
             count += checkFilters(((FilterAdapter) filter).getFilter());
         } else {
             count++;
@@ -457,8 +458,8 @@ public abstract class AbstractLog4j1ConfigurationTest {
         if (filter instanceof FilterWrapper) {
             // Don't create wrappers from adapters
             assertFalse(
-                    "found FilterWrapper of a FilterAdapter",
-                    ((FilterWrapper) filter).getFilter() instanceof FilterAdapter);
+                    ((FilterWrapper) filter).getFilter() instanceof FilterAdapter,
+                    "found FilterWrapper of a FilterAdapter");
             count += checkFilters(((FilterWrapper) filter).getFilter());
         } else {
             count++;
@@ -467,16 +468,18 @@ public abstract class AbstractLog4j1ConfigurationTest {
         // CompositeFilter of native Log4j 2.x filters
         // over a:
         // FilterAdapter of a chain of FilterWrappers.
-        assertNull("found chain of Log4j 1.x filters", filter.getNext());
+        assertNull(filter.getNext(), "found chain of Log4j 1.x filters");
         return count;
     }
 
     public void testMultipleFilters() throws Exception {
-        final File folder = tempFolder.newFolder();
-        System.setProperty("test.tmpDir", folder.getCanonicalPath());
+        System.setProperty("test.tmpDir", tempDir.getCanonicalPath());
+
         try (final LoggerContext loggerContext = configure("log4j-multipleFilters")) {
             final Configuration configuration = loggerContext.getConfiguration();
+
             assertNotNull(configuration);
+
             // Check only number of filters.
             final Filterable console = configuration.getAppender("CONSOLE");
             assertNotNull(console);
@@ -498,6 +501,7 @@ public abstract class AbstractLog4j1ConfigurationTest {
             final org.apache.logging.log4j.core.test.appender.ListAppender nativeAppender =
                     configuration.getAppender("LIST2");
             assertEquals(3, checkFilters(((Filterable) nativeAppender).getFilter()));
+
             final Logger logger = LogManager.getLogger(PropertiesConfigurationTest.class);
             int expected = 0;
             // message blocked by Threshold
@@ -561,62 +565,61 @@ public abstract class AbstractLog4j1ConfigurationTest {
         DefaultRolloverStrategy defaultRolloverStrategy;
         // Time policy with default attributes
         appender = configuration.getAppender("DEFAULT_TIME");
-        assertTrue("is RollingFileAppender", appender instanceof RollingFileAppender);
+        assertTrue(appender instanceof RollingFileAppender, "is RollingFileAppender");
         final RollingFileAppender defaultTime = (RollingFileAppender) appender;
-        assertTrue("append", defaultTime.getManager().isAppend());
-        assertEquals("bufferSize", 8192, defaultTime.getManager().getBufferSize());
-        assertTrue("immediateFlush", defaultTime.getImmediateFlush());
-        assertEquals("fileName", "target/EnhancedRollingFileAppender/defaultTime.log", defaultTime.getFileName());
+        assertTrue(defaultTime.getManager().isAppend(), "append");
+        assertEquals(8192, defaultTime.getManager().getBufferSize(), "bufferSize");
+        assertTrue(defaultTime.getImmediateFlush(), "immediateFlush");
+        assertEquals("target/EnhancedRollingFileAppender/defaultTime.log", defaultTime.getFileName(), "fileName");
         assertEquals(
-                "filePattern",
                 "target/EnhancedRollingFileAppender/defaultTime.%d{yyyy-MM-dd}.log",
-                defaultTime.getFilePattern());
+                defaultTime.getFilePattern(), "filePattern");
         policy = defaultTime.getTriggeringPolicy();
-        assertTrue("is TimeBasedTriggeringPolicy", policy instanceof TimeBasedTriggeringPolicy);
+        assertTrue(policy instanceof TimeBasedTriggeringPolicy, "is TimeBasedTriggeringPolicy");
         // Size policy with default attributes
         appender = configuration.getAppender("DEFAULT_SIZE");
-        assertTrue("is RollingFileAppender", appender instanceof RollingFileAppender);
+        assertTrue(appender instanceof RollingFileAppender, "is RollingFileAppender");
         final RollingFileAppender defaultSize = (RollingFileAppender) appender;
-        assertTrue("append", defaultSize.getManager().isAppend());
-        assertEquals("bufferSize", 8192, defaultSize.getManager().getBufferSize());
-        assertTrue("immediateFlush", defaultSize.getImmediateFlush());
-        assertEquals("fileName", "target/EnhancedRollingFileAppender/defaultSize.log", defaultSize.getFileName());
+        assertTrue(defaultSize.getManager().isAppend(), "append");
+        assertEquals(8192, defaultSize.getManager().getBufferSize(), "bufferSize");
+        assertTrue(defaultSize.getImmediateFlush(), "immediateFlush");
+        assertEquals("target/EnhancedRollingFileAppender/defaultSize.log", defaultSize.getFileName(), "fileName");
         assertEquals(
-                "filePattern", "target/EnhancedRollingFileAppender/defaultSize.%i.log", defaultSize.getFilePattern());
+                "target/EnhancedRollingFileAppender/defaultSize.%i.log", defaultSize.getFilePattern(), "filePattern");
         policy = defaultSize.getTriggeringPolicy();
-        assertTrue("is SizeBasedTriggeringPolicy", policy instanceof SizeBasedTriggeringPolicy);
+        assertTrue(policy instanceof SizeBasedTriggeringPolicy, "is SizeBasedTriggeringPolicy");
         assertEquals(10 * 1024 * 1024L, ((SizeBasedTriggeringPolicy) policy).getMaxFileSize());
         strategy = defaultSize.getManager().getRolloverStrategy();
-        assertTrue("is DefaultRolloverStrategy", strategy instanceof DefaultRolloverStrategy);
+        assertTrue(strategy instanceof DefaultRolloverStrategy, "is DefaultRolloverStrategy");
         defaultRolloverStrategy = (DefaultRolloverStrategy) strategy;
         assertEquals(1, defaultRolloverStrategy.getMinIndex());
         assertEquals(7, defaultRolloverStrategy.getMaxIndex());
         // Time policy with custom attributes
         appender = configuration.getAppender("TIME");
-        assertTrue("is RollingFileAppender", appender instanceof RollingFileAppender);
+        assertTrue(appender instanceof RollingFileAppender, "is RollingFileAppender");
         final RollingFileAppender time = (RollingFileAppender) appender;
-        assertFalse("append", time.getManager().isAppend());
-        assertEquals("bufferSize", 1000, time.getManager().getBufferSize());
-        assertFalse("immediateFlush", time.getImmediateFlush());
-        assertEquals("fileName", "target/EnhancedRollingFileAppender/time.log", time.getFileName());
+        assertFalse(time.getManager().isAppend(), "append");
+        assertEquals(1000, time.getManager().getBufferSize(), "bufferSize");
+        assertFalse(time.getImmediateFlush(), "immediateFlush");
+        assertEquals("target/EnhancedRollingFileAppender/time.log", time.getFileName(), "fileName");
         assertEquals(
-                "filePattern", "target/EnhancedRollingFileAppender/time.%d{yyyy-MM-dd}.log", time.getFilePattern());
+                "target/EnhancedRollingFileAppender/time.%d{yyyy-MM-dd}.log", time.getFilePattern(), "filePattern");
         policy = time.getTriggeringPolicy();
-        assertTrue("is TimeBasedTriggeringPolicy", policy instanceof TimeBasedTriggeringPolicy);
+        assertTrue(policy instanceof TimeBasedTriggeringPolicy, "is TimeBasedTriggeringPolicy");
         // Size policy with custom attributes
         appender = configuration.getAppender("SIZE");
-        assertTrue("is RollingFileAppender", appender instanceof RollingFileAppender);
+        assertTrue(appender instanceof RollingFileAppender, "is RollingFileAppender");
         final RollingFileAppender size = (RollingFileAppender) appender;
-        assertFalse("append", size.getManager().isAppend());
-        assertEquals("bufferSize", 1000, size.getManager().getBufferSize());
-        assertFalse("immediateFlush", size.getImmediateFlush());
-        assertEquals("fileName", "target/EnhancedRollingFileAppender/size.log", size.getFileName());
-        assertEquals("filePattern", "target/EnhancedRollingFileAppender/size.%i.log", size.getFilePattern());
+        assertFalse(size.getManager().isAppend(), "append");
+        assertEquals(1000, size.getManager().getBufferSize(), "bufferSize");
+        assertFalse(size.getImmediateFlush(), "immediateFlush");
+        assertEquals("target/EnhancedRollingFileAppender/size.log", size.getFileName(), "fileName");
+        assertEquals("target/EnhancedRollingFileAppender/size.%i.log", size.getFilePattern(), "filePattern");
         policy = size.getTriggeringPolicy();
-        assertTrue("is SizeBasedTriggeringPolicy", policy instanceof SizeBasedTriggeringPolicy);
+        assertTrue(policy instanceof SizeBasedTriggeringPolicy, "is SizeBasedTriggeringPolicy");
         assertEquals(10_000_000L, ((SizeBasedTriggeringPolicy) policy).getMaxFileSize());
         strategy = size.getManager().getRolloverStrategy();
-        assertTrue("is DefaultRolloverStrategy", strategy instanceof DefaultRolloverStrategy);
+        assertTrue(strategy instanceof DefaultRolloverStrategy, "is DefaultRolloverStrategy");
         defaultRolloverStrategy = (DefaultRolloverStrategy) strategy;
         assertEquals(11, defaultRolloverStrategy.getMinIndex());
         assertEquals(20, defaultRolloverStrategy.getMaxIndex());

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/AutoConfigTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/AutoConfigTest.java
@@ -16,8 +16,8 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -30,16 +30,16 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.spi.LoggerContext;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test configuration from XML.
  */
 public class AutoConfigTest {
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(ConfigurationFactory.LOG4J1_EXPERIMENTAL, "true");
     }
 
@@ -60,11 +60,11 @@ public class AutoConfigTest {
                 eventAppender = (ListAppender) ((AppenderAdapter.Adapter) entry.getValue()).getAppender();
             }
         }
-        assertNotNull("No Event Appender", eventAppender);
-        assertNotNull("No Message Appender", messageAppender);
+        assertNotNull(eventAppender, "No Event Appender");
+        assertNotNull(messageAppender, "No Message Appender");
         final List<LoggingEvent> events = eventAppender.getEvents();
-        assertTrue("No events", events != null && events.size() > 0);
+        assertTrue(events != null && events.size() > 0, "No events");
         final List<String> messages = messageAppender.getMessages();
-        assertTrue("No messages", messages != null && messages.size() > 0);
+        assertTrue(messages != null && messages.size() > 0, "No messages");
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationConverterHadoopTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationConverterHadoopTest.java
@@ -19,18 +19,22 @@ package org.apache.log4j.config;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class Log4j1ConfigurationConverterHadoopTest extends AbstractLog4j1ConfigurationConverterTest {
 
-    @Parameterized.Parameters(name = "{0}")
     public static List<Path> data() throws IOException {
         return getPaths("src/test/resources/config-1.2/hadoop");
     }
 
-    public Log4j1ConfigurationConverterHadoopTest(final Path path) {
-        super(path);
+    public Log4j1ConfigurationConverterHadoopTest() {
+        super();
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void test(Path path) throws Exception {
+        super.test(path);
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationConverterSparkTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationConverterSparkTest.java
@@ -19,18 +19,22 @@ package org.apache.log4j.config;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class Log4j1ConfigurationConverterSparkTest extends AbstractLog4j1ConfigurationConverterTest {
 
-    @Parameterized.Parameters(name = "{0}")
     public static List<Path> data() throws IOException {
         return getPaths("src/test/resources/config-1.2/spark");
     }
 
-    public Log4j1ConfigurationConverterSparkTest(final Path path) {
-        super(path);
+    public Log4j1ConfigurationConverterSparkTest() {
+        super();
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void test(Path path) throws Exception {
+        super.test(path);
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/Log4j1ConfigurationFactoryTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.Serializable;
 import java.net.URISyntaxException;
@@ -37,7 +37,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.core.layout.PatternLayout;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationTest {
 
@@ -46,7 +46,7 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
     @Override
     protected Configuration getConfiguration(final String configResource) throws URISyntaxException {
         final URL configLocation = ClassLoader.getSystemResource(configResource + SUFFIX);
-        assertNotNull(configResource, configLocation);
+        assertNotNull(configLocation, configResource);
         final Configuration configuration =
                 new Log4j1ConfigurationFactory().getConfiguration(null, "test", configLocation.toURI());
         assertNotNull(configuration);
@@ -58,7 +58,7 @@ public class Log4j1ConfigurationFactoryTest extends AbstractLog4j1ConfigurationT
         final String name = "Console";
         final ConsoleAppender appender = configuration.getAppender(name);
         assertNotNull(
-                "Missing appender '" + name + "' in configuration " + configResource + " → " + configuration, appender);
+                appender, "Missing appender '" + name + "' in configuration " + configResource + " → " + configuration);
         assertEquals(Target.SYSTEM_ERR, appender.getTarget());
         //
         final LoggerConfig loggerConfig = configuration.getLoggerConfig("com.example.foo");

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/MapRewriteAppenderTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/MapRewriteAppenderTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.List;
@@ -33,22 +33,22 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test RewriteAppender
  */
 public class MapRewriteAppenderTest {
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(
                 ConfigurationFactory.LOG4J1_CONFIGURATION_FILE_PROPERTY, "target/test-classes/log4j1-mapRewrite.xml");
     }
 
-    @After
+    @AfterEach
     public void after() {
         ThreadContext.clearMap();
     }
@@ -69,12 +69,11 @@ public class MapRewriteAppenderTest {
                 eventAppender = (ListAppender) ((AppenderAdapter.Adapter) entry.getValue()).getAppender();
             }
         }
-        assertNotNull("No Event Appender", eventAppender);
+        assertNotNull(eventAppender, "No Event Appender");
         final List<LoggingEvent> events = eventAppender.getEvents();
-        assertTrue("No events", events != null && events.size() > 0);
-        assertNotNull("No properties in the event", events.get(0).getProperties());
-        assertTrue("Key was not inserted", events.get(0).getProperties().containsKey("hello"));
-        assertEquals(
-                "Key value is incorrect", "world", events.get(0).getProperties().get("hello"));
+        assertTrue(events != null && events.size() > 0, "No events");
+        assertNotNull(events.get(0).getProperties(), "No properties in the event");
+        assertTrue(events.get(0).getProperties().containsKey("hello"), "Key was not inserted");
+        assertEquals("world", events.get(0).getProperties().get("hello"), "Key value is incorrect");
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationFactoryTest.java
@@ -16,22 +16,22 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test configuration from Properties.
  */
 public class PropertiesConfigurationFactoryTest {
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(
                 ConfigurationFactory.LOG4J1_CONFIGURATION_FILE_PROPERTY,
                 "target/test-classes/log4j1-file-1.properties");
@@ -42,10 +42,10 @@ public class PropertiesConfigurationFactoryTest {
         final Logger logger = LogManager.getLogger("test");
         logger.debug("This is a test of the root logger");
         File file = new File("target/temp.A1");
-        assertTrue("File A1 was not created", file.exists());
-        assertTrue("File A1 is empty", file.length() > 0);
+        assertTrue(file.exists(), "File A1 was not created");
+        assertTrue(file.length() > 0, "File A1 is empty");
         file = new File("target/temp.A2");
-        assertTrue("File A2 was not created", file.exists());
-        assertTrue("File A2 is empty", file.length() > 0);
+        assertTrue(file.exists(), "File A2 was not created");
+        assertTrue(file.length() > 0, "File A2 is empty");
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesConfigurationTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,7 +50,7 @@ import org.apache.logging.log4j.core.filter.DenyAllFilter;
 import org.apache.logging.log4j.core.filter.Filterable;
 import org.apache.logging.log4j.core.filter.LevelRangeFilter;
 import org.apache.logging.log4j.core.layout.PatternLayout;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test configuration from Properties.
@@ -67,7 +67,7 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
         final ConfigurationSource source = new ConfigurationSource(inputStream);
         final LoggerContext context = LoggerContext.getContext(false);
         final Configuration configuration = new PropertiesConfigurationFactory().getConfiguration(context, source);
-        assertNotNull("No configuration created", configuration);
+        assertNotNull(configuration, "No configuration created");
         configuration.initialize();
         return configuration;
     }
@@ -190,12 +190,12 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
                     eventAppender = (ListAppender) ((AppenderAdapter.Adapter) entry.getValue()).getAppender();
                 }
             }
-            assertNotNull("No Event Appender", eventAppender);
-            assertNotNull("No Message Appender", messageAppender);
+            assertNotNull(eventAppender, "No Event Appender");
+            assertNotNull(messageAppender, "No Message Appender");
             final List<LoggingEvent> events = eventAppender.getEvents();
-            assertTrue("No events", events != null && events.size() > 0);
+            assertTrue(events != null && events.size() > 0, "No events");
             final List<String> messages = messageAppender.getMessages();
-            assertTrue("No messages", messages != null && messages.size() > 0);
+            assertTrue(messages != null && messages.size() > 0, "No messages");
         }
     }
 
@@ -206,11 +206,11 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
             final Logger logger = LogManager.getLogger("test");
             logger.debug("This is a test of the root logger");
             File file = new File("target/temp.A1");
-            assertTrue("File A1 was not created", file.exists());
-            assertTrue("File A1 is empty", file.length() > 0);
+            assertTrue(file.exists(), "File A1 was not created");
+            assertTrue(file.length() > 0, "File A1 is empty");
             file = new File("target/temp.A2");
-            assertTrue("File A2 was not created", file.exists());
-            assertTrue("File A2 is empty", file.length() > 0);
+            assertTrue(file.exists(), "File A2 was not created");
+            assertTrue(file.length() > 0, "File A2 is empty");
         }
     }
 
@@ -225,8 +225,8 @@ public class PropertiesConfigurationTest extends AbstractLog4j1ConfigurationTest
             assertNotNull(configuration);
             final String name = "FILE_APPENDER";
             final Appender appender = configuration.getAppender(name);
-            assertNotNull(name, appender);
-            assertTrue(appender.getClass().getName(), appender instanceof FileAppender);
+            assertNotNull(appender, name);
+            assertTrue(appender instanceof FileAppender, appender.getClass().getName());
             final FileAppender fileAppender = (FileAppender) appender;
             // Two slashes because that's how the config file is setup.
             assertEquals(testPathLocation + "/hadoop.log", fileAppender.getFileName());

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesReconfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesReconfigurationTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,7 +42,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationListener;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.Reconfigurable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test reconfiguring with an XML configuration.
@@ -97,7 +97,7 @@ public class PropertiesReconfigurationTest {
             final FailableConsumer<String, IOException> configurator)
             throws IOException {
         final File file = new File(configPath);
-        assertTrue("No Config file", file.exists());
+        assertTrue(file.exists(), "No Config file");
         try (final LoggerContext context = TestConfigurator.configure(file.toString())) {
             final Logger logger = LogManager.getLogger("test");
             logger.info("Hello");
@@ -109,7 +109,7 @@ public class PropertiesReconfigurationTest {
 
     private void checkConfigureFileAppender(final String configPath, final boolean expectAppend) throws IOException {
         final File file = new File(configPath);
-        assertTrue("No Config file", file.exists());
+        assertTrue(file.exists(), "No Config file");
         try (final LoggerContext context = TestConfigurator.configure(file.toString())) {
             final Logger logger = LogManager.getLogger("test");
             logger.info("Hello");
@@ -209,9 +209,9 @@ public class PropertiesReconfigurationTest {
     public void testTestListener() throws Exception {
         System.setProperty(Log4j1Configuration.MONITOR_INTERVAL, "1");
         final File file = new File(CONFIG_FILE_APPENDER_1);
-        assertTrue("No Config file", file.exists());
+        assertTrue(file.exists(), "No Config file");
         final long configMillis = file.lastModified();
-        assertTrue("Unable to modified file time", file.setLastModified(configMillis - FIVE_MINUTES.toMillis()));
+        assertTrue(file.setLastModified(configMillis - FIVE_MINUTES.toMillis()), "Unable to modified file time");
         try (final LoggerContext context = TestConfigurator.configure(file.toString())) {
             final Logger logger = LogManager.getLogger("test");
             logger.info("Hello");
@@ -229,7 +229,7 @@ public class PropertiesReconfigurationTest {
                 fail("Reconfiguration interupted");
             }
             final Configuration updated = context.getConfiguration();
-            assertTrue("Configurations are the same", original != updated);
+            assertTrue(original != updated, "Configurations are the same");
         }
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesReconfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesReconfigurationTest.java
@@ -17,6 +17,7 @@
 package org.apache.log4j.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -229,7 +230,7 @@ public class PropertiesReconfigurationTest {
                 fail("Reconfiguration interupted");
             }
             final Configuration updated = context.getConfiguration();
-            assertTrue(original != updated, "Configurations are the same");
+            assertNotEquals(original, updated, "Configurations are the same");
         }
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesRollingWithPropertiesTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/PropertiesRollingWithPropertiesTest.java
@@ -16,18 +16,15 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.apache.logging.log4j.core.test.SystemPropertyTestRule;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestRule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test configuration from Properties.
@@ -36,13 +33,12 @@ public class PropertiesRollingWithPropertiesTest {
 
     private static final String TEST_DIR = "target/" + PropertiesRollingWithPropertiesTest.class.getSimpleName();
 
-    @ClassRule
-    public static TestRule SP_RULE = RuleChain.emptyRuleChain()
-            // @formatter:off
-            .around(SystemPropertyTestRule.create("test.directory", TEST_DIR))
-            .around(SystemPropertyTestRule.create(
-                    "log4j.configuration", "target/test-classes/log4j1-rolling-properties.properties"));
-    // @formatter:on
+    @BeforeAll
+    public static void setupSystemProperties() {
+        // Set system properties as a replacement for SystemPropertyTestRule
+        System.setProperty("test.directory", TEST_DIR);
+        System.setProperty("log4j.configuration", "target/test-classes/log4j1-rolling-properties.properties");
+    }
 
     @Test
     public void testProperties() throws Exception {
@@ -50,7 +46,7 @@ public class PropertiesRollingWithPropertiesTest {
         Files.deleteIfExists(path);
         final Logger logger = LogManager.getLogger("test");
         logger.debug("This is a test of the root logger");
-        assertTrue("Log file was not created", Files.exists(path));
-        assertTrue("Log file is empty", Files.size(path) > 0);
+        assertTrue(Files.exists(path), "Log file was not created");
+        assertTrue(Files.size(path) > 0, "Log file is empty");
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/RewriteAppenderTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/RewriteAppenderTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -32,22 +32,22 @@ import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test RewriteAppender
  */
 public class RewriteAppenderTest {
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(
                 ConfigurationFactory.LOG4J1_CONFIGURATION_FILE_PROPERTY, "target/test-classes/log4j1-rewrite.xml");
     }
 
-    @After
+    @AfterEach
     public void after() {
         ThreadContext.clearMap();
     }
@@ -68,13 +68,12 @@ public class RewriteAppenderTest {
                 eventAppender = (ListAppender) ((AppenderAdapter.Adapter) entry.getValue()).getAppender();
             }
         }
-        assertNotNull("No Event Appender", eventAppender);
+        assertNotNull(eventAppender, "No Event Appender");
         final List<LoggingEvent> events = eventAppender.getEvents();
-        assertTrue("No events", events != null && events.size() > 0);
-        assertNotNull("No properties in the event", events.get(0).getProperties());
-        assertTrue("Key was not inserted", events.get(0).getProperties().containsKey("key2"));
-        assertEquals(
-                "Key value is incorrect", "Log4j", events.get(0).getProperties().get("key2"));
-        assertTrue("Timestamp is before point of logging", events.get(0).getTimeStamp() >= logTime);
+        assertTrue(events != null && events.size() > 0, "No events");
+        assertNotNull(events.get(0).getProperties(), "No properties in the event");
+        assertTrue(events.get(0).getProperties().containsKey("key2"), "Key was not inserted");
+        assertEquals("Log4j", events.get(0).getProperties().get("key2"), "Key value is incorrect");
+        assertTrue(events.get(0).getTimeStamp() >= logTime, "Timestamp is before point of logging");
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/SocketAppenderConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/SocketAppenderConfigurationTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -30,7 +30,7 @@ import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.core.net.Protocol;
 import org.apache.logging.log4j.core.net.TcpSocketManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests configuring a Syslog appender.

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderConfigurationTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderTest.java
@@ -16,7 +16,8 @@
  */
 package org.apache.log4j.config;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 
 import java.io.IOException;
 import java.util.List;
@@ -34,7 +35,7 @@ public class SyslogAppenderTest {
     private static MockSyslogServer syslogServer;
 
     @BeforeAll
-    public static void beforeClass() throws IOException {
+    public static void beforeAll() throws IOException {
         initTCPTestEnvironment(null);
         System.setProperty("syslog.port", Integer.toString(syslogServer.getLocalPort()));
         System.setProperty(
@@ -42,7 +43,7 @@ public class SyslogAppenderTest {
     }
 
     @AfterAll
-    public static void afterClass() {
+    public static void afterAll() {
         System.clearProperty(ConfigurationFactory.LOG4J1_CONFIGURATION_FILE_PROPERTY);
         syslogServer.shutdown();
     }
@@ -59,7 +60,7 @@ public class SyslogAppenderTest {
                 break;
             }
         }
-        assertThat(messages).hasSize(1);
+        assertThat(messages, hasSize(1));
     }
 
     protected static void initTCPTestEnvironment(final String messageFormat) throws IOException {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/TestConfigurator.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/TestConfigurator.java
@@ -16,7 +16,7 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
@@ -45,7 +45,7 @@ public class TestConfigurator {
             } else {
                 fail("Test infra does not support " + configLocation);
             }
-            assertNotNull("No configuration created", configuration);
+            assertNotNull(configuration, "No configuration created");
             Configurator.reconfigure(configuration);
             return context;
         }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationFactoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationFactoryTest.java
@@ -16,22 +16,22 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test configuration from XML.
  */
 public class XmlConfigurationFactoryTest {
 
-    @BeforeClass
-    public static void beforeClass() {
+    @BeforeAll
+    public static void beforeAll() {
         System.setProperty(
                 ConfigurationFactory.LOG4J1_CONFIGURATION_FILE_PROPERTY, "target/test-classes/log4j1-file.xml");
     }
@@ -41,10 +41,10 @@ public class XmlConfigurationFactoryTest {
         final Logger logger = LogManager.getLogger("test");
         logger.debug("This is a test of the root logger");
         File file = new File("target/temp.A1");
-        assertTrue("File A1 was not created", file.exists());
-        assertTrue("File A1 is empty", file.length() > 0);
+        assertTrue(file.exists(), "File A1 was not created");
+        assertTrue(file.length() > 0, "File A1 is empty");
         file = new File("target/temp.A2");
-        assertTrue("File A2 was not created", file.exists());
-        assertTrue("File A2 is empty", file.length() > 0);
+        assertTrue(file.exists(), "File A2 was not created");
+        assertTrue(file.length() > 0, "File A2 is empty");
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,7 +41,7 @@ import org.apache.logging.log4j.core.appender.rolling.TimeBasedTriggeringPolicy;
 import org.apache.logging.log4j.core.appender.rolling.TriggeringPolicy;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test configuration from XML.
@@ -57,7 +57,7 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
         final ConfigurationSource source = new ConfigurationSource(inputStream);
         final LoggerContext context = LoggerContext.getContext(false);
         final Configuration configuration = new XmlConfigurationFactory().getConfiguration(context, source);
-        assertNotNull("No configuration created", configuration);
+        assertNotNull(configuration, "No configuration created");
         configuration.initialize();
         return configuration;
     }
@@ -78,12 +78,12 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
                 eventAppender = (ListAppender) ((AppenderAdapter.Adapter) entry.getValue()).getAppender();
             }
         }
-        assertNotNull("No Event Appender", eventAppender);
-        assertNotNull("No Message Appender", messageAppender);
+        assertNotNull(eventAppender, "No Event Appender");
+        assertNotNull(messageAppender, "No Message Appender");
         final List<LoggingEvent> events = eventAppender.getEvents();
-        assertTrue("No events", events != null && events.size() > 0);
+        assertTrue(events != null && events.size() > 0, "No events");
         final List<String> messages = messageAppender.getMessages();
-        assertTrue("No messages", messages != null && messages.size() > 0);
+        assertTrue(messages != null && messages.size() > 0, "No messages");
     }
 
     @Test
@@ -92,11 +92,11 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
         final Logger logger = LogManager.getLogger("test");
         logger.debug("This is a test of the root logger");
         File file = new File("target/temp.A1");
-        assertTrue("File A1 was not created", file.exists());
-        assertTrue("File A1 is empty", file.length() > 0);
+        assertTrue(file.exists(), "File A1 was not created");
+        assertTrue(file.length() > 0, "File A1 is empty");
         file = new File("target/temp.A2");
-        assertTrue("File A2 was not created", file.exists());
-        assertTrue("File A2 is empty", file.length() > 0);
+        assertTrue(file.exists(), "File A2 was not created");
+        assertTrue(file.length() > 0, "File A2 is empty");
     }
 
     @Override
@@ -191,13 +191,13 @@ public class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
             testEnhancedRollingFileAppender(configuration);
             // Only supported through XML configuration
             final Appender appender = configuration.getAppender("MIXED");
-            assertTrue("is RollingFileAppender", appender instanceof RollingFileAppender);
+            assertTrue(appender instanceof RollingFileAppender, "is RollingFileAppender");
             final TriggeringPolicy policy = ((RollingFileAppender) appender).getTriggeringPolicy();
-            assertTrue("is CompositeTriggeringPolicy", policy instanceof CompositeTriggeringPolicy);
+            assertTrue(policy instanceof CompositeTriggeringPolicy, "is CompositeTriggeringPolicy");
             final TriggeringPolicy[] policies = ((CompositeTriggeringPolicy) policy).getTriggeringPolicies();
             assertEquals(2, policies.length);
-            assertTrue("is TimeBasedTriggeringPolicy", policies[0] instanceof TimeBasedTriggeringPolicy);
-            assertTrue("is SizeBasedTriggeringPolicy", policies[1] instanceof SizeBasedTriggeringPolicy);
+            assertTrue(policies[0] instanceof TimeBasedTriggeringPolicy, "is TimeBasedTriggeringPolicy");
+            assertTrue(policies[1] instanceof SizeBasedTriggeringPolicy, "is SizeBasedTriggeringPolicy");
         }
     }
 

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlReconfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlReconfigurationTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.util.concurrent.CountDownLatch;
@@ -29,7 +29,7 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationListener;
 import org.apache.logging.log4j.core.config.Reconfigurable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test reconfiguring with an XML configuration.
@@ -45,9 +45,9 @@ public class XmlReconfigurationTest {
     public void testReconfiguration() throws Exception {
         System.setProperty(Log4j1Configuration.MONITOR_INTERVAL, "1");
         final File file = new File(CONFIG);
-        assertNotNull("No Config file", file);
+        assertNotNull(file, "No Config file");
         final long configMillis = file.lastModified();
-        assertTrue("Unable to modified file time", file.setLastModified(configMillis - FIVE_MINUTES));
+        assertTrue(file.setLastModified(configMillis - FIVE_MINUTES), "Unable to modified file time");
         final LoggerContext context = TestConfigurator.configure(file.toString());
         final Logger logger = LogManager.getLogger("test");
         logger.info("Hello");
@@ -65,7 +65,7 @@ public class XmlReconfigurationTest {
             fail("Reconfiguration interupted");
         }
         final Configuration updated = context.getConfiguration();
-        assertTrue("Configurations are the same", original != updated);
+        assertTrue(original != updated, "Configurations are the same");
     }
 
     private class TestListener implements ConfigurationListener {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlReconfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlReconfigurationTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.log4j.config;
 
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -65,7 +66,7 @@ public class XmlReconfigurationTest {
             fail("Reconfiguration interupted");
         }
         final Configuration updated = context.getConfiguration();
-        assertTrue(original != updated, "Configurations are the same");
+        assertNotEquals(original, updated, "Configurations are the same");
     }
 
     private class TestListener implements ConfigurationListener {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlRollingWithPropertiesTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlRollingWithPropertiesTest.java
@@ -16,18 +16,15 @@
  */
 package org.apache.log4j.config;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.apache.logging.log4j.core.test.SystemPropertyTestRule;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestRule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test configuration from Properties.
@@ -36,13 +33,11 @@ public class XmlRollingWithPropertiesTest {
 
     private static final String TEST_DIR = "target/" + XmlRollingWithPropertiesTest.class.getSimpleName();
 
-    @ClassRule
-    public static TestRule SP_RULE = RuleChain.emptyRuleChain()
-            // @formatter:off
-            .around(SystemPropertyTestRule.create("test.directory", TEST_DIR))
-            .around(SystemPropertyTestRule.create(
-                    "log4j.configuration", "target/test-classes/log4j1-rolling-properties.xml"));
-    // @formatter:on
+    @BeforeAll
+    public static void setupSystemProperties() {
+        System.setProperty("test.directory", TEST_DIR);
+        System.setProperty("log4j.configuration", "target/test-classes/log4j1-rolling-properties.xml");
+    }
 
     @Test
     public void testProperties() throws Exception {
@@ -51,7 +46,7 @@ public class XmlRollingWithPropertiesTest {
         Files.deleteIfExists(path);
         final Logger logger = LogManager.getLogger("test");
         logger.debug("This is a test of the root logger");
-        assertTrue("Log file was not created " + path, Files.exists(path));
-        assertTrue("Log file is empty " + path, Files.size(path) > 0);
+        assertTrue(Files.exists(path), "Log file was not created " + path);
+        assertTrue(Files.size(path) > 0, "Log file is empty " + path);
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/helpers/CyclicBufferTestCase.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/helpers/CyclicBufferTestCase.java
@@ -106,7 +106,7 @@ public class CyclicBufferTestCase extends TestCase {
         final int size = 2;
 
         CyclicBuffer cb = new CyclicBuffer(size);
-        assertEquals(cb.getMaxSize(), size);
+        assertEquals(size, cb.getMaxSize());
 
         cb.add(e[0]);
         assertEquals(cb.length(), 1);

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/helpers/UtilLoggingLevelTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/helpers/UtilLoggingLevelTest.java
@@ -17,7 +17,6 @@
 package org.apache.log4j.helpers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.stream.Stream;
 import org.apache.log4j.Level;
@@ -45,10 +44,10 @@ public class UtilLoggingLevelTest {
     @ParameterizedTest
     @MethodSource("namesAndLevels")
     public void testOptionConverterToLevel(final String name, final UtilLoggingLevel level) {
-        assertTrue(level == OptionConverter.toLevel(name, Level.ALL), "get v1 level by name");
+        assertEquals(level, OptionConverter.toLevel(name, Level.ALL), "get v1 level by name");
         // Comparison of Log4j 2.x levels
-        assertTrue(level.getVersion2Level() == org.apache.logging.log4j.Level.getLevel(name), "get v2 level by name");
+        assertEquals(level.getVersion2Level(), org.apache.logging.log4j.Level.getLevel(name), "get v2 level by name");
         // Test convertLevel
-        assertTrue(level == OptionConverter.convertLevel(level.getVersion2Level()), "convert level v2 -> v1");
+        assertEquals(level, OptionConverter.convertLevel(level.getVersion2Level()), "convert level v2 -> v1");
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/layout/Log4j1XmlLayoutTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/layout/Log4j1XmlLayoutTest.java
@@ -16,21 +16,18 @@
  */
 package org.apache.log4j.layout;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.impl.ContextDataFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.SimpleMessage;
-import org.apache.logging.log4j.test.junit.ThreadContextRule;
+import org.apache.logging.log4j.test.junit.UsingThreadContextStack;
 import org.apache.logging.log4j.util.StringMap;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+@UsingThreadContextStack
 public class Log4j1XmlLayoutTest {
-
-    @Rule
-    public ThreadContextRule threadContextRule = new ThreadContextRule();
 
     @Test
     public void testWithoutThrown() {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/pattern/Log4j1MdcPatternConverterTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/pattern/Log4j1MdcPatternConverterTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.log4j.pattern;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.core.impl.ContextDataFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.util.StringMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class Log4j1MdcPatternConverterTest {
 

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/pattern/Log4j1NdcPatternConverterTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/pattern/Log4j1NdcPatternConverterTest.java
@@ -16,21 +16,18 @@
  */
 package org.apache.log4j.pattern;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.SimpleMessage;
-import org.apache.logging.log4j.test.junit.ThreadContextStackRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.test.junit.UsingThreadContextStack;
+import org.junit.jupiter.api.Test;
 
+@UsingThreadContextStack
 public class Log4j1NdcPatternConverterTest {
-
-    @Rule
-    public final ThreadContextStackRule threadContextRule = new ThreadContextStackRule();
 
     @Test
     public void testEmpty() {

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/util/SerializationTestHelper.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/util/SerializationTestHelper.java
@@ -16,8 +16,8 @@
  */
 package org.apache.log4j.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -83,7 +83,7 @@ public final class SerializationTestHelper {
                 if ((skipIndex < skip.length) && (skip[skipIndex] == i)) {
                     skipIndex++;
                 } else if (expected[i] != actual[i]) {
-                    assertEquals("Difference at offset " + i, expected[i], actual[i]);
+                    assertEquals(expected[i], actual[i], "Difference at offset " + i);
                 }
             }
         } else {


### PR DESCRIPTION
Hello 👋

We are from Neighbourhoodie, the implementation partner of the [STF](https://www.sovereigntechfund.de/programs/bug-resilience) Bug Resilience Program. This work is part of our agreed Milestone 1. Upgrade from JUnit 4 to JUnit 5. This PR migrates the tests located in log4j-1.2-api to JUnit5.

Thank you!

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
