### PR TITLE
Migrate `log4j-slf4j-impl` to JUnit 5

### DIFF
--- a/log4j-slf4j-impl/pom.xml
+++ b/log4j-slf4j-impl/pom.xml
@@ -109,11 +109,6 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/log4j-slf4j-impl/src/test/java/org/apache/logging/other/pkg/LoggerContextAnchorTest.java
+++ b/log4j-slf4j-impl/src/test/java/org/apache/logging/other/pkg/LoggerContextAnchorTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.other.pkg;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -24,7 +24,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.status.StatusData;
 import org.apache.logging.log4j.status.StatusListener;
 import org.apache.logging.log4j.status.StatusLogger;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 /**

--- a/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/CallerInformationTest.java
+++ b/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/CallerInformationTest.java
@@ -16,41 +16,36 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@LoggerContextSource("log4j2-calling-class.xml")
 public class CallerInformationTest {
 
-    // config from log4j-core test-jar
-    private static final String CONFIG = "log4j2-calling-class.xml";
-
-    @ClassRule
-    public static final LoggerContextRule ctx = new LoggerContextRule(CONFIG);
-
     @Test
-    public void testClassLogger() throws Exception {
-        final ListAppender app = ctx.getListAppender("Class").clear();
+    public void testClassLogger(@Named("Class") final ListAppender app) throws Exception {
+        app.clear();
         final Logger logger = LoggerFactory.getLogger("ClassLogger");
         logger.info("Ignored message contents.");
         logger.warn("Verifying the caller class is still correct.");
         logger.error("Hopefully nobody breaks me!");
         final List<String> messages = app.getMessages();
-        assertEquals("Incorrect number of messages.", 3, messages.size());
+        assertEquals(3, messages.size(), "Incorrect number of messages.");
         for (final String message : messages) {
-            assertEquals("Incorrect caller class name.", this.getClass().getName(), message);
+            assertEquals(this.getClass().getName(), message, "Incorrect caller class name.");
         }
     }
 
     @Test
-    public void testMethodLogger() throws Exception {
-        final ListAppender app = ctx.getListAppender("Method").clear();
+    public void testMethodLogger(@Named("Method") final ListAppender app) throws Exception {
+        app.clear();
         final Logger logger = LoggerFactory.getLogger("MethodLogger");
         logger.info("More messages.");
         logger.warn("CATASTROPHE INCOMING!");
@@ -58,9 +53,9 @@ public class CallerInformationTest {
         logger.warn("brains~~~");
         logger.info("Itchy. Tasty.");
         final List<String> messages = app.getMessages();
-        assertEquals("Incorrect number of messages.", 5, messages.size());
+        assertEquals(5, messages.size(), "Incorrect number of messages.");
         for (final String message : messages) {
-            assertEquals("Incorrect caller method name.", "testMethodLogger", message);
+            assertEquals("testMethodLogger", message, "Incorrect caller method name.");
         }
     }
 }

--- a/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/Log4j1222Test.java
+++ b/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/Log4j1222Test.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +47,9 @@ public class Log4j1222Test {
 
         private void trigger() {
             Holder.LOGGER.info("Attempt to trigger");
-            assertTrue("Logger is of type " + Holder.LOGGER.getClass().getName(), Holder.LOGGER instanceof Log4jLogger);
+            assertTrue(
+                    Holder.LOGGER instanceof Log4jLogger,
+                    "Logger is of type " + Holder.LOGGER.getClass().getName());
         }
     }
 }

--- a/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/Log4j1222Test.java
+++ b/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/Log4j1222Test.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -47,8 +47,9 @@ public class Log4j1222Test {
 
         private void trigger() {
             Holder.LOGGER.info("Attempt to trigger");
-            assertTrue(
-                    Holder.LOGGER instanceof Log4jLogger,
+            assertInstanceOf(
+                    Log4jLogger.class,
+                    Holder.LOGGER,
                     "Logger is of type " + Holder.LOGGER.getClass().getName());
         }
     }

--- a/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/Log4jMarkerTest.java
+++ b/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/Log4jMarkerTest.java
@@ -16,17 +16,19 @@
  */
 package org.apache.logging.slf4j;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class Log4jMarkerTest {
 
     private static Log4jMarkerFactory markerFactory;
 
-    @BeforeClass
+    @BeforeAll
     public static void startup() {
         markerFactory = ((Log4jLoggerFactory) org.slf4j.LoggerFactory.getILoggerFactory()).getMarkerFactory();
     }
@@ -38,9 +40,9 @@ public class Log4jMarkerTest {
         final Log4jMarker marker1 = new Log4jMarker(markerFactory, markerA);
         final Log4jMarker marker2 = new Log4jMarker(markerFactory, markerA);
         final Log4jMarker marker3 = new Log4jMarker(markerFactory, markerB);
-        Assert.assertEquals(marker1, marker2);
-        Assert.assertNotEquals(marker1, null);
-        Assert.assertNotEquals(null, marker1);
-        Assert.assertNotEquals(marker1, marker3);
+        assertEquals(marker1, marker2);
+        assertNotEquals(marker1, null);
+        assertNotEquals(null, marker1);
+        assertNotEquals(marker1, marker3);
     }
 }

