### PR TITLE
Improve validation for AsyncWaitStrategyFactoryConfig for null/empty 'factoryClassName'. #3159

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfigTest.java
@@ -17,17 +17,19 @@
 package org.apache.logging.log4j.core.async;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.lmax.disruptor.WaitStrategy;
 import com.lmax.disruptor.YieldingWaitStrategy;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.categories.AsyncLoggers;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
 import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 @Category(AsyncLoggers.class)
@@ -66,6 +68,37 @@ public class AsyncWaitStrategyFactoryConfigTest {
         final AsyncWaitStrategyFactory asyncWaitStrategyFactory =
                 context.getConfiguration().getAsyncWaitStrategyFactory();
         assertNull(asyncWaitStrategyFactory);
+    }
+
+    /**
+     * Test that when XML element {@code AsyncWaitFactory} has no 'class' attribute.
+     *
+     * @param configuration the configuration
+     */
+    @Test
+    @LoggerContextSource("log4j2-asyncwaitfactoryconfig-3159-nok.xml")
+    void testInvalidBuilderConfiguration3159(final Configuration configuration) {
+        assertNull(configuration.getAsyncWaitStrategyFactory(), "The AsyncWaitStrategyFactory should be null.");
+    }
+
+    /**
+     * Test that when programmatically building a {@link AsyncWaitStrategyFactoryConfig} a {@code null}
+     * factory class-name throws an exception.
+     */
+    @Test
+    void testInvalidProgrammaticConfiguration3159WithNullFactoryClassName() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> AsyncWaitStrategyFactoryConfig.newBuilder()
+                .withFactoryClassName(null));
+    }
+
+    /**
+     * Test that when programmatically building a {@link AsyncWaitStrategyFactoryConfig} a blank ({@code ""})
+     * factory class-name throws an exception.
+     */
+    @Test
+    void testInvalidProgrammaticConfiguration3159WithEmptyFactoryClassName() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> AsyncWaitStrategyFactoryConfig.newBuilder()
+                .withFactoryClassName(""));
     }
 
     @Test

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfigTest.java
@@ -39,11 +39,11 @@ public class AsyncWaitStrategyFactoryConfigTest {
     @LoggerContextSource("AsyncWaitStrategyFactoryConfigTest.xml")
     public void testConfigWaitStrategyFactory(final LoggerContext context) throws Exception {
         final AsyncWaitStrategyFactory asyncWaitStrategyFactory =
-                context.getConfiguration().getAsyncWaitStrategyFactory();
+            context.getConfiguration().getAsyncWaitStrategyFactory();
         assertEquals(YieldingWaitStrategyFactory.class, asyncWaitStrategyFactory.getClass());
         assertThat(
-                "factory is YieldingWaitStrategyFactory",
-                asyncWaitStrategyFactory instanceof YieldingWaitStrategyFactory);
+            "factory is YieldingWaitStrategyFactory",
+            asyncWaitStrategyFactory instanceof YieldingWaitStrategyFactory);
     }
 
     @Test
@@ -53,20 +53,20 @@ public class AsyncWaitStrategyFactoryConfigTest {
         final org.apache.logging.log4j.Logger logger = context.getRootLogger();
 
         final AsyncLoggerConfig loggerConfig =
-                (AsyncLoggerConfig) ((org.apache.logging.log4j.core.Logger) logger).get();
+            (AsyncLoggerConfig) ((org.apache.logging.log4j.core.Logger) logger).get();
         final AsyncLoggerConfigDisruptor delegate =
-                (AsyncLoggerConfigDisruptor) loggerConfig.getAsyncLoggerConfigDelegate();
+            (AsyncLoggerConfigDisruptor) loggerConfig.getAsyncLoggerConfigDelegate();
         assertEquals(YieldingWaitStrategy.class, delegate.getWaitStrategy().getClass());
         assertThat(
-                "waitstrategy is YieldingWaitStrategy",
-                delegate.getWaitStrategy() instanceof com.lmax.disruptor.YieldingWaitStrategy);
+            "waitstrategy is YieldingWaitStrategy",
+            delegate.getWaitStrategy() instanceof com.lmax.disruptor.YieldingWaitStrategy);
     }
 
     @Test
     @LoggerContextSource("AsyncWaitStrategyIncorrectFactoryConfigTest.xml")
     public void testIncorrectConfigWaitStrategyFactory(final LoggerContext context) throws Exception {
         final AsyncWaitStrategyFactory asyncWaitStrategyFactory =
-                context.getConfiguration().getAsyncWaitStrategyFactory();
+            context.getConfiguration().getAsyncWaitStrategyFactory();
         assertNull(asyncWaitStrategyFactory);
     }
 
