### PR TITLE
Fixes property names in release notes

### DIFF
--- a/src/changelog/2.10.0/LOG4J2-2091_Log4j_respects_the_configured_log4j2_is_webapp_property.xml
+++ b/src/changelog/2.10.0/LOG4J2-2091_Log4j_respects_the_configured_log4j2_is_webapp_property.xml
@@ -4,5 +4,9 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <issue id="LOG4J2-2091" link="https://issues.apache.org/jira/browse/LOG4J2-2091"/>
-  <description format="asciidoc">Log4j respects the configured "log4j2.is.webapp" property</description>
+  <description format="asciidoc">
+    Log4j respects the configured
+    xref:manual/systemproperties.adoc#log4j2.isWebapp[`log4j2.isWebapp`]
+    property.
+  </description>
 </entry>

--- a/src/changelog/2.11.0/LOG4J2-2250_The_internal_status_logger_timestamp_format_is_now_configura.xml
+++ b/src/changelog/2.11.0/LOG4J2-2250_The_internal_status_logger_timestamp_format_is_now_configura.xml
@@ -4,5 +4,8 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="changed">
   <issue id="LOG4J2-2250" link="https://issues.apache.org/jira/browse/LOG4J2-2250"/>
-  <description format="asciidoc">The internal status logger timestamp format is now configurable with system property `log4j2.StatusLogger.DateFormat`.</description>
+  <description format="asciidoc">
+    The internal status logger timestamp format is now configurable with system property
+    xref:manual/status-logger.adoc#log4j2.statusLoggerDateFormat[`log4j2.statusLoggerDateFormat`].
+  </description>
 </entry>

--- a/src/changelog/2.15.0/LOG4J2-3160_Fix_documentation_on_how_to_toggle_log4j2_debug_system_prope.xml
+++ b/src/changelog/2.15.0/LOG4J2-3160_Fix_documentation_on_how_to_toggle_log4j2_debug_system_prope.xml
@@ -4,5 +4,9 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <issue id="LOG4J2-3160" link="https://issues.apache.org/jira/browse/LOG4J2-3160"/>
-  <description format="asciidoc">Fix documentation on how to toggle log4j2.debug system property.</description>
+  <description format="asciidoc">
+    Fix documentation on how to toggle
+    xref:manual/status-logger.adoc#log4j2.debug[`log4j2.debug`]
+    system property.
+  </description>
 </entry>

--- a/src/changelog/2.16.0/LOG4J2-3208_Disable_JNDI_by_default_Require_log4j2_enableJndi_to_be_set.xml
+++ b/src/changelog/2.16.0/LOG4J2-3208_Disable_JNDI_by_default_Require_log4j2_enableJndi_to_be_set.xml
@@ -4,5 +4,9 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <issue id="LOG4J2-3208" link="https://issues.apache.org/jira/browse/LOG4J2-3208"/>
-  <description format="asciidoc">Disable JNDI by default. Require log4j2.enableJndi to be set to true to allow JNDI.</description>
+  <description format="asciidoc">
+    Disable JNDI by default. Require
+    xref:manual/systemproperties.adoc#properties-jndi[`log4j2.enableJndi`]
+    to be set to true to allow JNDI.
+  </description>
 </entry>

--- a/src/changelog/2.17.0/.release-notes.adoc.ftl
+++ b/src/changelog/2.17.0/.release-notes.adoc.ftl
@@ -45,7 +45,11 @@ Recursive evaluation is still allowed while generating the configuration.
 * The `JndiLookup`, `JndiContextSelector`, and `JMSAppender` now require individual system properties to be enabled.
 * Remove LDAP and LDAPS as supported protocols from JNDI.
 
-The single `log4j2.enableJndi` property introduced in Log4j 2.16.0 has been replaced with three individual properties; `log4j2.enableJndiContextSelector`, `log4j2.enableJndiJms`, and `log4j2.enableJndiLookup`.
+The single `log4j2.enableJndi` property introduced in Log4j 2.16.0 has been replaced with three individual properties:
+xref:manual/systemproperties.adoc#log4j2.enableJndiContextSelector[`log4j2.enableJndiContextSelector`],
+xref:manual/systemproperties.adoc#log4j2.enableJndiJms[`log4j2.enableJndiJms`],
+and
+ xref:manual/systemproperties.adoc#log4j2.enableJndiLookup[`log4j2.enableJndiLookup`].
 
 The Log4j 2.17.0 API, as well as many core components, maintains binary compatibility with previous releases.
 

