### PR TITLE
JUnit 5 migration: Replace params with subclassing

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptAppenderTest.java
@@ -16,40 +16,41 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
+import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.AppenderControl;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.core.util.Constants;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  *
  */
 public abstract class DefaultRouteScriptAppenderTest {
 
-    @BeforeClass
+    @BeforeAll
     public static void beforeClass() {
         System.setProperty(Constants.SCRIPT_LANGUAGES, "Groovy, Javascript");
     }
 
-    @Rule
-    public final LoggerContextRule loggerContextRule;
+    public final LoggerContext loggerContext;
 
     private final boolean expectBindingEntries;
 
-    public DefaultRouteScriptAppenderTest(final String configLocation, final boolean expectBindingEntries) {
-        this.loggerContextRule = new LoggerContextRule(configLocation);
+    public DefaultRouteScriptAppenderTest(final LoggerContext context, boolean expectBindingEntries) {
+        this.loggerContext = context;
         this.expectBindingEntries = expectBindingEntries;
     }
 
@@ -65,60 +66,59 @@ public abstract class DefaultRouteScriptAppenderTest {
     private ListAppender getListAppender() {
         final String key = "Service2";
         final RoutingAppender routingAppender = getRoutingAppender();
-        Assert.assertTrue(routingAppender.isStarted());
+        assertTrue(routingAppender.isStarted());
         final Map<String, AppenderControl> appenders = routingAppender.getAppenders();
         final AppenderControl appenderControl = appenders.get(key);
-        assertNotNull("No appender control generated for '" + key + "'; appenders = " + appenders, appenderControl);
+        assertNotNull(appenderControl, "No appender control generated for '" + key + "'; appenders = " + appenders);
         final ListAppender listAppender = (ListAppender) appenderControl.getAppender();
         return listAppender;
     }
 
     private RoutingAppender getRoutingAppender() {
-        return loggerContextRule.getRequiredAppender("Routing", RoutingAppender.class);
+        return (RoutingAppender) loggerContext.getConfiguration().getAppenders().get("Routing");
     }
 
     private void logAndCheck() {
         final Marker marker = MarkerManager.getMarker("HEXDUMP");
-        final Logger logger = loggerContextRule.getLogger(DefaultRouteScriptAppenderTest.class);
+        final Logger logger = (Logger) loggerContext.getLogger(DefaultRouteScriptAppenderTest.class);
         logger.error("Hello");
         final ListAppender listAppender = getListAppender();
-        assertEquals("Incorrect number of events", 1, listAppender.getEvents().size());
+        assertEquals(1, listAppender.getEvents().size(), "Incorrect number of events");
         logger.error("World");
-        assertEquals("Incorrect number of events", 2, listAppender.getEvents().size());
+        assertEquals(2, listAppender.getEvents().size(), "Incorrect number of events");
         logger.error(marker, "DEADBEEF");
-        assertEquals("Incorrect number of events", 3, listAppender.getEvents().size());
+        assertEquals(3, listAppender.getEvents().size(), "Incorrect number of events");
     }
 
-    @Test(expected = AssertionError.class)
-    public void testAppenderAbsence() {
-        loggerContextRule.getListAppender("List1");
+    @Test
+    public void testNotListAppender() {
+        Appender appender = loggerContext.getConfiguration().getAppender("List1");
+        assertFalse(appender instanceof ListAppender);
     }
 
     @Test
     public void testListAppenderPresence() {
         // No appender until an event is routed, even thought we initialized the default route on startup.
-        Assert.assertNull(
-                "No appender control generated",
-                getRoutingAppender().getAppenders().get("Service2"));
+        assertNull(getRoutingAppender().getAppenders().get("Service2"), "No appender control generated");
     }
 
     @Test
     public void testNoPurgePolicy() {
         // No PurgePolicy in this test
-        Assert.assertNull("Unexpected PurgePolicy", getRoutingAppender().getPurgePolicy());
+        assertNull(getRoutingAppender().getPurgePolicy(), "Unexpected PurgePolicy");
     }
 
     @Test
     public void testNoRewritePolicy() {
         // No RewritePolicy in this test
-        Assert.assertNull("Unexpected RewritePolicy", getRoutingAppender().getRewritePolicy());
+        assertNull(getRoutingAppender().getRewritePolicy(), "Unexpected RewritePolicy");
     }
 
     @Test
     public void testRoutingAppenderDefaultRouteKey() {
         final RoutingAppender routingAppender = getRoutingAppender();
-        Assert.assertNotNull(routingAppender.getDefaultRouteScript());
-        Assert.assertNotNull(routingAppender.getDefaultRoute());
+        assertNotNull(routingAppender.getDefaultRouteScript());
+        assertNotNull(routingAppender.getDefaultRoute());
         assertEquals("Service2", routingAppender.getDefaultRoute().getKey());
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptAppenderTest.java
@@ -32,26 +32,11 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 /**
  *
  */
-@RunWith(Parameterized.class)
-public class DefaultRouteScriptAppenderTest {
-
-    @Parameterized.Parameters(name = "{0} {1}")
-    public static Object[][] getParameters() {
-        // @formatter:off
-        return new Object[][] {
-            {"log4j-routing-default-route-script-groovy.xml", false},
-            {"log4j-routing-default-route-script-javascript.xml", false},
-            {"log4j-routing-script-staticvars-javascript.xml", true},
-            {"log4j-routing-script-staticvars-groovy.xml", true},
-        };
-        // @formatter:on
-    }
+public abstract class DefaultRouteScriptAppenderTest {
 
     @BeforeClass
     public static void beforeClass() {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptGroovyAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptGroovyAppenderTest.java
@@ -18,8 +18,9 @@ package org.apache.logging.log4j.core.appender.routing;
 
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.ReconfigurationPolicy;
 
-@LoggerContextSource("log4j-routing-default-route-script-groovy.xml")
+@LoggerContextSource(value = "log4j-routing-default-route-script-groovy.xml", reconfigure = ReconfigurationPolicy.BEFORE_EACH)
 public class DefaultRouteScriptGroovyAppenderTest extends DefaultRouteScriptAppenderTest {
     public DefaultRouteScriptGroovyAppenderTest(LoggerContext context) {
         super(context, false);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptGroovyAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptGroovyAppenderTest.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.appender.routing;
+
+public class DefaultRouteScriptGroovyAppenderTest extends DefaultRouteScriptAppenderTest {
+    public DefaultRouteScriptGroovyAppenderTest() {
+        super("log4j-routing-default-route-script-groovy.xml", false);
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptGroovyAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptGroovyAppenderTest.java
@@ -16,8 +16,12 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+
+@LoggerContextSource("log4j-routing-default-route-script-groovy.xml")
 public class DefaultRouteScriptGroovyAppenderTest extends DefaultRouteScriptAppenderTest {
-    public DefaultRouteScriptGroovyAppenderTest() {
-        super("log4j-routing-default-route-script-groovy.xml", false);
+    public DefaultRouteScriptGroovyAppenderTest(LoggerContext context) {
+        super(context, false);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptJavaScriptAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptJavaScriptAppenderTest.java
@@ -16,8 +16,12 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+
+@LoggerContextSource("log4j-routing-default-route-script-javascript.xml")
 public class DefaultRouteScriptJavaScriptAppenderTest extends DefaultRouteScriptAppenderTest {
-    public DefaultRouteScriptJavaScriptAppenderTest() {
-        super("log4j-routing-default-route-script-javascript.xml", false);
+    public DefaultRouteScriptJavaScriptAppenderTest(LoggerContext context) {
+        super(context, false);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptJavaScriptAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptJavaScriptAppenderTest.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.appender.routing;
+
+public class DefaultRouteScriptJavaScriptAppenderTest extends DefaultRouteScriptAppenderTest {
+    public DefaultRouteScriptJavaScriptAppenderTest() {
+        super("log4j-routing-default-route-script-javascript.xml", false);
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptJavaScriptAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/DefaultRouteScriptJavaScriptAppenderTest.java
@@ -18,8 +18,9 @@ package org.apache.logging.log4j.core.appender.routing;
 
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.ReconfigurationPolicy;
 
-@LoggerContextSource("log4j-routing-default-route-script-javascript.xml")
+@LoggerContextSource(value = "log4j-routing-default-route-script-javascript.xml", reconfigure = ReconfigurationPolicy.BEFORE_EACH)
 public class DefaultRouteScriptJavaScriptAppenderTest extends DefaultRouteScriptAppenderTest {
     public DefaultRouteScriptJavaScriptAppenderTest(LoggerContext context) {
         super(context, false);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/ScriptStaticVarsGroovyAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/ScriptStaticVarsGroovyAppenderTest.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.appender.routing;
+
+public class ScriptStaticVarsGroovyAppenderTest extends DefaultRouteScriptAppenderTest {
+    public ScriptStaticVarsGroovyAppenderTest() {
+        super("log4j-routing-script-staticvars-groovy.xml", true);
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/ScriptStaticVarsGroovyAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/ScriptStaticVarsGroovyAppenderTest.java
@@ -18,8 +18,9 @@ package org.apache.logging.log4j.core.appender.routing;
 
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.ReconfigurationPolicy;
 
-@LoggerContextSource("log4j-routing-script-staticvars-groovy.xml")
+@LoggerContextSource(value = "log4j-routing-script-staticvars-groovy.xml", reconfigure = ReconfigurationPolicy.BEFORE_EACH)
 public class ScriptStaticVarsGroovyAppenderTest extends DefaultRouteScriptAppenderTest {
     public ScriptStaticVarsGroovyAppenderTest(LoggerContext context) {
         super(context, true);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/ScriptStaticVarsGroovyAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/ScriptStaticVarsGroovyAppenderTest.java
@@ -16,8 +16,12 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+
+@LoggerContextSource("log4j-routing-script-staticvars-groovy.xml")
 public class ScriptStaticVarsGroovyAppenderTest extends DefaultRouteScriptAppenderTest {
-    public ScriptStaticVarsGroovyAppenderTest() {
-        super("log4j-routing-script-staticvars-groovy.xml", true);
+    public ScriptStaticVarsGroovyAppenderTest(LoggerContext context) {
+        super(context, true);
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/ScriptStaticVarsJavaScriptAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/ScriptStaticVarsJavaScriptAppenderTest.java
@@ -18,8 +18,9 @@ package org.apache.logging.log4j.core.appender.routing;
 
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.ReconfigurationPolicy;
 
-@LoggerContextSource("log4j-routing-script-staticvars-javascript.xml")
+@LoggerContextSource(value = "log4j-routing-script-staticvars-javascript.xml", reconfigure = ReconfigurationPolicy.BEFORE_EACH)
 public class ScriptStaticVarsJavaScriptAppenderTest extends DefaultRouteScriptAppenderTest {
     public ScriptStaticVarsJavaScriptAppenderTest(LoggerContext context) {
         super(context, true);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/ScriptStaticVarsJavaScriptAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/ScriptStaticVarsJavaScriptAppenderTest.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.appender.routing;
+
+public class ScriptStaticVarsJavaScriptAppenderTest extends DefaultRouteScriptAppenderTest {
+    public ScriptStaticVarsJavaScriptAppenderTest() {
+        super("log4j-routing-script-staticvars-javascript.xml", true);
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/ScriptStaticVarsJavaScriptAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/routing/ScriptStaticVarsJavaScriptAppenderTest.java
@@ -16,8 +16,12 @@
  */
 package org.apache.logging.log4j.core.appender.routing;
 
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+
+@LoggerContextSource("log4j-routing-script-staticvars-javascript.xml")
 public class ScriptStaticVarsJavaScriptAppenderTest extends DefaultRouteScriptAppenderTest {
-    public ScriptStaticVarsJavaScriptAppenderTest() {
-        super("log4j-routing-script-staticvars-javascript.xml", true);
+    public ScriptStaticVarsJavaScriptAppenderTest(LoggerContext context) {
+        super(context, true);
     }
 }


### PR DESCRIPTION
Hi :wave: this is James from Neighbourhoodie, working on the STF agreed milestone to migrate the test suite to JUnit 5.

This PR demonstrates an attempt to get a set of tests that use `@Parameterized` from JUnit 4 and try to get them running on JUnit 5. We have run into an odd problem where logger config files seem to be ignored and we're not sure how to resolve it.

The class `DefaultRouteScriptAppenderTest` is parameterised like so:

```java
@RunWith(Parameterized.class)
public class DefaultRouteScriptAppenderTest {

    @Parameterized.Parameters(name = "{0} {1}")
    public static Object[][] getParameters() {
        return new Object[][] {
            {"log4j-routing-default-route-script-groovy.xml", false},
            {"log4j-routing-default-route-script-javascript.xml", false},
            {"log4j-routing-script-staticvars-javascript.xml", true},
            {"log4j-routing-script-staticvars-groovy.xml", true},
        };    
    }

    // ...
}
```

We need to replicate the effect of this parameterisation under JUnit 5. Our understanding is that, whereas in JUnit 4 it is the _constructor_ that is parameterised, in JUnit 5 the `@ParameterizedTest` annotation applies to individual test methods.

The class also uses `LoggerContextRule`, and makes use of the API of that class to inspect the loggers/appenders that are configured. Our understanding is that this has been replaced with the class-level `@LoggerContextSource` annotation, which causes a `LoggerContext` to be passed into the constructor.

This PR shows an idea we had for refactoring this test class to JUnit 5. Rather than label each of its individual tests as parameterised, and then have to invoke code to set up a `LoggerContext` and the necessary before/after hooks in each one, we observe that parameterisation can be achieved by subclassing. If the `DefaultRouteScriptAppenderTest` constructor accepts the parameters that define each "version" of the tests, then we can write subclasses of `DefaultRouteScriptAppenderTest` that each invoke their parent's constructor with different inputs.

Since the parameterisation is expressed in the form of classes, we can then also use `@LoggerContextSource` on each of those classes to turn the config filename into a `LoggerContext` implicitly and not have to write/call any additional setup code ourselves.

In the first commit we remove the `@Parameterized.Parameters` block and add several subclasses, each of which sets up the parent class with one of the parameter sets, e.g.

```java
public class DefaultRouteScriptGroovyAppenderTest extends DefaultRouteScriptAppenderTest {
    public DefaultRouteScriptGroovyAppenderTest() {
        super("log4j-routing-default-route-script-groovy.xml", false);
    }
}
```

This works fine and the tests continue to pass.

In the next commit, we attempt to migrate `DefaultRouteScriptAppenderTest` to JUnit 5, and as part of that we remove `LoggerContextRule` from that class and add `LoggerContextSource` to the subclasses:

```java
@LoggerContextSource("log4j-routing-default-route-script-groovy.xml")
public class DefaultRouteScriptGroovyAppenderTest extends DefaultRouteScriptAppenderTest {
    public DefaultRouteScriptGroovyAppenderTest(LoggerContext context) {
        super(context, false);
    }
}
```

We have tried to migrate the use of `LoggerContextRule` methods like `getListAppender()` to their equivalents on `LoggerContext`. However, these tests no longer pass; e.g. this is the result of running `mvn test -Dtest=ScriptStaticVarsJavaScriptAppenderTest`:

```
[ERROR] Tests run: 8, Failures: 1, Errors: 6, Skipped: 0, Time elapsed: 0.377 s <<< FAILURE! -- in org.apache.logging.log4j.core.appender.routing.ScriptStaticVarsJavaScriptAppenderTest                                                                                        [ERROR] org.apache.logging.log4j.core.appender.routing.ScriptStaticVarsJavaScriptAppenderTest.testListAppenderPresence -- Time elapsed: 0.012 s <<< ERROR!
java.lang.NullPointerException: Cannot invoke "org.apache.logging.log4j.core.appender.routing.RoutingAppender.getAppenders()" because the return value of "org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.getRoutingAppender()" is null
        at org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.testListAppenderPresence(DefaultRouteScriptAppenderTest.java:103)                                                                                                                              at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)                                                                                                                                                                                                                   at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

[ERROR] org.apache.logging.log4j.core.appender.routing.ScriptStaticVarsJavaScriptAppenderTest.testNoPurgePolicy -- Time elapsed: 0.002 s <<< ERROR!
java.lang.NullPointerException: Cannot invoke "org.apache.logging.log4j.core.appender.routing.RoutingAppender.getPurgePolicy()" because the return value of "org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.getRoutingAppender()" is null
        at org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.testNoPurgePolicy(DefaultRouteScriptAppenderTest.java:109)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

[ERROR] org.apache.logging.log4j.core.appender.routing.ScriptStaticVarsJavaScriptAppenderTest.testRoutingPresence1 -- Time elapsed: 0.007 s <<< ERROR!
java.lang.NullPointerException: Cannot invoke "org.apache.logging.log4j.core.appender.routing.RoutingAppender.isStarted()" because "routingAppender" is null
        at org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.getListAppender(DefaultRouteScriptAppenderTest.java:69)
        at org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.logAndCheck(DefaultRouteScriptAppenderTest.java:85)
        at org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.testRoutingPresence1(DefaultRouteScriptAppenderTest.java:133)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

[ERROR] org.apache.logging.log4j.core.appender.routing.ScriptStaticVarsJavaScriptAppenderTest.testRoutingPresence2 -- Time elapsed: 0.001 s <<< ERROR!
java.lang.NullPointerException: Cannot invoke "org.apache.logging.log4j.core.appender.routing.RoutingAppender.isStarted()" because "routingAppender" is null
        at org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.getListAppender(DefaultRouteScriptAppenderTest.java:69)
        at org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.logAndCheck(DefaultRouteScriptAppenderTest.java:85)
        at org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.testRoutingPresence2(DefaultRouteScriptAppenderTest.java:139)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

[ERROR] org.apache.logging.log4j.core.appender.routing.ScriptStaticVarsJavaScriptAppenderTest.testNotListAppender -- Time elapsed: 0.001 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: not <null>
        at org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.testNotListAppender(DefaultRouteScriptAppenderTest.java:96)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

[ERROR] org.apache.logging.log4j.core.appender.routing.ScriptStaticVarsJavaScriptAppenderTest.testNoRewritePolicy -- Time elapsed: 0 s <<< ERROR!
java.lang.NullPointerException: Cannot invoke "org.apache.logging.log4j.core.appender.routing.RoutingAppender.getRewritePolicy()" because the return value of "org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.getRoutingAppender()" is null
        at org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.testNoRewritePolicy(DefaultRouteScriptAppenderTest.java:115)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

[ERROR] org.apache.logging.log4j.core.appender.routing.ScriptStaticVarsJavaScriptAppenderTest.testRoutingAppenderDefaultRouteKey -- Time elapsed: 0.001 s <<< ERROR!
java.lang.NullPointerException: Cannot invoke "org.apache.logging.log4j.core.appender.routing.RoutingAppender.getDefaultRouteScript()" because "routingAppender" is null
        at org.apache.logging.log4j.core.appender.routing.DefaultRouteScriptAppenderTest.testRoutingAppenderDefaultRouteKey(DefaultRouteScriptAppenderTest.java:121)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

It seems as though the config filename passed to `@LoggerContextSource` is being ignored -- changing the referenced files' content has no effect on the test outcome, and using a filename for a file that does not exist does not cause a different kind of failure. It just looks like the file is ignored entirely, and we're not sure why.

Is there a quirk of `@LoggerContextSource` that means it doesn't work with subclassing, or something else we're not aware of? Should we be going about this in a different way, and if so how would you recommend turning a config filename into a working `LoggerContext`?