### PR TITLE
Upgrades JUnit to version `5.11.2`

### DIFF
--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/SetTestProperty.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/SetTestProperty.java
@@ -39,8 +39,7 @@ import org.junitpioneer.jupiter.ReadsSystemProperty;
 @Target({TYPE, METHOD})
 @Inherited
 @Documented
-@ExtendWith(ExtensionContextAnchor.class)
-@ExtendWith(TestPropertyResolver.class)
+@ExtendWith({ExtensionContextAnchor.class, TestPropertyResolver.class})
 @Repeatable(SetTestProperty.SetTestProperties.class)
 @ReadsSystemProperty
 @ReadsEnvironmentVariable
@@ -54,7 +53,7 @@ public @interface SetTestProperty {
     @Target({TYPE, METHOD})
     @Documented
     @Inherited
-    public @interface SetTestProperties {
+    @interface SetTestProperties {
 
         SetTestProperty[] value();
     }

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/TempLoggingDir.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/TempLoggingDir.java
@@ -37,8 +37,7 @@ import org.junit.jupiter.api.io.CleanupMode;
 @Target({FIELD, PARAMETER})
 @Inherited
 @Documented
-@ExtendWith(ExtensionContextAnchor.class)
-@ExtendWith(TempLoggingDirectory.class)
+@ExtendWith({ExtensionContextAnchor.class, TempLoggingDirectory.class})
 public @interface TempLoggingDir {
 
     CleanupMode cleanup() default CleanupMode.DEFAULT;

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/UsingStatusListener.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/UsingStatusListener.java
@@ -35,7 +35,5 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Retention(RUNTIME)
 @Target({TYPE, METHOD})
 @Documented
-@ExtendWith(ExtensionContextAnchor.class)
-@ExtendWith(TestPropertyResolver.class)
-@ExtendWith(StatusListenerExtension.class)
+@ExtendWith({ExtensionContextAnchor.class, TestPropertyResolver.class, StatusListenerExtension.class})
 public @interface UsingStatusListener {}

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/UsingTestProperties.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/UsingTestProperties.java
@@ -37,8 +37,7 @@ import org.junitpioneer.jupiter.ReadsSystemProperty;
 @Target({TYPE, METHOD})
 @Inherited
 @Documented
-@ExtendWith(ExtensionContextAnchor.class)
-@ExtendWith(TestPropertyResolver.class)
+@ExtendWith({ExtensionContextAnchor.class, TestPropertyResolver.class})
 @ReadsSystemProperty
 @ReadsEnvironmentVariable
 public @interface UsingTestProperties {}

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/package-info.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/package-info.java
@@ -15,10 +15,8 @@
  * limitations under the license.
  */
 @Export
-@Version("2.24.0")
-@BaselineIgnore("2.24.0")
+@Version("2.24.1")
 package org.apache.logging.log4j.test.junit;
 
-import aQute.bnd.annotation.baseline.BaselineIgnore;
 import org.osgi.annotation.bundle.Export;
 import org.osgi.annotation.versioning.Version;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/LoggerContextSource.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/LoggerContextSource.java
@@ -52,10 +52,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Documented
 @Inherited
 @Tag("functional")
-@ExtendWith(TempLoggingDirectory.class)
-@ExtendWith(LoggerContextResolver.class)
-@ExtendWith(ConfigurationResolver.class)
-@ExtendWith(AppenderResolver.class)
+@ExtendWith({
+    TempLoggingDirectory.class,
+    LoggerContextResolver.class,
+    ConfigurationResolver.class,
+    AppenderResolver.class
+})
 public @interface LoggerContextSource {
     /**
      * Specifies the name of the configuration file to use for the annotated test.

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/package-info.java
@@ -20,7 +20,7 @@
  * @see org.junit.rules.TestRule
  */
 @Export
-@Version("2.23.0")
+@Version("2.23.1")
 package org.apache.logging.log4j.core.test.junit;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -109,7 +109,7 @@
     <jmdns.version>3.5.12</jmdns.version>
     <jmh.version>1.37</jmh.version>
     <junit.version>4.13.2</junit.version>
-    <junit-jupiter.version>5.10.3</junit-jupiter.version>
+    <junit-jupiter.version>5.11.2</junit-jupiter.version>
     <junit-pioneer.version>1.9.1</junit-pioneer.version>
     <kafka.version>3.8.0</kafka.version>
     <lightcouch.version>0.2.0</lightcouch.version>


### PR DESCRIPTION
Due to a minor bug in JUnit 5.11.2 (junit-team/junit5#4054), fields meta-annotated with multiple `@ExtendWith` annotations are no longer recognized. We combine those annotations into single `@ExtendWith` annotations, which also looks better.

Closes #2843.

**Edit**: No changelog is necessary, since improvements to our test runtime are not advertised. One day we need to find a way to thank the suppliers of our test runtime.