### PR TITLE
Prefix stack traces with a newline in Status Logger

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
@@ -182,7 +182,7 @@ public class StatusData implements Serializable {
             effectiveThrowable = throwable;
         }
         if (effectiveThrowable != null) {
-            sb.append(SPACE);
+            sb.append(System.lineSeparator());
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             effectiveThrowable.printStackTrace(new PrintStream(baos));
             /*

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/AbstractActionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/AbstractActionTest.java
@@ -47,8 +47,9 @@ class AbstractActionTest {
         assertThat(
                 formattedMessage,
                 containsString("Exception reported by action 'class org.apache."
-                        + "logging.log4j.core.appender.rolling.action.AbstractActionTest$TestAction' java.io.IOException: "
-                        + "failed" + System.lineSeparator()
+                        + "logging.log4j.core.appender.rolling.action.AbstractActionTest$TestAction'"
+                        + System.lineSeparator()
+                        + "java.io.IOException: failed" + System.lineSeparator()
                         + "\tat org.apache.logging.log4j.core.appender.rolling.action.AbstractActionTest"
                         + "$TestAction.execute(AbstractActionTest.java:"));
     }

--- a/src/changelog/.2.x.x/3149_change_StatusData_prefix.xml
+++ b/src/changelog/.2.x.x/3149_change_StatusData_prefix.xml
@@ -3,6 +3,6 @@
        xmlns="https://logging.apache.org/xml/ns"
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="changed">
-  <issue id="3045" link="https://github.com/apache/logging-log4j2/pull/3045"/>
-  <description format="asciidoc">Switch prefixing stack traces in Pattern Layout from whitespace to newline</description>
+  <issue id="3149" link="https://github.com/apache/logging-log4j2/pull/3149"/>
+  <description format="asciidoc">Switch prefixing stack traces in Status Logger from whitespace to newline</description>
 </entry>


### PR DESCRIPTION
Similar to what we have done for Pattern Layout in #3045, switch stack trace prefix of Status Logger from whitespace to newline.