### PR TITLE
Migrate `log4j-osgi-test` to JUnit 5

### DIFF
--- a/log4j-osgi-test/src/test/java/org/apache/logging/log4j/osgi/tests/OsgiExt.java
+++ b/log4j-osgi-test/src/test/java/org/apache/logging/log4j/osgi/tests/OsgiExt.java
@@ -21,7 +21,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
-import org.junit.rules.ExternalResource;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.launch.Framework;
 import org.osgi.framework.launch.FrameworkFactory;
@@ -29,17 +31,16 @@ import org.osgi.framework.launch.FrameworkFactory;
 /**
  * JUnit rule to initialize and shutdown an OSGi framework.
  */
-class OsgiRule extends ExternalResource {
-
+class OsgiExt implements AfterEachCallback, BeforeEachCallback {
     private final FrameworkFactory factory;
     private Framework framework;
 
-    OsgiRule(final FrameworkFactory factory) {
+    OsgiExt(final FrameworkFactory factory) {
         this.factory = factory;
     }
 
     @Override
-    protected void after() {
+    public void afterEach(ExtensionContext context) {
         if (framework != null) {
             try {
                 framework.stop();
@@ -52,8 +53,8 @@ class OsgiRule extends ExternalResource {
     }
 
     @Override
-    protected void before() throws Throwable {
-        try (final InputStream is = OsgiRule.class.getResourceAsStream("/osgi.properties")) {
+    public void beforeEach(ExtensionContext context) throws Exception {
+        try (final InputStream is = OsgiExt.class.getResourceAsStream("/osgi.properties")) {
             final Properties props = new Properties();
             props.load(is);
             final Map<String, String> configMap = props.entrySet().stream()
@@ -74,6 +75,6 @@ class OsgiRule extends ExternalResource {
 
     @Override
     public String toString() {
-        return "OsgiRule [factory=" + factory + ", framework=" + framework + "]";
+        return "OsgiExt [factory=" + factory + ", framework=" + framework + "]";
     }
 }


### PR DESCRIPTION
Hello 👋

We are from Neighbourhoodie, the implementation partner of the STF Bug Resilience Program. This work is part of our agreed Milestone 1. Upgrade from JUnit 4 to JUnit 5. This PR migrates the tests located in `log4j-osgi-test`.

Thank you!

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