@@ -82,13 +82,22 @@ public class AsyncWaitStrategyFactoryConfigTest {
     }
 
     /**
+     * Test that when programmatically building a {@link AsyncWaitStrategyFactoryConfig} not setting a valid
+     * factory class-name throws an exception.
+     */
+    @Test
+    void testInvalidProgrammaticConfiguration3159WithFactoryClassNameNotSet() {
+        Assertions.assertNull(AsyncWaitStrategyFactoryConfig.newBuilder().build());
+    }
+
+    /**
      * Test that when programmatically building a {@link AsyncWaitStrategyFactoryConfig} a {@code null}
      * factory class-name throws an exception.
      */
     @Test
-    void testInvalidProgrammaticConfiguration3159WithNullFactoryClassName() {
+    void testInvalidProgrammaticConfiguration3159WithFactoryClassNameNull() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> AsyncWaitStrategyFactoryConfig.newBuilder()
-                .withFactoryClassName(null));
+                                                                                                    .withFactoryClassName(null));
     }
 
     /**
@@ -96,26 +105,26 @@ public class AsyncWaitStrategyFactoryConfigTest {
      * factory class-name throws an exception.
      */
     @Test
-    void testInvalidProgrammaticConfiguration3159WithEmptyFactoryClassName() {
+    void testInvalidProgrammaticConfiguration3159WithFactoryClassNameEmpty() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> AsyncWaitStrategyFactoryConfig.newBuilder()
-                .withFactoryClassName(""));
+                                                                                                    .withFactoryClassName(""));
     }
 
     @Test
     @LoggerContextSource("AsyncWaitStrategyIncorrectFactoryConfigTest.xml")
     public void testIncorrectWaitStrategyFallsBackToDefault(
-            @Named("WaitStrategyAppenderList") final ListAppender list1, final LoggerContext context) throws Exception {
+        @Named("WaitStrategyAppenderList") final ListAppender list1, final LoggerContext context) throws Exception {
         final org.apache.logging.log4j.Logger logger = context.getRootLogger();
 
         final AsyncLoggerConfig loggerConfig =
-                (AsyncLoggerConfig) ((org.apache.logging.log4j.core.Logger) logger).get();
+            (AsyncLoggerConfig) ((org.apache.logging.log4j.core.Logger) logger).get();
         final AsyncLoggerConfigDisruptor delegate =
-                (AsyncLoggerConfigDisruptor) loggerConfig.getAsyncLoggerConfigDelegate();
+            (AsyncLoggerConfigDisruptor) loggerConfig.getAsyncLoggerConfigDelegate();
         assertEquals(
-                TimeoutBlockingWaitStrategy.class, delegate.getWaitStrategy().getClass());
+            TimeoutBlockingWaitStrategy.class, delegate.getWaitStrategy().getClass());
         assertThat(
-                "waitstrategy is TimeoutBlockingWaitStrategy",
-                delegate.getWaitStrategy() instanceof TimeoutBlockingWaitStrategy);
+            "waitstrategy is TimeoutBlockingWaitStrategy",
+            delegate.getWaitStrategy() instanceof TimeoutBlockingWaitStrategy);
     }
 
     public static class YieldingWaitStrategyFactory implements AsyncWaitStrategyFactory {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfigTest.java
@@ -39,11 +39,11 @@ public class AsyncWaitStrategyFactoryConfigTest {
     @LoggerContextSource("AsyncWaitStrategyFactoryConfigTest.xml")
     public void testConfigWaitStrategyFactory(final LoggerContext context) throws Exception {
         final AsyncWaitStrategyFactory asyncWaitStrategyFactory =
-            context.getConfiguration().getAsyncWaitStrategyFactory();
+                context.getConfiguration().getAsyncWaitStrategyFactory();
         assertEquals(YieldingWaitStrategyFactory.class, asyncWaitStrategyFactory.getClass());
         assertThat(
-            "factory is YieldingWaitStrategyFactory",
-            asyncWaitStrategyFactory instanceof YieldingWaitStrategyFactory);
+                "factory is YieldingWaitStrategyFactory",
+                asyncWaitStrategyFactory instanceof YieldingWaitStrategyFactory);
     }
 
     @Test
@@ -53,20 +53,20 @@ public class AsyncWaitStrategyFactoryConfigTest {
         final org.apache.logging.log4j.Logger logger = context.getRootLogger();
 
         final AsyncLoggerConfig loggerConfig =
-            (AsyncLoggerConfig) ((org.apache.logging.log4j.core.Logger) logger).get();
+                (AsyncLoggerConfig) ((org.apache.logging.log4j.core.Logger) logger).get();
         final AsyncLoggerConfigDisruptor delegate =
-            (AsyncLoggerConfigDisruptor) loggerConfig.getAsyncLoggerConfigDelegate();
+                (AsyncLoggerConfigDisruptor) loggerConfig.getAsyncLoggerConfigDelegate();
         assertEquals(YieldingWaitStrategy.class, delegate.getWaitStrategy().getClass());
         assertThat(
-            "waitstrategy is YieldingWaitStrategy",
-            delegate.getWaitStrategy() instanceof com.lmax.disruptor.YieldingWaitStrategy);
+                "waitstrategy is YieldingWaitStrategy",
+                delegate.getWaitStrategy() instanceof com.lmax.disruptor.YieldingWaitStrategy);
     }
 
     @Test
     @LoggerContextSource("AsyncWaitStrategyIncorrectFactoryConfigTest.xml")
     public void testIncorrectConfigWaitStrategyFactory(final LoggerContext context) throws Exception {
         final AsyncWaitStrategyFactory asyncWaitStrategyFactory =
-            context.getConfiguration().getAsyncWaitStrategyFactory();
+                context.getConfiguration().getAsyncWaitStrategyFactory();
         assertNull(asyncWaitStrategyFactory);
     }
 