--- a/src/changelog/2.17.0/LOG4J2-3242_Limit_JNDI_to_the_java_protocol_only_JNDI_will_remain_disab.xml
+++ b/src/changelog/2.17.0/LOG4J2-3242_Limit_JNDI_to_the_java_protocol_only_JNDI_will_remain_disab.xml
@@ -4,6 +4,15 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <issue id="LOG4J2-3242" link="https://issues.apache.org/jira/browse/LOG4J2-3242"/>
-  <description format="asciidoc">Limit JNDI to the java protocol only. JNDI will remain disabled by default. Rename JNDI enablement property from
-        'log4j2.enableJndi' to 'log4j2.enableJndiLookup', 'log4j2.enableJndiJms', and 'log4j2.enableJndiContextSelector'.</description>
+  <description format="asciidoc">
+    Limit JNDI to the java protocol only.
+    JNDI will remain disabled by default.
+    Rename JNDI enablement property from
+    xref:manual/systemproperties.adoc#properties-jndi[`log4j2.enableJndi`]
+    to
+    xref:manual/systemproperties.adoc#log4j2.enableJndiLookup[`log4j2.enableJndiLookup`],
+    xref:manual/systemproperties.adoc#log4j2.enableJndiJms[`log4j2.enableJndiJms`],
+    and
+    xref:manual/systemproperties.adoc#log4j2.enableJndiContextSelector[`log4j2.enableJndiContextSelector`].
+  </description>
 </entry>

--- a/src/changelog/2.17.1/LOG4J2-3293_JdbcAppender_now_uses_JndiManager_to_access_JNDI_resources.xml
+++ b/src/changelog/2.17.1/LOG4J2-3293_JdbcAppender_now_uses_JndiManager_to_access_JNDI_resources.xml
@@ -4,6 +4,11 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <issue id="LOG4J2-3293" link="https://issues.apache.org/jira/browse/LOG4J2-3293"/>
-  <description format="asciidoc">JdbcAppender now uses JndiManager to access JNDI resources. JNDI is only enabled when system property
-        log4j2.enableJndiJdbc is set to true.</description>
+  <description format="asciidoc">
+    xref:manual/appenders/database.adoc#JdbcAppender[JDBC Appender]
+    now uses `JndiManager` to access JNDI resources.
+    JNDI is only enabled when the system property
+    xref:manual/systemproperties.adoc#log4j2.enableJndiJdbc[`log4j2.enableJndiJdbc`]
+    is set to `true`.
+  </description>
 </entry>

--- a/src/changelog/2.17.2/LOG4J2-2486_Require_log4j2_Script_enableLanguages_to_be_specified_to_ena.xml
+++ b/src/changelog/2.17.2/LOG4J2-2486_Require_log4j2_Script_enableLanguages_to_be_specified_to_ena.xml
@@ -4,5 +4,9 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="added">
   <issue id="LOG4J2-2486" link="https://issues.apache.org/jira/browse/LOG4J2-2486"/>
-  <description format="asciidoc">Require log4j2.Script.enableLanguages to be specified to enable scripting for specific languages.</description>
+  <description format="asciidoc">
+    Require
+    xref:manual/systemproperties.adoc#log4j2.scriptEnableLanguages[`log4j2.scriptEnableLanguages`]
+    to be specified to enable scripting for specific languages.
+  </description>
 </entry>

--- a/src/changelog/2.22.0/change_basic_auth_encoding.xml
+++ b/src/changelog/2.22.0/change_basic_auth_encoding.xml
@@ -5,6 +5,8 @@
        type="changed">
   <issue id="1970" link="https://github.com/apache/logging-log4j2/pull/1970"/>
   <description format="asciidoc">
