### PR TITLE
Migrate `log4j-jul` to JUnit 5

### DIFF
--- a/log4j-jul/pom.xml
+++ b/log4j-jul/pom.xml
@@ -73,8 +73,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -92,15 +92,6 @@
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
         </configuration>
-        <dependencies>
-          <!-- Manual override of the Surefire provider -->
-          <!-- The `surefire-platform` provider initializes JUL before calling our tests -->
-          <dependency>
-            <groupId>org.apache.maven.surefire</groupId>
-            <artifactId>surefire-junit47</artifactId>
-            <version>${surefire.version}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>default-test</id>
@@ -109,9 +100,12 @@
             </goals>
             <phase>test</phase>
             <configuration>
-              <excludes>
-                <exclude>Log4jBridgeHandlerTest.java</exclude>
-              </excludes>
+              <includes>
+                <include>DefaultLevelConverterCustomJulLevelsTest.java</include>
+                <include>DefaultLevelConverterTest.java</include>
+                <include>JavaLevelTranslatorTest.java</include>
+                <include>Log4jLevelTranslatorTest.java</include>
+              </includes>
             </configuration>
           </execution>
           <execution>
@@ -128,6 +122,56 @@
               <systemPropertyVariables>
                 <java.util.logging.config.file>src/test/resources/logging-test.properties</java.util.logging.config.file>
                 <log4j2.configurationFile>log4j2-julBridge-test.xml</log4j2.configurationFile>
+              </systemPropertyVariables>
+            </configuration>
+          </execution>
+          <execution>
+            <id>async-logger-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <includes>
+                <include>**/AsyncLoggerThreadsTest.java</include>
+              </includes>
+              <!-- Use custom `j.u.l.LogManager` and an asynchronous selector -->
+              <systemPropertyVariables>
+                <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager</java.util.logging.manager>
+                <log4j2.contextSelector>org.apache.logging.log4j.core.async.AsyncLoggerContextSelector</log4j2.contextSelector>
+              </systemPropertyVariables>
+            </configuration>
+          </execution>
+          <execution>
+            <id>log-manager</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <includes>
+                <include>**/*ApiLoggerTest.java</include>
+                <include>**/*BracketInNotInterpolatedMessageTest.java</include>
+                <include>**/*CallerInformationTest.java</include>
+              </includes>
+              <systemPropertyVariables>
+                <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager</java.util.logging.manager>
+              </systemPropertyVariables>
+            </configuration>
+          </execution>
+          <execution>
+            <id>core-logger-test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <includes>
+                <include>**/CoreLoggerTest.java</include>
+              </includes>
+              <systemPropertyVariables>
+                <java.util.logging.manager>org.apache.logging.log4j.jul.LogManager</java.util.logging.manager>
+                <log4j2.julLoggerAdapter>org.apache.logging.log4j.jul.CoreLoggerAdapter</log4j2.julLoggerAdapter>
               </systemPropertyVariables>
             </configuration>
           </execution>

--- a/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/CallerInformationTest.java
+++ b/log4j-jul/src/test/java/org/apache/logging/log4j/jul/test/CallerInformationTest.java
@@ -16,53 +16,45 @@
  */
 package org.apache.logging.log4j.jul.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import java.util.logging.Logger;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.apache.logging.log4j.jul.LogManager;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 public class CallerInformationTest {
 
     // config from log4j-core test-jar
     private static final String CONFIG = "log4j2-calling-class.xml";
 
-    @Rule
-    public final LoggerContextRule ctx = new LoggerContextRule(CONFIG);
-
-    @BeforeClass
-    public static void setUpClass() {
-        System.setProperty("java.util.logging.manager", LogManager.class.getName());
-    }
-
-    @AfterClass
+    @AfterAll
     public static void tearDownClass() {
         System.clearProperty("java.util.logging.manager");
     }
 
     @Test
-    public void testClassLogger() {
-        final ListAppender app = ctx.getListAppender("Class").clear();
+    @LoggerContextSource(CONFIG)
+    public void testClassLogger(@Named("Class") final ListAppender app) {
+        app.clear();
         final Logger logger = Logger.getLogger("ClassLogger");
         logger.info("Ignored message contents.");
         logger.warning("Verifying the caller class is still correct.");
         logger.severe("Hopefully nobody breaks me!");
         final List<String> messages = app.getMessages();
-        assertEquals("Incorrect number of messages.", 3, messages.size());
+        assertEquals(3, messages.size(), "Incorrect number of messages.");
         for (final String message : messages) {
-            assertEquals("Incorrect caller class name.", this.getClass().getName(), message);
+            assertEquals(this.getClass().getName(), message, "Incorrect caller class name.");
         }
     }
 
     @Test
-    public void testMethodLogger() {
-        final ListAppender app = ctx.getListAppender("Method").clear();
+    @LoggerContextSource(CONFIG)
+    public void testMethodLogger(@Named("Method") final ListAppender app) {
+        app.clear();
         final Logger logger = Logger.getLogger("MethodLogger");
         logger.info("More messages.");
         logger.warning("CATASTROPHE INCOMING!");
@@ -70,9 +62,9 @@ public class CallerInformationTest {
         logger.warning("brains~~~");
         logger.info("Itchy. Tasty.");
         final List<String> messages = app.getMessages();
-        assertEquals("Incorrect number of messages.", 5, messages.size());
+        assertEquals(5, messages.size(), "Incorrect number of messages.");
         for (final String message : messages) {
-            assertEquals("Incorrect caller method name.", "testMethodLogger", message);
+            assertEquals("testMethodLogger", message, "Incorrect caller method name.");
         }
     }
 }


### PR DESCRIPTION
Hello 👋

We are from Neighbourhoodie, the implementation partner of the STF Bug Resilience Program. This work is part of our agreed Milestone 1. Upgrade from JUnit 4 to JUnit 5. This PR migrates the tests located in `log4j-jul`.

Thank you!

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
