### PR TITLE
Remove outdated `@BaselineIgnore` annotations

### DIFF
--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/Log4jStaticResources.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/Log4jStaticResources.java
@@ -16,13 +16,11 @@
  */
 package org.apache.logging.log4j.test.junit;
 
-import aQute.bnd.annotation.baseline.BaselineIgnore;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 /**
  * Constants to use the {@link ResourceLock} annotation.
  */
-@BaselineIgnore("2.24.0")
 public final class Log4jStaticResources {
 
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Level.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j;
 
 import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
-import aQute.bnd.annotation.baseline.BaselineIgnore;
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -75,7 +74,6 @@ import org.apache.logging.log4j.util.Strings;
  * used in logging configurations.
  * </p>
  */
-@BaselineIgnore("2.22.0")
 public final class Level implements Comparable<Level>, Serializable {
 
     private static final Level[] EMPTY_ARRAY = {};

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
@@ -16,7 +16,6 @@
  */
 package org.apache.logging.log4j.message;
 
-import aQute.bnd.annotation.baseline.BaselineIgnore;
 import com.google.errorprone.annotations.InlineMe;
 import java.io.Serializable;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
@@ -257,7 +256,6 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      */
     @Deprecated
     // This method should have been `final` from the start, we don't expect anyone to override it.
-    @BaselineIgnore("2.22.0")
     @InlineMe(replacement = "this.makeId(defaultId, String.valueOf(anEnterpriseNumber))")
     public final StructuredDataId makeId(final String defaultId, final int anEnterpriseNumber) {
         return makeId(defaultId, String.valueOf(anEnterpriseNumber));

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ServiceLoaderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ServiceLoaderUtil.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.util;
 
 import static java.util.Objects.requireNonNull;
 
-import aQute.bnd.annotation.baseline.BaselineIgnore;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -50,7 +49,6 @@ import org.apache.logging.log4j.Logger;
  * </ol>
  */
 @InternalApi
-@BaselineIgnore("2.24.0")
 public final class ServiceLoaderUtil {
 
     private static final int MAX_BROKEN_SERVICES = 8;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/package-info.java
@@ -20,7 +20,7 @@
  * There are no guarantees for binary or logical compatibility in this package.
  */
 @Export
-@Version("2.24.0")
+@Version("2.24.1")
 package org.apache.logging.log4j.util;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/JsonConstants.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/JsonConstants.java
@@ -16,12 +16,9 @@
  */
 package org.apache.logging.log4j.core.jackson;
 
-import aQute.bnd.annotation.baseline.BaselineIgnore;
-
 /**
  * Keeps constants separate from any class that may depend on third party jars.
  */
-@BaselineIgnore("2.24.0")
 public final class JsonConstants {
     public static final String ELT_CAUSE = "cause";
     public static final String ELT_CONTEXT_MAP = "contextMap";

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/package-info.java
@@ -19,7 +19,7 @@
  * library.
  */
 @Export
-@Version("2.24.0")
+@Version("2.24.1")
 package org.apache.logging.log4j.core.jackson;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/datetime/package-info.java
@@ -18,10 +18,8 @@
  * Log4j 2 date formatting classes.
  */
 @Export
-@Version("2.21.1")
-@BaselineIgnore("2.22.0")
+@Version("2.21.2")
 package org.apache.logging.log4j.core.util.datetime;
 
-import aQute.bnd.annotation.baseline.BaselineIgnore;
 import org.osgi.annotation.bundle.Export;
 import org.osgi.annotation.versioning.Version;

--- a/log4j-slf4j-impl/src/main/java/org/apache/logging/slf4j/package-info.java
+++ b/log4j-slf4j-impl/src/main/java/org/apache/logging/slf4j/package-info.java
@@ -21,11 +21,9 @@
  */
 @Export
 @Header(name = Constants.BUNDLE_ACTIVATIONPOLICY, value = Constants.ACTIVATION_LAZY)
-@Version("2.23.0")
-@BaselineIgnore("2.23.0")
+@Version("2.23.1")
 package org.apache.logging.slf4j;
 
-import aQute.bnd.annotation.baseline.BaselineIgnore;
 import org.osgi.annotation.bundle.Export;
 import org.osgi.annotation.bundle.Header;
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Outdated `@BaselineIgnore` annotation are no longer needed to successfully build newer versions.

Until [JDK-8342833](https://bugs.openjdk.org/browse/JDK-8342833) is resolved, these annotations cause linter warnings during compilation (see #3110 for example), so it is better to remove them as soon as they are no longer used.

