### PR TITLE
Avoid levels like `INFO#org.apache.log4j.Level`

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/Level.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/Level.java
@@ -115,8 +115,7 @@ public class Level extends Priority implements Serializable {
             final String levelStr,
             final int syslogEquivalent,
             final org.apache.logging.log4j.Level version2Equivalent) {
-        super(level, levelStr, syslogEquivalent);
-        this.version2Level = version2Equivalent != null ? version2Equivalent : OptionConverter.createLevel(this);
+        super(level, levelStr, syslogEquivalent, version2Equivalent);
     }
 
     /**
@@ -222,6 +221,7 @@ public class Level extends Priority implements Serializable {
         if (levelStr == null) {
             levelStr = Strings.EMPTY;
         }
+        version2Level = OptionConverter.createLevel(this);
     }
 
     /**

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/Priority.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/Priority.java
@@ -16,6 +16,8 @@
  */
 package org.apache.log4j;
 
+import org.apache.log4j.helpers.OptionConverter;
+
 /**
  * <em style="color:#A44">Refrain from using this class directly, use
  * the {@link Level} class instead.</em>
@@ -64,31 +66,31 @@ public class Priority {
      * @deprecated Use {@link Level#FATAL} instead.
      */
     @Deprecated
-    public static final Priority FATAL = new Level(FATAL_INT, "FATAL", 0);
+    public static final Priority FATAL = new Priority(FATAL_INT, "FATAL", 0, org.apache.logging.log4j.Level.FATAL);
 
     /**
      * @deprecated Use {@link Level#ERROR} instead.
      */
     @Deprecated
-    public static final Priority ERROR = new Level(ERROR_INT, "ERROR", 3);
+    public static final Priority ERROR = new Priority(ERROR_INT, "ERROR", 3, org.apache.logging.log4j.Level.ERROR);
 
     /**
      * @deprecated Use {@link Level#WARN} instead.
      */
     @Deprecated
-    public static final Priority WARN = new Level(WARN_INT, "WARN", 4);
+    public static final Priority WARN = new Priority(WARN_INT, "WARN", 4, org.apache.logging.log4j.Level.WARN);
 
     /**
      * @deprecated Use {@link Level#INFO} instead.
      */
     @Deprecated
-    public static final Priority INFO = new Level(INFO_INT, "INFO", 6);
+    public static final Priority INFO = new Priority(INFO_INT, "INFO", 6, org.apache.logging.log4j.Level.INFO);
 
     /**
      * @deprecated Use {@link Level#DEBUG} instead.
      */
     @Deprecated
