### PR TITLE
Run reproducibility check after each deployment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
         8
         17
       site-enabled: true
-      reproducibility-check-enabled: ${{ startsWith(github.ref_name, 'release/') }}
+      reproducibility-check-enabled: false
       develocity-enabled: ${{ ! startsWith(github.ref_name, 'release/') }}
 
   deploy-snapshot:
@@ -73,3 +73,14 @@ jobs:
         8
         17
       project-id: log4j
+
+  verify-reproducibility:
+    needs: [ deploy-snapshot, deploy-release ]
+    if: ${{ always() && (needs.deploy-snapshot.result == 'success' || needs.deploy-release.result == 'success') }}
+    uses: apache/logging-parent/.github/workflows/verify-reproducibility-reusable.yaml@rel/12.0.0
+    with:
+      nexus-url: ${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.nexus-url || needs.deploy-snapshot.outputs.nexus-url }}
+      # Checkout the repository by branch name, since the deployment job might add commits to the branch
+      ref: ${{ github.ref_name }}
+      # Encode the `runs-on` input as JSON array
+      runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,10 +77,21 @@ jobs:
   verify-reproducibility:
     needs: [ deploy-snapshot, deploy-release ]
     if: ${{ always() && (needs.deploy-snapshot.result == 'success' || needs.deploy-release.result == 'success') }}
+    name: "verify-reproducibility (${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.project-version || needs.deploy-snapshot.outputs.project-version }})"
     uses: apache/logging-parent/.github/workflows/verify-reproducibility-reusable.yaml@rel/12.0.0
     with:
       nexus-url: ${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.nexus-url || needs.deploy-snapshot.outputs.nexus-url }}
-      # Checkout the repository by branch name, since the deployment job might add commits to the branch
-      ref: ${{ github.ref_name }}
       # Encode the `runs-on` input as JSON array
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
+
+  # Run integration-tests automatically after a snapshot or RC is published
+  integration-test:
+    needs: [ deploy-snapshot, deploy-release ]
+    if: ${{ always() && (needs.deploy-snapshot.result == 'success' || needs.deploy-release.result == 'success') }}
+    name: "integration-test (${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.project-version || needs.deploy-snapshot.outputs.project-version }})"
+    uses: apache/logging-log4j-samples/.github/workflows/integration-test.yaml@main
+    with:
+      log4j-version: ${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.project-version || needs.deploy-snapshot.outputs.project-version }}
+      log4j-repository-url: ${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.nexus-url || needs.deploy-snapshot.outputs.nexus-url }}
+      # Use the `main` branch of `logging-log4j-samples`
+      samples-ref: 'refs/heads/main'

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
   <properties>
 
     <!-- project version -->
-    <revision>2.25.0-SNAPSHOT</revision>
+    <revision>2.25.0.pr3105-SNAPSHOT</revision>
     <!-- Versions used on the site: no snapshots! -->
     <site-log4j-api.version>2.24.3</site-log4j-api.version>
     <site-log4j-core.version>2.24.3</site-log4j-core.version>


### PR DESCRIPTION
This PR starts a separate `verify-reproducibility` job, whenever a snapshot or release is deployed.

