### PR TITLE
Fix(#3239) NPE, for RegexFilter creator.

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/filter/RegexFilterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/filter/RegexFilterTest.java
@@ -18,6 +18,7 @@ package org.apache.logging.log4j.core.filter;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -37,6 +38,13 @@ class RegexFilterTest {
     @BeforeAll
     static void before() {
         StatusLogger.getLogger().setLevel(Level.OFF);
+    }
+
+    @Test
+    void testRegexFilterDoesNotThrowWithAllTheParametersExceptRegexEqualNull() {
+        assertDoesNotThrow(() -> {
+            RegexFilter.createFilter(".* test .*", null, null, null, null);
+        });
     }
 
     @Test

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/RegexFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/RegexFilter.java
@@ -148,7 +148,8 @@ public final class RegexFilter extends AbstractFilter {
             LOGGER.error("A regular expression must be provided for RegexFilter");
             return null;
         }
-        return new RegexFilter(useRawMsg, Pattern.compile(regex, toPatternFlags(patternFlags)), match, mismatch);
+        return new RegexFilter(
+                Boolean.TRUE.equals(useRawMsg), Pattern.compile(regex, toPatternFlags(patternFlags)), match, mismatch);
     }
 
     private static int toPatternFlags(final String[] patternFlags)

--- a/src/changelog/2.24.3/3239_npe_fix_regex_filter_creator.xml
+++ b/src/changelog/2.24.3/3239_npe_fix_regex_filter_creator.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <issue id="3239" link="https://github.com/apache/logging-log4j2/issues/3239"/>
+    <description format="asciidoc">
+        Fix for RegexCreator NPE, the constructor expects a boolean primitive,
+        but the createFilter static method was boxed. Fixed that to remove the NPE issues.
+    </description>
+</entry>


### PR DESCRIPTION
fix for #3239 

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)