--- a/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/LoggerContextTest.java
+++ b/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/LoggerContextTest.java
@@ -16,12 +16,12 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.spi.LoggerContext;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -35,9 +35,9 @@ public class LoggerContextTest {
         factory.getLogger("test");
         Set<LoggerContext> set = factory.getLoggerContexts();
         final LoggerContext ctx1 = set.toArray(LoggerContext.EMPTY_ARRAY)[0];
-        assertTrue("LoggerContext is not enabled for shutdown", ctx1 instanceof LifeCycle);
+        assertTrue(ctx1 instanceof LifeCycle, "LoggerContext is not enabled for shutdown");
         ((LifeCycle) ctx1).stop();
         set = factory.getLoggerContexts();
-        assertTrue("Expected no LoggerContexts", set.isEmpty());
+        assertTrue(set.isEmpty(), "Expected no LoggerContexts");
     }
 }

--- a/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/LoggerContextTest.java
+++ b/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/LoggerContextTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.slf4j;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
@@ -35,7 +36,7 @@ public class LoggerContextTest {
         factory.getLogger("test");
         Set<LoggerContext> set = factory.getLoggerContexts();
         final LoggerContext ctx1 = set.toArray(LoggerContext.EMPTY_ARRAY)[0];
-        assertTrue(ctx1 instanceof LifeCycle, "LoggerContext is not enabled for shutdown");
+        assertInstanceOf(LifeCycle.class, ctx1, "LoggerContext is not enabled for shutdown");
         ((LifeCycle) ctx1).stop();
         set = factory.getLoggerContexts();
         assertTrue(set.isEmpty(), "Expected no LoggerContexts");

--- a/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/LoggerTest.java
+++ b/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/LoggerTest.java
@@ -16,18 +16,19 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -37,14 +38,16 @@ import org.slf4j.spi.LocationAwareLogger;
 /**
  *
  */
+@LoggerContextSource("log4j-test1.xml")
 public class LoggerTest {
 
-    private static final String CONFIG = "log4j-test1.xml";
+    private final Logger logger;
+    private final LoggerContext ctx;
 
-    @ClassRule
-    public static LoggerContextRule ctx = new LoggerContextRule(CONFIG);
-
-    Logger logger = LoggerFactory.getLogger("LoggerTest");
+    public LoggerTest(final LoggerContext context) {
+        this.ctx = context;
+        this.logger = LoggerFactory.getLogger("LoggerTest");
+    }
 
     @Test
     public void debug() {
@@ -93,7 +96,7 @@ public class LoggerTest {
     @Test
     public void testRootLogger() {
         final Logger l = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-        assertNotNull("No Root Logger", l);
+        assertNotNull(l, "No Root Logger");
         assertEquals(Logger.ROOT_LOGGER_NAME, l.getName());
     }
 
@@ -138,34 +141,35 @@ public class LoggerTest {
     }
 
     private ListAppender getAppenderByName(final String name) {
-        final ListAppender listApp = ctx.getListAppender(name);
-        assertNotNull("Missing Appender", listApp);
+        final ListAppender listApp = ctx.getConfiguration().getAppender(name);
+        assertNotNull(listApp, "Missing Appender");
         return listApp;
     }
 
     private void verify(final String expected) {
         final ListAppender listApp = getAppenderByName("List");
         final List<String> events = listApp.getMessages();
-        assertEquals("Incorrect number of messages. Expected 1 Actual " + events.size(), 1, events.size());
+        assertEquals(1, events.size(), "Incorrect number of messages. Expected 1 Actual " + events.size());
         final String actual = events.get(0);
-        assertEquals("Incorrect message. Expected " + expected + ". Actual " + actual, expected, actual);
+        assertEquals(expected, actual, "Incorrect message. Expected " + expected + ". Actual " + actual);
         listApp.clear();
     }
 
     private void verifyThrowable(final Throwable expected) {
         final ListAppender listApp = getAppenderByName("UnformattedList");
         final List<LogEvent> events = listApp.getEvents();
-        assertEquals("Incorrect number of messages", 1, events.size());
+        assertEquals(1, events.size(), "Incorrect number of messages");
         final LogEvent actual = events.get(0);
-        assertEquals("Incorrect throwable.", expected, actual.getThrown());
+        assertEquals(expected, actual.getThrown(), "Incorrect throwable.");
         listApp.clear();
     }
 
-    @Before
-    @After
-    public void cleanup() {
+    @BeforeEach
+    @AfterEach
+    public void cleanup(
+            @Named("List") final ListAppender list, @Named("UnformattedList") final ListAppender unformattedList) {
         MDC.clear();
-        ctx.getListAppender("List").clear();
-        ctx.getListAppender("UnformattedList").clear();
+        list.clear();
+        unformattedList.clear();
     }
 }

--- a/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/MarkerTest.java
+++ b/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/MarkerTest.java
@@ -16,18 +16,18 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  *
@@ -38,13 +38,13 @@ public class MarkerTest {
     private static final String PARENT_MARKER_NAME = MarkerTest.class.getSimpleName() + "-PARENT";
     private static Log4jMarkerFactory markerFactory;
 
-    @BeforeClass
+    @BeforeAll
     public static void startup() {
         markerFactory = ((Log4jLoggerFactory) org.slf4j.LoggerFactory.getILoggerFactory()).getMarkerFactory();
     }
 
-    @Before
-    @After
+    @BeforeEach
+    @AfterEach
     public void clearMarkers() {
         MarkerManager.clear();
     }
@@ -59,17 +59,17 @@ public class MarkerTest {
         final Marker log4jParent = MarkerManager.getMarker(parentMarkerName);
         final Marker log4jMarker = MarkerManager.getMarker(childMakerName);
 
-        assertTrue("Incorrect Marker class", slf4jMarker instanceof Log4jMarker);
+        assertTrue(slf4jMarker instanceof Log4jMarker, "Incorrect Marker class");
         assertTrue(
+                log4jMarker.isInstanceOf(log4jParent),
                 String.format(
                         "%s (log4jMarker=%s) is not an instance of %s (log4jParent=%s) in Log4j",
-                        childMakerName, parentMarkerName, log4jMarker, log4jParent),
-                log4jMarker.isInstanceOf(log4jParent));
+                        childMakerName, parentMarkerName, log4jMarker, log4jParent));
         assertTrue(
+                slf4jMarker.contains(slf4jParent),
                 String.format(
                         "%s (slf4jMarker=%s) is not an instance of %s (log4jParent=%s) in SLF4J",
-                        childMakerName, parentMarkerName, slf4jMarker, slf4jParent),
-                slf4jMarker.contains(slf4jParent));
+                        childMakerName, parentMarkerName, slf4jMarker, slf4jParent));
     }
 
     @Test
@@ -109,15 +109,15 @@ public class MarkerTest {
         final Marker log4jParent = MarkerManager.getMarker(parentMakerName);
         final Marker log4jMarker = MarkerManager.getMarker(childMarkerName);
         assertTrue(
+                log4jMarker.isInstanceOf(log4jParent),
                 String.format(
                         "%s (log4jMarker=%s) is not an instance of %s (log4jParent=%s) in Log4j",
-                        childMarkerName, parentMakerName, log4jMarker, log4jParent),
-                log4jMarker.isInstanceOf(log4jParent));
+                        childMarkerName, parentMakerName, log4jMarker, log4jParent));
         assertTrue(
+                slf4jMarker.contains(slf4jParent),
                 String.format(
                         "%s (slf4jMarker=%s) is not an instance of %s (log4jParent=%s) in SLF4J",
-                        childMarkerName, parentMakerName, slf4jMarker, slf4jParent),
-                slf4jMarker.contains(slf4jParent));
+                        childMarkerName, parentMakerName, slf4jMarker, slf4jParent));
     }
 
     @Test
