### PR TITLE
Bump JUnit to version 5.11.2

### DIFF
--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/LoggingResolvers.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/junit/LoggingResolvers.java
@@ -48,11 +48,13 @@ import org.junit.platform.commons.support.ReflectionSupport;
 @Inherited
 @Documented
 @Log4jTest
-@ExtendWith(LoggerContextResolver.class)
-@ExtendWith(ConfigurationResolver.class)
-@ExtendWith(AppenderResolver.class)
-@ExtendWith(AppenderManagerResolver.class)
-@ExtendWith(LoggerResolver.class)
+@ExtendWith({
+    LoggerContextResolver.class,
+    ConfigurationResolver.class,
+    AppenderResolver.class,
+    AppenderManagerResolver.class,
+    LoggerResolver.class
+})
 public @interface LoggingResolvers {}
 
 /**

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -121,7 +121,7 @@
     <json-unit.version>3.4.1</json-unit.version>
     <jspecify.version>1.0.0</jspecify.version>
     <junit.version>4.13.2</junit.version>
-    <junit-jupiter.version>5.10.3</junit-jupiter.version>
+    <junit-jupiter.version>5.11.2</junit-jupiter.version>
     <junit-pioneer.version>2.2.0</junit-pioneer.version>
     <log4j.version>1.2.17</log4j.version>
     <log4j2-custom-layout.version>1.1.0</log4j2-custom-layout.version>

--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
     <project.build.outputTimestamp>2024-02-17T17:58:36Z</project.build.outputTimestamp>
 
     <!-- Version of Log4j API required -->
-    <log4j-api.version>2.24.1</log4j-api.version>
+    <log4j-api.version>2.25.0-SNAPSHOT</log4j-api.version>
 
     <!-- ========================
          Site-specific properties


### PR DESCRIPTION
This port #3069 to `main`.

**Note**: This PR bumps the version of Log4j API from `2.24.1` to the `2.25.0-SNAPSHOT`. It should not be merged before the `2.25.0` release.
