### PR TITLE
Add missing `uses` declarations in module descriptor

### DIFF
--- a/log4j-conversant/src/test/java/org/apache/logging/log4j/conversant/test/DisruptorRecyclerFactoryProviderTest.java
+++ b/log4j-conversant/src/test/java/org/apache/logging/log4j/conversant/test/DisruptorRecyclerFactoryProviderTest.java
@@ -18,6 +18,8 @@ package org.apache.logging.log4j.conversant.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.util.Comparator;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -27,6 +29,7 @@ import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.ServiceLoaderUtil;
 import org.junit.jupiter.api.Test;
 
+@ServiceConsumer(value = RecyclerFactoryProvider.class, resolution = Cardinality.MULTIPLE)
 class DisruptorRecyclerFactoryProviderTest {
 
     @Test

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/CoreDefaultBundle.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/CoreDefaultBundle.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.core.impl;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -83,6 +85,7 @@ import org.jspecify.annotations.Nullable;
  * @see LogEventFactory
  * @see StrSubstitutor
  */
+@ServiceConsumer(value = RecyclerFactoryProvider.class, cardinality = Cardinality.MULTIPLE)
 public final class CoreDefaultBundle {
 
     @SingletonFactory

--- a/log4j-jctools/src/test/java/org/apache/logging/log4j/jctools/JCToolsRecyclerFactoryProviderTest.java
+++ b/log4j-jctools/src/test/java/org/apache/logging/log4j/jctools/JCToolsRecyclerFactoryProviderTest.java
@@ -18,6 +18,8 @@ package org.apache.logging.log4j.jctools;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.util.Comparator;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -26,6 +28,7 @@ import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.ServiceLoaderUtil;
 import org.junit.jupiter.api.Test;
 
+@ServiceConsumer(value = RecyclerFactoryProvider.class, cardinality = Cardinality.MULTIPLE)
 class JCToolsRecyclerFactoryProviderTest {
 
     @Test

--- a/log4j-kit/src/test/java/org/apache/logging/log4j/kit/recycler/internal/RecyclerFactoryTestUtil.java
+++ b/log4j-kit/src/test/java/org/apache/logging/log4j/kit/recycler/internal/RecyclerFactoryTestUtil.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.kit.recycler.internal;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -27,6 +29,7 @@ import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.ServiceLoaderUtil;
 import org.jspecify.annotations.Nullable;
 
+@ServiceConsumer(value = RecyclerFactoryProvider.class, cardinality = Cardinality.MULTIPLE)
 final class RecyclerFactoryTestUtil {
 
     private RecyclerFactoryTestUtil() {}

--- a/log4j-plugins/src/main/java/org/apache/logging/log4j/plugins/di/DI.java
+++ b/log4j-plugins/src/main/java/org/apache/logging/log4j/plugins/di/DI.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.plugins.di;
 
+import aQute.bnd.annotation.Cardinality;
+import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -36,6 +38,7 @@ import org.apache.logging.log4j.util.ServiceLoaderUtil;
  * {@link ConfigurableInstanceFactory} using bindings registered before and after standard
  * {@link ConfigurableInstanceFactoryPostProcessor} service provider classes are invoked.
  */
+@ServiceConsumer(value = ConfigurableInstanceFactoryPostProcessor.class, cardinality = Cardinality.MULTIPLE)
 public final class DI {
     private DI() {
         throw new IllegalStateException("Utility class");

--- a/log4j-plugins/src/main/java/org/apache/logging/log4j/plugins/di/spi/ConfigurableInstanceFactoryPostProcessor.java
+++ b/log4j-plugins/src/main/java/org/apache/logging/log4j/plugins/di/spi/ConfigurableInstanceFactoryPostProcessor.java
@@ -16,7 +16,6 @@
  */
 package org.apache.logging.log4j.plugins.di.spi;
 
-import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.util.ServiceLoader;
 import org.apache.logging.log4j.plugins.Ordered;
 import org.apache.logging.log4j.plugins.di.ConfigurableInstanceFactory;
@@ -27,7 +26,6 @@ import org.apache.logging.log4j.plugins.di.ConfigurableInstanceFactory;
  * {@link Ordered} annotation on the class for overriding the order it will be invoked.
  */
 @FunctionalInterface
-@ServiceConsumer(ConfigurableInstanceFactoryPostProcessor.class)
 public interface ConfigurableInstanceFactoryPostProcessor {
 
     /**

--- a/src/changelog/.3.x.x/3250_declare_uses.xml
+++ b/src/changelog/.3.x.x/3250_declare_uses.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3250" link="https://github.com/apache/logging-log4j2/issues/3250"/>
+  <description format="asciidoc">Add missing `uses` declarations in module descriptor.</description>
+</entry>


### PR DESCRIPTION
All `ServiceLoader.load()` calls need a `uses` clause in the JPMS module descriptor. This PR:

- Adds the missing `@ServiceConsumer` annotation to `CoreDefaultBundle`.
- To simplify code review, it places `@ServiceConsumer` on each class (even a test case) that makes a `ServiceLoader.load` call and only those classes.

Fixes #3250

Since we don't have JPMS tests in the main repo, this PR is blocked by apache/logging-log4j-samples#231