@@ -150,13 +150,13 @@ public class MarkerTest {
         final Log4jMarker log4jSlf4jMarker = new Log4jMarker(markerFactory, log4jMarker);
         final org.slf4j.Marker nullMarker = null;
         try {
-            Assert.assertFalse(log4jSlf4jParent.contains(nullMarker));
+            assertFalse(log4jSlf4jParent.contains(nullMarker));
             fail("Expected " + IllegalArgumentException.class.getName());
         } catch (final IllegalArgumentException e) {
             // expected
         }
         try {
-            Assert.assertFalse(log4jSlf4jMarker.contains(nullMarker));
+            assertFalse(log4jSlf4jMarker.contains(nullMarker));
             fail("Expected " + IllegalArgumentException.class.getName());
         } catch (final IllegalArgumentException e) {
             // expected
@@ -175,8 +175,8 @@ public class MarkerTest {
         final Log4jMarker log4jSlf4jParent = new Log4jMarker(markerFactory, log4jParent);
         final Log4jMarker log4jSlf4jMarker = new Log4jMarker(markerFactory, log4jMarker);
         final String nullStr = null;
-        Assert.assertFalse(log4jSlf4jParent.contains(nullStr));
-        Assert.assertFalse(log4jSlf4jMarker.contains(nullStr));
+        assertFalse(log4jSlf4jParent.contains(nullStr));
+        assertFalse(log4jSlf4jMarker.contains(nullStr));
     }
 
     @Test
@@ -191,7 +191,7 @@ public class MarkerTest {
         final Log4jMarker log4jSlf4jParent = new Log4jMarker(markerFactory, log4jParent);
         final Log4jMarker log4jSlf4jMarker = new Log4jMarker(markerFactory, log4jMarker);
         final org.slf4j.Marker nullMarker = null;
-        Assert.assertFalse(log4jSlf4jParent.remove(nullMarker));
-        Assert.assertFalse(log4jSlf4jMarker.remove(nullMarker));
+        assertFalse(log4jSlf4jParent.remove(nullMarker));
+        assertFalse(log4jSlf4jMarker.remove(nullMarker));
     }
 }

--- a/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/MarkerTest.java
+++ b/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/MarkerTest.java
@@ -18,6 +18,7 @@ package org.apache.logging.slf4j;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -59,7 +60,7 @@ public class MarkerTest {
         final Marker log4jParent = MarkerManager.getMarker(parentMarkerName);
         final Marker log4jMarker = MarkerManager.getMarker(childMakerName);
 
-        assertTrue(slf4jMarker instanceof Log4jMarker, "Incorrect Marker class");
+        assertInstanceOf(Log4jMarker.class, slf4jMarker, "Incorrect Marker class");
         assertTrue(
                 log4jMarker.isInstanceOf(log4jParent),
                 String.format(

--- a/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/OptionalTest.java
+++ b/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/OptionalTest.java
@@ -16,16 +16,17 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -35,15 +36,16 @@ import org.slf4j.MarkerFactory;
 /**
  *
  */
+@LoggerContextSource(value = "log4j-test1.xml")
 public class OptionalTest {
-
-    private static final String CONFIG = "log4j-test1.xml";
-
-    @ClassRule
-    public static final LoggerContextRule CTX = new LoggerContextRule(CONFIG);
 
     Logger logger = LoggerFactory.getLogger("EventLogger");
     Marker marker = MarkerFactory.getMarker("EVENT");
+    private final LoggerContext CTX;
+
+    public OptionalTest(final LoggerContext context) {
+        this.CTX = context;
+    }
 
     @Test
     public void testEventLogger() {
@@ -53,17 +55,17 @@ public class OptionalTest {
     }
 
     private void verify(final String name, final String expected) {
-        final ListAppender listApp = CTX.getListAppender(name);
+        final ListAppender listApp = CTX.getConfiguration().getAppender(name);
         final List<String> events = listApp.getMessages();
-        assertTrue("Incorrect number of messages. Expected 1 Actual " + events.size(), events.size() == 1);
+        assertTrue(events.size() == 1, "Incorrect number of messages. Expected 1 Actual " + events.size());
         final String actual = events.get(0);
-        assertEquals("Incorrect message. Expected " + expected + ". Actual " + actual, expected, actual);
+        assertEquals(expected, actual, "Incorrect message. Expected " + expected + ". Actual " + actual);
         listApp.clear();
     }
 
-    @Before
-    public void cleanup() {
-        CTX.getListAppender("List").clear();
-        CTX.getListAppender("EventLogger").clear();
+    @BeforeEach
+    public void cleanup(@Named("List") final ListAppender list, @Named("EventLogger") final ListAppender eventLogger) {
+        list.clear();
+        eventLogger.clear();
     }
 }

--- a/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/OverflowTest.java
+++ b/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/OverflowTest.java
@@ -16,10 +16,10 @@
  */
 package org.apache.logging.slf4j;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.logging.log4j.LoggingException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 /**

--- a/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/SerializeTest.java
+++ b/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/SerializeTest.java
@@ -20,21 +20,16 @@ import static org.apache.logging.log4j.test.SerializableMatchers.serializesRound
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.Serializable;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  *
  */
+@LoggerContextSource("log4j-test1.xml")
 public class SerializeTest {
-
-    private static final String CONFIG = "log4j-test1.xml";
-
-    @ClassRule
-    public static final LoggerContextRule CTX = new LoggerContextRule(CONFIG);
 
     Logger logger = LoggerFactory.getLogger("LoggerTest");
 


### PR DESCRIPTION
Hello 👋

We are from Neighbourhoodie, the implementation partner of the STF Bug Resilience Program. This work is part of our agreed Milestone 1. Upgrade from JUnit 4 to JUnit 5. This PR migrates the tests located in `log4j-slf4j-impl`.

This refactor is related to https://github.com/apache/logging-log4j2/pull/3080, where I was asked to replace some assertions to use `assertInstanceOf` instead.

Please note that, with the removal of `junit-vintage-engine`, the tests of [`Log4j2_1482_Slf4jTest.java`](https://github.com/apache/logging-log4j2/blob/cbe7e91304cd0d3681a3c6eedc1782b25cb96242/log4j-slf4j-impl/src/test/java/org/apache/logging/slf4j/Log4j2_1482_Slf4jTest.java) are not being executed (total of 2 tests). They extend from [`log4j-core-test/.../Log4j2_1482_Test.java`](https://github.com/apache/logging-log4j2/blob/cbe7e91304cd0d3681a3c6eedc1782b25cb96242/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/layout/Log4j2_1482_Test.java), currently written in JUnit 4. My coworker is refactoring those in https://github.com/apache/logging-log4j2/pull/3061.

Thank you!

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
