### PR TITLE
Run integration tests after each deployment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
     needs: build
     # FIXME: Restore `2.x` before merging
     # if: github.repository == 'apache/logging-log4j2' && github.ref_name == '2.x'
-    if: github.repository == 'apache/logging-log4j2' && github.ref_name == 'feature/2.x/run-integration-tests'
+    if: github.repository == 'apache/logging-log4j2' && github.ref == 'refs/pull/3105/merge'
     uses: apache/logging-parent/.github/workflows/deploy-snapshot-reusable.yaml@feature/reproducibility-check
     # Secrets for deployments
     secrets:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,7 +79,7 @@ jobs:
   verify-reproducibility:
     needs: [ deploy-snapshot, deploy-release ]
     if: ${{ always() && (needs.deploy-snapshot.result == 'success' || needs.deploy-release.result == 'success') }}
-    name: "Verify reproducibility (`${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.project-version || needs.deploy-snapshot.outputs.project-version }}`)"
+    name: "verify-reproducibility (${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.project-version || needs.deploy-snapshot.outputs.project-version }})"
     uses: apache/logging-parent/.github/workflows/verify-reproducibility-reusable.yaml@feature/reproducibility-check
     with:
       nexus-url: ${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.nexus-url || needs.deploy-snapshot.outputs.nexus-url }}
@@ -90,7 +90,7 @@ jobs:
   integration-test:
     needs: [ deploy-snapshot, deploy-release ]
     if: ${{ always() && (needs.deploy-snapshot.result == 'success' || needs.deploy-release.result == 'success') }}
-    name: "Integration tests (`${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.project-version || needs.deploy-snapshot.outputs.project-version }}`)"
+    name: "integration-test (${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.project-version || needs.deploy-snapshot.outputs.project-version }})"
     uses: apache/logging-log4j-samples/.github/workflows/integration-test.yaml@main
     with:
       log4j-version: ${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.project-version || needs.deploy-snapshot.outputs.project-version }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,8 +83,6 @@ jobs:
     uses: apache/logging-parent/.github/workflows/verify-reproducibility-reusable.yaml@feature/reproducibility-check
     with:
       nexus-url: ${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.nexus-url || needs.deploy-snapshot.outputs.nexus-url }}
-      # Checkout the repository by branch name, since the deployment job might add commits to the branch
-      ref: ${{ github.ref_name }}
       # Encode the `runs-on` input as JSON array
       runs-on: '["ubuntu-latest", "macos-latest", "windows-latest"]'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
 
   build:
     if: github.actor != 'dependabot[bot]'
-    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@rel/11.3.0
+    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@feature/reproducibility-check
     secrets:
       DV_ACCESS_TOKEN: ${{ startsWith(github.ref_name, 'release/') && '' || secrets.GE_ACCESS_TOKEN }}
     with:
@@ -43,8 +43,10 @@ jobs:
 
   deploy-snapshot:
     needs: build
-    if: github.repository == 'apache/logging-log4j2' && github.ref_name == '2.x'
-    uses: apache/logging-parent/.github/workflows/deploy-snapshot-reusable.yaml@rel/11.3.0
+    # FIXME: Restore `2.x` before merging
+    # if: github.repository == 'apache/logging-log4j2' && github.ref_name == '2.x'
+    if: github.repository == 'apache/logging-log4j2' && github.ref_name == 'feature/2.x/run-integration-tests'
+    uses: apache/logging-parent/.github/workflows/deploy-snapshot-reusable.yaml@feature/reproducibility-check
     # Secrets for deployments
     secrets:
       NEXUS_USERNAME: ${{ secrets.NEXUS_USER }}
@@ -57,7 +59,7 @@ jobs:
   deploy-release:
     needs: build
     if: github.repository == 'apache/logging-log4j2' && startsWith(github.ref_name, 'release/')
-    uses: apache/logging-parent/.github/workflows/deploy-release-reusable.yaml@rel/11.3.0
+    uses: apache/logging-parent/.github/workflows/deploy-release-reusable.yaml@feature/reproducibility-check
     # Secrets for deployments
     secrets:
       GPG_SECRET_KEY: ${{ secrets.LOGGING_GPG_SECRET_KEY }}
@@ -73,3 +75,14 @@ jobs:
         8
         17
       project-id: log4j
+
+  # Run integration-tests automatically after a snapshot or RC is published
+  integration-test:
+    needs: [ deploy-snapshot, deploy-release ]
+    if: ${{ always() && (needs.deploy-snapshot.result == 'success' || needs.deploy-release.result == 'success') }}
+    uses: apache/logging-log4j-samples/.github/workflows/integration-test.yaml@main
+    with:
+      log4j-version: ${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.project-version || needs.deploy-snapshot.outputs.project-version }}
+      log4j-repository-url: ${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.nexus-url || needs.deploy-snapshot.outputs.nexus-url }}
+      # Use the `main` branch of `logging-log4j-samples`
+      samples-ref: 'refs/heads/main'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,6 +79,7 @@ jobs:
   verify-reproducibility:
     needs: [ deploy-snapshot, deploy-release ]
     if: ${{ always() && (needs.deploy-snapshot.result == 'success' || needs.deploy-release.result == 'success') }}
+    name: "Verify reproducibility (`${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.project-version || needs.deploy-snapshot.outputs.project-version }}`)"
     uses: apache/logging-parent/.github/workflows/verify-reproducibility-reusable.yaml@feature/reproducibility-check
     with:
       nexus-url: ${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.nexus-url || needs.deploy-snapshot.outputs.nexus-url }}
@@ -91,6 +92,7 @@ jobs:
   integration-test:
     needs: [ deploy-snapshot, deploy-release ]
     if: ${{ always() && (needs.deploy-snapshot.result == 'success' || needs.deploy-release.result == 'success') }}
+    name: "Integration tests (`${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.project-version || needs.deploy-snapshot.outputs.project-version }}`)"
     uses: apache/logging-log4j-samples/.github/workflows/integration-test.yaml@main
     with:
       log4j-version: ${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.project-version || needs.deploy-snapshot.outputs.project-version }}

--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
   <properties>
 
     <!-- project version -->
-    <revision>2.25.0-SNAPSHOT</revision>
+    <revision>2.25.0.pr3105-SNAPSHOT</revision>
     <!-- Versions used on the site: no snapshots! -->
     <site-log4j-api.version>2.24.1</site-log4j-api.version>
     <site-log4j-core.version>2.24.1</site-log4j-core.version>


### PR DESCRIPTION
This PR starts an `integration-test` job, whenever a snapshot or release is deployed.