-    Change default encoding of HTTP Basic Authentication to UTF-8 and add `log4j2.configurationAuthorizationEncoding` property to overwrite it.
+    Change default encoding of HTTP Basic Authentication to UTF-8 and add
+    xref:manual/systemproperties.adoc#log4j2.configurationAuthorizationEncoding[`log4j2.configurationAuthorizationEncoding`]
+    property to overwrite it.
   </description>
 </entry>

--- a/src/changelog/2.23.1/fix_StatusLogger_instant_formatting.xml
+++ b/src/changelog/2.23.1/fix_StatusLogger_instant_formatting.xml
@@ -5,7 +5,9 @@
        type="fixed">
   <issue id="2322" link="https://github.com/apache/logging-log4j2/pull/2322"/>
   <description format="asciidoc">
-    Add `log4j2.StatusLogger.dateFormatZone` system property to set the time-zone `StatusLogger` uses to format `java.time.Instant`.
+    Add
+    xref:manual/statusLogger.adoc#log4j2.statusLoggerDateFormatZone[`log4j2.statusLoggerDateFormatZone`]
+    system property to set the time-zone `StatusLogger` uses to format `java.time.Instant`.
     Without this, formatting patterns accessing to time-zone-specific fields (e.g., year-of-era) cause failures.
   </description>
 </entry>

--- a/src/changelog/2.24.0/.release-notes.adoc.ftl
+++ b/src/changelog/2.24.0/.release-notes.adoc.ftl
@@ -58,6 +58,8 @@ Please migrate to xref:components.adoc#log4j-mongodb[`log4j-mongodb`] (client ve
 
 === JMX changes
 
-Starting in version 2.24.0, JMX support is disabled by default and can be re-enabled via the `log4j2.disableJmx=false` system property.
+Starting in version 2.24.0, JMX support is disabled by default and can be re-enabled via the
+xref:manual/systemproperties.adoc#log4j2.disableJmx[`log4j2.disableJmx`]
+system property.
 
 <#include "../.changelog.adoc.ftl">

--- a/src/changelog/2.24.0/2363_add_logback_throwable_consuming_semantics.xml
+++ b/src/changelog/2.24.0/2363_add_logback_throwable_consuming_semantics.xml
@@ -6,6 +6,8 @@
   <issue id="2363" link="https://github.com/apache/logging-log4j2/issues/2363"/>
   <description format="asciidoc">
     Add Logback throwable-consuming semantics as an option in `log4j-slf4j-impl` and `log4j-slf4j2-impl`.
-    Users can enable it by setting the property `log4j2.messageFactory` to `org.apache.logging.slf4j.message.ThrowableConsumingMessageFactory`.
+    Users can enable it by setting the property
+    xref:manual/systemproperties.adoc#log4j2.messageFactory[`log4j2.messageFactory`]
+    to `org.apache.logging.slf4j.message.ThrowableConsumingMessageFactory`.
   </description>
 </entry>

--- a/src/changelog/2.24.0/2374_refactor_initialization.xml
+++ b/src/changelog/2.24.0/2374_refactor_initialization.xml
@@ -4,5 +4,9 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="changed">
   <issue id="2374" link="https://github.com/apache/logging-log4j2/pull/2374"/>
-  <description format="asciidoc">Centralize initialization in the `Provider` class and deprecate `log4j2.loggerContextFactory` property.</description>
+  <description format="asciidoc">
+    Centralize initialization in the `Provider` class and deprecate the
+    xref:manual/systemproperties.adoc#log4j2.loggerContextFactory[`log4j2.loggerContextFactory`]
+    property.
+  </description>
 </entry>

--- a/src/changelog/2.24.0/2379_fix_message_factory_properties.xml
+++ b/src/changelog/2.24.0/2379_fix_message_factory_properties.xml
@@ -3,6 +3,12 @@
        xmlns="https://logging.apache.org/xml/ns"
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
-  <issue id="2505" link="https://github.com/apache/logging-log4j2/pull/2505"/>
-  <description format="asciidoc">Fix handling of `log4j2.messageFactory` and `log4j2.flowMessageFactory` properties</description>
+  <issue id="2379" link="https://github.com/apache/logging-log4j2/issues/2379"/>
+  <description format="asciidoc">
+    Fix handling of
+    xref:manual/systemproperties.adoc#log4j2.messageFactory[`log4j2.messageFactory`]
+    and
+    xref:manual/systemproperties.adoc#log4j2.flowMessageFactory[`log4j2.flowMessageFactory`]
+    properties.
+  </description>
 </entry>

