### PR TITLE
Improve validation for StringMatchFilter for null/empty text #3153

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/filter/StringMatchFilterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/filter/StringMatchFilterTest.java
@@ -1,0 +1,70 @@
+package org.apache.logging.log4j.core.filter;
+
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit test for {@link StringMatchFilter}.
+ */
+public class StringMatchFilterTest {
+
+  /**
+   * Test that if no match-string is set on the builder, the '{@link StringMatchFilter.Builder#build()}' returns
+   * {@code null}.
+   */
+  @Test
+  public void testFilterBuilderFailsWithNullText() {
+    Assertions.assertNull(StringMatchFilter.newBuilder().build());
+  }
+
+  /**
+   * Test that if a {@code null} string is set as a match-pattern, an {@code IllegalArgumentExeption} is thrown.
+   */
+  @Test
+  void testFilterBuilderFailsWithExceptionOnNullText() {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> StringMatchFilter.newBuilder().setMatchString(null));
+  }
+
+  /**
+   * Test that if an empty ({@code ""}) string is set as a match-pattern, an {@code IllegalArgumentException} is thrown.
+   */
+  @Test
+  void testFilterBuilderFailsWithExceptionOnEmptyText() {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> StringMatchFilter.newBuilder().setMatchString(""));
+  }
+
+  /**
+   * Test that if a {@link StringMatchFilter} is specified with a 'text' attribute it is correctly instantiated.
+   *
+   * @param configuration the configuration
+   */
+  @Test
+  @LoggerContextSource("log4j2-stringmatchfilter-3153-ok.xml")
+  void testConfigurationWithTextPOS(final Configuration configuration) {
+    final Filter filter = configuration.getFilter();
+    assertNotNull(filter, "The filter should not be null.");
+    assertInstanceOf(StringMatchFilter.class, filter, "Expected a StringMatchFilter, but got: " + filter.getClass());
+    assertEquals("FooBar", filter.toString());
+  }
+
+  /**
+   * Test that if a {@link StringMatchFilter} is specified without a 'text' attribute it is not instantiated.
+   *
+   * @param configuration the configuration
+   */
+  @Test
+  @LoggerContextSource("log4j2-stringmatchfilter-3153-nok.xml")
+  void testConfigurationWithTextNEG(final Configuration configuration) {
+    final Filter filter = configuration.getFilter();
+    assertNull(filter, "The filter should be null.");
+  }
+
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/filter/StringMatchFilterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/filter/StringMatchFilterTest.java
@@ -16,71 +16,73 @@
  */
 package org.apache.logging.log4j.core.filter;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
 /**
  * Unit test for {@link StringMatchFilter}.
  */
 public class StringMatchFilterTest {
 
-  /**
-   * Test that if no match-string is set on the builder, the '{@link StringMatchFilter.Builder#build()}' returns
-   * {@code null}.
-   */
-  @Test
-  public void testFilterBuilderFailsWithNullText() {
-    Assertions.assertNull(StringMatchFilter.newBuilder().build());
-  }
+    /**
+     * Test that if no match-string is set on the builder, the '{@link StringMatchFilter.Builder#build()}' returns
+     * {@code null}.
+     */
+    @Test
+    public void testFilterBuilderFailsWithNullText() {
+        Assertions.assertNull(StringMatchFilter.newBuilder().build());
+    }
 
-  /**
-   * Test that if a {@code null} string is set as a match-pattern, an {@code IllegalArgumentExeption} is thrown.
-   */
-  @Test
-  void testFilterBuilderFailsWithExceptionOnNullText() {
-    Assertions.assertThrows(IllegalArgumentException.class, () -> StringMatchFilter.newBuilder().setMatchString(null));
-  }
+    /**
+     * Test that if a {@code null} string is set as a match-pattern, an {@code IllegalArgumentExeption} is thrown.
+     */
+    @Test
+    void testFilterBuilderFailsWithExceptionOnNullText() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> StringMatchFilter.newBuilder()
+                .setMatchString(null));
+    }
 
-  /**
-   * Test that if an empty ({@code ""}) string is set as a match-pattern, an {@code IllegalArgumentException} is thrown.
-   */
-  @Test
-  void testFilterBuilderFailsWithExceptionOnEmptyText() {
-    Assertions.assertThrows(IllegalArgumentException.class, () -> StringMatchFilter.newBuilder().setMatchString(""));
-  }
+    /**
+     * Test that if an empty ({@code ""}) string is set as a match-pattern, an {@code IllegalArgumentException} is thrown.
+     */
+    @Test
+    void testFilterBuilderFailsWithExceptionOnEmptyText() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> StringMatchFilter.newBuilder()
+                .setMatchString(""));
+    }
 