@@ -97,7 +97,7 @@ public class AsyncWaitStrategyFactoryConfigTest {
     @Test
     void testInvalidProgrammaticConfiguration3159WithFactoryClassNameNull() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> AsyncWaitStrategyFactoryConfig.newBuilder()
-                                                                                                    .withFactoryClassName(null));
+                .withFactoryClassName(null));
     }
 
     /**
@@ -107,24 +107,24 @@ public class AsyncWaitStrategyFactoryConfigTest {
     @Test
     void testInvalidProgrammaticConfiguration3159WithFactoryClassNameEmpty() {
         Assertions.assertThrows(IllegalArgumentException.class, () -> AsyncWaitStrategyFactoryConfig.newBuilder()
-                                                                                                    .withFactoryClassName(""));
+                .withFactoryClassName(""));
     }
 
     @Test
     @LoggerContextSource("AsyncWaitStrategyIncorrectFactoryConfigTest.xml")
     public void testIncorrectWaitStrategyFallsBackToDefault(
-        @Named("WaitStrategyAppenderList") final ListAppender list1, final LoggerContext context) throws Exception {
+            @Named("WaitStrategyAppenderList") final ListAppender list1, final LoggerContext context) throws Exception {
         final org.apache.logging.log4j.Logger logger = context.getRootLogger();
 
         final AsyncLoggerConfig loggerConfig =
-            (AsyncLoggerConfig) ((org.apache.logging.log4j.core.Logger) logger).get();
+                (AsyncLoggerConfig) ((org.apache.logging.log4j.core.Logger) logger).get();
         final AsyncLoggerConfigDisruptor delegate =
-            (AsyncLoggerConfigDisruptor) loggerConfig.getAsyncLoggerConfigDelegate();
+                (AsyncLoggerConfigDisruptor) loggerConfig.getAsyncLoggerConfigDelegate();
         assertEquals(
-            TimeoutBlockingWaitStrategy.class, delegate.getWaitStrategy().getClass());
+                TimeoutBlockingWaitStrategy.class, delegate.getWaitStrategy().getClass());
         assertThat(
-            "waitstrategy is TimeoutBlockingWaitStrategy",
-            delegate.getWaitStrategy() instanceof TimeoutBlockingWaitStrategy);
+                "waitstrategy is TimeoutBlockingWaitStrategy",
+                delegate.getWaitStrategy() instanceof TimeoutBlockingWaitStrategy);
     }
 
     public static class YieldingWaitStrategyFactory implements AsyncWaitStrategyFactory {

--- a/log4j-core-test/src/test/resources/log4j2-asyncwaitfactoryconfig-3159-nok.xml
+++ b/log4j-core-test/src/test/resources/log4j2-asyncwaitfactoryconfig-3159-nok.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="warn">
+   <AsyncWaitStrategyFactory/> <!-- no 'class' attribute -->
+</Configuration>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncWaitStrategyFactoryConfig.java
@@ -16,12 +16,12 @@
  */
 package org.apache.logging.log4j.core.async;
 
