### PR TITLE
Use garbage-free formatter for `s` and `S` patterns

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatterTest.java
@@ -32,7 +32,7 @@ import java.util.TimeZone;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.core.time.MutableInstant;
-import org.apache.logging.log4j.core.util.internal.instant.InstantPatternDynamicFormatter.DateTimeFormatterPatternSequence;
+import org.apache.logging.log4j.core.util.internal.instant.InstantPatternDynamicFormatter.DynamicPatternSequence;
 import org.apache.logging.log4j.core.util.internal.instant.InstantPatternDynamicFormatter.PatternSequence;
 import org.apache.logging.log4j.core.util.internal.instant.InstantPatternDynamicFormatter.SecondPatternSequence;
 import org.apache.logging.log4j.core.util.internal.instant.InstantPatternDynamicFormatter.StaticPatternSequence;
@@ -59,19 +59,19 @@ class InstantPatternDynamicFormatterTest {
         testCases.add(Arguments.of(":'foo',", ChronoUnit.DAYS, singletonList(new StaticPatternSequence(":foo,"))));
 
         // `SSSX` should be treated constant for daily updates
-        testCases.add(Arguments.of("SSSX", ChronoUnit.DAYS, asList(pMilliSec(), pDtf("X"))));
+        testCases.add(Arguments.of("SSSX", ChronoUnit.DAYS, asList(pMilliSec(), pDyn("X"))));
 
         // `yyyyMMddHHmmssSSSX` instant cache updated hourly
         testCases.add(Arguments.of(
                 "yyyyMMddHHmmssSSSX",
                 ChronoUnit.HOURS,
-                asList(pDtf("yyyyMMddHH", ChronoUnit.HOURS), pDtf("mm"), pSec("", 3), pDtf("X"))));
+                asList(pDyn("yyyyMMddHH", ChronoUnit.HOURS), pDyn("mm"), pSec("", 3), pDyn("X"))));
 
         // `yyyyMMddHHmmssSSSX` instant cache updated per minute
         testCases.add(Arguments.of(
                 "yyyyMMddHHmmssSSSX",
                 ChronoUnit.MINUTES,
-                asList(pDtf("yyyyMMddHHmm", ChronoUnit.MINUTES), pSec("", 3), pDtf("X"))));
+                asList(pDyn("yyyyMMddHHmm", ChronoUnit.MINUTES), pSec("", 3), pDyn("X"))));
 
         // ISO9601 instant cache updated daily
         final String iso8601InstantPattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
@@ -79,36 +79,36 @@ class InstantPatternDynamicFormatterTest {
                 iso8601InstantPattern,
                 ChronoUnit.DAYS,
                 asList(
-                        pDtf("yyyy'-'MM'-'dd'T'", ChronoUnit.DAYS),
-                        pDtf("HH':'mm':'", ChronoUnit.MINUTES),
+                        pDyn("yyyy'-'MM'-'dd'T'", ChronoUnit.DAYS),
+                        pDyn("HH':'mm':'", ChronoUnit.MINUTES),
                         pSec(".", 3),
-                        pDtf("X"))));
+                        pDyn("X"))));
 
         // ISO9601 instant cache updated per minute
         testCases.add(Arguments.of(
                 iso8601InstantPattern,
                 ChronoUnit.MINUTES,
-                asList(pDtf("yyyy'-'MM'-'dd'T'HH':'mm':'", ChronoUnit.MINUTES), pSec(".", 3), pDtf("X"))));
+                asList(pDyn("yyyy'-'MM'-'dd'T'HH':'mm':'", ChronoUnit.MINUTES), pSec(".", 3), pDyn("X"))));
 
         // ISO9601 instant cache updated per second
         testCases.add(Arguments.of(
                 iso8601InstantPattern,
                 ChronoUnit.SECONDS,
-                asList(pDtf("yyyy'-'MM'-'dd'T'HH':'mm':'", ChronoUnit.MINUTES), pSec(".", 3), pDtf("X"))));
+                asList(pDyn("yyyy'-'MM'-'dd'T'HH':'mm':'", ChronoUnit.MINUTES), pSec(".", 3), pDyn("X"))));
 
         // Seconds and micros
         testCases.add(Arguments.of(
-                "HH:mm:ss.SSSSSS", ChronoUnit.MINUTES, asList(pDtf("HH':'mm':'", ChronoUnit.MINUTES), pSec(".", 6))));
+                "HH:mm:ss.SSSSSS", ChronoUnit.MINUTES, asList(pDyn("HH':'mm':'", ChronoUnit.MINUTES), pSec(".", 6))));
 
         return testCases;
     }
 