-  /**
-   * Test that if a {@link StringMatchFilter} is specified with a 'text' attribute it is correctly instantiated.
-   *
-   * @param configuration the configuration
-   */
-  @Test
-  @LoggerContextSource("log4j2-stringmatchfilter-3153-ok.xml")
-  void testConfigurationWithTextPOS(final Configuration configuration) {
-    final Filter filter = configuration.getFilter();
-    assertNotNull(filter, "The filter should not be null.");
-    assertInstanceOf(StringMatchFilter.class, filter, "Expected a StringMatchFilter, but got: " + filter.getClass());
-    assertEquals("FooBar", filter.toString());
-  }
+    /**
+     * Test that if a {@link StringMatchFilter} is specified with a 'text' attribute it is correctly instantiated.
+     *
+     * @param configuration the configuration
+     */
+    @Test
+    @LoggerContextSource("log4j2-stringmatchfilter-3153-ok.xml")
+    void testConfigurationWithTextPOS(final Configuration configuration) {
+        final Filter filter = configuration.getFilter();
+        assertNotNull(filter, "The filter should not be null.");
+        assertInstanceOf(
+                StringMatchFilter.class, filter, "Expected a StringMatchFilter, but got: " + filter.getClass());
+        assertEquals("FooBar", filter.toString());
+    }
 
-  /**
-   * Test that if a {@link StringMatchFilter} is specified without a 'text' attribute it is not instantiated.
-   *
-   * @param configuration the configuration
-   */
-  @Test
-  @LoggerContextSource("log4j2-stringmatchfilter-3153-nok.xml")
-  void testConfigurationWithTextNEG(final Configuration configuration) {
-    final Filter filter = configuration.getFilter();
-    assertNull(filter, "The filter should be null.");
-  }
-
+    /**
+     * Test that if a {@link StringMatchFilter} is specified without a 'text' attribute it is not instantiated.
+     *
+     * @param configuration the configuration
+     */
+    @Test
+    @LoggerContextSource("log4j2-stringmatchfilter-3153-nok.xml")
+    void testConfigurationWithTextNEG(final Configuration configuration) {
+        final Filter filter = configuration.getFilter();
+        assertNull(filter, "The filter should be null.");
+    }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/filter/StringMatchFilterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/filter/StringMatchFilterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.logging.log4j.core.filter;
 
 import org.apache.logging.log4j.core.Filter;

--- a/log4j-core-test/src/test/resources/log4j2-stringmatchfilter-3153-nok.xml
+++ b/log4j-core-test/src/test/resources/log4j2-stringmatchfilter-3153-nok.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="warn">
+   <StringMatchFfilter/>
+</Configuration>

--- a/log4j-core-test/src/test/resources/log4j2-stringmatchfilter-3153-ok.xml
+++ b/log4j-core-test/src/test/resources/log4j2-stringmatchfilter-3153-ok.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="warn">
+   <StringMatchFilter text="FooBar"/>
+</Configuration>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/StringMatchFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/StringMatchFilter.java
@@ -25,6 +25,8 @@ import org.apache.logging.log4j.core.config.Node;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+import org.apache.logging.log4j.core.util.Assert;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.PerformanceSensitive;
 
@@ -41,7 +43,7 @@ public final class StringMatchFilter extends AbstractFilter {
 
     private StringMatchFilter(final String text, final Result onMatch, final Result onMismatch) {
         super(onMatch, onMismatch);
-        this.text = text;
+        this.text = Assert.requireNonEmpty(text, "text");
     }
 
     @Override
@@ -235,8 +237,10 @@ public final class StringMatchFilter extends AbstractFilter {
 
     public static class Builder extends AbstractFilterBuilder<StringMatchFilter.Builder>
             implements org.apache.logging.log4j.core.util.Builder<StringMatchFilter> {
+
         @PluginBuilderAttribute
-        private String text = "";
+        @Required(message = "No text provided for StringMatchFilter")
+        private String text;
 
         /**
          * Sets the text to search in event messages.
@@ -244,12 +248,15 @@ public final class StringMatchFilter extends AbstractFilter {
          * @return this instance.
          */
         public StringMatchFilter.Builder setMatchString(final String text) {
-            this.text = text;
+            this.text = Assert.requireNonEmpty(text, "The 'text' argument must not be null or empty.");
             return this;
         }
 
         @Override
         public StringMatchFilter build() {
+            if (!isValid()) {
+                return null;
+            }
             return new StringMatchFilter(this.text, this.getOnMatch(), this.getOnMismatch());
         }
     }

--- a/src/changelog/.2.x.x/3153_fix_StringMatchFilter_guardNPE.xml
+++ b/src/changelog/.2.x.x/3153_fix_StringMatchFilter_guardNPE.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="3153" link="https://github.com/apache/logging-log4j2/issues/3153"/>
+  <description format="asciidoc">Add improved validation to StringMatchFilter for null/empty text. GitHub issue #3153.</description>
+</entry>


### PR DESCRIPTION
This should fix a potential NPE in StringMatchFilter if the 'text' field is not set or set to null/empty string. #3153
* Added '@Required' to @PluginAttribute
* removed default value of ""
* added notEmpty assert to Builder setText
* added notEmpty assert to StringMatchFilter constructor.
* added changelog XML file.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
