### PR TITLE
Fix key removal issues in Thread Context (`2.24.x` branch)

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/internal/map/UnmodifiableArrayBackedMapTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/internal/map/UnmodifiableArrayBackedMapTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.TriConsumer;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class UnmodifiableArrayBackedMapTest {
@@ -372,5 +373,24 @@ public class UnmodifiableArrayBackedMapTest {
         UnmodifiableArrayBackedMap map = UnmodifiableArrayBackedMap.EMPTY_MAP.copyAndPut("test", "test");
         // verify same instance, not just equals()
         assertTrue(map == map.toMap());
+    }
+
+    @Test
+    void copyAndRemoveAll_should_work() {
+
+        // Create the actual map
+        UnmodifiableArrayBackedMap actualMap = UnmodifiableArrayBackedMap.EMPTY_MAP;
+        actualMap = actualMap.copyAndPut("outer", "two");
+        actualMap = actualMap.copyAndPut("inner", "one");
+        actualMap = actualMap.copyAndPut("not-in-closeable", "true");
+
+        // Create the expected map
+        UnmodifiableArrayBackedMap expectedMap = UnmodifiableArrayBackedMap.EMPTY_MAP;
+        expectedMap = expectedMap.copyAndPut("outer", "two");
+        expectedMap = expectedMap.copyAndPut("not-in-closeable", "true");
+
+        // Remove the key and verify
+        actualMap = actualMap.copyAndRemoveAll(Collections.singleton("inner"));
+        Assertions.assertThat(actualMap).isEqualTo(expectedMap);
     }
 }

--- a/src/changelog/.2.x.x/3048_fix_ThreadContext_remove.xml
+++ b/src/changelog/.2.x.x/3048_fix_ThreadContext_remove.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3048" link="https://github.com/apache/logging-log4j2/pull/3048"/>
+  <description format="asciidoc">Fix key removal issues in Thread Context</description>
+</entry>


### PR DESCRIPTION
This backports #3050 to the `2.24.x` branch.