-import java.util.Objects;
 import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
+import org.apache.logging.log4j.core.util.Assert;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.LoaderUtil;
 
@@ -41,7 +41,7 @@ public class AsyncWaitStrategyFactoryConfig {
     private final String factoryClassName;
 
     public AsyncWaitStrategyFactoryConfig(final String factoryClassName) {
-        this.factoryClassName = Objects.requireNonNull(factoryClassName, "factoryClassName");
+        this.factoryClassName = Assert.requireNonEmpty(factoryClassName, "factoryClassName");
     }
 
     @PluginBuilderFactory
@@ -67,12 +67,16 @@ public class AsyncWaitStrategyFactoryConfig {
         }
 
         public B withFactoryClassName(final String className) {
-            this.factoryClassName = className;
+            this.factoryClassName =
+                    Assert.requireNonEmpty(className, "The 'className' argument must not be null or empty.");
             return asBuilder();
         }
 
         @Override
         public AsyncWaitStrategyFactoryConfig build() {
+            if (!isValid()) {
+                return null;
+            }
             return new AsyncWaitStrategyFactoryConfig(factoryClassName);
         }
 

--- a/src/changelog/.2.x.x/3159_fix_AsyncWaitStrategyFactoryConfig_guardNPE.xml
+++ b/src/changelog/.2.x.x/3159_fix_AsyncWaitStrategyFactoryConfig_guardNPE.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="3159" link="https://github.com/apache/logging-log4j2/issues/3159"/>
+  <description format="asciidoc">Add improved validation to AsyncWaitStrategyFactoryConfig for null/empty factoryClassName. GitHub issue #3159.</description>
+</entry>


### PR DESCRIPTION
This should fix a potential NPE in AsyncWaitStrategyFactoryConfig if the builder 'class' field is not set or set to null/empty string. https://github.com/apache/logging-log4j2/issues/3159

* added notEmpty assert to Builder setFactoryClassName
* changed notNull to notEmpty assert to AsyncWaitStrategyFactoryConfig constructor.
* added changelog XML file.
* added new tests to AsyncWaitStrategyFactoryConfigTest

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
