### PR TITLE
Migrate `log4j-api-test` to junit5

### DIFF
--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/AbstractSerializationTest.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/AbstractSerializationTest.java
@@ -20,29 +20,22 @@ import static org.apache.logging.log4j.test.SerializableMatchers.serializesRound
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.Serializable;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
 
 /**
  * Subclasses tests {@link Serializable} objects.
  */
-@RunWith(Parameterized.class)
 public abstract class AbstractSerializationTest {
 
-    private final Serializable serializable;
-
-    public AbstractSerializationTest(final Serializable serializable) {
-        this.serializable = serializable;
-    }
+    public AbstractSerializationTest() {}
 
     @Test
-    public void testSerializationRoundtripEquals() {
+    public void testSerializationRoundtripEquals(Serializable serializable) {
         assertThat(serializable, serializesRoundTrip(serializable));
     }
 
     @Test
-    public void testSerializationRoundtripNoException() {
+    public void testSerializationRoundtripNoException(Serializable serializable) {
         assertThat(serializable, serializesRoundTrip());
     }
 }

--- a/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/SecurityManagerExtension.java
+++ b/log4j-api-test/src/main/java/org/apache/logging/log4j/test/junit/SecurityManagerExtension.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.test.junit;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class SecurityManagerExtension implements BeforeEachCallback, AfterEachCallback {
+    private SecurityManager securityManagerBefore;
+    private final SecurityManager securityManager;
+
+    public SecurityManagerExtension(final SecurityManager securityManager) {
+        this.securityManager = securityManager;
+    }
+
+    public void beforeEach(ExtensionContext ctx) {
+        securityManagerBefore = System.getSecurityManager();
+        System.setSecurityManager(securityManager);
+    }
+
+    public void afterEach(ExtensionContext ctx) {
+        System.setSecurityManager(securityManagerBefore);
+    }
+}

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/MessageFormatMessageSerializationTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/MessageFormatMessageSerializationTest.java
@@ -18,16 +18,17 @@ package org.apache.logging.log4j.message;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.io.Serializable;
 import org.apache.logging.log4j.test.AbstractSerializationTest;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
 public class MessageFormatMessageSerializationTest extends AbstractSerializationTest {
 
-    @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
             {new MessageFormatMessage("Test")},
@@ -36,7 +37,19 @@ public class MessageFormatMessageSerializationTest extends AbstractSerialization
         });
     }
 