-    private static DateTimeFormatterPatternSequence pDtf(final String singlePattern) {
-        return new DateTimeFormatterPatternSequence(singlePattern);
+    private static DynamicPatternSequence pDyn(final String singlePattern) {
+        return new DynamicPatternSequence(singlePattern);
     }
 
-    private static DateTimeFormatterPatternSequence pDtf(final String pattern, final ChronoUnit precision) {
-        return new DateTimeFormatterPatternSequence(pattern, precision);
+    private static DynamicPatternSequence pDyn(final String pattern, final ChronoUnit precision) {
+        return new DynamicPatternSequence(pattern, precision);
     }
 
     private static SecondPatternSequence pSec(String separator, int fractionalDigits) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatterTest.java
@@ -317,9 +317,11 @@ class InstantPatternDynamicFormatterTest {
 
     private static MutableInstant randomInstant() {
         final MutableInstant instant = new MutableInstant();
-        // In the 1970's some time zones had sub-minute offsets to UTC, e.g., Africa/Monrovia
-        final int startEighties = 315_532_800;
-        final long epochSecond = startEighties + RANDOM.nextInt(1_621_280_470 - startEighties); // 2021-05-17 21:41:10
+        // In the 1970's some time zones had sub-minute offsets to UTC, e.g., Africa/Monrovia.
+        // We will exclude them for tests:
+        final long minEpochSecond = 315_532_800; // 1980-01-01 01:00:00
+        final long maxEpochSecond = 1_621_280_470; // 2021-05-17 21:41:10
+        final long epochSecond = RANDOM.nextLong(minEpochSecond, maxEpochSecond);
         final int epochSecondNano = randomNanos();
         instant.initFromEpochSecond(epochSecond, epochSecondNano);
         return instant;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatterTest.java
@@ -322,9 +322,9 @@ class InstantPatternDynamicFormatterTest {
         final MutableInstant instant = new MutableInstant();
         // In the 1970's some time zones had sub-minute offsets to UTC, e.g., Africa/Monrovia.
         // We will exclude them for tests:
-        final long minEpochSecond = 315_532_800; // 1980-01-01 01:00:00
-        final long maxEpochSecond = 1_621_280_470; // 2021-05-17 21:41:10
-        final long epochSecond = minEpochSecond + RANDOM.nextLong(maxEpochSecond - minEpochSecond);
+        final int minEpochSecond = 315_532_800; // 1980-01-01 01:00:00
+        final int maxEpochSecond = 1_621_280_470; // 2021-05-17 21:41:10
+        final long epochSecond = minEpochSecond + RANDOM.nextInt(maxEpochSecond - minEpochSecond);
         final int epochSecondNano = randomNanos();
         instant.initFromEpochSecond(epochSecond, epochSecondNano);
         return instant;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatterTest.java
@@ -103,8 +103,8 @@ class InstantPatternDynamicFormatterTest {
         return testCases;
     }
 
-    private static DateTimeFormatterPatternSequence pDtf(final String simplePattern) {
-        return new DateTimeFormatterPatternSequence(simplePattern);
+    private static DateTimeFormatterPatternSequence pDtf(final String singlePattern) {
+        return new DateTimeFormatterPatternSequence(singlePattern);
     }
 
     private static DateTimeFormatterPatternSequence pDtf(final String pattern, final ChronoUnit precision) {
@@ -324,7 +324,7 @@ class InstantPatternDynamicFormatterTest {
         // We will exclude them for tests:
         final long minEpochSecond = 315_532_800; // 1980-01-01 01:00:00
         final long maxEpochSecond = 1_621_280_470; // 2021-05-17 21:41:10
-        final long epochSecond = RANDOM.nextLong(minEpochSecond, maxEpochSecond);
+        final long epochSecond = minEpochSecond + RANDOM.nextLong(maxEpochSecond - minEpochSecond);
         final int epochSecondNano = randomNanos();
         instant.initFromEpochSecond(epochSecond, epochSecondNano);
         return instant;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternThreadLocalCachedFormatterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternThreadLocalCachedFormatterTest.java
@@ -107,7 +107,7 @@ class InstantPatternThreadLocalCachedFormatterTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"S", "SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS", "n", "N"})
+    @ValueSource(strings = {"SSSS", "SSSSS", "SSSSSS", "SSSSSSS", "SSSSSSSS", "SSSSSSSSS", "n", "N"})
     void ofMilliPrecision_should_fail_on_inconsistent_precision(final String subMilliPattern) {
         final InstantPatternDynamicFormatter dynamicFormatter =
                 new InstantPatternDynamicFormatter(subMilliPattern, LOCALE, TIME_ZONE);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
@@ -561,34 +561,36 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
         }
 
         /**
-         * @param simplePattern a single-letter directive simplePattern complying (e.g., {@code H}, {@code HH}, or {@code pHH})
+         * @param singlePattern a single-letter directive singlePattern complying (e.g., {@code H}, {@code HH}, or {@code pHH})
          * @return the time precision of the directive
          */
-        private static ChronoUnit patternPrecision(final String simplePattern) {
+        private static ChronoUnit patternPrecision(final String singlePattern) {
 
-            validateContent(simplePattern);
-            final String paddingRemovedContent = removePadding(simplePattern);
+            validateContent(singlePattern);
+            final String paddingRemovedContent = removePadding(singlePattern);
 
-            if (paddingRemovedContent.matches("[GuyY]+")) {
+            if (paddingRemovedContent.matches("G+")) {
+                return ChronoUnit.ERAS;
+            } else if (paddingRemovedContent.matches("[uyY]+")) {
                 return ChronoUnit.YEARS;
             } else if (paddingRemovedContent.matches("[MLQq]+")) {
                 return ChronoUnit.MONTHS;
-            } else if (paddingRemovedContent.matches("[wW]+")) {
+            } else if (paddingRemovedContent.matches("w+")) {
                 return ChronoUnit.WEEKS;
-            } else if (paddingRemovedContent.matches("[DdgEecF]+")) {
+            } else if (paddingRemovedContent.matches("[DdgEecFW]+")) {
                 return ChronoUnit.DAYS;
-            } else if (paddingRemovedContent.matches("[aBhKkH]+")
-                    // Time-zone directives
-                    || paddingRemovedContent.matches("[ZxXOzvV]+")) {
+            } else if (paddingRemovedContent.matches("[aBhKkH]+")) {
                 return ChronoUnit.HOURS;
-            } else if (paddingRemovedContent.contains("m")) {
+            } else if (paddingRemovedContent.contains("m")
+                    // Time-zone directives
+                    || paddingRemovedContent.matches("[ZxXOzVv]+")) {
                 return ChronoUnit.MINUTES;
             } else if (paddingRemovedContent.contains("s")) {
                 return ChronoUnit.SECONDS;
             }
 
             // 2 to 3 consequent `S` characters output millisecond precision
-            else if (paddingRemovedContent.matches("S{2,3}")
+            else if (paddingRemovedContent.matches("S{1,3}")
                     // `A` (milli-of-day) outputs millisecond precision.
                     || paddingRemovedContent.contains("A")) {
                 return ChronoUnit.MILLIS;
@@ -599,17 +601,15 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
                 return ChronoUnit.MICROS;
             }
 
-            // A single `S` (fraction-of-second) outputs nanosecond precision
-            else if (paddingRemovedContent.equals("S")
-                    // 7 to 9 consequent `S` characters output nanosecond precision
-                    || paddingRemovedContent.matches("S{7,9}")
+            // 7 to 9 consequent `S` characters output nanosecond precision
+            else if (paddingRemovedContent.matches("S{7,9}")
                     // `n` (nano-of-second) and `N` (nano-of-day) always output nanosecond precision.
                     // This is independent of how many times they occur sequentially.
                     || paddingRemovedContent.matches("[nN]+")) {
                 return ChronoUnit.NANOS;
             }
 
-            final String message = String.format("unrecognized pattern: `%s`", simplePattern);
+            final String message = String.format("unrecognized pattern: `%s`", singlePattern);
             throw new IllegalArgumentException(message);
         }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
@@ -422,6 +422,31 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
             return precision.compareTo(thresholdPrecision) >= 0;
         }
 
+        static String escapeLiteral(String literal) {
+            StringBuilder sb = new StringBuilder(literal.length() + 2);
+            boolean inSingleQuotes = false;
+            for (int i = 0; i < literal.length(); i++) {
+                char c = literal.charAt(i);
+                if (c == '\'') {
+                    if (inSingleQuotes) {
+                        sb.append("'");
+                    }
+                    inSingleQuotes = false;
+                    sb.append("''");
+                } else {
+                    if (!inSingleQuotes) {
+                        sb.append("'");
+                    }
+                    inSingleQuotes = true;
+                    sb.append(c);
+                }
+            }
+            if (inSingleQuotes) {
+                sb.append("'");
+            }
+            return sb.toString();
+        }
+
         @Override
         public boolean equals(final Object object) {
             if (this == object) {
@@ -478,31 +503,6 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
                 return new DynamicPatternSequence(this.pattern + otherDtf.pattern, otherDtf.precision);
             }
             return null;
-        }
-
-        static String escapeLiteral(String literal) {
-            StringBuilder sb = new StringBuilder(literal.length() + 2);
-            boolean inSingleQuotes = false;
-            for (int i = 0; i < literal.length(); i++) {
-                char c = literal.charAt(i);
-                if (c == '\'') {
-                    if (inSingleQuotes) {
-                        sb.append("'");
-                    }
-                    inSingleQuotes = false;
-                    sb.append("''");
-                } else {
-                    if (!inSingleQuotes) {
-                        sb.append("'");
-                    }
-                    inSingleQuotes = true;
-                    sb.append(c);
-                }
-            }
-            if (inSingleQuotes) {
-                sb.append("'");
-            }
-            return sb.toString();
         }
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
@@ -270,30 +270,32 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
     /**
      * Merges pattern sequences using {@link PatternSequence#tryMerge}.
      *
+     * <h2>Example</h2>
+     *
      * <p>
-     * For example, given the {@code yyyy-MM-dd'T'HH:mm:ss.SSS} pattern and a precision threshold of {@link ChronoUnit#MINUTES},
+     * For example, given the {@code yyyy-MM-dd'T'HH:mm:ss.SSS} pattern, a precision threshold of {@link ChronoUnit#MINUTES}
+     * and the three implementations ({@link DateTimeFormatterPatternSequence}, {@link StaticPatternSequence} and
+     * {@link SecondPatternSequence}) from this class,
      * this method will combine pattern sequences associated with {@code yyyy-MM-dd'T'HH:mm:} into a single sequence,
      * since these are consecutive and effectively constant sequences.
      * </p>
      *
-     * <h2>Example</h2>
-     *
      * <pre>{@code
      * [
-     *     dynamic(pattern="yyyy", precision=YEARS),
+     *     dateTimeFormatter(pattern="yyyy", precision=YEARS),
      *     static(literal="-"),
-     *     dynamic(pattern="MM", precision=MONTHS),
+     *     dateTimeFormatter(pattern="MM", precision=MONTHS),
      *     static(literal="-"),
-     *     dynamic(pattern="dd", precision=DAYS),
+     *     dateTimeFormatter(pattern="dd", precision=DAYS),
      *     static(literal="T"),
-     *     dynamic(pattern="HH", precision=HOURS),
+     *     dateTimeFormatter(pattern="HH", precision=HOURS),
      *     static(literal=":"),
-     *     dynamic(pattern="mm", precision=MINUTES),
+     *     dateTimeFormatter(pattern="mm", precision=MINUTES),
      *     static(literal=":"),
-     *     dynamic(pattern="ss", precision=SECONDS),
+     *     second(pattern="ss", precision=SECONDS),
      *     static(literal="."),
-     *     dynamic(pattern="SSS", precision=MILLISECONDS)
-     *     dynamic(pattern="X", precision=HOURS),
+     *     second(pattern="SSS", precision=MILLISECONDS)
+     *     dateTimeFormatter(pattern="X", precision=HOURS),
      * ]
      * }</pre>
      *
@@ -304,9 +306,9 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
      *
      * <pre>{@code
      * [
-     *     dynamic(pattern="yyyy-MM-dd'T'HH:mm", precision=MINUTES),
-     *     dynamic(pattern="ss.SSS", precision=MILLISECONDS),
-     *     dynamic(pattern="X", precision=MINUTES)
+     *     dateTimeFormatter(pattern="yyyy-MM-dd'T'HH:mm", precision=MINUTES),
+     *     second(pattern="ss.SSS", precision=MILLISECONDS),
+     *     dateTimeFormatter(pattern="X", precision=MINUTES)
      * ]
      * }</pre>
      *

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
@@ -408,6 +408,30 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
         /**
          * Tries to merge two pattern sequences.
          *
+         * <p>
+         *     If not {@link null}, the pattern sequence returned by this method must:
+         * </p>
+         * <ol>
+         *     <li>Have a {@link #precision}, which is the minimum of the precisions of the two merged sequences.</li>
+         *     <li>
+         *         Create formatters that are equivalent to the concatenation of the formatters produced by the
+         *         two merged sequences.
+         *     </li>
+         * </ol>
+         * <p>
+         *     The returned pattern sequence should try to achieve these two goals:
+         * </p>
+         * <ol>
+         *     <li>
+         *         Create formatters which are faster than the concatenation of the formatters produced by the
+         *         two merged sequences.
+         *     </li>
+         *     <li>
+         *         It should be {@link null} if one of the pattern sequences is effectively constant over
+         *         {@code thresholdPrecision}, but the other one is not.
+         *     </li>
+         * </ol>
+         *
          * @param other A pattern sequence.
          * @param thresholdPrecision A precision threshold to determine effectively constant sequences.
          *                           This prevents merging effectively constant and dynamic pattern sequences.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
@@ -504,7 +504,7 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
                 return new DateTimeFormatterPatternFormatterFactory(
                         this.pattern + otherDtf.pattern, otherDtf.precision);
             }
-            return super.tryMerge(other, thresholdPrecision);
+            return null;
         }
 
         static String escapeLiteral(String literal) {
@@ -585,7 +585,7 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
                 final StaticPatternFormatterFactory otherStatic = (StaticPatternFormatterFactory) other;
                 return new DateTimeFormatterPatternFormatterFactory(this.pattern + otherStatic.pattern, this.precision);
             }
-            return super.tryMerge(other, thresholdPrecision);
+            return null;
         }
 
         /**
@@ -781,7 +781,7 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
                             printSeconds, this.separator, this.fractionalDigits + secondOther.fractionalDigits);
                 }
             }
-            return super.tryMerge(other, thresholdPrecision);
+            return null;
         }
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
@@ -351,7 +351,7 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
                 : java.time.Instant.ofEpochSecond(instant.getEpochSecond(), instant.getNanoOfSecond());
     }
 
-    abstract static class AbstractFormatter implements InstantPatternFormatter {
+    private abstract static class AbstractFormatter implements InstantPatternFormatter {
 
         private final String pattern;
 

--- a/log4j-perf-test/pom.xml
+++ b/log4j-perf-test/pom.xml
@@ -196,6 +196,21 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-uber-jar</id>
+            <configuration>
+              <transformers combine.children="append">
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Main-Class>org.openjdk.jmh.Main</Main-Class>
+                    <Multi-Release>true</Multi-Release>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
     </plugins>

--- a/src/site/antora/modules/ROOT/pages/manual/json-template-layout.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/json-template-layout.adoc
@@ -1291,6 +1291,13 @@ unit          = "unit" -> (
 rounded       = "rounded" -> boolean
 ----
 
+[NOTE]
+====
+The resolvers based on the `epochConfig` expression are garbage-free.
+
+The resolvers based on the `patternConfig` expression are low-garbage and generate temporary objects only once a minute.
+====
+
 .See examples
 [%collapsible]
 ====

--- a/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
@@ -1607,7 +1607,9 @@ Format modifiers to control such things as field width, padding, left, and right
 
 |<<converter-date,%d +
 %date>>
-|Only the predefined date formats (`DEFAULT`, `ISO8601`, `UNIX`, `UNIX_MILLIS`, etc.) are garbage-free
+|
+The numeric formats (`UNIX` and `UNIX_MILLIS`) are garbage-free.
+The remaining formats are low-garbage and only generate temporary objects once per minute.
 
 |<<converter-encode,%enc\{pattern} +
 %encode\{pattern}>>


### PR DESCRIPTION
This PR improves #3139, by introducing a new `InstantPatternFormatter` for patterns of the form "ss\.S{n}". Unlike the previous formatter based on `DateTimeFormatter`, the formatter is garbage-free.

We also simplify the merging algorithm for pattern formatter factories, by moving the merging logic to the pattern formatter factories themselves.

This PR does not contain a separate change log entry, since #3139 has not been published yet.

Fixes #3337.

