### PR TITLE
Migrate log4j-iostreams to use JUnit 5 APIs and compatible helper classes

### DIFF
--- a/log4j-iostreams/pom.xml
+++ b/log4j-iostreams/pom.xml
@@ -60,11 +60,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/AbstractLoggerOutputStreamTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/AbstractLoggerOutputStreamTest.java
@@ -16,15 +16,16 @@
  */
 package org.apache.logging.log4j.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractLoggerOutputStreamTest extends AbstractStreamTest {
 
@@ -35,7 +36,11 @@ public abstract class AbstractLoggerOutputStreamTest extends AbstractStreamTest 
 
     protected abstract OutputStream createOutputStreamWrapper();
 
-    @Before
+    AbstractLoggerOutputStreamTest(LoggerContext context) {
+        super(context);
+    }
+
+    @BeforeEach
     public void createStream() {
         this.wrapped = createOutputStream();
         this.out = createOutputStreamWrapper();

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/AbstractLoggerWriterTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/AbstractLoggerWriterTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
@@ -24,14 +24,19 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.Writer;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class AbstractLoggerWriterTest extends AbstractStreamTest {
     protected StringWriter wrapped;
     protected Writer writer;
 
-    @Before
+    AbstractLoggerWriterTest(LoggerContext context) {
+        super(context);
+    }
+
+    @BeforeEach
     public void createStream() {
         this.wrapped = createWriter();
         this.writer = createWriterWrapper();

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/AbstractStreamTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/AbstractStreamTest.java
@@ -18,19 +18,27 @@ package org.apache.logging.log4j.io;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringStartsWith.startsWith;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.spi.ExtendedLogger;
-import org.junit.Before;
-import org.junit.ClassRule;
+import org.junit.jupiter.api.BeforeEach;
 
+@LoggerContextSource("log4j2-streams-unit-test.xml")
 public abstract class AbstractStreamTest {
 
-    protected static ExtendedLogger getExtendedLogger() {
-        return ctx.getLogger("UnitTestLogger");
+    private LoggerContext context = null;
+
+    AbstractStreamTest(LoggerContext context) {
+        this.context = context;
+    }
+
+    protected ExtendedLogger getExtendedLogger() {
+        return context.getLogger("UnitTestLogger");
     }
 
     protected static final String NEWLINE = System.lineSeparator();
@@ -39,20 +47,19 @@ public abstract class AbstractStreamTest {
 
     protected static final String LAST = "last";
 
-    @ClassRule
-    public static LoggerContextRule ctx = new LoggerContextRule("log4j2-streams-unit-test.xml");
-
     protected void assertMessages(final String... messages) {
-        final List<String> actualMsgs = ctx.getListAppender("UnitTest").getMessages();
-        assertEquals("Unexpected number of results.", messages.length, actualMsgs.size());
+        ListAppender listApp = context.getConfiguration().getAppender("UnitTest");
+        final List<String> actualMsgs = listApp.getMessages();
+        assertEquals(messages.length, actualMsgs.size(), "Unexpected number of results.");
         for (int i = 0; i < messages.length; i++) {
             final String start = LEVEL.name() + ' ' + messages[i];
             assertThat(actualMsgs.get(i), startsWith(start));
         }
     }
 
-    @Before
+    @BeforeEach
     public void clearAppender() {
-        ctx.getListAppender("UnitTest").clear();
+        ListAppender listApp = context.getConfiguration().getAppender("UnitTest");
+        listApp.clear();
     }
 }

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/IoBuilderCallerInfoTesting.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/IoBuilderCallerInfoTesting.java
@@ -16,40 +16,45 @@
  */
 package org.apache.logging.log4j.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.Before;
-import org.junit.ClassRule;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.BeforeEach;
 
+@LoggerContextSource("log4j2-streams-calling-info.xml")
 public class IoBuilderCallerInfoTesting {
 
-    protected static Logger getExtendedLogger() {
-        return ctx.getLogger("ClassAndMethodLogger");
+    private LoggerContext context = null;
+
+    IoBuilderCallerInfoTesting(LoggerContext context) {
+        this.context = context;
     }
 
-    protected static Logger getLogger() {
+    protected Logger getExtendedLogger() {
+        return context.getLogger("ClassAndMethodLogger");
+    }
+
+    protected Logger getLogger() {
         return getExtendedLogger();
     }
 
     protected static final Level LEVEL = Level.WARN;
 
-    @ClassRule
-    public static LoggerContextRule ctx = new LoggerContextRule("log4j2-streams-calling-info.xml");
-
     public void assertMessages(final String msg, final int size, final String methodName) {
-        final ListAppender appender = ctx.getListAppender("ClassAndMethod");
-        assertEquals(msg + ".size", size, appender.getMessages().size());
+        final ListAppender appender = context.getConfiguration().getAppender("ClassAndMethod");
+        assertEquals(size, appender.getMessages().size(), msg + ".size");
         for (final String message : appender.getMessages()) {
-            assertEquals(msg + " has incorrect caller info", this.getClass().getName() + '.' + methodName, message);
+            assertEquals(this.getClass().getName() + '.' + methodName, message, msg + " has incorrect caller info");
         }
     }
 
-    @Before
+    @BeforeEach
     public void clearAppender() {
-        ctx.getListAppender("ClassAndMethod").clear();
+        ListAppender listApp = context.getConfiguration().getAppender("ClassAndMethod");
+        listApp.clear();
     }
 }

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/IoBuilderTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/IoBuilderTest.java
@@ -24,21 +24,25 @@ import static org.hamcrest.Matchers.startsWith;
 
 import java.io.PrintStream;
 import java.util.List;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.Test;
 
+@LoggerContextSource("log4j2-streams-calling-info.xml")
 public class IoBuilderTest {
 
-    @ClassRule
-    public static LoggerContextRule context = new LoggerContextRule("log4j2-streams-calling-info.xml");
+    private LoggerContext context = null;
+
+    IoBuilderTest(LoggerContext context) {
+        this.context = context;
+    }
 
     @Test
     public void testNoArgBuilderCallerClassInfo() {
         try (final PrintStream ps = IoBuilder.forLogger().buildPrintStream()) {
             ps.println("discarded");
-            final ListAppender app = context.getListAppender("IoBuilderTest");
+            final ListAppender app = context.getConfiguration().getAppender("IoBuilderTest");
             final List<String> messages = app.getMessages();
             assertThat(messages, not(empty()));
             assertThat(messages, hasSize(1));

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerBufferedInputStreamCallerInfoTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerBufferedInputStreamCallerInfoTest.java
@@ -19,12 +19,17 @@ package org.apache.logging.log4j.io;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LoggerBufferedInputStreamCallerInfoTest extends IoBuilderCallerInfoTesting {
 
     private BufferedInputStream logIn;
+
+    LoggerBufferedInputStreamCallerInfoTest(LoggerContext context) {
+        super(context);
+    }
 
     @Test
     public void close() throws Exception {
@@ -58,7 +63,7 @@ public class LoggerBufferedInputStreamCallerInfoTest extends IoBuilderCallerInfo
         this.logIn.close();
     }
 
-    @Before
+    @BeforeEach
     public void setupStreams() {
         final InputStream srcInputStream = new ByteArrayInputStream("a\nb\nc\nd".getBytes());
         this.logIn = (BufferedInputStream) IoBuilder.forLogger(getLogger())

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerBufferedInputStreamTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerBufferedInputStreamTest.java
@@ -18,8 +18,13 @@ package org.apache.logging.log4j.io;
 
 import java.io.InputStream;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LoggerContext;
 
 public class LoggerBufferedInputStreamTest extends LoggerInputStreamTest {
+
+    LoggerBufferedInputStreamTest(LoggerContext context) {
+        super(context);
+    }
 
     @Override
     protected InputStream createInputStream() {

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerBufferedReaderCallerInfoTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerBufferedReaderCallerInfoTest.java
@@ -21,12 +21,17 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.nio.CharBuffer;
 import org.apache.logging.log4j.Level;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LoggerBufferedReaderCallerInfoTest extends IoBuilderCallerInfoTesting {
 
     BufferedReader logReader;
+
+    LoggerBufferedReaderCallerInfoTest(LoggerContext context) {
+        super(context);
+    }
 
     @Test
     public void close() throws Exception {
@@ -76,7 +81,7 @@ public class LoggerBufferedReaderCallerInfoTest extends IoBuilderCallerInfoTesti
         this.logReader.close();
     }
 
-    @Before
+    @BeforeEach
     public void setupReader() {
         final Reader srcReader = new StringReader("a\nb\nc\nd");
         this.logReader = (BufferedReader) IoBuilder.forLogger(getLogger())

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerBufferedReaderTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerBufferedReaderTest.java
@@ -16,14 +16,19 @@
  */
 package org.apache.logging.log4j.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.Reader;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.Test;
 
 public class LoggerBufferedReaderTest extends LoggerReaderTest {
     private BufferedReader bufferedReader;
+
+    LoggerBufferedReaderTest(LoggerContext context) {
+        super(context);
+    }
 
     @Override
     protected Reader createReader() {
@@ -36,9 +41,9 @@ public class LoggerBufferedReaderTest extends LoggerReaderTest {
 
     @Test
     public void testReadLine() throws Exception {
-        assertEquals("first line", FIRST, this.bufferedReader.readLine());
+        assertEquals(FIRST, this.bufferedReader.readLine(), "first line");
         assertMessages(FIRST);
-        assertEquals("second line", LAST, this.bufferedReader.readLine());
+        assertEquals(LAST, this.bufferedReader.readLine(), "second line");
         assertMessages(FIRST, LAST);
     }
 }

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerFilterOutputStreamTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerFilterOutputStreamTest.java
@@ -19,8 +19,13 @@ package org.apache.logging.log4j.io;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LoggerContext;
 
 public class LoggerFilterOutputStreamTest extends AbstractLoggerOutputStreamTest {
+
+    LoggerFilterOutputStreamTest(LoggerContext context) {
+        super(context);
+    }
 
     @Override
     protected ByteArrayOutputStream createOutputStream() {

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerFilterWriterTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerFilterWriterTest.java
@@ -18,8 +18,13 @@ package org.apache.logging.log4j.io;
 
 import java.io.StringWriter;
 import java.io.Writer;
+import org.apache.logging.log4j.core.LoggerContext;
 
 public class LoggerFilterWriterTest extends AbstractLoggerWriterTest {
+
+    LoggerFilterWriterTest(LoggerContext context) {
+        super(context);
+    }
 
     @Override
     protected StringWriter createWriter() {

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerInputStreamCallerInfoTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerInputStreamCallerInfoTest.java
@@ -19,12 +19,17 @@ package org.apache.logging.log4j.io;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import org.apache.logging.log4j.Level;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LoggerInputStreamCallerInfoTest extends IoBuilderCallerInfoTesting {
 
     private InputStream logIn;
+
+    LoggerInputStreamCallerInfoTest(LoggerContext context) {
+        super(context);
+    }
 
     @Test
     public void read() throws Exception {
@@ -45,7 +50,7 @@ public class LoggerInputStreamCallerInfoTest extends IoBuilderCallerInfoTesting 
         assertMessages("after close size", 4, "read");
     }
 
-    @Before
+    @BeforeEach
     public void setupStreams() {
         final InputStream srcInputStream = new ByteArrayInputStream("a\nb\nc\nd".getBytes());
         this.logIn = IoBuilder.forLogger(getLogger())

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerInputStreamTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerInputStreamTest.java
@@ -16,20 +16,25 @@
  */
 package org.apache.logging.log4j.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LoggerInputStreamTest extends AbstractStreamTest {
     protected ByteArrayInputStream wrapped;
     protected ByteArrayOutputStream read;
     protected InputStream in;
+
+    LoggerInputStreamTest(LoggerContext context) {
+        super(context);
+    }
 
     protected InputStream createInputStream() {
         return IoBuilder.forLogger(getExtendedLogger())
@@ -38,7 +43,7 @@ public class LoggerInputStreamTest extends AbstractStreamTest {
                 .buildInputStream();
     }
 
-    @Before
+    @BeforeEach
     public void createStream() {
         this.wrapped = new ByteArrayInputStream((FIRST + "\r\n" + LAST).getBytes());
         this.read = new ByteArrayOutputStream();
@@ -69,7 +74,7 @@ public class LoggerInputStreamTest extends AbstractStreamTest {
     @Test
     public void testRead_ByteArray() throws Exception {
         final byte[] bytes = new byte[FIRST.length()];
-        assertEquals("len", bytes.length, this.in.read(bytes));
+        assertEquals(bytes.length, this.in.read(bytes), "len");
         if (!(this.in instanceof BufferedInputStream)) {
             assertMessages();
         }
@@ -80,7 +85,7 @@ public class LoggerInputStreamTest extends AbstractStreamTest {
     @Test
     public void testRead_ByteArray_Offset_Length() throws Exception {
         final byte[] bytes = new byte[FIRST.length() * 2];
-        assertEquals("len", FIRST.length(), this.in.read(bytes, 0, FIRST.length()));
+        assertEquals(FIRST.length(), this.in.read(bytes, 0, FIRST.length()), "len");
         if (!(this.in instanceof BufferedInputStream)) {
             assertMessages();
         }
@@ -107,11 +112,11 @@ public class LoggerInputStreamTest extends AbstractStreamTest {
         if (!(this.in instanceof BufferedInputStream)) {
             assertMessages();
         }
-        assertEquals("carriage return", '\r', this.in.read());
+        assertEquals('\r', this.in.read(), "carriage return");
         if (!(this.in instanceof BufferedInputStream)) {
             assertMessages();
         }
-        assertEquals("newline", '\n', this.in.read());
+        assertEquals('\n', this.in.read(), "newline");
         assertMessages(FIRST);
     }
 

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerOutputStreamCallerInfoTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerOutputStreamCallerInfoTest.java
@@ -18,14 +18,19 @@ package org.apache.logging.log4j.io;
 
 import java.io.OutputStream;
 import org.apache.logging.log4j.Level;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LoggerOutputStreamCallerInfoTest extends IoBuilderCallerInfoTesting {
 
     private OutputStream logOut;
 
-    @Before
+    LoggerOutputStreamCallerInfoTest(LoggerContext context) {
+        super(context);
+    }
+
+    @BeforeEach
     public void setupStreams() {
         this.logOut =
                 IoBuilder.forLogger(getExtendedLogger()).setLevel(Level.WARN).buildOutputStream();

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerOutputStreamTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerOutputStreamTest.java
@@ -19,8 +19,13 @@ package org.apache.logging.log4j.io;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LoggerContext;
 
 public class LoggerOutputStreamTest extends AbstractLoggerOutputStreamTest {
+
+    LoggerOutputStreamTest(LoggerContext context) {
+        super(context);
+    }
 
     @Override
     protected ByteArrayOutputStream createOutputStream() {

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerPrintStreamCallerInfoTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerPrintStreamCallerInfoTest.java
@@ -19,12 +19,17 @@ package org.apache.logging.log4j.io;
 import java.io.PrintStream;
 import java.util.Locale;
 import org.apache.logging.log4j.Level;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LoggerPrintStreamCallerInfoTest extends IoBuilderCallerInfoTesting {
 
     private PrintStream logOut;
+
+    LoggerPrintStreamCallerInfoTest(LoggerContext context) {
+        super(context);
+    }
 
     @Test
     public void close() {
@@ -118,7 +123,7 @@ public class LoggerPrintStreamCallerInfoTest extends IoBuilderCallerInfoTesting 
         assertMessages("println", 1, "print_string");
     }
 
-    @Before
+    @BeforeEach
     public void setupStreams() {
         this.logOut = IoBuilder.forLogger(getLogger()).setLevel(Level.WARN).buildPrintStream();
     }

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerPrintStreamTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerPrintStreamTest.java
@@ -16,16 +16,21 @@
  */
 package org.apache.logging.log4j.io;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.Test;
 
 public class LoggerPrintStreamTest extends AbstractLoggerOutputStreamTest {
     private PrintStream print;
+
+    LoggerPrintStreamTest(LoggerContext context) {
+        super(context);
+    }
 
     @Override
     protected ByteArrayOutputStream createOutputStream() {

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerPrintWriterCallerInfoTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerPrintWriterCallerInfoTest.java
@@ -19,12 +19,17 @@ package org.apache.logging.log4j.io;
 import java.io.PrintWriter;
 import java.util.Locale;
 import org.apache.logging.log4j.Level;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LoggerPrintWriterCallerInfoTest extends IoBuilderCallerInfoTesting {
 
     private PrintWriter logOut;
+
+    LoggerPrintWriterCallerInfoTest(LoggerContext context) {
+        super(context);
+    }
 
     @Test
     public void close() {
@@ -118,7 +123,7 @@ public class LoggerPrintWriterCallerInfoTest extends IoBuilderCallerInfoTesting 
         assertMessages("println", 1, "print_string");
     }
 
-    @Before
+    @BeforeEach
     public void setupStreams() {
         this.logOut = IoBuilder.forLogger(getLogger()).setLevel(Level.WARN).buildPrintWriter();
     }

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerPrintWriterTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerPrintWriterTest.java
@@ -16,16 +16,21 @@
  */
 package org.apache.logging.log4j.io;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.Test;
 
 public class LoggerPrintWriterTest extends AbstractLoggerWriterTest {
     private PrintWriter print;
+
+    LoggerPrintWriterTest(LoggerContext context) {
+        super(context);
+    }
 
     @Override
     protected StringWriter createWriter() {

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerReaderCallerInfoTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerReaderCallerInfoTest.java
@@ -19,12 +19,17 @@ package org.apache.logging.log4j.io;
 import java.io.Reader;
 import java.io.StringReader;
 import java.nio.CharBuffer;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LoggerReaderCallerInfoTest extends IoBuilderCallerInfoTesting {
 
     Reader logReader;
+
+    LoggerReaderCallerInfoTest(LoggerContext context) {
+        super(context);
+    }
 
     @Test
     public void read() throws Exception {
@@ -48,7 +53,7 @@ public class LoggerReaderCallerInfoTest extends IoBuilderCallerInfoTesting {
         assertMessages("after close size", 5, "read");
     }
 
-    @Before
+    @BeforeEach
     public void setupReader() {
         final Reader srcReader = new StringReader("a\nb\nc\nd\ne");
         this.logReader = IoBuilder.forLogger(getLogger())

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerReaderTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerReaderTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.io;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -24,13 +24,18 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.nio.CharBuffer;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LoggerReaderTest extends AbstractStreamTest {
     protected StringReader wrapped;
     protected StringWriter read;
     protected Reader reader;
+
+    LoggerReaderTest(LoggerContext context) {
+        super(context);
+    }
 
     protected Reader createReader() {
         return IoBuilder.forLogger(getExtendedLogger())
@@ -39,7 +44,7 @@ public class LoggerReaderTest extends AbstractStreamTest {
                 .buildReader();
     }
 
-    @Before
+    @BeforeEach
     public void createStream() {
         this.wrapped = new StringReader(FIRST + "\r\n" + LAST);
         this.read = new StringWriter();
@@ -72,7 +77,7 @@ public class LoggerReaderTest extends AbstractStreamTest {
     @Test
     public void testRead_CharArray() throws Exception {
         final char[] chars = new char[FIRST.length()];
-        assertEquals("len", FIRST.length(), this.reader.read(chars));
+        assertEquals(FIRST.length(), this.reader.read(chars), "len");
         if (!(this.reader instanceof BufferedReader)) {
             assertMessages();
         }
@@ -83,7 +88,7 @@ public class LoggerReaderTest extends AbstractStreamTest {
     @Test
     public void testRead_CharArray_Offset_Length() throws Exception {
         final char[] chars = new char[1024];
-        assertEquals("len", FIRST.length(), this.reader.read(chars, 0, FIRST.length()));
+        assertEquals(FIRST.length(), this.reader.read(chars, 0, FIRST.length()), "len");
         if (!(this.reader instanceof BufferedReader)) {
             assertMessages();
         }
@@ -95,7 +100,7 @@ public class LoggerReaderTest extends AbstractStreamTest {
     @Test
     public void testRead_CharBuffer() throws Exception {
         final CharBuffer chars = CharBuffer.allocate(1024);
-        assertEquals("len", FIRST.length() + LAST.length() + 2, this.reader.read(chars));
+        assertEquals(FIRST.length() + LAST.length() + 2, this.reader.read(chars), "len");
         this.reader.close();
         assertMessages(FIRST, LAST);
     }
@@ -121,11 +126,11 @@ public class LoggerReaderTest extends AbstractStreamTest {
         if (!(this.reader instanceof BufferedReader)) {
             assertMessages();
         }
-        assertEquals("carriage return", '\r', this.reader.read());
+        assertEquals('\r', this.reader.read(), "carriage return");
         if (!(this.reader instanceof BufferedReader)) {
             assertMessages();
         }
-        assertEquals("newline", '\n', this.reader.read());
+        assertEquals('\n', this.reader.read(), "newline");
         assertMessages(FIRST);
     }
 

--- a/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerWriterTest.java
+++ b/log4j-iostreams/src/test/java/org/apache/logging/log4j/io/LoggerWriterTest.java
@@ -18,8 +18,13 @@ package org.apache.logging.log4j.io;
 
 import java.io.StringWriter;
 import java.io.Writer;
+import org.apache.logging.log4j.core.LoggerContext;
 
 public class LoggerWriterTest extends AbstractLoggerWriterTest {
+
+    LoggerWriterTest(LoggerContext context) {
+        super(context);
+    }
 
     @Override
     protected StringWriter createWriter() {


### PR DESCRIPTION
Hi, I'm from Neighbourhoodie, the implementation partner of the STF Bug Resilience Program. This work is part of our agreed Milestone 1. Upgrade from JUnit 4 to JUnit 5. This PR migrates the tests located in log4j-iostreams.

These changes are mostly straightforward replacements of the JUnit 4 annotations with JUnit 5 ones. The only thing I was unsure about is that I had to add constructors to all the test classes to accept the `LoggerContext` argument -- I was wondering if there's a way of just doing this in the abstract classes and having all their children just work without this extra boilerplate.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