-    public MessageFormatMessageSerializationTest(final MessageFormatMessage message) {
-        super(message);
+    public MessageFormatMessageSerializationTest() {
+        super();
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testSerializationRoundtripEquals(Serializable serializable) {
+        super.testSerializationRoundtripEquals(serializable);
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testSerializationRoundtripNoException(Serializable serializable) {
+        super.testSerializationRoundtripNoException(serializable);
     }
 }

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/MessageFormatMessageSerializationTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/MessageFormatMessageSerializationTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.logging.log4j.message;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
-import java.io.Serializable;
 import org.apache.logging.log4j.test.AbstractSerializationTest;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/EnvironmentPropertySourceSecurityManagerIT.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/EnvironmentPropertySourceSecurityManagerIT.java
@@ -17,9 +17,9 @@
 package org.apache.logging.log4j.util;
 
 import java.security.Permission;
-import org.apache.logging.log4j.test.junit.SecurityManagerTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.test.junit.SecurityManagerExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 /**
@@ -37,8 +37,8 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 @ResourceLock("java.lang.SecurityManager")
 public class EnvironmentPropertySourceSecurityManagerIT {
 
-    @Rule
-    public final SecurityManagerTestRule rule = new SecurityManagerTestRule(new TestSecurityManager());
+    @RegisterExtension
+    public final SecurityManagerExtension ext = new SecurityManagerExtension(new TestSecurityManager());
 
     /**
      * Always throws a SecurityException for any environment variables permission

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/LoaderUtilSecurityManagerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/LoaderUtilSecurityManagerTest.java
@@ -20,15 +20,15 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.security.Permission;
-import org.apache.logging.log4j.test.junit.SecurityManagerTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.test.junit.SecurityManagerExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 @ResourceLock("java.lang.SecurityManager")
 public class LoaderUtilSecurityManagerTest {
-    @Rule
-    public final SecurityManagerTestRule rule = new SecurityManagerTestRule(new TestSecurityManager());
+    @RegisterExtension
+    public final SecurityManagerExtension ext = new SecurityManagerExtension(new TestSecurityManager());
 
     private static class TestSecurityManager extends SecurityManager {
         @Override

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/PropertyFilePropertySourceSecurityManagerIT.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/PropertyFilePropertySourceSecurityManagerIT.java
@@ -16,18 +16,18 @@
  */
 package org.apache.logging.log4j.util;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.FilePermission;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.Permission;
 import java.util.PropertyPermission;
-import org.apache.logging.log4j.test.junit.SecurityManagerTestRule;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.test.junit.SecurityManagerExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 /**
@@ -46,13 +46,13 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 @ResourceLock("java.lang.SecurityManager")
 public class PropertyFilePropertySourceSecurityManagerIT {
 
-    @BeforeClass
-    public static void beforeClass() {
-        assertTrue(TEST_FIXTURE_PATH, Files.exists(Paths.get(TEST_FIXTURE_PATH)));
+    @BeforeAll
+    public static void beforeAll() {
+        assertTrue(Files.exists(Paths.get(TEST_FIXTURE_PATH)), TEST_FIXTURE_PATH);
     }
 
-    @Rule
-    public final SecurityManagerTestRule rule = new SecurityManagerTestRule(new TestSecurityManager());
+    @RegisterExtension
+    public final SecurityManagerExtension ext = new SecurityManagerExtension(new TestSecurityManager());
 
     private static final String TEST_FIXTURE_PATH = "src/test/resources/PropertiesUtilTest.properties";
 

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/StackLocatorTestIT.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/StackLocatorTestIT.java
@@ -20,9 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.security.Permission;
 import java.util.Deque;
-import org.apache.logging.log4j.test.junit.SecurityManagerTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.test.junit.SecurityManagerExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 /**
@@ -39,8 +39,8 @@ import org.junit.jupiter.api.parallel.ResourceLock;
  */
 @ResourceLock("java.lang.SecurityManager")
 public class StackLocatorTestIT {
-    @Rule
-    public final SecurityManagerTestRule rule = new SecurityManagerTestRule(new TestSecurityManager());
+    @RegisterExtension
+    public final SecurityManagerExtension ext = new SecurityManagerExtension(new TestSecurityManager());
 
     /**
      * Always throws a SecurityException for any reques to create a new SecurityManager

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/SystemPropertiesPropertySourceSecurityManagerIT.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/SystemPropertiesPropertySourceSecurityManagerIT.java
@@ -16,13 +16,13 @@
  */
 package org.apache.logging.log4j.util;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.security.Permission;
 import java.util.PropertyPermission;
-import org.apache.logging.log4j.test.junit.SecurityManagerTestRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.test.junit.SecurityManagerExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 /**
@@ -41,8 +41,8 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 @ResourceLock("java.lang.SecurityManager")
 public class SystemPropertiesPropertySourceSecurityManagerIT {
 
-    @Rule
-    public final SecurityManagerTestRule rule = new SecurityManagerTestRule(new TestSecurityManager());
+    @RegisterExtension
+    public final SecurityManagerExtension ext = new SecurityManagerExtension(new TestSecurityManager());
 
     /**
      * Always throws a SecurityException for any environment variables permission

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/LoggerSerializationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/LoggerSerializationTest.java
@@ -21,11 +21,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.test.AbstractSerializationTest;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class LoggerSerializationTest extends AbstractSerializationTest {
 
-    @Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
             {new LoggerContext("").getLogger("", null)},
@@ -35,7 +35,19 @@ public class LoggerSerializationTest extends AbstractSerializationTest {
         });
     }
 
-    public LoggerSerializationTest(final Serializable serializable) {
-        super(serializable);
+    public LoggerSerializationTest() {
+        super();
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testSerializationRoundtripEquals(Serializable serializable) {
+        super.testSerializationRoundtripEquals(serializable);
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    public void testSerializationRoundtripNoException(Serializable serializable) {
+        super.testSerializationRoundtripNoException(serializable);
     }
 }


### PR DESCRIPTION
We are from Neighbourhoodie, the implementation partner of the [STF](https://www.sovereigntechfund.de/programs/bug-resilience) Bug Resilience Program. This work is part of our agreed Milestone 1. Upgrade from JUnit 4 to JUnit 5. 
This PR migrates the tests located in log4j-api-test to JUnit5.

## Checklist

* [x] Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
