### PR TITLE
Correct example property syntax under ScriptPatternSelector

### DIFF
--- a/src/site/antora/modules/ROOT/examples/manual/pattern-layout/script-pattern-selector/log4j2.properties
+++ b/src/site/antora/modules/ROOT/examples/manual/pattern-layout/script-pattern-selector/log4j2.properties
@@ -30,12 +30,12 @@ if (logEvent.getLoggerName().equals("NoLocation")) {\
 } else {\
   return null;\
 }
-appender.0.layout.patternSelector.patternMatch.0.type = PatternMatch
-appender.0.layout.patternSelector.patternMatch.0.key = NoLocation
-appender.0.layout.patternSelector.patternMatch.0.pattern = [%-5level] %c{1.} %msg%n
-appender.0.layout.patternSelector.patternMatch.1.type = PatternMatch
-appender.0.layout.patternSelector.patternMatch.1.key = Flow
-appender.0.layout.patternSelector.patternMatch.1.pattern = [%-5level] %c{1.} ====== %C{1.}.%M:%L %msg ======%n
+appender.0.layout.patternSelector.0.type = PatternMatch
+appender.0.layout.patternSelector.0.key = NoLocation
+appender.0.layout.patternSelector.0.pattern = [%-5level] %c{1.} %msg%n
+appender.0.layout.patternSelector.1.type = PatternMatch
+appender.0.layout.patternSelector.1.key = Flow
+appender.0.layout.patternSelector.1.pattern = [%-5level] %c{1.} ====== %C{1.}.%M:%L %msg ======%n
 
 rootLogger.level = WARN
 rootLogger.appenderRef.0.ref = CONSOLE


### PR DESCRIPTION
Fixes #3078

Attempting to do as requested in https://github.com/apache/logging-log4j2/issues/3078#issuecomment-2413258884 for @ppkarwasz.

> ## Checklist

Just excuses here, I'm afraid:

> Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise

I don't know what I'm doing wrt branches, here or otherwise, I'm afraid.

> `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)

Java 17 would be tricky.

> Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory

I'm hoping it's regarded as trivial.

> Tests for the changes are provided

Yeah, I didn't do that, but apparently the examples aren't tested, so that's not a regression.

> [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)

I don't have that set up.