### PR TITLE
Emulate effects of `j.u.l.Logger.setLevel`

### DIFF
--- a/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/ApiLoggerTest.java
+++ b/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/ApiLoggerTest.java
@@ -16,8 +16,7 @@
  */
 package org.apache.logging.log4j.jul.test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -46,7 +45,7 @@ public class ApiLoggerTest extends AbstractLoggerTest {
     public void setUp() {
         logger = Logger.getLogger(LOGGER_NAME);
         logger.setFilter(null);
-        assertThat(logger.getLevel(), equalTo(java.util.logging.Level.FINE));
+        assertThat(getEffectiveLevel(logger)).isEqualTo(java.util.logging.Level.FINE);
         eventAppender = ListAppender.getListAppender("TestAppender");
         flowAppender = ListAppender.getListAppender("FlowAppender");
         stringAppender = ListAppender.getListAppender("StringAppender");

--- a/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/CoreLoggerTest.java
+++ b/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/CoreLoggerTest.java
@@ -34,27 +34,6 @@ import org.junit.Test;
 
 public class CoreLoggerTest extends AbstractLoggerTest {
 
-    private static final Level[] LEVELS = new Level[] {
-        Level.ALL,
-        Level.FINEST,
-        Level.FINER,
-        Level.FINE,
-        Level.CONFIG,
-        Level.INFO,
-        Level.WARNING,
-        Level.SEVERE,
-        Level.OFF
-    };
-
-    private static Level getEffectiveLevel(final Logger logger) {
-        for (final Level level : LEVELS) {
-            if (logger.isLoggable(level)) {
-                return level;
-            }
-        }
-        throw new RuntimeException("No level is enabled.");
-    }
-
     @BeforeClass
     public static void setUpClass() {
         System.setProperty("java.util.logging.manager", LogManager.class.getName());

--- a/src/changelog/.2.x.x/3119_set_level_call_parent.xml
+++ b/src/changelog/.2.x.x/3119_set_level_call_parent.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3119" link="https://github.com/apache/logging-log4j2/issues/3119"/>
+  <description format="asciidoc">
+    Ensures synchronization between `j.u.l.Logger.getLevel()` and `j.u.l.Logger.setLevel()` methods.
+  </description>
+</entry>


### PR DESCRIPTION
Some libraries rely on `j.u.l.Logger.getLevel` returning the value that was set using `j.u.l.Logger.setLevel`.

This PR changes #2353 so that:

- By default, the **effective** configuration of the logging backend is not modified by `log4j-jul`.
- Calling `setLevel` modifies the return value of `getLevel`. Both these methods should **not** be used in user code, because the **effective** level of a logger should be checked with `j.u.l.isLoggable` instead. Therefore, I don't see any potential problems with these modifications.

Closes #3119