-    public static final Priority DEBUG = new Level(DEBUG_INT, "DEBUG", 7);
+    public static final Priority DEBUG = new Priority(DEBUG_INT, "DEBUG", 7, org.apache.logging.log4j.Level.DEBUG);
 
     /*
      * These variables should be private but were not in Log4j 1.2 so are left the same way here.
@@ -102,9 +104,7 @@ public class Priority {
      * Default constructor for deserialization.
      */
     protected Priority() {
-        level = DEBUG_INT;
-        levelStr = "DEBUG";
-        syslogEquivalent = 7;
+        this(DEBUG_INT, "DEBUG", 7, org.apache.logging.log4j.Level.DEBUG);
     }
 
     /**
@@ -114,9 +114,18 @@ public class Priority {
      * @param syslogEquivalent The equivalent syslog value.
      */
     protected Priority(final int level, final String levelStr, final int syslogEquivalent) {
+        this(level, levelStr, syslogEquivalent, null);
+    }
+
+    Priority(
+            final int level,
+            final String levelStr,
+            final int syslogEquivalent,
+            final org.apache.logging.log4j.Level version2Equivalent) {
         this.level = level;
         this.levelStr = levelStr;
         this.syslogEquivalent = syslogEquivalent;
+        this.version2Level = version2Equivalent != null ? version2Equivalent : OptionConverter.createLevel(this);
     }
 
     /**
@@ -229,7 +238,8 @@ public class Priority {
      */
     @Deprecated
     public static Priority toPriority(final int val, final Priority defaultPriority) {
-        return Level.toLevel(val, (Level) defaultPriority);
+        Level result = Level.toLevel(val, null);
+        return result == null ? defaultPriority : result;
     }
 
     /**
@@ -240,6 +250,7 @@ public class Priority {
      */
     @Deprecated
     public static Priority toPriority(final String sArg, final Priority defaultPriority) {
-        return Level.toLevel(sArg, (Level) defaultPriority);
+        Level result = Level.toLevel(sArg, null);
+        return result == null ? defaultPriority : result;
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LevelTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LevelTest.java
@@ -16,12 +16,15 @@
  */
 package org.apache.log4j;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Locale;
+import org.apache.log4j.helpers.OptionConverter;
 import org.apache.log4j.util.SerializationTestHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests of Level.
@@ -77,6 +80,7 @@ public class LevelTest {
         assertEquals(Level.INFO.level, clone.level);
         assertEquals(Level.INFO.levelStr, clone.levelStr);
         assertEquals(Level.INFO.syslogEquivalent, clone.syslogEquivalent);
+        assertEquals(OptionConverter.createLevel(custom), clone.version2Level);
     }
 
     /**
@@ -203,6 +207,15 @@ public class LevelTest {
     @Test
     public void testALL() {
         assertTrue(Level.ALL instanceof Level);
+    }
+
+    /**
+     * Tests version2Level.
+     */
+    @ParameterizedTest
+    @MethodSource("org.apache.log4j.helpers.OptionConverterLevelTest#standardLevels")
+    public void testVersion2Level(final Level log4j1Level, final org.apache.logging.log4j.Level log4j2Level) {
+        assertEquals(log4j2Level, log4j1Level.getVersion2Level());
     }
 
     /**

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/PriorityTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/PriorityTest.java
@@ -16,12 +16,16 @@
  */
 package org.apache.log4j;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Locale;
-import org.junit.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests of Priority.
@@ -85,13 +89,32 @@ public class PriorityTest {
         assertEquals(Integer.MIN_VALUE, Priority.ALL_INT);
     }
 
+    @SuppressWarnings("deprecation")
+    static Stream<Arguments> testVersion2Level() {
+        return Stream.of(
+                Arguments.of(Priority.FATAL, org.apache.logging.log4j.Level.FATAL),
+                Arguments.of(Priority.ERROR, org.apache.logging.log4j.Level.ERROR),
+                Arguments.of(Priority.WARN, org.apache.logging.log4j.Level.WARN),
+                Arguments.of(Priority.INFO, org.apache.logging.log4j.Level.INFO),
+                Arguments.of(Priority.DEBUG, org.apache.logging.log4j.Level.DEBUG));
+    }
+
+    /**
+     * Tests version2Level.
+     */
+    @ParameterizedTest
+    @MethodSource()
+    public void testVersion2Level(final Priority log4j1Priority, final org.apache.logging.log4j.Level log4j2Level) {
+        assertEquals(log4j2Level, log4j1Priority.getVersion2Level());
+    }
+
     /**
      * Tests Priority.FATAL.
      */
     @Test
     @SuppressWarnings("deprecation")
-    public void testFatal() {
-        assertTrue(Priority.FATAL instanceof Level);
+    public void testFATAL() {
+        assertFalse(Priority.FATAL instanceof Level);
     }
 
     /**
@@ -100,7 +123,7 @@ public class PriorityTest {
     @Test
     @SuppressWarnings("deprecation")
     public void testERROR() {
-        assertTrue(Priority.ERROR instanceof Level);
+        assertFalse(Priority.ERROR instanceof Level);
     }
 
     /**
@@ -109,7 +132,7 @@ public class PriorityTest {
     @Test
     @SuppressWarnings("deprecation")
     public void testWARN() {
-        assertTrue(Priority.WARN instanceof Level);
+        assertFalse(Priority.WARN instanceof Level);
     }
 
     /**
@@ -118,7 +141,7 @@ public class PriorityTest {
     @Test
     @SuppressWarnings("deprecation")
     public void testINFO() {
-        assertTrue(Priority.INFO instanceof Level);
+        assertFalse(Priority.INFO instanceof Level);
     }
 
     /**
@@ -127,7 +150,7 @@ public class PriorityTest {
     @Test
     @SuppressWarnings("deprecation")
     public void testDEBUG() {
-        assertTrue(Priority.DEBUG instanceof Level);
+        assertFalse(Priority.DEBUG instanceof Level);
     }
 
     /**

--- a/src/changelog/.2.x.x/3085_fix_log4j_1_priority.xml
+++ b/src/changelog/.2.x.x/3085_fix_log4j_1_priority.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3085" link="https://github.com/apache/logging-log4j2/pull/3085"/>
+  <description format="asciidoc">Fix the conversion of `o.a.l.Priority` classes to Log4j 2 levels.</description>
+</entry>


### PR DESCRIPTION
If somebody (for example an external library) uses the deprecated `Priority` class there will be a custom level created even though there already exists a corresponding level.