### PR TITLE
Migrate `log4j-taglib` to JUnit 5

### DIFF
--- a/log4j-taglib/pom.xml
+++ b/log4j-taglib/pom.xml
@@ -90,11 +90,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>

--- a/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/EnterTagTest.java
+++ b/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/EnterTagTest.java
@@ -16,31 +16,35 @@
  */
 package org.apache.logging.log4j.taglib;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import javax.servlet.jsp.tagext.Tag;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockPageContext;
 
 /**
  *
  */
+@LoggerContextSource("log4j-test1.xml")
 public class EnterTagTest {
+
+    private final LoggerContext context;
+    private final Logger logger;
+    private EntryTag tag;
     private static final String CONFIG = "log4j-test1.xml";
 
-    @ClassRule
-    public static LoggerContextRule context = new LoggerContextRule(CONFIG);
+    public EnterTagTest(final LoggerContext context) {
+        this.context = context;
+        this.logger = context.getLogger("LoggingMessageTagSupportTestLogger");
+    }
 
-    private final Logger logger = context.getLogger("LoggingMessageTagSupportTestLogger");
-    private EntryTag tag;
-
-    @Before
+    @BeforeEach
     public void setUp() {
         this.tag = new EntryTag();
         this.tag.setPageContext(new MockPageContext());
@@ -49,7 +53,7 @@ public class EnterTagTest {
 
     @Test
     public void testDoEndTag() throws Exception {
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Enter TRACE M-ENTER[ FLOW ] E");
     }
 
@@ -58,16 +62,16 @@ public class EnterTagTest {
         this.tag.setDynamicAttribute(null, null, CONFIG);
         this.tag.setDynamicAttribute(null, null, 5792);
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Enter params(log4j-test1.xml, 5792) TRACE M-ENTER[ FLOW ] E");
     }
 
     private void verify(final String expected) {
-        final ListAppender listApp = context.getListAppender("List");
+        final ListAppender listApp = context.getConfiguration().getAppender("List");
         final List<String> events = listApp.getMessages();
         try {
-            assertEquals("Incorrect number of messages.", 1, events.size());
-            assertEquals("Incorrect message.", "o.a.l.l.t.EnterTagTest " + expected, events.get(0));
+            assertEquals(1, events.size(), "Incorrect number of messages.");
+            assertEquals("o.a.l.l.t.EnterTagTest " + expected, events.get(0), "Incorrect message.");
         } finally {
             listApp.clear();
         }

--- a/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/ExitTagTest.java
+++ b/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/ExitTagTest.java
@@ -16,31 +16,34 @@
  */
 package org.apache.logging.log4j.taglib;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import javax.servlet.jsp.tagext.Tag;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockPageContext;
 
 /**
  *
  */
+@LoggerContextSource("log4j-test1.xml")
 public class ExitTagTest {
     private static final String CONFIG = "log4j-test1.xml";
-
-    @ClassRule
-    public static LoggerContextRule context = new LoggerContextRule(CONFIG);
-
-    private final Logger logger = context.getLogger("LoggingMessageTagSupportTestLogger");
+    private final LoggerContext context;
+    private final Logger logger;
     private ExitTag tag;
 
-    @Before
+    public ExitTagTest(final LoggerContext context) {
+        this.context = context;
+        this.logger = context.getLogger("LoggingMessageTagSupportTestLogger");
+    }
+
+    @BeforeEach
     public void setUp() {
         this.tag = new ExitTag();
         this.tag.setPageContext(new MockPageContext());
@@ -49,7 +52,7 @@ public class ExitTagTest {
 
     @Test
     public void testDoEndTag() throws Exception {
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Exit TRACE M-EXIT[ FLOW ] E");
     }
 
@@ -57,7 +60,7 @@ public class ExitTagTest {
     public void testDoEndTagResult01() throws Exception {
         this.tag.setResult(CONFIG);
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Exit with(log4j-test1.xml) TRACE M-EXIT[ FLOW ] E");
     }
 
@@ -65,16 +68,16 @@ public class ExitTagTest {
     public void testDoEndTagResult02() throws Exception {
         this.tag.setResult(5792);
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Exit with(5792) TRACE M-EXIT[ FLOW ] E");
     }
 
     private void verify(final String expected) {
-        final ListAppender listApp = context.getListAppender("List");
+        final ListAppender listApp = context.getConfiguration().getAppender("List");
         final List<String> events = listApp.getMessages();
         try {
-            assertEquals("Incorrect number of messages.", 1, events.size());
-            assertEquals("Incorrect message.", "o.a.l.l.t.ExitTagTest " + expected, events.get(0));
+            assertEquals(1, events.size(), "Incorrect number of messages.");
+            assertEquals("o.a.l.l.t.ExitTagTest " + expected, events.get(0), "Incorrect message.");
         } finally {
             listApp.clear();
         }

--- a/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/IfEnabledTagTest.java
+++ b/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/IfEnabledTagTest.java
@@ -16,31 +16,32 @@
  */
 package org.apache.logging.log4j.taglib;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import javax.servlet.jsp.tagext.Tag;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.MarkerManager;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockPageContext;
 
 /**
  *
  */
+@LoggerContextSource("log4j-test1.xml")
 public class IfEnabledTagTest {
-    private static final String CONFIG = "log4j-test1.xml";
 
-    @ClassRule
-    public static LoggerContextRule context = new LoggerContextRule(CONFIG);
-
-    private final Logger logger = context.getLogger("IfEnabledTagTest");
+    private final Logger logger;
     private IfEnabledTag tag;
 
-    @Before
+    public IfEnabledTagTest(final LoggerContext context) {
+        this.logger = context.getLogger("IfEnabledTagTest");
+    }
+
+    @BeforeEach
     public void setUp() {
         this.tag = new IfEnabledTag();
         this.tag.setPageContext(new MockPageContext());
@@ -51,14 +52,14 @@ public class IfEnabledTagTest {
     public void testDoStartTagEnabledString() throws Exception {
         this.tag.setLevel("warn");
 
-        assertEquals("The return value is not correct.", Tag.EVAL_BODY_INCLUDE, this.tag.doStartTag());
+        assertEquals(Tag.EVAL_BODY_INCLUDE, this.tag.doStartTag(), "The return value is not correct.");
     }
 
     @Test
     public void testDoStartTagEnabledLevel() throws Exception {
         this.tag.setLevel(Level.WARN);
 
-        assertEquals("The return value is not correct.", Tag.EVAL_BODY_INCLUDE, this.tag.doStartTag());
+        assertEquals(Tag.EVAL_BODY_INCLUDE, this.tag.doStartTag(), "The return value is not correct.");
     }
 
     @Test
@@ -66,7 +67,7 @@ public class IfEnabledTagTest {
         this.tag.setMarker(MarkerManager.getMarker("E01"));
         this.tag.setLevel("error");
 
-        assertEquals("The return value is not correct.", Tag.EVAL_BODY_INCLUDE, this.tag.doStartTag());
+        assertEquals(Tag.EVAL_BODY_INCLUDE, this.tag.doStartTag(), "The return value is not correct.");
     }
 
     @Test
@@ -74,21 +75,21 @@ public class IfEnabledTagTest {
         this.tag.setMarker(MarkerManager.getMarker("F02"));
         this.tag.setLevel(Level.ERROR);
 
-        assertEquals("The return value is not correct.", Tag.EVAL_BODY_INCLUDE, this.tag.doStartTag());
+        assertEquals(Tag.EVAL_BODY_INCLUDE, this.tag.doStartTag(), "The return value is not correct.");
     }
 
     @Test
     public void testDoStartTagDisabledString() throws Exception {
         this.tag.setLevel("info");
 
-        assertEquals("The return value is not correct.", Tag.SKIP_BODY, this.tag.doStartTag());
+        assertEquals(Tag.SKIP_BODY, this.tag.doStartTag(), "The return value is not correct.");
     }
 
     @Test
     public void testDoStartTagDisabledLevel() throws Exception {
         this.tag.setLevel(Level.INFO);
 
-        assertEquals("The return value is not correct.", Tag.SKIP_BODY, this.tag.doStartTag());
+        assertEquals(Tag.SKIP_BODY, this.tag.doStartTag(), "The return value is not correct.");
     }
 
     @Test
@@ -96,7 +97,7 @@ public class IfEnabledTagTest {
         this.tag.setMarker(MarkerManager.getMarker("E01"));
         this.tag.setLevel("trace");
 
-        assertEquals("The return value is not correct.", Tag.SKIP_BODY, this.tag.doStartTag());
+        assertEquals(Tag.SKIP_BODY, this.tag.doStartTag(), "The return value is not correct.");
     }
 
     @Test
@@ -104,6 +105,6 @@ public class IfEnabledTagTest {
         this.tag.setMarker(MarkerManager.getMarker("F02"));
         this.tag.setLevel(Level.TRACE);
 
-        assertEquals("The return value is not correct.", Tag.SKIP_BODY, this.tag.doStartTag());
+        assertEquals(Tag.SKIP_BODY, this.tag.doStartTag(), "The return value is not correct.");
     }
 }

--- a/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/LoggingMessageTagSupportTest.java
+++ b/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/LoggingMessageTagSupportTest.java
@@ -17,8 +17,8 @@
 package org.apache.logging.log4j.taglib;
 
 import static org.apache.logging.log4j.util.Strings.LINE_SEPARATOR;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.Writer;
 import java.util.List;
@@ -28,26 +28,28 @@ import javax.servlet.jsp.tagext.Tag;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.MarkerManager;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.util.Strings;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockBodyContent;
 import org.springframework.mock.web.MockPageContext;
 
 /**
  *
  */
+@LoggerContextSource("log4j-test1.xml")
 public class LoggingMessageTagSupportTest {
 
-    private static final String CONFIG = "log4j-test1.xml";
-
-    @ClassRule
-    public static LoggerContextRule context = new LoggerContextRule(CONFIG);
-
-    private final Logger logger = context.getLogger("LoggingMessageTagSupportTestLogger");
+    private final LoggerContext context;
+    private final Logger logger;
     private LoggingMessageTagSupport tag;
+
+    LoggingMessageTagSupportTest(final LoggerContext context) {
+        this.context = context;
+        this.logger = context.getLogger("LoggingMessageTagSupportTestLogger");
+    }
 
     private void setUp(final Level level) {
         this.tag = new LoggingMessageTagSupport() {
@@ -66,7 +68,7 @@ public class LoggingMessageTagSupportTest {
     public void testDoStartTag() {
         this.setUp(null);
 
-        assertEquals("The return value is not correct.", BodyTag.EVAL_BODY_BUFFERED, this.tag.doStartTag());
+        assertEquals(BodyTag.EVAL_BODY_BUFFERED, this.tag.doStartTag(), "The return value is not correct");
     }
 
     @Test
@@ -75,7 +77,7 @@ public class LoggingMessageTagSupportTest {
 
         this.tag.setMessage("This is my message 01.");
 
-        assertEquals("The message is not correct.", "This is my message 01.", this.tag.getMessage());
+        assertEquals("This is my message 01.", this.tag.getMessage(), "The message is not correct.");
     }
 
     @Test
@@ -85,7 +87,7 @@ public class LoggingMessageTagSupportTest {
         final Object message = new Object();
         this.tag.setMessage(message);
 
-        assertSame("The message is not correct.", message, this.tag.getMessage());
+        assertSame(message, this.tag.getMessage(), "The message is not correct.");
     }
 
     @Test
@@ -95,7 +97,7 @@ public class LoggingMessageTagSupportTest {
         final MockBodyContent content = new MockBodyContent("This is the body content 01.", (Writer) null);
         this.tag.setBodyContent(content);
 
-        assertEquals("The message is not correct.", "This is the body content 01.", this.tag.getMessage());
+        assertEquals("This is the body content 01.", this.tag.getMessage(), "The message is not correct.");
     }
 
     @Test
@@ -106,7 +108,7 @@ public class LoggingMessageTagSupportTest {
         this.tag.setBodyContent(content);
         this.tag.setMessage("This is another message 02.");
 
-        assertEquals("The message is not correct.", "This is another message 02.", this.tag.getMessage());
+        assertEquals("This is another message 02.", this.tag.getMessage(), "The message is not correct.");
     }
 
     @Test
@@ -115,7 +117,7 @@ public class LoggingMessageTagSupportTest {
 
         this.tag.setMessage("Hello message for testDoEndTagStringMessageNoMarkerNoException");
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Hello message for testDoEndTagStringMessageNoMarkerNoException WARN M- E");
     }
 
@@ -126,7 +128,7 @@ public class LoggingMessageTagSupportTest {
         this.tag.setMarker(MarkerManager.getMarker("E01"));
         this.tag.setMessage("Goodbye message for testDoEndTagStringMessageMarkerNoException");
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Goodbye message for testDoEndTagStringMessageMarkerNoException INFO M-E01 E");
     }
 
@@ -137,7 +139,7 @@ public class LoggingMessageTagSupportTest {
         this.tag.setException(new Exception("This is a test"));
         this.tag.setMessage("Another message for testDoEndTagStringMessageNoMarkerException");
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Another message for testDoEndTagStringMessageNoMarkerException ERROR M- E" + LINE_SEPARATOR
                 + "java.lang.Exception: This is a test" + LINE_SEPARATOR);
     }
@@ -150,7 +152,7 @@ public class LoggingMessageTagSupportTest {
         this.tag.setMarker(MarkerManager.getMarker("F02"));
         this.tag.setMessage("Final message for testDoEndTagStringMessageMarkerException");
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Final message for testDoEndTagStringMessageMarkerException TRACE M-F02 E" + LINE_SEPARATOR
                 + "java.lang.RuntimeException: This is another test" + Strings.LINE_SEPARATOR);
     }
@@ -163,7 +165,7 @@ public class LoggingMessageTagSupportTest {
         this.tag.setDynamicAttribute(null, null, TimeUnit.HOURS);
         this.tag.setMessage("Test message with [{}] parameter of [{}]");
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Test message with [A] parameter of [HOURS] FATAL M- E");
     }
 
@@ -177,7 +179,7 @@ public class LoggingMessageTagSupportTest {
         this.tag.setDynamicAttribute(null, null, TimeUnit.SECONDS);
         this.tag.setMessage("Final message with [{}] parameter of [{}]");
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Final message with [Z] parameter of [SECONDS] DEBUG M-N03 E" + LINE_SEPARATOR
                 + "java.lang.Error: This is the last test" + LINE_SEPARATOR);
     }
@@ -189,7 +191,7 @@ public class LoggingMessageTagSupportTest {
         this.tag.setMessage(
                 logger.getMessageFactory().newMessage("First message for testDoEndTagMessageNoMarkerNoException"));
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("First message for testDoEndTagMessageNoMarkerNoException INFO M- E");
     }
 
@@ -201,7 +203,7 @@ public class LoggingMessageTagSupportTest {
         this.tag.setMessage(
                 logger.getMessageFactory().newMessage("Another message for testDoEndTagMessageMarkerNoException"));
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Another message for testDoEndTagMessageMarkerNoException WARN M-E01 E");
     }
 
@@ -213,7 +215,7 @@ public class LoggingMessageTagSupportTest {
         this.tag.setMessage(
                 logger.getMessageFactory().newMessage("Third message for testDoEndTagMessageNoMarkerException"));
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Third message for testDoEndTagMessageNoMarkerException TRACE M- E" + LINE_SEPARATOR
                 + "java.lang.Exception: This is a test" + LINE_SEPARATOR);
     }
@@ -227,7 +229,7 @@ public class LoggingMessageTagSupportTest {
         this.tag.setMessage(
                 logger.getMessageFactory().newMessage("Final message for testDoEndTagMessageMarkerException"));
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Final message for testDoEndTagMessageMarkerException ERROR M-F02 E" + LINE_SEPARATOR
                 + "java.lang.RuntimeException: " + "This is another test" + LINE_SEPARATOR);
     }
@@ -238,7 +240,7 @@ public class LoggingMessageTagSupportTest {
 
         this.tag.setMessage(new MyMessage("First message for testDoEndTagObjectNoMarkerNoException"));
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("First message for testDoEndTagObjectNoMarkerNoException INFO M- E");
     }
 
@@ -249,7 +251,7 @@ public class LoggingMessageTagSupportTest {
         this.tag.setMarker(MarkerManager.getMarker("E01"));
         this.tag.setMessage(new MyMessage("Another message for testDoEndTagObjectMarkerNoException"));
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Another message for testDoEndTagObjectMarkerNoException WARN M-E01 E");
     }
 
@@ -260,7 +262,7 @@ public class LoggingMessageTagSupportTest {
         this.tag.setException(new Exception("This is a test"));
         this.tag.setMessage(new MyMessage("Third message for testDoEndTagObjectNoMarkerException"));
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Third message for testDoEndTagObjectNoMarkerException TRACE M- E" + LINE_SEPARATOR
                 + "java.lang.Exception: This is a test" + LINE_SEPARATOR);
     }
@@ -273,17 +275,17 @@ public class LoggingMessageTagSupportTest {
         this.tag.setMarker(MarkerManager.getMarker("F02"));
         this.tag.setMessage(new MyMessage("Final message for testDoEndTagObjectMarkerException"));
 
-        assertEquals("The return value is not correct.", Tag.EVAL_PAGE, this.tag.doEndTag());
+        assertEquals(Tag.EVAL_PAGE, this.tag.doEndTag(), "The return value is not correct.");
         verify("Final message for testDoEndTagObjectMarkerException ERROR M-F02 E" + LINE_SEPARATOR
                 + "java.lang.RuntimeException: " + "This is another test" + LINE_SEPARATOR);
     }
 
     private void verify(final String expected) {
-        final ListAppender listApp = context.getListAppender("List");
+        final ListAppender listApp = context.getConfiguration().getAppender("List");
         final List<String> events = listApp.getMessages();
         try {
-            assertEquals("Incorrect number of messages.", 1, events.size());
-            assertEquals("Incorrect message.", "o.a.l.l.t.LoggingMessageTagSupportTest " + expected, events.get(0));
+            assertEquals(1, events.size(), "Incorrect number of messages.");
+            assertEquals("o.a.l.l.t.LoggingMessageTagSupportTest " + expected, events.get(0), "Incorrect message.");
         } finally {
             listApp.clear();
         }

--- a/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/TagLevelTest.java
+++ b/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/TagLevelTest.java
@@ -18,28 +18,27 @@ package org.apache.logging.log4j.taglib;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.Arrays;
-import java.util.Collection;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.Level;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class TagLevelTest {
 
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-            {DebugTag.class, Level.DEBUG},
-            {ErrorTag.class, Level.ERROR},
-            {FatalTag.class, Level.FATAL},
-            {InfoTag.class, Level.INFO},
-            {TraceTag.class, Level.TRACE},
-            {WarnTag.class, Level.WARN}
-        });
+    static Stream<Arguments> testGetLevel() {
+        return Stream.of(
+                Arguments.of(DebugTag.class, Level.DEBUG),
+                Arguments.of(ErrorTag.class, Level.ERROR),
+                Arguments.of(FatalTag.class, Level.FATAL),
+                Arguments.of(InfoTag.class, Level.INFO),
+                Arguments.of(TraceTag.class, Level.TRACE),
+                Arguments.of(WarnTag.class, Level.WARN));
     }
 
-    @MethodSource("data")
     @ParameterizedTest
+    @MethodSource()
     void testGetLevel(final Class<? extends LoggingMessageTagSupport> cls, final Level level) throws Exception {
-        assertEquals(level, cls.newInstance().getLevel());
+        assertEquals(level, cls.getDeclaredConstructor().newInstance().getLevel());
     }
 }


### PR DESCRIPTION
Hello 👋

We are from Neighbourhoodie, the implementation partner of the STF Bug Resilience Program. This work is part of our agreed Milestone 1. Upgrade from JUnit 4 to JUnit 5. This PR migrates the tests located in `log4j-taglib`.

Thank you!

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
