### PR TITLE
Add requiresLocation function for FailoverAppender #3257

### DIFF
--- a/log4j-core-test/src/test/resources/log4j-failover-location.xml
+++ b/log4j-core-test/src/test/resources/log4j-failover-location.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="OFF" name="RoutingTest">
+
+    <Appenders>
+        <Console name="CONSOLE">
+            <PatternLayout pattern="%m%L%n"/>
+        </Console>
+        <Console name="CONSOLE2">
+            <PatternLayout pattern="%m%L%n"/>
+        </Console>
+        <Failover name="Failover" primary="CONSOLE">
+            <Failovers>
+                <AppenderRef ref="CONSOLE2"/>
+            </Failovers>
+        </Failover>
+    </Appenders>
+
+    <Loggers>
+        <Root level="debug" includeLocation="true">
+            <AppenderRef ref="Failover"/>
+        </Root>
+    </Loggers>
+
+</Configuration>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FailoverAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FailoverAppender.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.impl.LocationAware;
 import org.apache.logging.log4j.core.util.Booleans;
 import org.apache.logging.log4j.core.util.Constants;
 
@@ -222,5 +223,21 @@ public final class FailoverAppender extends AbstractAppender {
 
         return new FailoverAppender(
                 name, filter, primary, failovers, retryIntervalMillis, config, ignoreExceptions, null);
+    }
+
+    @Override
+    public boolean requiresLocation() {
+        if (primary != null
+                && primary.getAppender() instanceof LocationAware
+                && ((LocationAware) primary.getAppender()).requiresLocation()) {
+            return true;
+        }
+        for (final AppenderControl control : failoverAppenders) {
+            final Appender appender = control.getAppender();
+            if (appender instanceof LocationAware && ((LocationAware) appender).requiresLocation()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/changelog/.2.x.x/3257_fix_FailoverAppender_requiresLocation.xml
+++ b/src/changelog/.2.x.x/3257_fix_FailoverAppender_requiresLocation.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <issue id="3257" link="https://github.com/apache/logging-log4j2/issues/3257"/>
+    <description format="asciidoc">Fix detection of location requirements in `FailoverAppender`.</description>
+</entry>


### PR DESCRIPTION
Fix #3257 

- Add `requiresLocation` implementation for `FailoverAppender`
- Isolate `LoggerContext` for each test case in `FailoverAppenderTest`