--- a/src/changelog/2.24.0/2462_disable_jmx_by_default.xml
+++ b/src/changelog/2.24.0/2462_disable_jmx_by_default.xml
@@ -3,6 +3,11 @@
        xmlns="https://logging.apache.org/xml/ns"
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="changed">
-    <issue id="2462" link="https://github.com/apache/logging-log4j2/issues/2462"/>
-    <description format="asciidoc">Disable JMX support by default. Require `log4j2.disableJmx` to be set to `false` to enable JMX support.</description>
+  <issue id="2462" link="https://github.com/apache/logging-log4j2/issues/2462"/>
+  <description format="asciidoc">
+    Disable JMX support by default.
+    Requires
+    xref:manual/systemproperties.adoc#log4j2.disableJmx[`log4j2.disableJmx`]
+    to be set to `false` to enable JMX support.
+  </description>
 </entry>

--- a/src/changelog/2.24.0/2703_log4j_debug.xml
+++ b/src/changelog/2.24.0/2703_log4j_debug.xml
@@ -4,5 +4,8 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <issue id="2703" link="https://github.com/apache/logging-log4j2/issues/2703"/>
-  <description format="asciidoc">Fix handling of `log4j2.debug`.</description>
+  <description format="asciidoc">
+    Fix handling of
+    xref:manual/status-logger#log4j2.debug[`log4j2.debug`].
+  </description>
 </entry>

--- a/src/changelog/2.24.0/change-is-webapp.xml
+++ b/src/changelog/2.24.0/change-is-webapp.xml
@@ -5,6 +5,12 @@
        type="changed">
   <issue id="2517" link="https://github.com/apache/logging-log4j2/pull/2517"/>
   <description format="asciidoc">
-    Prioritize user-defined values of `log4j2.enableThreadLocals`, `log4j2.garbagefreeThreadContextMap` and `log4j2.shutdownHookEnabled` over the value of `log4j.isWebapp`.
+    Prioritize user-defined values of
+    xref:manual/systemproperties.adoc#log4j2.enableThreadlocals[`log4j2.enableThreadlocals`],
+    xref:manual/systemproperties.adoc#log4j2.garbagefreeThreadContextMap[`log4j2.garbagefreeThreadContextMap`]
+    and
+    xref:manual/systemproperties.adoc#log4j2.shutdownHookEnabled[`log4j2.shutdownHookEnabled`]
+    over the value of
+    xref:manual/systemproperties.adoc#log4j2.isWebapp[`log4j2.isWebapp`].
   </description>
 </entry>

--- a/src/changelog/2.24.0/deprecate_log4j2_default_status_level.xml
+++ b/src/changelog/2.24.0/deprecate_log4j2_default_status_level.xml
@@ -4,5 +4,8 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="changed">
   <issue id="2481" link="https://github.com/apache/logging-log4j2/pull/2481"/>
-  <description format="asciidoc">Deprecate `log4j2.defaultStatusLevel` property in Log4j Core in favor of `log4j2.statusLoggerLevel`</description>
+  <description format="asciidoc">
+    Deprecate `log4j2.defaultStatusLevel` property in Log4j Core in favor of
+    xref:manual/status-logger.adoc#log4j2.statusLoggerLevel[`log4j2.statusLoggerLevel`].
+  </description>
 </entry>

--- a/src/site/antora/modules/ROOT/pages/manual/systemproperties.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/systemproperties.adoc
@@ -46,7 +46,7 @@ If a `log4j2.system.properties` file is available on the classpath its contents 
 
 [WARNING]
 ====
-To provide backward compatibility with versions older than 2.10 a certain number of additional property names is also supported using a fuzzy matching algorithm.
+To provide backward compatibility with versions older than 2.10.0 a certain number of additional property names are also supported using a fuzzy matching algorithm.
 
 In case of problems with the properties sub-system, make sure that your application does not use property names with the following case-insensitive prefixes:
 


### PR DESCRIPTION
Fixes the names of configuration properties introduced after `2.10.0` to always use the normalized form.

Fixes #3079
