### PR TITLE
Corrected incorrect <Rogger> tag to <Logger> in XInclude logger example

### DIFF
--- a/src/site/antora/modules/ROOT/examples/manual/configuration/xinclude-loggers.xml
+++ b/src/site/antora/modules/ROOT/examples/manual/configuration/xinclude-loggers.xml
@@ -16,9 +16,9 @@
   ~ limitations under the License.
   -->
 <Loggers>
-  <Rogger name="org.example" level="DEBUG" additivity="false">
+  <Logger name="org.example" level="DEBUG" additivity="false">
     <AppenderRef ref="FILE" />
-  </Rogger>
+  </Logger>
   <Root level="ERROR">
     <AppenderRef ref="CONSOLE" />
   </Root>


### PR DESCRIPTION
The `Logger` tag in XInclude logger example seems incorrect. Corrected the incorrect `Rogger` tag to `Logger`.
