### PR TITLE
Fix(#2769): Modify the annotation processor in 2.x to give a warning if a plugin builder attribute does not have a public setter.

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/FakePluginPublicSetter.java.source
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/FakePluginPublicSetter.java.source
@@ -37,13 +37,13 @@ import org.apache.logging.log4j.core.config.plugins.PluginValue;
  */
 @Plugin(name = "Fake", category = "Test")
 @PluginAliases({"AnotherFake", "StillFake"})
-public class FakePlugin {
+public class FakePluginPublicSetter {
 
     @Plugin(name = "Nested", category = "Test")
     public static class Nested {}
 
     @PluginFactory
-    public static FakePlugin newPlugin(
+    public static FakePluginPublicSetter newPlugin(
             @PluginAttribute("attribute") int attribute,
             @PluginElement("layout") Layout<? extends Serializable> layout,
             @PluginConfiguration Configuration config,
@@ -57,10 +57,9 @@ public class FakePlugin {
         return new Builder();
     }
 
-    public static class Builder implements org.apache.logging.log4j.core.util.Builder<FakePlugin> {
+    public static class Builder implements org.apache.logging.log4j.core.util.Builder<FakePluginPublicSetter> {
 
         @PluginBuilderAttribute
-        @SuppressWarnings("log4j.public.setter")
         private int attribute;
 
         @PluginBuilderAttribute
@@ -83,7 +82,7 @@ public class FakePlugin {
         private String value;
 
         @Override
-        public FakePlugin build() {
+        public FakePluginPublicSetter build() {
             return null;
         }
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessorTest.java
@@ -65,6 +65,7 @@ class GraalVmProcessorTest {
             "fields",
             asList(
                     asMap("name", "attribute"),
+                    asMap("name", "attributeWithoutPublicSetterButWithSuppressAnnotation"),
                     asMap("name", "config"),
                     asMap("name", "layout"),
                     asMap("name", "loggerContext"),

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessorPublicSetterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessorPublicSetterTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.config.plugins.processor;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PluginProcessorPublicSetterTest {
+
+    private static final String FAKE_PLUGIN_CLASS_PATH =
+            "src/test/java/org/apache/logging/log4j/core/config/plugins/processor/" + FakePlugin.class.getSimpleName()
+                    + "PublicSetter.java.source";
+
+    private File createdFile;
+    private DiagnosticCollector<JavaFileObject> diagnosticCollector;
+    private List<Diagnostic<? extends JavaFileObject>> errorDiagnostics;
+
+    @BeforeEach
+    void setup() {
+        // Instantiate the tooling
+        final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        diagnosticCollector = new DiagnosticCollector<>();
+        final StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, Locale.ROOT, UTF_8);
+
+        // Get the source files
+        Path sourceFile = Paths.get(FAKE_PLUGIN_CLASS_PATH);
+
+        assertThat(sourceFile).exists();
+
+        final File orig = sourceFile.toFile();
+        createdFile = new File(orig.getParentFile(), "FakePluginPublicSetter.java");
+        assertDoesNotThrow(() -> FileUtils.copyFile(orig, createdFile));
+
+        // get compilation units
+        Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjects(createdFile);
+
+        JavaCompiler.CompilationTask task = compiler.getTask(
+                null,
+                fileManager,
+                diagnosticCollector,
+                Arrays.asList("-proc:only", "-processor", PluginProcessor.class.getName()),
+                null,
+                compilationUnits);
+        task.call();
+
+        errorDiagnostics = diagnosticCollector.getDiagnostics().stream()
+                .filter(diagnostic -> diagnostic.getKind() == Diagnostic.Kind.ERROR)
+                .collect(Collectors.toList());
+    }
+
+    @AfterEach
+    void tearDown() {
+        assertDoesNotThrow(() -> FileUtils.delete(createdFile));
+        File pluginsDatFile = Paths.get("Log4j2Plugins.dat").toFile();
+        if (pluginsDatFile.exists()) {
+            pluginsDatFile.delete();
+        }
+    }
+
+    @Test
+    void warnWhenPluginBuilderAttributeLacksPublicSetter() {
+
+        assertThat(errorDiagnostics).anyMatch(errorMessage -> errorMessage
+                .getMessage(Locale.ROOT)
+                .contains("The field `attribute` does not have a public setter"));
+    }
+
+    @Test
+    void ignoreWarningWhenSuppressWarningsIsPresent() {
+        assertThat(errorDiagnostics)
+                .allMatch(
+                        errorMessage -> !errorMessage
+                                .getMessage(Locale.ROOT)
+                                .contains(
+                                        "The field `attributeWithoutPublicSetterButWithSuppressAnnotation` does not have a public setter"));
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/jdbc/JdbcAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/jdbc/JdbcAppender.java
@@ -60,6 +60,7 @@ public final class JdbcAppender extends AbstractDatabaseAppender<JdbcDatabaseMan
         private ConnectionSource connectionSource;
 
         @PluginBuilderAttribute
+        @SuppressWarnings("log4j.public.setter")
         private boolean immediateFail;
 
         @PluginBuilderAttribute
@@ -80,6 +81,7 @@ public final class JdbcAppender extends AbstractDatabaseAppender<JdbcDatabaseMan
 
         // TODO Consider moving up to AbstractDatabaseAppender.Builder.
         @PluginBuilderAttribute
+        @SuppressWarnings("log4j.public.setter")
         private long reconnectIntervalMillis = DEFAULT_RECONNECT_INTERVAL_MILLIS;
 
         @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SocketPerformancePreferences.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SocketPerformancePreferences.java
@@ -40,14 +40,17 @@ public class SocketPerformancePreferences implements Builder<SocketPerformancePr
 
     @PluginBuilderAttribute
     @Required
+    @SuppressWarnings("log4j.public.setter")
     private int bandwidth;
 
     @PluginBuilderAttribute
     @Required
+    @SuppressWarnings("log4j.public.setter")
     private int connectionTime;
 
     @PluginBuilderAttribute
     @Required
+    @SuppressWarnings("log4j.public.setter")
     private int latency;
 
     public void apply(final Socket socket) {

--- a/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/appender/ServletAppender.java
+++ b/log4j-jakarta-web/src/main/java/org/apache/logging/log4j/web/appender/ServletAppender.java
@@ -40,6 +40,7 @@ public final class ServletAppender extends AbstractAppender {
             implements org.apache.logging.log4j.core.util.Builder<ServletAppender> {
 
         @PluginBuilderAttribute
+        @SuppressWarnings("log4j.public.setter")
         private boolean logThrowables;
 
         @Override

--- a/log4j-web/src/main/java/org/apache/logging/log4j/web/appender/ServletAppender.java
+++ b/log4j-web/src/main/java/org/apache/logging/log4j/web/appender/ServletAppender.java
@@ -40,6 +40,7 @@ public final class ServletAppender extends AbstractAppender {
             implements org.apache.logging.log4j.core.util.Builder<ServletAppender> {
 
         @PluginBuilderAttribute
+        @SuppressWarnings("log4j.public.setter") // The setter is not assignable.
         private boolean logThrowables;
 
         @Override

--- a/src/changelog/.2.x.x/2769_pluginAttribute_publicSetterWarning.xml
+++ b/src/changelog/.2.x.x/2769_pluginAttribute_publicSetterWarning.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <issue id="2769" link="https://github.com/apache/logging-log4j2/issues/2769"/>
+    <description format="asciidoc">Adding a compilation warning for Plugin Builder Attributes that do not have a public setter.</description>
+</entry>


### PR DESCRIPTION
The following commit modifies the annotation processor in 2.x to shell out a warning if the plugin builder attribute does not have a public setter. 

A ` @SuppressWarnings("log4j.public.setter")` attribute can be used to ignore this compilation warning incase it is a known issue.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
