### PR TITLE
Removes weak references from `LoggerRepository`

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/spi/LoggerRegistryTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/spi/LoggerRegistryTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.spi;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.ref.WeakReference;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.message.MessageFactory;
+import org.apache.logging.log4j.message.ParameterizedMessageFactory;
+import org.apache.logging.log4j.message.ReusableMessageFactory;
+import org.apache.logging.log4j.test.TestLogger;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class LoggerRegistryTest {
+
+    private static final String LOGGER_NAME = LoggerRegistryTest.class.getName();
+
+    static Stream<@Nullable MessageFactory> doesNotLoseLoggerReferences() {
+        return Stream.of(
+                ParameterizedMessageFactory.INSTANCE,
+                ReusableMessageFactory.INSTANCE,
+                new ParameterizedMessageFactory(),
+                null);
+    }
+
+    /**
+     * @see <a href="https://github.com/apache/logging-log4j2/issues/3143>Issue #3143</a>
+     */
+    @ParameterizedTest
+    @MethodSource
+    void doesNotLoseLoggerReferences(@Nullable MessageFactory messageFactory) {
+        LoggerRegistry<TestLogger> loggerRegistry = new LoggerRegistry<>();
+        TestLogger logger = new TestLogger(LOGGER_NAME, messageFactory);
+        WeakReference<TestLogger> loggerRef = new WeakReference<>(logger);
+        // Register logger
+        loggerRegistry.putIfAbsent(LOGGER_NAME, messageFactory, logger);
+        // The JIT compiler/optimizer might figure out by himself the `logger` and `messageFactory` are no longer used:
+        //   https://shipilev.net/jvm/anatomy-quarks/8-local-var-reachability/
+        // We help him with the task though.
+        logger = null;
+        // Trigger a GC run
+        System.gc();
+        // Check if the logger is still there
+        assertThat(loggerRef.get()).isNotNull();
+        assertThat(loggerRegistry.getLogger(LOGGER_NAME, messageFactory)).isInstanceOf(TestLogger.class);
+    }
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContext.java
@@ -102,7 +102,12 @@ public class SimpleLoggerContext implements LoggerContext {
     public ExtendedLogger getLogger(final String name, @Nullable final MessageFactory messageFactory) {
         final MessageFactory effectiveMessageFactory =
                 messageFactory != null ? messageFactory : DEFAULT_MESSAGE_FACTORY;
-        return loggerRegistry.computeIfAbsent(name, effectiveMessageFactory, this::createLogger);
+        ExtendedLogger logger = loggerRegistry.getLogger(name, effectiveMessageFactory);
+        if (logger == null) {
+            logger = createLogger(name, effectiveMessageFactory);
+            loggerRegistry.putIfAbsent(name, effectiveMessageFactory, logger);
+        }
+        return logger;
     }
 
     private ExtendedLogger createLogger(final String name, @Nullable final MessageFactory messageFactory) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContext.java
@@ -102,12 +102,13 @@ public class SimpleLoggerContext implements LoggerContext {
     public ExtendedLogger getLogger(final String name, @Nullable final MessageFactory messageFactory) {
         final MessageFactory effectiveMessageFactory =
                 messageFactory != null ? messageFactory : DEFAULT_MESSAGE_FACTORY;
-        ExtendedLogger logger = loggerRegistry.getLogger(name, effectiveMessageFactory);
-        if (logger == null) {
-            logger = createLogger(name, effectiveMessageFactory);
-            loggerRegistry.putIfAbsent(name, effectiveMessageFactory, logger);
+        final ExtendedLogger oldLogger = loggerRegistry.getLogger(name, effectiveMessageFactory);
+        if (oldLogger != null) {
+            return oldLogger;
         }
-        return logger;
+        final ExtendedLogger newLogger = createLogger(name, effectiveMessageFactory);
+        loggerRegistry.putIfAbsent(name, effectiveMessageFactory, newLogger);
+        return loggerRegistry.getLogger(name, effectiveMessageFactory);
     }
 
     private ExtendedLogger createLogger(final String name, @Nullable final MessageFactory messageFactory) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerRegistry.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerRegistry.java
@@ -257,7 +257,6 @@ public class LoggerRegistry<T extends ExtendedLogger> {
      * @deprecated As of version {@code 2.25.0}, planned to be removed!
      * Use {@link #computeIfAbsent(String, MessageFactory, BiFunction)} instead.
      */
-    @Deprecated
     public void putIfAbsent(
             @Nullable final String name, @Nullable final MessageFactory messageFactory, final T logger) {
 
@@ -277,6 +276,15 @@ public class LoggerRegistry<T extends ExtendedLogger> {
         }
     }
 
+    /**
+     * Returns an existent logger or creates a new one.
+     *
+     * @param name The logger name.
+     * @param messageFactory The message factory to use.
+     * @param loggerSupplier Used to create the logger if it does not exist already
+     * @return A logger
+     * @since 2.25.0
+     */
     public T computeIfAbsent(
             final String name,
             final MessageFactory messageFactory,

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/package-info.java
@@ -19,7 +19,7 @@
  * API classes.
  */
 @Export
-@Version("2.24.1")
+@Version("2.24.2")
 package org.apache.logging.log4j.spi;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/package-info.java
@@ -19,7 +19,7 @@
  * API classes.
  */
 @Export
-@Version("2.25.0")
+@Version("2.24.1")
 package org.apache.logging.log4j.spi;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/InternalLoggerRegistry.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/InternalLoggerRegistry.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.util.internal;
+
+import static java.util.Objects.requireNonNull;
+
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.WeakHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.message.MessageFactory;
+import org.apache.logging.log4j.status.StatusLogger;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Convenience class used by {@link org.apache.logging.log4j.core.LoggerContext}
+ * <p>
+ *   We don't use {@link org.apache.logging.log4j.spi.LoggerRegistry} from the Log4j API to keep Log4j Core independent
+ *   from the version of the Log4j API at runtime.
+ * </p>
+ * @since 2.25.0
+ */
+@NullMarked
+public final class InternalLoggerRegistry {
+
+    private final Map<MessageFactory, Map<String, WeakReference<Logger>>> loggerRefByNameByMessageFactory =
+            new WeakHashMap<>();
+
+    private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    private final Lock readLock = lock.readLock();
+
+    private final Lock writeLock = lock.writeLock();
+
+    public InternalLoggerRegistry() {}
+
+    /**
+     * Returns the logger associated with the given name and message factory.
+     *
+     * @param name a logger name
+     * @param messageFactory a message factory
+     * @return the logger associated with the given name and message factory
+     */
+    public @Nullable Logger getLogger(final String name, final MessageFactory messageFactory) {
+        requireNonNull(name, "name");
+        requireNonNull(messageFactory, "messageFactory");
+        readLock.lock();
+        try {
+            return Optional.of(loggerRefByNameByMessageFactory)
+                    .map(loggerRefByNameByMessageFactory -> loggerRefByNameByMessageFactory.get(messageFactory))
+                    .map(loggerRefByName -> loggerRefByName.get(name))
+                    .map(WeakReference::get)
+                    .orElse(null);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public Stream<Logger> getLoggers() {
+        readLock.lock();
+        try {
+            return loggerRefByNameByMessageFactory.values().stream()
+                    .flatMap(loggerRefByName -> loggerRefByName.values().stream())
+                    .flatMap(loggerRef -> {
+                        @Nullable Logger logger = loggerRef.get();
+                        return logger != null ? Stream.of(logger) : Stream.empty();
+                    });
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    /**
+     * Checks if a logger associated with the given name and message factory exists.
+     *
+     * @param name a logger name
+     * @param messageFactory a message factory
+     * @return {@code true}, if the logger exists; {@code false} otherwise.
+     */
+    public boolean hasLogger(final String name, final MessageFactory messageFactory) {
+        requireNonNull(name, "name");
+        requireNonNull(messageFactory, "messageFactory");
+        return getLogger(name, messageFactory) != null;
+    }
+
+    /**
+     * Checks if a logger associated with the given name and message factory type exists.
+     *
+     * @param name a logger name
+     * @param messageFactoryClass a message factory class
+     * @return {@code true}, if the logger exists; {@code false} otherwise.
+     */
+    public boolean hasLogger(final String name, final Class<? extends MessageFactory> messageFactoryClass) {
+        requireNonNull(name, "name");
+        requireNonNull(messageFactoryClass, "messageFactoryClass");
+        readLock.lock();
+        try {
+            return loggerRefByNameByMessageFactory.entrySet().stream()
+                    .filter(entry -> messageFactoryClass.equals(entry.getKey().getClass()))
+                    .anyMatch(entry -> entry.getValue().containsKey(name));
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public Logger computeIfAbsent(
+            final String name,
+            final MessageFactory messageFactory,
+            final BiFunction<String, MessageFactory, Logger> loggerSupplier) {
+
+        // Check arguments
+        requireNonNull(name, "name");
+        requireNonNull(messageFactory, "messageFactory");
+        requireNonNull(loggerSupplier, "loggerSupplier");
+
+        // Read lock fast path: See if logger already exists
+        @Nullable Logger logger = getLogger(name, messageFactory);
+        if (logger != null) {
+            return logger;
+        }
+
+        // Write lock slow path: Insert the logger
+        writeLock.lock();
+        try {
+
+            // See if the logger is created by another thread in the meantime
+            final Map<String, WeakReference<Logger>> loggerRefByName =
+                    loggerRefByNameByMessageFactory.computeIfAbsent(messageFactory, ignored -> new HashMap<>());
+            WeakReference<Logger> loggerRef = loggerRefByName.get(name);
+            if (loggerRef != null && (logger = loggerRef.get()) != null) {
+                return logger;
+            }
+
+            // Create the logger
+            logger = loggerSupplier.apply(name, messageFactory);
+
+            // Report message factory mismatches, if there is any
+            final MessageFactory loggerMessageFactory = logger.getMessageFactory();
+            if (!loggerMessageFactory.equals(messageFactory)) {
+                StatusLogger.getLogger()
+                        .error(
+                                "Newly registered logger with name `{}` and message factory `{}`, is requested to be associated with a different message factory: `{}`.\n"
+                                        + "Effectively the message factory of the logger will be used and the other one will be ignored.\n"
+                                        + "This generally hints a problem at the logger context implementation.\n"
+                                        + "Please report this using the Log4j project issue tracker.",
+                                name,
+                                loggerMessageFactory,
+                                messageFactory);
+            }
+
+            // Insert the logger
+            loggerRefByName.put(name, new WeakReference<>(logger));
+            return logger;
+        } finally {
+            writeLock.unlock();
+        }
+    }
+}

--- a/log4j-taglib/src/main/java/org/apache/logging/log4j/taglib/Log4jTaglibLoggerContext.java
+++ b/log4j-taglib/src/main/java/org/apache/logging/log4j/taglib/Log4jTaglibLoggerContext.java
@@ -73,7 +73,12 @@ final class Log4jTaglibLoggerContext implements LoggerContext {
     public Log4jTaglibLogger getLogger(final String name, @Nullable final MessageFactory messageFactory) {
         final MessageFactory effectiveMessageFactory =
                 messageFactory != null ? messageFactory : DEFAULT_MESSAGE_FACTORY;
-        return loggerRegistry.computeIfAbsent(name, effectiveMessageFactory, this::createLogger);
+        Log4jTaglibLogger logger = loggerRegistry.getLogger(name, effectiveMessageFactory);
+        if (logger == null) {
+            logger = createLogger(name, effectiveMessageFactory);
+            loggerRegistry.putIfAbsent(name, effectiveMessageFactory, logger);
+        }
+        return logger;
     }
 
     private Log4jTaglibLogger createLogger(final String name, @Nullable final MessageFactory messageFactory) {

--- a/log4j-taglib/src/main/java/org/apache/logging/log4j/taglib/Log4jTaglibLoggerContext.java
+++ b/log4j-taglib/src/main/java/org/apache/logging/log4j/taglib/Log4jTaglibLoggerContext.java
@@ -73,15 +73,16 @@ final class Log4jTaglibLoggerContext implements LoggerContext {
     public Log4jTaglibLogger getLogger(final String name, @Nullable final MessageFactory messageFactory) {
         final MessageFactory effectiveMessageFactory =
                 messageFactory != null ? messageFactory : DEFAULT_MESSAGE_FACTORY;
-        Log4jTaglibLogger logger = loggerRegistry.getLogger(name, effectiveMessageFactory);
-        if (logger == null) {
-            logger = createLogger(name, effectiveMessageFactory);
-            loggerRegistry.putIfAbsent(name, effectiveMessageFactory, logger);
+        final Log4jTaglibLogger oldLogger = loggerRegistry.getLogger(name, effectiveMessageFactory);
+        if (oldLogger != null) {
+            return oldLogger;
         }
-        return logger;
+        final Log4jTaglibLogger newLogger = createLogger(name, effectiveMessageFactory);
+        loggerRegistry.putIfAbsent(name, effectiveMessageFactory, newLogger);
+        return loggerRegistry.getLogger(name, effectiveMessageFactory);
     }
 
-    private Log4jTaglibLogger createLogger(final String name, @Nullable final MessageFactory messageFactory) {
+    private Log4jTaglibLogger createLogger(final String name, final MessageFactory messageFactory) {
         final LoggerContext loggerContext = LogManager.getContext(false);
         final ExtendedLogger delegateLogger = loggerContext.getLogger(name, messageFactory);
         return new Log4jTaglibLogger(delegateLogger, name, delegateLogger.getMessageFactory());

--- a/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/JULLoggerContext.java
+++ b/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/JULLoggerContext.java
@@ -52,7 +52,12 @@ class JULLoggerContext implements LoggerContext {
     public ExtendedLogger getLogger(final String name, @Nullable final MessageFactory messageFactory) {
         final MessageFactory effectiveMessageFactory =
                 messageFactory != null ? messageFactory : DEFAULT_MESSAGE_FACTORY;
-        return loggerRegistry.computeIfAbsent(name, effectiveMessageFactory, JULLoggerContext::createLogger);
+        ExtendedLogger logger = loggerRegistry.getLogger(name, effectiveMessageFactory);
+        if (logger == null) {
+            logger = createLogger(name, effectiveMessageFactory);
+            loggerRegistry.putIfAbsent(name, effectiveMessageFactory, logger);
+        }
+        return logger;
     }
 
     private static ExtendedLogger createLogger(final String name, @Nullable final MessageFactory messageFactory) {

--- a/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/JULLoggerContext.java
+++ b/log4j-to-jul/src/main/java/org/apache/logging/log4j/tojul/JULLoggerContext.java
@@ -52,12 +52,13 @@ class JULLoggerContext implements LoggerContext {
     public ExtendedLogger getLogger(final String name, @Nullable final MessageFactory messageFactory) {
         final MessageFactory effectiveMessageFactory =
                 messageFactory != null ? messageFactory : DEFAULT_MESSAGE_FACTORY;
-        ExtendedLogger logger = loggerRegistry.getLogger(name, effectiveMessageFactory);
-        if (logger == null) {
-            logger = createLogger(name, effectiveMessageFactory);
-            loggerRegistry.putIfAbsent(name, effectiveMessageFactory, logger);
+        final ExtendedLogger oldLogger = loggerRegistry.getLogger(name, effectiveMessageFactory);
+        if (oldLogger != null) {
+            return oldLogger;
         }
-        return logger;
+        final ExtendedLogger newLogger = createLogger(name, effectiveMessageFactory);
+        loggerRegistry.putIfAbsent(name, effectiveMessageFactory, newLogger);
+        return loggerRegistry.getLogger(name, effectiveMessageFactory);
     }
 
     private static ExtendedLogger createLogger(final String name, @Nullable final MessageFactory messageFactory) {

--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLoggerContext.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLoggerContext.java
@@ -45,12 +45,13 @@ public class SLF4JLoggerContext implements LoggerContext {
     public ExtendedLogger getLogger(final String name, @Nullable final MessageFactory messageFactory) {
         final MessageFactory effectiveMessageFactory =
                 messageFactory != null ? messageFactory : DEFAULT_MESSAGE_FACTORY;
-        ExtendedLogger logger = loggerRegistry.getLogger(name, effectiveMessageFactory);
-        if (logger == null) {
-            logger = createLogger(name, effectiveMessageFactory);
-            loggerRegistry.putIfAbsent(name, effectiveMessageFactory, logger);
+        final ExtendedLogger oldLogger = loggerRegistry.getLogger(name, effectiveMessageFactory);
+        if (oldLogger != null) {
+            return oldLogger;
         }
-        return logger;
+        final ExtendedLogger newLogger = createLogger(name, effectiveMessageFactory);
+        loggerRegistry.putIfAbsent(name, effectiveMessageFactory, newLogger);
+        return loggerRegistry.getLogger(name, effectiveMessageFactory);
     }
 
     private static ExtendedLogger createLogger(final String name, @Nullable final MessageFactory messageFactory) {

--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLoggerContext.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLoggerContext.java
@@ -45,7 +45,12 @@ public class SLF4JLoggerContext implements LoggerContext {
     public ExtendedLogger getLogger(final String name, @Nullable final MessageFactory messageFactory) {
         final MessageFactory effectiveMessageFactory =
                 messageFactory != null ? messageFactory : DEFAULT_MESSAGE_FACTORY;
-        return loggerRegistry.computeIfAbsent(name, effectiveMessageFactory, SLF4JLoggerContext::createLogger);
+        ExtendedLogger logger = loggerRegistry.getLogger(name, effectiveMessageFactory);
+        if (logger == null) {
+            logger = createLogger(name, effectiveMessageFactory);
+            loggerRegistry.putIfAbsent(name, effectiveMessageFactory, logger);
+        }
+        return logger;
     }
 
     private static ExtendedLogger createLogger(final String name, @Nullable final MessageFactory messageFactory) {

--- a/src/changelog/.2.x.x/3143_logger_registry.xml
+++ b/src/changelog/.2.x.x/3143_logger_registry.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="deprecated">
+  <issue id="3143" link="https://github.com/apache/logging-log4j2/issues/3143"/>
+  <description format="asciidoc">
+    Use hard references to `Logger`s in `LoggerRegistry`.
+  </description>
+</entry>


### PR DESCRIPTION
Removes weak references to `Logger`s in `LoggerRepository`. The usage of weak references in `LoggerRepository` might cause `null` to be returned by `LogManager.getLogger()` of all Log4j Core versions up to `2.24.1`. Versions of Log4j API up to `2.24.0` did hold **hard** references to all the registered loggers, so the change will not alter the previous behavior.

This PR also inverts the order of the `String` and `MessageFactory` keys to the `LoggerRepository` multi-map to limit the number of internal maps. The external map is a `WeakHashMap` to allow logger-specific message factories to be GC-ed.

Closes #3143.

