### PR TITLE
Document all API changes in `log4j-api`

### DIFF
--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/internal/DefaultObjectInputFilter.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/internal/DefaultObjectInputFilter.java
@@ -21,6 +21,9 @@ import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_
 
 import java.io.ObjectInputFilter;
 
+/**
+ * @since 2.11.0
+ */
 public class DefaultObjectInputFilter implements ObjectInputFilter {
 
     private final ObjectInputFilter delegate;

--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/internal/DefaultObjectInputFilter.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/internal/DefaultObjectInputFilter.java
@@ -21,9 +21,6 @@ import static org.apache.logging.log4j.util.internal.SerializationUtil.REQUIRED_
 
 import java.io.ObjectInputFilter;
 
-/**
- * @since 2.11.0
- */
 public class DefaultObjectInputFilter implements ObjectInputFilter {
 
     private final ObjectInputFilter delegate;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/BridgeAware.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/BridgeAware.java
@@ -20,6 +20,7 @@ package org.apache.logging.log4j;
  * Extended interface to allow bridges between logging systems to convey the
  * correct location information.
  *
+ * @since 2.19.0
  */
 public interface BridgeAware {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/CloseableThreadContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/CloseableThreadContext.java
@@ -99,6 +99,9 @@ public class CloseableThreadContext {
         return new CloseableThreadContext.Instance().putAll(values);
     }
 
+    /**
+     * @since 2.6
+     */
     public static class Instance implements AutoCloseable {
 
         private int pushCount = 0;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/EventLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/EventLogger.java
@@ -22,7 +22,8 @@ import org.apache.logging.log4j.spi.ExtendedLogger;
 /**
  * Convenience to log {@link StructuredDataMessage}s.
  *
- * @deprecated {@link Logger} accepts {@link StructuredDataMessage}s, users should use to that instead.
+ * @deprecated Deprecated since 2.24.0.
+ * {@link Logger} accepts {@link StructuredDataMessage}s, users should use to that instead.
  */
 @Deprecated
 public final class EventLogger {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
@@ -130,6 +130,7 @@ public interface LogBuilder {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      *
+     * @since 2.13.1
      * @see org.apache.logging.log4j.util.Unbox
      */
     default void log(final String message, final Object p0) {}
@@ -141,6 +142,7 @@ public interface LogBuilder {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      *
+     * @since 2.13.1
      * @see org.apache.logging.log4j.util.Unbox
      */
     default void log(final String message, final Object p0, final Object p1) {}
@@ -153,6 +155,7 @@ public interface LogBuilder {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      *
+     * @since 2.13.1
      * @see org.apache.logging.log4j.util.Unbox
      */
     default void log(final String message, final Object p0, final Object p1, final Object p2) {}
@@ -166,6 +169,7 @@ public interface LogBuilder {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      *
+     * @since 2.13.1
      * @see org.apache.logging.log4j.util.Unbox
      */
     default void log(final String message, final Object p0, final Object p1, final Object p2, final Object p3) {}
@@ -180,6 +184,7 @@ public interface LogBuilder {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      *
+     * @since 2.13.1
      * @see org.apache.logging.log4j.util.Unbox
      */
     default void log(
@@ -201,6 +206,7 @@ public interface LogBuilder {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      *
+     * @since 2.13.1
      * @see org.apache.logging.log4j.util.Unbox
      */
     default void log(
@@ -224,6 +230,7 @@ public interface LogBuilder {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      *
+     * @since 2.13.1
      * @see org.apache.logging.log4j.util.Unbox
      */
     default void log(
@@ -249,6 +256,7 @@ public interface LogBuilder {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      *
+     * @since 2.13.1
      * @see org.apache.logging.log4j.util.Unbox
      */
     default void log(
@@ -276,6 +284,7 @@ public interface LogBuilder {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      *
+     * @since 2.13.1
      * @see org.apache.logging.log4j.util.Unbox
      */
     default void log(
@@ -305,6 +314,7 @@ public interface LogBuilder {
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
      *
+     * @since 2.13.1
      * @see org.apache.logging.log4j.util.Unbox
      */
     default void log(

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
@@ -332,6 +332,8 @@ public interface LogBuilder {
 
     /**
      * Causes all the data collected to be logged. Default implementatoin does nothing.
+     *
+     * @since 2.14.1
      */
     default void log() {}
 }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
@@ -112,7 +112,7 @@ public interface LogBuilder {
      *
      * @param messageSupplier The supplier of the message to log.
      * @return the message logger or {@code null} if no logging occurred.
-     * @since 2.20
+     * @since 2.20.0
      */
     default Message logAndGet(final Supplier<Message> messageSupplier) {
         return null;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogBuilder.java
@@ -22,6 +22,8 @@ import org.apache.logging.log4j.util.Supplier;
 /**
  * Interface for constructing log events before logging them. Instances of LogBuilders should only be created
  * by calling one of the Logger methods that return a LogBuilder.
+ *
+ * @since 2.13.0
  */
 public interface LogBuilder {
     /** NOOP Logbuilder */

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
@@ -43,6 +43,7 @@ public class LogManager {
     /**
      * Log4j's property to set to the fully qualified class name of a custom implementation of
      * {@link LoggerContextFactory}.
+     * @since 2.0.1
      * @deprecated Replaced since 2.24.0 with {@value org.apache.logging.log4j.spi.Provider#PROVIDER_PROPERTY_NAME}.
      */
     @Deprecated

--- a/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/LogManager.java
@@ -298,6 +298,7 @@ public class LogManager {
      * @param configLocation The URI for the configuration to use.
      * @param name The LoggerContext name.
      * @return a LoggerContext.
+     * @since 2.9.1
      */
     protected static LoggerContext getContext(
             final String fqcn,

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -142,6 +142,7 @@ public interface Logger {
      *
      * @param marker the marker data specific to this log statement
      * @param message the message CharSequence to log.
+     * @since 2.6
      */
     void debug(Marker marker, CharSequence message);
 
@@ -152,6 +153,7 @@ public interface Logger {
      * @param marker the marker data specific to this log statement
      * @param message the message CharSequence to log.
      * @param throwable the {@code Throwable} to log, including its stack trace.
+     * @since 2.6
      */
     void debug(Marker marker, CharSequence message, Throwable throwable);
 
@@ -274,6 +276,7 @@ public interface Logger {
      * Logs a message CharSequence with the {@link Level#DEBUG DEBUG} level.
      *
      * @param message the message object to log.
+     * @since 2.6
      */
     void debug(CharSequence message);
 
@@ -283,6 +286,7 @@ public interface Logger {
      *
      * @param message the message CharSequence to log.
      * @param throwable the {@code Throwable} to log, including its stack trace.
+     * @since 2.6
      */
     void debug(CharSequence message, Throwable throwable);
 
@@ -363,6 +367,7 @@ public interface Logger {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
+     * @since 2.6
      */
     void debug(Marker marker, String message, Object p0);
 
@@ -373,6 +378,7 @@ public interface Logger {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
+     * @since 2.6
      */
     void debug(Marker marker, String message, Object p0, Object p1);
 
@@ -384,6 +390,7 @@ public interface Logger {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
+     * @since 2.6
      */
     void debug(Marker marker, String message, Object p0, Object p1, Object p2);
 
@@ -396,6 +403,7 @@ public interface Logger {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
+     * @since 2.6
      */
     void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3);
 
@@ -409,6 +417,7 @@ public interface Logger {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
+     * @since 2.6
      */
     void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
@@ -423,6 +432,7 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
+     * @since 2.6
      */
     void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
 
@@ -438,6 +448,7 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
+     * @since 2.6
      */
     void debug(
             Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
@@ -455,6 +466,7 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
+     * @since 2.6
      */
     void debug(
             Marker marker,
@@ -482,6 +494,7 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
+     * @since 2.6
      */
     void debug(
             Marker marker,
@@ -511,6 +524,7 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
+     * @since 2.6
      */
     void debug(
             Marker marker,
@@ -531,6 +545,7 @@ public interface Logger {
      *
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
+     * @since 2.6
      */
     void debug(String message, Object p0);
 
@@ -540,6 +555,7 @@ public interface Logger {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
+     * @since 2.6
      */
     void debug(String message, Object p0, Object p1);
 
@@ -550,6 +566,7 @@ public interface Logger {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
+     * @since 2.6
      */
     void debug(String message, Object p0, Object p1, Object p2);
 
@@ -561,6 +578,7 @@ public interface Logger {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
+     * @since 2.6
      */
     void debug(String message, Object p0, Object p1, Object p2, Object p3);
 
@@ -573,6 +591,7 @@ public interface Logger {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
+     * @since 2.6
      */
     void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
@@ -586,6 +605,7 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
+     * @since 2.6
      */
     void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
 
@@ -600,6 +620,7 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
+     * @since 2.6
      */
     void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
 
@@ -615,6 +636,7 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
+     * @since 2.6
      */
     void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
 
@@ -631,6 +653,7 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
+     * @since 2.6
      */
     void debug(
             String message,
@@ -658,6 +681,7 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
+     * @since 2.6
      */
     void debug(
             String message,
@@ -675,7 +699,7 @@ public interface Logger {
     /**
      * Logs entry to a method. Used when the method in question has no parameters or when the parameters should not be
      * logged.
-     * @deprecated Use {@link #traceEntry()} instead which performs the same function.
+     * @deprecated :uUse {@link #traceEntry()} instead which performs the same function.
      */
     @Deprecated
     void entry();
@@ -747,6 +771,7 @@ public interface Logger {
      *
      * @param marker the marker data specific to this log statement.
      * @param message the message CharSequence to log.
+     * @since 2.6
      */
     void error(Marker marker, CharSequence message);
 
@@ -757,6 +782,7 @@ public interface Logger {
      * @param marker the marker data specific to this log statement.
      * @param message the message CharSequence to log.
      * @param throwable the {@code Throwable} to log, including its stack trace.
+     * @since 2.6
      */
     void error(Marker marker, CharSequence message, Throwable throwable);
 
@@ -879,6 +905,7 @@ public interface Logger {
      * Logs a message CharSequence with the {@link Level#ERROR ERROR} level.
      *
      * @param message the message CharSequence to log.
+     * @since 2.6
      */
     void error(CharSequence message);
 
@@ -888,6 +915,7 @@ public interface Logger {
      *
      * @param message the message CharSequence to log.
      * @param throwable the {@code Throwable} to log, including its stack trace.
+     * @since 2.6
      */
     void error(CharSequence message, Throwable throwable);
 
@@ -968,6 +996,7 @@ public interface Logger {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
+     * @since 2.6
      */
     void error(Marker marker, String message, Object p0);
 
@@ -978,6 +1007,7 @@ public interface Logger {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
+     * @since 2.6
      */
     void error(Marker marker, String message, Object p0, Object p1);
 
@@ -989,6 +1019,7 @@ public interface Logger {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
+     * @since 2.6
      */
     void error(Marker marker, String message, Object p0, Object p1, Object p2);
 
@@ -1001,6 +1032,7 @@ public interface Logger {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
+     * @since 2.6
      */
     void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3);
 
@@ -1014,6 +1046,7 @@ public interface Logger {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
+     * @since 2.6
      */
     void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
@@ -1028,6 +1061,7 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
+     * @since 2.6
      */
     void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
 
@@ -1043,6 +1077,7 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
+     * @since 2.6
      */
     void error(
             Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
@@ -1060,6 +1095,7 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
+     * @since 2.6
      */
     void error(
             Marker marker,
@@ -1087,6 +1123,7 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
+     * @since 2.6
      */
     void error(
             Marker marker,
@@ -1116,6 +1153,7 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
+     * @since 2.6
      */
     void error(
             Marker marker,
@@ -1136,6 +1174,7 @@ public interface Logger {
      *
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
+     * @since 2.6
      */
     void error(String message, Object p0);
 
@@ -1145,6 +1184,7 @@ public interface Logger {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
+     * @since 2.6
      */
     void error(String message, Object p0, Object p1);
 
@@ -1155,6 +1195,7 @@ public interface Logger {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
+     * @since 2.6
      */
     void error(String message, Object p0, Object p1, Object p2);
 
@@ -1166,6 +1207,7 @@ public interface Logger {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
+     * @since 2.6
      */
     void error(String message, Object p0, Object p1, Object p2, Object p3);
 
@@ -1178,6 +1220,7 @@ public interface Logger {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
+     * @since 2.6
      */
     void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
@@ -1191,6 +1234,7 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
+     * @since 2.6
      */
     void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
 
@@ -1205,6 +1249,7 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
+     * @since 2.6
      */
     void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
 
@@ -1220,6 +1265,7 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
+     * @since 2.6
      */
     void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
 
@@ -1236,6 +1282,7 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
+     * @since 2.6
      */
     void error(
             String message,
@@ -1263,6 +1310,7 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
+     * @since 2.6
      */
     void error(
             String message,
@@ -1279,7 +1327,7 @@ public interface Logger {
 
     /**
      * Logs exit from a method. Used for methods that do not return anything.
-     * @deprecated Use {@link #traceExit()} instead which performs the same function.
+     * @deprecated Since 2.6, use {@link #traceExit()} instead which performs the same function.
      */
     @Deprecated
     void exit();
@@ -1294,7 +1342,7 @@ public interface Logger {
      * @param <R> The type of the parameter and object being returned.
      * @param result The result being returned from the method call.
      * @return the result.
-     * @deprecated Use {@link #traceExit(Object)} instead which performs the same function.
+     * @deprecated Since 2.6, use {@link #traceExit(Object)} instead which performs the same function.
      */
     @Deprecated
     <R> R exit(R result);
@@ -1344,6 +1392,7 @@ public interface Logger {
      *
      * @param marker The marker data specific to this log statement.
      * @param message the message CharSequence to log.
+     * @since 2.6
      */
     void fatal(Marker marker, CharSequence message);
 
@@ -1354,6 +1403,7 @@ public interface Logger {
      * @param marker The marker data specific to this log statement.
      * @param message the message CharSequence to log.
      * @param throwable the {@code Throwable} to log, including its stack trace.
+     * @since 2.6
      */
     void fatal(Marker marker, CharSequence message, Throwable throwable);
 
@@ -1476,6 +1526,7 @@ public interface Logger {
      * Logs a message CharSequence with the {@link Level#FATAL FATAL} level.
      *
      * @param message the message CharSequence to log.
+     * @since 2.6
      */
     void fatal(CharSequence message);
 
@@ -1485,6 +1536,7 @@ public interface Logger {
      *
      * @param message the message CharSequence to log.
      * @param throwable the {@code Throwable} to log, including its stack trace.
+     * @since 2.6
      */
     void fatal(CharSequence message, Throwable throwable);
 
@@ -1565,6 +1617,7 @@ public interface Logger {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
+     * @since 2.6
      */
     void fatal(Marker marker, String message, Object p0);
 
@@ -1575,6 +1628,7 @@ public interface Logger {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
+     * @since 2.6
      */
     void fatal(Marker marker, String message, Object p0, Object p1);
 
@@ -1586,6 +1640,7 @@ public interface Logger {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
+     * @since 2.6
      */
     void fatal(Marker marker, String message, Object p0, Object p1, Object p2);
 
@@ -1598,6 +1653,7 @@ public interface Logger {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
+     * @since 2.6
      */
     void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3);
 
@@ -1611,6 +1667,7 @@ public interface Logger {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
+     * @since 2.6
      */
     void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
@@ -1625,6 +1682,7 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
+     * @since 2.6
      */
     void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
 
@@ -1640,6 +1698,7 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
+     * @since 2.6
      */
     void fatal(
             Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
@@ -1657,6 +1716,7 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
+     * @since 2.6
      */
     void fatal(
             Marker marker,
@@ -1684,6 +1744,7 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
+     * @since 2.6
      */
     void fatal(
             Marker marker,
@@ -1713,6 +1774,7 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
+     * @since 2.6
      */
     void fatal(
             Marker marker,
@@ -1733,6 +1795,7 @@ public interface Logger {
      *
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
+     * @since 2.6
      */
     void fatal(String message, Object p0);
 
@@ -1742,6 +1805,7 @@ public interface Logger {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
+     * @since 2.6
      */
     void fatal(String message, Object p0, Object p1);
 
@@ -1752,6 +1816,7 @@ public interface Logger {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
+     * @since 2.6
      */
     void fatal(String message, Object p0, Object p1, Object p2);
 
@@ -1763,6 +1828,7 @@ public interface Logger {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
+     * @since 2.6
      */
     void fatal(String message, Object p0, Object p1, Object p2, Object p3);
 
@@ -1775,6 +1841,7 @@ public interface Logger {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
+     * @since 2.6
      */
     void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
@@ -1788,6 +1855,7 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
+     * @since 2.6
      */
     void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
 
@@ -1802,6 +1870,7 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
+     * @since 2.6
      */
     void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
 
@@ -1817,6 +1886,7 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
+     * @since 2.6
      */
     void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
 
@@ -1833,6 +1903,7 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
+     * @since 2.6
      */
     void fatal(
             String message,
@@ -1860,6 +1931,7 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
+     * @since 2.6
      */
     void fatal(
             String message,
@@ -1955,6 +2027,7 @@ public interface Logger {
      *
      * @param marker the marker data specific to this log statement
      * @param message the message CharSequence to log.
+     * @since 2.6
      */
     void info(Marker marker, CharSequence message);
 
@@ -1965,6 +2038,7 @@ public interface Logger {
      * @param marker the marker data specific to this log statement
      * @param message the message CharSequence to log.
      * @param throwable the {@code Throwable} to log, including its stack trace.
+     * @since 2.6
      */
     void info(Marker marker, CharSequence message, Throwable throwable);
 
@@ -2176,6 +2250,7 @@ public interface Logger {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
+     * @since 2.6
      */
     void info(Marker marker, String message, Object p0);
 
@@ -2186,6 +2261,7 @@ public interface Logger {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
+     * @since 2.6
      */
     void info(Marker marker, String message, Object p0, Object p1);
 
@@ -2197,6 +2273,7 @@ public interface Logger {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
+     * @since 2.6
      */
     void info(Marker marker, String message, Object p0, Object p1, Object p2);
 
@@ -2209,6 +2286,7 @@ public interface Logger {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
+     * @since 2.6
      */
     void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3);
 
@@ -2222,6 +2300,7 @@ public interface Logger {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
+     * @since 2.6
      */
     void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
@@ -2236,6 +2315,7 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
+     * @since 2.6
      */
     void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
 
@@ -2251,6 +2331,7 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
+     * @since 2.6
      */
     void info(
             Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
@@ -2268,6 +2349,7 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
+     * @since 2.6
      */
     void info(
             Marker marker,
@@ -2295,6 +2377,7 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
+     * @since 2.6
      */
     void info(
             Marker marker,
@@ -2324,6 +2407,7 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
+     * @since 2.6
      */
     void info(
             Marker marker,
@@ -2344,6 +2428,7 @@ public interface Logger {
      *
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
+     * @since 2.6
      */
     void info(String message, Object p0);
 
@@ -2353,6 +2438,7 @@ public interface Logger {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
+     * @since 2.6
      */
     void info(String message, Object p0, Object p1);
 
@@ -2363,6 +2449,7 @@ public interface Logger {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
+     * @since 2.6
      */
     void info(String message, Object p0, Object p1, Object p2);
 
@@ -2374,6 +2461,7 @@ public interface Logger {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
+     * @since 2.6
      */
     void info(String message, Object p0, Object p1, Object p2, Object p3);
 
@@ -2386,6 +2474,7 @@ public interface Logger {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
+     * @since 2.6
      */
     void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
@@ -2399,6 +2488,7 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
+     * @since 2.6
      */
     void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
 
@@ -2413,6 +2503,7 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
+     * @since 2.6
      */
     void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
 
@@ -2428,6 +2519,7 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
+     * @since 2.6
      */
     void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
 
@@ -2444,6 +2536,7 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
+     * @since 2.6
      */
     void info(
             String message,
@@ -2471,6 +2564,7 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
+     * @since 2.6
      */
     void info(
             String message,
@@ -2651,6 +2745,7 @@ public interface Logger {
      * @param level the logging level
      * @param marker the marker data specific to this log statement
      * @param message the message CharSequence to log.
+     * @since 2.6
      */
     void log(Level level, Marker marker, CharSequence message);
 
@@ -2662,6 +2757,7 @@ public interface Logger {
      * @param marker the marker data specific to this log statement
      * @param message the message CharSequence to log.
      * @param throwable the {@code Throwable} to log, including its stack trace.
+     * @since 2.6
      */
     void log(Level level, Marker marker, CharSequence message, Throwable throwable);
 
@@ -2795,6 +2891,7 @@ public interface Logger {
      *
      * @param level the logging level
      * @param message the message CharSequence to log.
+     * @since 2.6
      */
     void log(Level level, CharSequence message);
 
@@ -2805,6 +2902,7 @@ public interface Logger {
      * @param level the logging level
      * @param message the message CharSequence to log.
      * @param throwable the {@code Throwable} to log, including its stack trace.
+     * @since 2.6
      */
     void log(Level level, CharSequence message, Throwable throwable);
 
@@ -2893,6 +2991,7 @@ public interface Logger {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
+     * @since 2.6
      */
     void log(Level level, Marker marker, String message, Object p0);
 
@@ -2904,6 +3003,7 @@ public interface Logger {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
+     * @since 2.6
      */
     void log(Level level, Marker marker, String message, Object p0, Object p1);
 
@@ -2916,6 +3016,7 @@ public interface Logger {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
+     * @since 2.6
      */
     void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2);
 
@@ -2929,6 +3030,7 @@ public interface Logger {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
+     * @since 2.6
      */
     void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3);
 
@@ -2943,6 +3045,7 @@ public interface Logger {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
+     * @since 2.6
      */
     void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
@@ -2958,6 +3061,7 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
+     * @since 2.6
      */
     void log(
             Level level,
@@ -2983,6 +3087,7 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
+     * @since 2.6
      */
     void log(
             Level level,
@@ -3010,6 +3115,7 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
+     * @since 2.6
      */
     void log(
             Level level,
@@ -3039,6 +3145,7 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
+     * @since 2.6
      */
     void log(
             Level level,
@@ -3070,6 +3177,7 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
+     * @since 2.6
      */
     void log(
             Level level,
@@ -3092,6 +3200,7 @@ public interface Logger {
      * @param level the logging level
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
+     * @since 2.6
      */
     void log(Level level, String message, Object p0);
 
@@ -3102,6 +3211,7 @@ public interface Logger {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
+     * @since 2.6
      */
     void log(Level level, String message, Object p0, Object p1);
 
@@ -3113,6 +3223,7 @@ public interface Logger {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
+     * @since 2.6
      */
     void log(Level level, String message, Object p0, Object p1, Object p2);
 
@@ -3125,6 +3236,7 @@ public interface Logger {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
+     * @since 2.6
      */
     void log(Level level, String message, Object p0, Object p1, Object p2, Object p3);
 
@@ -3138,6 +3250,7 @@ public interface Logger {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
+     * @since 2.6
      */
     void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
@@ -3152,6 +3265,7 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
+     * @since 2.6
      */
     void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
 
@@ -3167,6 +3281,7 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
+     * @since 2.6
      */
     void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
 
@@ -3183,6 +3298,7 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
+     * @since 2.6
      */
     void log(
             Level level,
@@ -3210,6 +3326,7 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
+     * @since 2.6
      */
     void log(
             Level level,
@@ -3239,6 +3356,7 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
+     * @since 2.6
      */
     void log(
             Level level,
@@ -3346,6 +3464,7 @@ public interface Logger {
      *
      * @param marker the marker data specific to this log statement
      * @param message the message CharSequence to log.
+     * @since 2.6
      */
     void trace(Marker marker, CharSequence message);
 
@@ -3357,6 +3476,7 @@ public interface Logger {
      * @param message the message CharSequence to log.
      * @param throwable the {@code Throwable} to log, including its stack trace.
      * @see #debug(String)
+     * @since 2.6
      */
     void trace(Marker marker, CharSequence message, Throwable throwable);
 
@@ -3573,6 +3693,7 @@ public interface Logger {
      * @param marker the marker data specific to this log statement
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
+     * @since 2.6
      */
     void trace(Marker marker, String message, Object p0);
 
@@ -3583,6 +3704,7 @@ public interface Logger {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
+     * @since 2.6
      */
     void trace(Marker marker, String message, Object p0, Object p1);
 
@@ -3594,6 +3716,7 @@ public interface Logger {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
+     * @since 2.6
      */
     void trace(Marker marker, String message, Object p0, Object p1, Object p2);
 
@@ -3606,6 +3729,7 @@ public interface Logger {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
+     * @since 2.6
      */
     void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3);
 
@@ -3619,6 +3743,7 @@ public interface Logger {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
+     * @since 2.6
      */
     void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
@@ -3633,6 +3758,7 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
+     * @since 2.6
      */
     void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
 
@@ -3648,6 +3774,7 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
+     * @since 2.6
      */
     void trace(
             Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
@@ -3665,6 +3792,7 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
+     * @since 2.6
      */
     void trace(
             Marker marker,
@@ -3692,6 +3820,7 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
+     * @since 2.6
      */
     void trace(
             Marker marker,
@@ -3721,6 +3850,7 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
+     * @since 2.6
      */
     void trace(
             Marker marker,
@@ -3741,6 +3871,7 @@ public interface Logger {
      *
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
+     * @since 2.6
      */
     void trace(String message, Object p0);
 
@@ -3750,6 +3881,7 @@ public interface Logger {
      * @param message the message to log; the format depends on the message factory.
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
+     * @since 2.6
      */
     void trace(String message, Object p0, Object p1);
 
@@ -3760,6 +3892,7 @@ public interface Logger {
      * @param p0 parameter to the message.
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
+     * @since 2.6
      */
     void trace(String message, Object p0, Object p1, Object p2);
 
@@ -3771,6 +3904,7 @@ public interface Logger {
      * @param p1 parameter to the message.
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
+     * @since 2.6
      */
     void trace(String message, Object p0, Object p1, Object p2, Object p3);
 
@@ -3783,6 +3917,7 @@ public interface Logger {
      * @param p2 parameter to the message.
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
+     * @since 2.6
      */
     void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4);
 
@@ -3796,6 +3931,7 @@ public interface Logger {
      * @param p3 parameter to the message.
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
+     * @since 2.6
      */
     void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5);
 
@@ -3810,6 +3946,7 @@ public interface Logger {
      * @param p4 parameter to the message.
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
+     * @since 2.6
      */
     void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6);
 
@@ -3825,6 +3962,7 @@ public interface Logger {
      * @param p5 parameter to the message.
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
+     * @since 2.6
      */
     void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7);
 
@@ -3841,6 +3979,7 @@ public interface Logger {
      * @param p6 parameter to the message.
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
+     * @since 2.6
      */
     void trace(
             String message,
@@ -3868,6 +4007,7 @@ public interface Logger {
      * @param p7 parameter to the message.
      * @param p8 parameter to the message.
      * @param p9 parameter to the message.
+     * @since 2.6
      */
     void trace(
             String message,
@@ -4110,6 +4250,7 @@ public interface Logger {
      *
      * @param marker the marker data specific to this log statement
      * @param message the message CharSequence to log.
+     * @since 2.6
      */
     void warn(Marker marker, CharSequence message);
 
@@ -4120,6 +4261,7 @@ public interface Logger {
      * @param marker the marker data specific to this log statement
      * @param message the message CharSequence to log.
      * @param throwable the {@code Throwable} to log, including its stack trace.
+     * @since 2.6
      */
     void warn(Marker marker, CharSequence message, Throwable throwable);
 
@@ -4242,6 +4384,7 @@ public interface Logger {
      * Logs a message CharSequence with the {@link Level#WARN WARN} level.
      *
      * @param message the message CharSequence to log.
+     * @since 2.6
      */
     void warn(CharSequence message);
 
@@ -4251,6 +4394,7 @@ public interface Logger {
      *
      * @param message the message CharSequence to log.
      * @param throwable the {@code Throwable} to log, including its stack trace.
+     * @since 2.6
      */
     void warn(CharSequence message, Throwable throwable);
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -699,7 +699,7 @@ public interface Logger {
     /**
      * Logs entry to a method. Used when the method in question has no parameters or when the parameters should not be
      * logged.
-     * @deprecated :uUse {@link #traceEntry()} instead which performs the same function.
+     * @deprecated Since 2.6, use {@link #traceEntry()} instead which performs the same function.
      */
     @Deprecated
     void entry();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -1971,7 +1971,7 @@ public interface Logger {
      * Gets the flow message factory used to convert messages into flow messages.
      *
      * @return the flow message factory, as an instance of {@link FlowMessageFactory}.
-     * @since 2.20
+     * @since 2.20.0
      */
     FlowMessageFactory getFlowMessageFactory();
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/Logger.java
@@ -721,7 +721,7 @@ public interface Logger {
      * </p>
      *
      * @param params The parameters to the method.
-     * @deprecated Use {@link #traceEntry(String, Object...)} instead which performs the same function.
+     * @deprecated since 2.11.2, use {@link #traceEntry(String, Object...)} instead which performs the same function.
      */
     @Deprecated
     void entry(Object... params);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/ThreadContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/ThreadContext.java
@@ -214,6 +214,8 @@ public final class ThreadContext {
 
     /**
      * <em>Consider private, used for testing.</em>
+     *
+     * @since 2.20.0
      */
     public static void init() {
         final PropertiesUtil properties = PropertiesUtil.getProperties();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/internal/LogManagerStatus.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/internal/LogManagerStatus.java
@@ -18,6 +18,8 @@ package org.apache.logging.log4j.internal;
 
 /**
  * Keeps track of LogManager initialization status;
+ *
+ * @since 2.14.1
  */
 public class LogManagerStatus {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/internal/LogManagerStatus.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/internal/LogManagerStatus.java
@@ -18,8 +18,6 @@ package org.apache.logging.log4j.internal;
 
 /**
  * Keeps track of LogManager initialization status;
- *
- * @since 2.14.1
  */
 public class LogManagerStatus {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/DefaultFlowMessageFactory.java
@@ -32,6 +32,9 @@ public class DefaultFlowMessageFactory implements FlowMessageFactory, Serializab
     private static final String ENTRY_DEFAULT_PREFIX = "Enter";
     private static final long serialVersionUID = 8578655591131397576L;
 
+    /**
+     * @since 2.24.0
+     */
     public static final FlowMessageFactory INSTANCE = new DefaultFlowMessageFactory();
 
     private final String entryText;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/FlowMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/FlowMessageFactory.java
@@ -28,7 +28,7 @@ public interface FlowMessageFactory {
      * @param message format string
      * @param params  parameters
      * @return the new entry message
-     * @since 2.20
+     * @since 2.20.0
      */
     EntryMessage newEntryMessage(String message, Object... params);
 
@@ -46,7 +46,7 @@ public interface FlowMessageFactory {
      * @param format a format string
      * @param result the return value
      * @return the new exit message
-     * @since 2.20
+     * @since 2.20.0
      */
     ExitMessage newExitMessage(String format, Object result);
 
@@ -55,7 +55,7 @@ public interface FlowMessageFactory {
      *
      * @param message the original entry message
      * @return the new exit message
-     * @since 2.20
+     * @since 2.20.0
      */
     ExitMessage newExitMessage(Message message);
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
@@ -598,7 +598,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      *
      * @param candidateKey The candidate key.
      * @return The candidate key.
-     * @since 2.12
+     * @since 2.12.0
      */
     protected String toKey(final String candidateKey) {
         return candidateKey;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
@@ -740,6 +740,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param candidateKey The name of the data item.
      * @param value The value of the data item.
      * @return {@code this}
+     * @since 2.5
      */
     @SuppressWarnings("unchecked")
     public M with(final String candidateKey, final String value) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
@@ -420,6 +420,9 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
         MapMessageJsonFormatter.format(sb, data);
     }
 
+    /**
+     * @since 2.11.2
+     */
     protected void asJavaUnquoted(final StringBuilder sb) {
         asJava(sb, false);
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
@@ -79,6 +79,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
          *
          * @param format a MapFormat name
          * @return a MapFormat
+         * @since 2.8
          */
         public static MapFormat lookupIgnoreCase(final String format) {
             return XML.name().equalsIgnoreCase(format)
@@ -96,6 +97,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
          * All {@code MapFormat} names.
          *
          * @return All {@code MapFormat} names.
+         * @since 2.8
          */
         public static String[] names() {
             return new String[] {XML.name(), JSON.name(), JAVA.name(), JAVA_UNQUOTED.name()};

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MapMessage.java
@@ -117,6 +117,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * Constructs a new instance.
      *
      * @param  initialCapacity the initial capacity.
+     * @since 2.9.0
      */
     public MapMessage(final int initialCapacity) {
         this.data = new SortedArrayStringMap(initialCapacity);
@@ -191,7 +192,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      *
      * @param key the key whose presence to check. May be {@code null}.
      * @return {@code true} if this data structure contains the specified key, {@code false} otherwise
-     * @since 2.9
+     * @since 2.9.0
      */
     public boolean containsKey(final String key) {
         return data.containsKey(key);
@@ -279,10 +280,9 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param action The action to be performed for each key-value pair in this collection
      * @param <CV> type of the consumer value
      * @throws java.util.ConcurrentModificationException some implementations may not support structural modifications
-     *          to this data structure while iterating over the contents with {@link #forEach(BiConsumer)} or
-     *          {@link #forEach(TriConsumer, Object)}.
+     *          to this data structure while iterating over the contents.
      * @see ReadOnlyStringMap#forEach(BiConsumer)
-     * @since 2.9
+     * @since 2.9.0
      */
     public <CV> void forEach(final BiConsumer<String, ? super CV> action) {
         data.forEach(action);
@@ -308,10 +308,9 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param <CV> type of the consumer value
      * @param <S> type of the third parameter
      * @throws java.util.ConcurrentModificationException some implementations may not support structural modifications
-     *          to this data structure while iterating over the contents with {@link #forEach(BiConsumer)} or
-     *          {@link #forEach(TriConsumer, Object)}.
+     *          to this data structure while iterating over the contents.
      * @see ReadOnlyStringMap#forEach(TriConsumer, Object)
-     * @since 2.9
+     * @since 2.9.0
      */
     public <CV, S> void forEach(final TriConsumer<String, ? super CV, S> action, final S state) {
         data.forEach(action, state);
@@ -504,7 +503,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     /**
      * Default implementation does nothing.
      *
-     * @since 2.9
+     * @since 2.9.0
      */
     protected void validate(final String key, final boolean value) {
         // do nothing
@@ -513,7 +512,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     /**
      * Default implementation does nothing.
      *
-     * @since 2.9
+     * @since 2.9.0
      */
     protected void validate(final String key, final byte value) {
         // do nothing
@@ -522,7 +521,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     /**
      * Default implementation does nothing.
      *
-     * @since 2.9
+     * @since 2.9.0
      */
     protected void validate(final String key, final char value) {
         // do nothing
@@ -531,7 +530,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     /**
      * Default implementation does nothing.
      *
-     * @since 2.9
+     * @since 2.9.0
      */
     protected void validate(final String key, final double value) {
         // do nothing
@@ -540,7 +539,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     /**
      * Default implementation does nothing.
      *
-     * @since 2.9
+     * @since 2.9.0
      */
     protected void validate(final String key, final float value) {
         // do nothing
@@ -549,7 +548,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     /**
      * Default implementation does nothing.
      *
-     * @since 2.9
+     * @since 2.9.0
      */
     protected void validate(final String key, final int value) {
         // do nothing
@@ -558,7 +557,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     /**
      * Default implementation does nothing.
      *
-     * @since 2.9
+     * @since 2.9.0
      */
     protected void validate(final String key, final long value) {
         // do nothing
@@ -567,7 +566,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     /**
      * Default implementation does nothing.
      *
-     * @since 2.9
+     * @since 2.9.0
      */
     protected void validate(final String key, final Object value) {
         // do nothing
@@ -576,7 +575,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     /**
      * Default implementation does nothing.
      *
-     * @since 2.9
+     * @since 2.9.0
      */
     protected void validate(final String key, final short value) {
         // do nothing
@@ -585,7 +584,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
     /**
      * Default implementation does nothing.
      *
-     * @since 2.9
+     * @since 2.9.0
      */
     protected void validate(final String key, final String value) {
         // do nothing
@@ -607,7 +606,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param candidateKey The name of the data item.
      * @param value The value of the data item.
      * @return this object
-     * @since 2.9
+     * @since 2.9.0
      */
     @SuppressWarnings("unchecked")
     public M with(final String candidateKey, final boolean value) {
@@ -622,7 +621,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param candidateKey The name of the data item.
      * @param value The value of the data item.
      * @return this object
-     * @since 2.9
+     * @since 2.9.0
      */
     @SuppressWarnings("unchecked")
     public M with(final String candidateKey, final byte value) {
@@ -637,7 +636,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param candidateKey The name of the data item.
      * @param value The value of the data item.
      * @return this object
-     * @since 2.9
+     * @since 2.9.0
      */
     @SuppressWarnings("unchecked")
     public M with(final String candidateKey, final char value) {
@@ -652,7 +651,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param candidateKey The name of the data item.
      * @param value The value of the data item.
      * @return this object
-     * @since 2.9
+     * @since 2.9.0
      */
     @SuppressWarnings("unchecked")
     public M with(final String candidateKey, final double value) {
@@ -667,7 +666,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param candidateKey The name of the data item.
      * @param value The value of the data item.
      * @return this object
-     * @since 2.9
+     * @since 2.9.0
      */
     @SuppressWarnings("unchecked")
     public M with(final String candidateKey, final float value) {
@@ -682,7 +681,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param candidateKey The name of the data item.
      * @param value The value of the data item.
      * @return this object
-     * @since 2.9
+     * @since 2.9.0
      */
     @SuppressWarnings("unchecked")
     public M with(final String candidateKey, final int value) {
@@ -697,7 +696,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param candidateKey The name of the data item.
      * @param value The value of the data item.
      * @return this object
-     * @since 2.9
+     * @since 2.9.0
      */
     @SuppressWarnings("unchecked")
     public M with(final String candidateKey, final long value) {
@@ -712,7 +711,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param candidateKey The name of the data item.
      * @param value The value of the data item.
      * @return this object
-     * @since 2.9
+     * @since 2.9.0
      */
     @SuppressWarnings("unchecked")
     public M with(final String candidateKey, final Object value) {
@@ -727,7 +726,7 @@ public class MapMessage<M extends MapMessage<M, V>, V> implements MultiFormatStr
      * @param candidateKey The name of the data item.
      * @param value The value of the data item.
      * @return this object
-     * @since 2.9
+     * @since 2.9.0
      */
     @SuppressWarnings("unchecked")
     public M with(final String candidateKey, final short value) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageCollectionMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/MessageCollectionMessage.java
@@ -19,5 +19,6 @@ package org.apache.logging.log4j.message;
 /**
  * A Message that is a collection of Messages.
  * @param <T> The Message type.
+ * @since 2.9.0
  */
 public interface MessageCollectionMessage<T> extends Message, Iterable<T> {}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterConsumer.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterConsumer.java
@@ -26,7 +26,7 @@ package org.apache.logging.log4j.message;
  *
  * @param <S> state data
  * @see ReusableMessage
- * @since 2.11
+ * @since 2.11.0
  */
 public interface ParameterConsumer<S> {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterVisitable.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterVisitable.java
@@ -22,7 +22,7 @@ import org.apache.logging.log4j.util.PerformanceSensitive;
  * Allows message parameters to be iterated over without any allocation
  * or memory copies.
  *
- * @since 2.11
+ * @since 2.11.0
  */
 @PerformanceSensitive("allocation")
 public interface ParameterVisitable {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedMessage.java
@@ -112,7 +112,7 @@ public class ParameterizedMessage implements Message, StringBuilderFormattable {
      * @param pattern a formatting pattern
      * @param args arguments to be formatted
      * @param throwable a {@link Throwable}
-     * @deprecated Use {@link #ParameterizedMessage(String, Object[], Throwable)} instead
+     * @deprecated Since 2.6, use {@link #ParameterizedMessage(String, Object[], Throwable)} instead
      */
     @InlineMe(
             replacement = "this(pattern, Arrays.stream(args).toArray(Object[]::new), throwable)",

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedNoReferenceMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterizedNoReferenceMessageFactory.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.status.StatusLogger;
  * This class does <em>not</em> implement any {@link MessageFactory2} methods and lets the superclass funnel those calls
  * through {@link #newMessage(String, Object...)}.
  * </p>
+ * @since 2.5
  */
 public final class ParameterizedNoReferenceMessageFactory extends AbstractMessageFactory {
     private static final long serialVersionUID = 5027639245636870500L;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableMessageFactory.java
@@ -37,7 +37,7 @@ import org.apache.logging.log4j.util.PerformanceSensitive;
 public final class ReusableMessageFactory implements MessageFactory2, Serializable {
 
     /**
-     * Instance of ReusableMessageFactory..
+     * Instance of ReusableMessageFactory.
      */
     public static final ReusableMessageFactory INSTANCE = new ReusableMessageFactory();
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableObjectMessage.java
@@ -131,6 +131,9 @@ public class ReusableObjectMessage implements ReusableMessage, ParameterVisitabl
         return new ObjectMessage(obj);
     }
 
+    /**
+     * @since 2.11.1
+     */
     @Override
     public void clear() {
         obj = null;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
@@ -135,18 +135,27 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return null;
     }
 
+    /**
+     * @since 2.24.0
+     */
     public ReusableParameterizedMessage set(final String messagePattern, final Object... arguments) {
         init(messagePattern, arguments == null ? 0 : arguments.length, arguments);
         varargs = arguments;
         return this;
     }
 
+    /**
+     * @since 2.24.0
+     */
     public ReusableParameterizedMessage set(final String messagePattern, final Object p0) {
         params[0] = p0;
         init(messagePattern, 1, params);
         return this;
     }
 
+    /**
+     * @since 2.24.0
+     */
     public ReusableParameterizedMessage set(final String messagePattern, final Object p0, final Object p1) {
         params[0] = p0;
         params[1] = p1;
@@ -154,6 +163,9 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
+    /**
+     * @since 2.24.0
+     */
     public ReusableParameterizedMessage set(
             final String messagePattern, final Object p0, final Object p1, final Object p2) {
         params[0] = p0;
@@ -163,6 +175,9 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
+    /**
+     * @since 2.24.0
+     */
     public ReusableParameterizedMessage set(
             final String messagePattern, final Object p0, final Object p1, final Object p2, final Object p3) {
         params[0] = p0;
@@ -173,6 +188,9 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
+    /**
+     * @since 2.24.0
+     */
     public ReusableParameterizedMessage set(
             final String messagePattern,
             final Object p0,
@@ -189,6 +207,9 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
+    /**
+     * @since 2.24.0
+     */
     public ReusableParameterizedMessage set(
             final String messagePattern,
             final Object p0,
@@ -207,6 +228,9 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
+    /**
+     * @since 2.24.0
+     */
     public ReusableParameterizedMessage set(
             final String messagePattern,
             final Object p0,
@@ -227,6 +251,9 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
+    /**
+     * @since 2.24.0
+     */
     public ReusableParameterizedMessage set(
             final String messagePattern,
             final Object p0,
@@ -249,6 +276,9 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
+    /**
+     * @since 2.24.0
+     */
     public ReusableParameterizedMessage set(
             final String messagePattern,
             final Object p0,
@@ -273,6 +303,9 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
         return this;
     }
 
+    /**
+     * @since 2.24.0
+     */
     public ReusableParameterizedMessage set(
             final String messagePattern,
             final Object p0,

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableParameterizedMessage.java
@@ -369,6 +369,9 @@ public class ReusableParameterizedMessage implements ReusableMessage, ParameterV
                 + ", throwableProvided=" + (getThrowable() != null) + ']';
     }
 
+    /**
+     * @since 2.11.1
+     */
     @Override
     public void clear() { // LOG4J2-1583
         // This method does not clear parameter values, those are expected to be swapped to a

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ReusableSimpleMessage.java
@@ -105,6 +105,9 @@ public class ReusableSimpleMessage implements ReusableMessage, CharSequence, Par
         return charSequence.subSequence(start, end);
     }
 
+    /**
+     * @since 2.11.1
+     */
     @Override
     public void clear() {
         charSequence = null;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StringMapMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StringMapMessage.java
@@ -22,7 +22,7 @@ import org.apache.logging.log4j.util.PerformanceSensitive;
 /**
  * A {@link StringMapMessage} typed to {@link String}-only values. This is like the MapMessage class before 2.9.
  *
- * @since 2.9
+ * @since 2.9.0
  */
 @PerformanceSensitive("allocation")
 @AsynchronouslyFormattable

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataCollectionMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataCollectionMessage.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.util.StringBuilderFormattable;
 
 /**
  * A collection of StructuredDataMessages.
+ * @since 2.9.0
  */
 public class StructuredDataCollectionMessage
         implements StringBuilderFormattable, MessageCollectionMessage<StructuredDataMessage> {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
@@ -61,7 +61,7 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
     /**
      * Creates a StructuredDataId based on the name.
      * @param name The Structured Data Element name (maximum length is 32)
-     * @since 2.9
+     * @since 2.9.0
      */
     public StructuredDataId(final String name) {
         this(name, null, null, MAX_LENGTH);
@@ -71,7 +71,7 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * Creates a StructuredDataId based on the name.
      * @param name The Structured Data Element name.
      * @param maxLength The maximum length of the name.
-     * @since 2.9
+     * @since 2.9.0
      */
     public StructuredDataId(final String name, final int maxLength) {
         this(name, null, null, maxLength);
@@ -94,7 +94,7 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @param required The list of keys that are required for this id.
      * @param optional The list of keys that are optional for this id.
      * @param maxLength The maximum length of the id's name.
-     * @since 2.9
+     * @since 2.9.0
      */
     public StructuredDataId(final String name, final String[] required, final String[] optional, int maxLength) {
         int index = -1;
@@ -192,7 +192,7 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @param required The list of keys that are required for this id.
      * @param optional The list of keys that are optional for this id.
      * @param maxLength The maximum length of the StructuredData Id key.
-     * @since 2.9
+     * @since 2.9.0
      * @deprecated Use {@link #StructuredDataId(String, String, String[], String[], int)} instead.
      */
     @InlineMe(replacement = "this(name, String.valueOf(enterpriseNumber), required, optional, maxLength)")

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataId.java
@@ -46,6 +46,7 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
 
     /**
      * Reserved enterprise number.
+     * @since 2.18.0
      */
     public static final String RESERVED = "-1";
 
@@ -127,6 +128,7 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @param enterpriseNumber The enterprise number.
      * @param required The list of keys that are required for this id.
      * @param optional The list of keys that are optional for this id.
+     * @since 2.18.0
      */
     public StructuredDataId(
             final String name, final String enterpriseNumber, final String[] required, final String[] optional) {
@@ -140,7 +142,7 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @param enterpriseNumber The enterprise number.
      * @param required The list of keys that are required for this id.
      * @param optional The list of keys that are optional for this id.
-     * @deprecated Use {@link #StructuredDataId(String, String, String[], String[])} instead.
+     * @deprecated Since 2.18.0, use {@link #StructuredDataId(String, String, String[], String[])} instead.
      */
     @Deprecated
     @InlineMe(replacement = "this(name, String.valueOf(enterpriseNumber), required, optional)")
@@ -157,7 +159,7 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @param required The list of keys that are required for this id.
      * @param optional The list of keys that are optional for this id.
      * @param maxLength The maximum length of the StructuredData Id key.
-     * @since 2.9
+     * @since 2.18.0
      */
     public StructuredDataId(
             final String name,
@@ -193,7 +195,7 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @param optional The list of keys that are optional for this id.
      * @param maxLength The maximum length of the StructuredData Id key.
      * @since 2.9.0
-     * @deprecated Use {@link #StructuredDataId(String, String, String[], String[], int)} instead.
+     * @deprecated Since 2.18.0, use {@link #StructuredDataId(String, String, String[], String[], int)} instead.
      */
     @InlineMe(replacement = "this(name, String.valueOf(enterpriseNumber), required, optional, maxLength)")
     @Deprecated
@@ -225,6 +227,7 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @param defaultId The default id to use if this StructuredDataId doesn't have a name.
      * @param anEnterpriseNumber The enterprise number.
      * @return a StructuredDataId.
+     * @since 2.18.0
      */
     public StructuredDataId makeId(final String defaultId, final String anEnterpriseNumber) {
         String id;
@@ -252,7 +255,7 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * @param defaultId The default id to use if this StructuredDataId doesn't have a name.
      * @param anEnterpriseNumber The enterprise number.
      * @return a StructuredDataId.
-     * @deprecated Use {@link StructuredDataId#makeId(String, String)} instead
+     * @deprecated Since 2.18.0, use {@link StructuredDataId#makeId(String, String)} instead
      */
     @Deprecated
     // This method should have been `final` from the start, we don't expect anyone to override it.
@@ -292,6 +295,7 @@ public class StructuredDataId implements Serializable, StringBuilderFormattable 
      * Returns the enterprise number.
      *
      * @return the enterprise number.
+     * @since 2.18.0
      */
     public String getEnterpriseNumber() {
         return enterpriseNumber;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
@@ -318,6 +318,7 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param structuredDataId The SD-ID as described in RFC 5424. If null the value in the StructuredData
      *                         will be used.
      * @param sb The StringBuilder to append the formatted message to.
+     * @since 2.8
      */
     public final void asString(final Format format, final StructuredDataId structuredDataId, final StringBuilder sb) {
         final boolean full = Format.FULL.equals(format);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
@@ -73,7 +73,7 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param msg The message.
      * @param type The message type.
      * @param maxLength The maximum length of keys;
-     * @since 2.9
+     * @since 2.9.0
      */
     public StructuredDataMessage(final String id, final String msg, final String type, final int maxLength) {
         this.id = new StructuredDataId(id, null, null, maxLength);
@@ -102,7 +102,7 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param type The message type.
      * @param data The StructuredData map.
      * @param maxLength The maximum length of keys;
-     * @since 2.9
+     * @since 2.9.0
      */
     public StructuredDataMessage(
             final String id, final String msg, final String type, final Map<String, String> data, final int maxLength) {
@@ -129,7 +129,7 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param msg The message.
      * @param type The message type.
      * @param maxLength The maximum length of keys;
-     * @since 2.9
+     * @since 2.9.0
      */
     public StructuredDataMessage(final StructuredDataId id, final String msg, final String type, final int maxLength) {
         this.id = id;
@@ -159,7 +159,7 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
      * @param type The message type.
      * @param data The StructuredData map.
      * @param maxLength The maximum length of keys;
-     * @since 2.9
+     * @since 2.9.0
      */
     public StructuredDataMessage(
             final StructuredDataId id,
@@ -521,6 +521,9 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
         validateKey(key);
     }
 
+    /**
+     * @since 2.9.0
+     */
     protected void validateKey(final String key) {
         if (maxLength > 0 && key.length() > maxLength) {
             throw new IllegalArgumentException(

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadDumpMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadDumpMessage.java
@@ -162,8 +162,10 @@ public class ThreadDumpMessage implements Message, StringBuilderFormattable {
      * <p>
      * Implementations of this class are loaded via the standard java Service Provider interface.
      * </p>
+     *
+     * @since 2.9.0
      */
-    public static interface ThreadInfoFactory {
+    public interface ThreadInfoFactory {
         Map<ThreadInformation, StackTraceElement[]> createThreadInfo();
     }
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadInformation.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadInformation.java
@@ -18,6 +18,8 @@ package org.apache.logging.log4j.message;
 
 /**
  * Interface used to print basic or extended thread information.
+ *
+ * @since 2.9.0
  */
 public interface ThreadInformation {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContextFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/simple/SimpleLoggerContextFactory.java
@@ -27,6 +27,8 @@ public class SimpleLoggerContextFactory implements LoggerContextFactory {
 
     /**
      * Singleton instance.
+     *
+     * @since 2.17.2
      */
     public static final SimpleLoggerContextFactory INSTANCE = new SimpleLoggerContextFactory();
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -138,6 +138,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param name the logger name (if null, will be derived from this class)
      * @param messageFactory the {@link Message} factory (if null, {@link ParameterizedMessageFactory} will be used)
      * @param flowMessageFactory the {@link org.apache.logging.log4j.message.FlowMessage} factory (if null, {@link DefaultFlowMessageFactory} will be used)
+     * @since 2.24.0
      */
     protected AbstractLogger(
             final String name, final MessageFactory messageFactory, final FlowMessageFactory flowMessageFactory) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -679,18 +679,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         return flowMessage;
     }
 
-    /**
-     * @deprecated since 2.11.0
-     */
     @Deprecated
     @Override
     public void entry() {
         entry(FQCN, (Object[]) null);
     }
 
-    /**
-     * @deprecated since 2.22.0, use {@link #traceEntry(String, Object...)} instead.
-     */
     @Deprecated
     @Override
     public void entry(final Object... params) {
@@ -1095,18 +1089,12 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
-    /**
-     * @deprecated since 2.11.0
-     */
     @Deprecated
     @Override
     public void exit() {
         exit(FQCN, (Object) null);
     }
 
-    /**
-     * @deprecated since 2.11.0
-     */
     @Deprecated
     @Override
     public <R> R exit(final R result) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -2946,6 +2946,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * one if a single logging call without nested logging calls has been made, or more depending on the level of
      * nesting.
      * @return the depth of the nested logging calls in the current Thread
+     * @since 2.10.0
      */
     public static int getRecursionDepth() {
         return getRecursionDepthHolder()[0];

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -89,6 +89,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
 
     /**
      * The default FlowMessageFactory class.
+     * @since 2.6
      */
     public static final Class<? extends FlowMessageFactory> DEFAULT_FLOW_MESSAGE_FACTORY_CLASS =
             DefaultFlowMessageFactory.class;
@@ -584,6 +585,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param fqcn The fully qualified class name of the <b>caller</b>.
      * @param format Format String for the parameters.
      * @param paramSuppliers The Suppliers of the parameters.
+     * @since 2.6
      */
     @SuppressWarnings("deprecation")
     protected EntryMessage enter(final String fqcn, final String format, final Supplier<?>... paramSuppliers) {
@@ -605,6 +607,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param fqcn The fully qualified class name of the <b>caller</b>.
      * @param format The format String for the parameters.
      * @param paramSuppliers The parameters to the method.
+     * @since 2.6
      */
     @Deprecated
     protected EntryMessage enter(final String fqcn, final String format, final MessageSupplier... paramSuppliers) {
@@ -621,6 +624,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param fqcn The fully qualified class name of the <b>caller</b>.
      * @param format The format String for the parameters.
      * @param params The parameters to the method.
+     * @since 2.6
      */
     protected EntryMessage enter(final String fqcn, final String format, final Object... params) {
         EntryMessage entryMsg = null;
@@ -640,6 +644,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      *
      * @param fqcn The fully qualified class name of the <b>caller</b>.
      * @param messageSupplier The Supplier of the Message.
+     * @since 2.6
      */
     @Deprecated
     protected EntryMessage enter(final String fqcn, final MessageSupplier messageSupplier) {
@@ -702,10 +707,16 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         }
     }
 
+    /**
+     * @since 2.6
+     */
     protected EntryMessage entryMsg(final String format, final Object... params) {
         return flowMessageFactory.newEntryMessage(format, params);
     }
 
+    /**
+     * @since 2.6
+     */
     protected EntryMessage entryMsg(final String format, final MessageSupplier... paramSuppliers) {
         final int count = paramSuppliers == null ? 0 : paramSuppliers.length;
         final Object[] params = new Object[count];
@@ -715,7 +726,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         return entryMsg(format, params);
     }
 
-    @SuppressWarnings("deprecation")
+    /**
+     * @since 2.6
+     */
     protected EntryMessage entryMsg(final String format, final Supplier<?>... paramSuppliers) {
         return entryMsg(format, LambdaUtil.getAll(paramSuppliers));
     }
@@ -1109,6 +1122,7 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
      * @param <R> The type of the parameter and object being returned.
      * @param result The result being returned from the method call.
      * @return the return value passed to this method.
+     * @since 2.6
      */
     protected <R> R exit(final String fqcn, final String format, final R result) {
         if (isEnabled(Level.TRACE, EXIT_MARKER, (CharSequence) null, null)) {
@@ -1117,6 +1131,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         return result;
     }
 
+    /**
+     * @since 2.6
+     */
     protected Message exitMsg(final String format, final Object result) {
         return flowMessageFactory.newExitMessage(format, result);
     }
@@ -2570,6 +2587,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         }
     }
 
+    /**
+     * @since 2.6
+     */
     protected void logMessage(
             final String fqcn,
             final Level level,
@@ -2638,12 +2658,18 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
+    /**
+     * @since 2.6
+     */
     protected void logMessage(
             final String fqcn, final Level level, final Marker marker, final String message, final Object p0) {
         final Message msg = messageFactory.newMessage(message, p0);
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
+    /**
+     * @since 2.6
+     */
     protected void logMessage(
             final String fqcn,
             final Level level,
@@ -2655,6 +2681,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
+    /**
+     * @since 2.6
+     */
     protected void logMessage(
             final String fqcn,
             final Level level,
@@ -2667,6 +2696,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
+    /**
+     * @since 2.6
+     */
     protected void logMessage(
             final String fqcn,
             final Level level,
@@ -2680,6 +2712,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
+    /**
+     * @since 2.6
+     */
     protected void logMessage(
             final String fqcn,
             final Level level,
@@ -2694,6 +2729,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
+    /**
+     * @since 2.6
+     */
     protected void logMessage(
             final String fqcn,
             final Level level,
@@ -2709,6 +2747,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
+    /**
+     * @since 2.6
+     */
     protected void logMessage(
             final String fqcn,
             final Level level,
@@ -2725,6 +2766,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
+    /**
+     * @since 2.6
+     */
     protected void logMessage(
             final String fqcn,
             final Level level,
@@ -2742,6 +2786,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
+    /**
+     * @since 2.6
+     */
     protected void logMessage(
             final String fqcn,
             final Level level,
@@ -2760,6 +2807,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
+    /**
+     * @since 2.6
+     */
     protected void logMessage(
             final String fqcn,
             final Level level,

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -687,6 +687,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         entry(FQCN, (Object[]) null);
     }
 
+    /**
+     * @deprecated since 2.22.0, use {@link #traceEntry(String, Object...)} instead.
+     */
     @Deprecated
     @Override
     public void entry(final Object... params) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -2870,6 +2870,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         }
     }
 
+    /**
+     * @since 2.12.1
+     */
     protected void log(
             final Level level,
             final Marker marker,
@@ -3813,6 +3816,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logIfEnabled(FQCN, Level.WARN, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
+    /**
+     * @since 2.12.1
+     */
     protected boolean requiresLocation() {
         return false;
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -2588,6 +2588,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, messageFactory.newMessage(message), throwable);
     }
 
+    /**
+     * @since 2.4
+     */
     protected void logMessage(
             final String fqcn,
             final Level level,
@@ -2600,7 +2603,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, message, effectiveThrowable);
     }
 
-    @SuppressWarnings("deprecation")
+    /**
+     * @since 2.4
+     */
     protected void logMessage(
             final String fqcn,
             final Level level,
@@ -2774,7 +2779,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logMessageSafely(fqcn, level, marker, msg, msg.getThrowable());
     }
 
-    @SuppressWarnings("deprecation")
+    /**
+     * @since 2.4
+     */
     protected void logMessage(
             final String fqcn,
             final Level level,

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLogger.java
@@ -678,6 +678,9 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         return flowMessage;
     }
 
+    /**
+     * @deprecated since 2.11.0
+     */
     @Deprecated
     @Override
     public void entry() {
@@ -1088,12 +1091,18 @@ public abstract class AbstractLogger implements ExtendedLogger, LocationAwareLog
         logIfEnabled(FQCN, Level.ERROR, null, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
     }
 
+    /**
+     * @deprecated since 2.11.0
+     */
     @Deprecated
     @Override
     public void exit() {
         exit(FQCN, (Object) null);
     }
 
+    /**
+     * @deprecated since 2.11.0
+     */
     @Deprecated
     @Override
     public <R> R exit(final R result) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLoggerAdapter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/AbstractLoggerAdapter.java
@@ -94,6 +94,8 @@ public abstract class AbstractLoggerAdapter<L> implements LoggerAdapter<L>, Logg
 
     /**
      * For unit testing. Consider to be private.
+     *
+     * @since 2.12.1
      */
     public Set<LoggerContext> getLoggerContexts() {
         return new HashSet<>(registry.keySet());

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/DefaultThreadContextMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/DefaultThreadContextMap.java
@@ -97,6 +97,9 @@ public class DefaultThreadContextMap implements ThreadContextMap, ReadOnlyString
         }
     }
 
+    /**
+     * @since 2.8
+     */
     public void removeAll(final Iterable<String> keys) {
         final Object[] state = localState.get();
         if (state != null) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLogger.java
@@ -633,6 +633,7 @@ public interface ExtendedLogger extends Logger {
      * @param marker A Marker or null.
      * @param msgSupplier A function, which when called, produces the desired log message.
      * @param t the exception to log, including its stack trace.
+     * @since 2.4
      */
     void logIfEnabled(String fqcn, Level level, Marker marker, MessageSupplier msgSupplier, Throwable t);
 
@@ -645,6 +646,7 @@ public interface ExtendedLogger extends Logger {
      * @param marker A Marker or null.
      * @param message The message format.
      * @param paramSuppliers An array of functions, which when called, produce the desired log message parameters.
+     * @since 2.4
      */
     @SuppressWarnings("deprecation")
     void logIfEnabled(String fqcn, Level level, Marker marker, String message, Supplier<?>... paramSuppliers);
@@ -658,6 +660,7 @@ public interface ExtendedLogger extends Logger {
      * @param marker A Marker or null.
      * @param msgSupplier A function, which when called, produces the desired log message.
      * @param t the exception to log, including its stack trace.
+     * @since 2.4
      */
     @SuppressWarnings("deprecation")
     void logIfEnabled(String fqcn, Level level, Marker marker, Supplier<?> msgSupplier, Throwable t);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ExtendedLogger.java
@@ -48,6 +48,7 @@ public interface ExtendedLogger extends Logger {
      * @param message The message.
      * @param t A Throwable.
      * @return True if logging is enabled, false otherwise.
+     * @since 2.6
      */
     boolean isEnabled(Level level, Marker marker, CharSequence message, Throwable t);
 
@@ -102,6 +103,7 @@ public interface ExtendedLogger extends Logger {
      * @param message The message.
      * @param p0 the message parameters
      * @return True if logging is enabled, false otherwise.
+     * @since 2.6
      */
     boolean isEnabled(Level level, Marker marker, String message, Object p0);
 
@@ -114,6 +116,7 @@ public interface ExtendedLogger extends Logger {
      * @param p0 the message parameters
      * @param p1 the message parameters
      * @return True if logging is enabled, false otherwise.
+     * @since 2.6
      */
     boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1);
 
@@ -127,6 +130,7 @@ public interface ExtendedLogger extends Logger {
      * @param p1 the message parameters
      * @param p2 the message parameters
      * @return True if logging is enabled, false otherwise.
+     * @since 2.6
      */
     boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2);
 
@@ -141,6 +145,7 @@ public interface ExtendedLogger extends Logger {
      * @param p2 the message parameters
      * @param p3 the message parameters
      * @return True if logging is enabled, false otherwise.
+     * @since 2.6
      */
     boolean isEnabled(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3);
 
@@ -156,6 +161,7 @@ public interface ExtendedLogger extends Logger {
      * @param p3 the message parameters
      * @param p4 the message parameters
      * @return True if logging is enabled, false otherwise.
+     * @since 2.6
      */
     boolean isEnabled(
             Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4);
@@ -173,6 +179,7 @@ public interface ExtendedLogger extends Logger {
      * @param p4 the message parameters
      * @param p5 the message parameters
      * @return True if logging is enabled, false otherwise.
+     * @since 2.6
      */
     boolean isEnabled(
             Level level,
@@ -199,6 +206,7 @@ public interface ExtendedLogger extends Logger {
      * @param p5 the message parameters
      * @param p6 the message parameters
      * @return True if logging is enabled, false otherwise.
+     * @since 2.6
      */
     boolean isEnabled(
             Level level,
@@ -227,6 +235,7 @@ public interface ExtendedLogger extends Logger {
      * @param p6 the message parameters
      * @param p7 the message parameters
      * @return True if logging is enabled, false otherwise.
+     * @since 2.6
      */
     boolean isEnabled(
             Level level,
@@ -257,6 +266,7 @@ public interface ExtendedLogger extends Logger {
      * @param p7 the message parameters
      * @param p8 the message parameters
      * @return True if logging is enabled, false otherwise.
+     * @since 2.6
      */
     boolean isEnabled(
             Level level,
@@ -289,6 +299,7 @@ public interface ExtendedLogger extends Logger {
      * @param p8 the message parameters
      * @param p9 the message parameters
      * @return True if logging is enabled, false otherwise.
+     * @since 2.6
      */
     boolean isEnabled(
             Level level,
@@ -326,6 +337,7 @@ public interface ExtendedLogger extends Logger {
      * @param marker A Marker or null.
      * @param message The CharSequence message.
      * @param t the exception to log, including its stack trace.
+     * @since 2.6
      */
     void logIfEnabled(String fqcn, Level level, Marker marker, CharSequence message, Throwable t);
 
@@ -385,6 +397,7 @@ public interface ExtendedLogger extends Logger {
      * @param marker A Marker or null.
      * @param message The message format.
      * @param p0 the message parameters
+     * @since 2.6
      */
     void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0);
 
@@ -398,6 +411,7 @@ public interface ExtendedLogger extends Logger {
      * @param message The message format.
      * @param p0 the message parameters
      * @param p1 the message parameters
+     * @since 2.6
      */
     void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1);
 
@@ -412,6 +426,7 @@ public interface ExtendedLogger extends Logger {
      * @param p0 the message parameters
      * @param p1 the message parameters
      * @param p2 the message parameters
+     * @since 2.6
      */
     void logIfEnabled(String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2);
 
@@ -427,6 +442,7 @@ public interface ExtendedLogger extends Logger {
      * @param p1 the message parameters
      * @param p2 the message parameters
      * @param p3 the message parameters
+     * @since 2.6
      */
     void logIfEnabled(
             String fqcn, Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3);
@@ -444,6 +460,7 @@ public interface ExtendedLogger extends Logger {
      * @param p2 the message parameters
      * @param p3 the message parameters
      * @param p4 the message parameters
+     * @since 2.6
      */
     void logIfEnabled(
             String fqcn,
@@ -470,6 +487,7 @@ public interface ExtendedLogger extends Logger {
      * @param p3 the message parameters
      * @param p4 the message parameters
      * @param p5 the message parameters
+     * @since 2.6
      */
     void logIfEnabled(
             String fqcn,
@@ -498,6 +516,7 @@ public interface ExtendedLogger extends Logger {
      * @param p4 the message parameters
      * @param p5 the message parameters
      * @param p6 the message parameters
+     * @since 2.6
      */
     void logIfEnabled(
             String fqcn,
@@ -528,6 +547,7 @@ public interface ExtendedLogger extends Logger {
      * @param p5 the message parameters
      * @param p6 the message parameters
      * @param p7 the message parameters
+     * @since 2.6
      */
     void logIfEnabled(
             String fqcn,
@@ -560,6 +580,7 @@ public interface ExtendedLogger extends Logger {
      * @param p6 the message parameters
      * @param p7 the message parameters
      * @param p8 the message parameters
+     * @since 2.6
      */
     void logIfEnabled(
             String fqcn,
@@ -594,6 +615,7 @@ public interface ExtendedLogger extends Logger {
      * @param p7 the message parameters
      * @param p8 the message parameters
      * @param p9 the message parameters
+     * @since 2.6
      */
     void logIfEnabled(
             String fqcn,

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LocationAwareLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LocationAwareLogger.java
@@ -22,6 +22,8 @@ import org.apache.logging.log4j.message.Message;
 
 /**
  * Logger that accepts the location of the caller.
+ *
+ * @since 2.12.1
  */
 public interface LocationAwareLogger {
     void logMessage(

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContext.java
@@ -27,6 +27,7 @@ public interface LoggerContext {
 
     /**
      * Empty array.
+     * @since 2.17.2
      */
     LoggerContext[] EMPTY_ARRAY = {};
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextShutdownAware.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextShutdownAware.java
@@ -19,6 +19,8 @@ package org.apache.logging.log4j.spi;
 /**
  * Interface allowing interested classes to know when a LoggerContext has shutdown - if the LoggerContext
  * implementation provides a way to register listeners.
+ *
+ * @since 2.12.1
  */
 public interface LoggerContextShutdownAware {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextShutdownEnabled.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerContextShutdownEnabled.java
@@ -20,6 +20,8 @@ import java.util.List;
 
 /**
  * LoggerContexts implementing this are able register LoggerContextShutdownAware classes.
+ *
+ * @since 2.12.1
  */
 public interface LoggerContextShutdownEnabled {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerRegistry.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/LoggerRegistry.java
@@ -36,6 +36,7 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * Convenience class to be used as an {@link ExtendedLogger} registry by {@code LoggerContext} implementations.
+ * @since 2.6
  */
 @NullMarked
 public class LoggerRegistry<T extends ExtendedLogger> {
@@ -52,6 +53,7 @@ public class LoggerRegistry<T extends ExtendedLogger> {
      * Data structure contract for the internal storage of admitted loggers.
      *
      * @param <T> subtype of {@code ExtendedLogger}
+     * @since 2.6
      * @deprecated As of version {@code 2.25.0}, planned to be removed!
      */
     @Deprecated
@@ -68,6 +70,7 @@ public class LoggerRegistry<T extends ExtendedLogger> {
      * {@link MapFactory} implementation using {@link ConcurrentHashMap}.
      *
      * @param <T> subtype of {@code ExtendedLogger}
+     * @since 2.6
      * @deprecated As of version {@code 2.25.0}, planned to be removed!
      */
     @Deprecated
@@ -93,6 +96,7 @@ public class LoggerRegistry<T extends ExtendedLogger> {
      * {@link MapFactory} implementation using {@link WeakHashMap}.
      *
      * @param <T> subtype of {@code ExtendedLogger}
+     * @since 2.6
      * @deprecated As of version {@code 2.25.0}, planned to be removed!
      */
     @Deprecated

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/Provider.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/Provider.java
@@ -43,6 +43,7 @@ import org.jspecify.annotations.Nullable;
 public class Provider {
     /**
      * Constant inlined by the compiler
+     * @since 2.24.0
      */
     protected static final String CURRENT_VERSION = "2.6.0";
 
@@ -317,7 +318,7 @@ public class Provider {
      *
      * @return the URL corresponding to the Provider {@code META-INF/log4j-provider.properties} file or {@code null}
      * for a provider class.
-     * @deprecated since 2.24.0, without replacement.
+     * @deprecated since 2.24.0, without a replacement.
      */
     @Deprecated
     public @Nullable URL getUrl() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/Provider.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/Provider.java
@@ -133,6 +133,7 @@ public class Provider {
      * @param versions Minimal API version required, should be set to {@link #CURRENT_VERSION},
      * @param loggerContextFactoryClass A public exported implementation of {@link LoggerContextFactory} or {@code
      * null} if {@link #getLoggerContextFactory()} is also implemented.
+     * @since 2.9.0
      */
     public Provider(
             final @Nullable Integer priority,
@@ -148,6 +149,7 @@ public class Provider {
      * null} if {@link #getLoggerContextFactory()} is also implemented,
      * @param threadContextMapClass A public exported implementation of {@link ThreadContextMap} or {@code null} if
      * {@link #getThreadContextMapInstance()} is implemented.
+     * @since 2.9.0
      */
     public Provider(
             final @Nullable Integer priority,
@@ -168,6 +170,8 @@ public class Provider {
     /**
      * Returns the Log4j API versions supported by the implementation.
      * @return A String containing the Log4j versions supported.
+     *
+     * @since 2.9.0
      */
     public String getVersions() {
         return versions != null ? versions : "";

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/Provider.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/Provider.java
@@ -48,6 +48,7 @@ public class Provider {
 
     /**
      * Property name to set for a Log4j 2 provider to specify the priority of this implementation.
+     * @since 2.0.1
      * @deprecated since 2.24.0
      */
     @Deprecated
@@ -55,6 +56,7 @@ public class Provider {
 
     /**
      * Property name to set to the implementation of {@link ThreadContextMap}.
+     * @since 2.0.1
      * @deprecated since 2.24.0
      */
     @Deprecated
@@ -62,6 +64,7 @@ public class Provider {
 
     /**
      * Property name to set to the implementation of {@link LoggerContextFactory}.
+     * @since 2.0.1
      * @deprecated since 2.24.0
      */
     @Deprecated
@@ -100,6 +103,7 @@ public class Provider {
 
     /**
      * Constructor used by the deprecated {@code META-INF/log4j-provider.properties} format.
+     * @since 2.0.1
      * @deprecated since 2.24.0
      */
     @Deprecated
@@ -194,6 +198,7 @@ public class Provider {
      * Loads the {@link LoggerContextFactory} class specified by this Provider.
      *
      * @return the LoggerContextFactory implementation class or {@code null} if unspecified or a loader error occurred.
+     * @since 2.0.1
      */
     public @Nullable Class<? extends LoggerContextFactory> loadLoggerContextFactory() {
         if (loggerContextFactoryClass != null) {
@@ -254,6 +259,7 @@ public class Provider {
      *
      * @return the {@code ThreadContextMap} implementation class or {@code null} if unspecified or a loading error
      * occurred.
+     * @since 2.0.1
      */
     public @Nullable Class<? extends ThreadContextMap> loadThreadContextMap() {
         if (threadContextMapClass != null) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMapFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextMapFactory.java
@@ -46,6 +46,8 @@ public final class ThreadContextMapFactory {
     /**
      * Initializes static variables based on system properties. Normally called when this class is initialized by the VM
      * and when Log4j is reconfigured.
+     *
+     * @since 2.11.0
      */
     public static void init() {
         ProviderUtil.getProvider().getThreadContextMapInstance();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusConsoleListener.java
@@ -142,7 +142,7 @@ public class StatusConsoleListener implements StatusListener {
      * Adds package name filters to exclude.
      *
      * @param filters An array of package names to exclude.
-     * @deprecated This method is ineffective and only kept for binary backward compatibility.
+     * @deprecated since 2.23.0, this method is ineffective and only kept for binary backward compatibility.
      */
     @Deprecated
     public void setFilters(final String... filters) {}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
@@ -60,6 +60,7 @@ public class StatusData implements Serializable {
      * @param message a message
      * @param throwable the error occurred
      * @param threadName the thread name
+     * @since 2.4
      */
     public StatusData(
             @Nullable final StackTraceElement caller,
@@ -141,6 +142,7 @@ public class StatusData implements Serializable {
      * Returns the name of the thread associated with the event.
      *
      * @return the name of the thread associated with the event
+     * @since 2.4
      */
     public String getThreadName() {
         return threadName;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusData.java
@@ -94,6 +94,7 @@ public class StatusData implements Serializable {
      * Returns the instant of the event.
      *
      * @return the event's instant
+     * @since 2.23.0
      */
     public Instant getInstant() {
         return instant;
@@ -103,7 +104,7 @@ public class StatusData implements Serializable {
      * Returns the instant of the event.
      *
      * @return the event's instant
-     * @deprecated Use {@link #getInstant()} instead.
+     * @deprecated since 2.23.0, use {@link #getInstant()} instead.
      */
     @Deprecated
     public long getTimestamp() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -633,6 +633,7 @@ public class StatusLogger extends AbstractLogger {
      * Sets the level of the fallback listener.
      *
      * @param level a level
+     * @since 2.6
      * @deprecated Instead use the {@link StatusConsoleListener#setLevel(Level) setLevel(Level)} method on the fallback listener returned by {@link #getFallbackListener()}.
      */
     @Deprecated

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -581,6 +581,7 @@ public class StatusLogger extends AbstractLogger {
      * Returns the fallback listener.
      *
      * @return the fallback listener
+     * @since 2.23.0
      */
     public StatusConsoleListener getFallbackListener() {
         return fallbackListener;
@@ -590,7 +591,8 @@ public class StatusLogger extends AbstractLogger {
      * Sets the level of the fallback listener.
      *
      * @param level a level
-     * @deprecated Instead use the {@link StatusConsoleListener#setLevel(Level) setLevel(Level)} method on the fallback listener returned by {@link #getFallbackListener()}.
+     * @deprecated Since 2.23.0, instead use the {@link StatusConsoleListener#setLevel(Level) setLevel(Level)} method
+     * on the fallback listener returned by {@link #getFallbackListener()}.
      */
     @Deprecated
     public void setLevel(final Level level) {
@@ -634,7 +636,8 @@ public class StatusLogger extends AbstractLogger {
      *
      * @param level a level
      * @since 2.6
-     * @deprecated Instead use the {@link StatusConsoleListener#setLevel(Level) setLevel(Level)} method on the fallback listener returned by {@link #getFallbackListener()}.
+     * @deprecated Since 2.23.0, instead use the {@link StatusConsoleListener#setLevel(Level) setLevel(Level)} method
+     * on the fallback listener returned by {@link #getFallbackListener()}.
      */
     @Deprecated
     public void updateListenerLevel(final Level level) {
@@ -690,7 +693,8 @@ public class StatusLogger extends AbstractLogger {
     /**
      * Returns buffered events.
      *
-     * @deprecated Instead of relying on the buffering provided by {@code StatusLogger}, users should register their own listeners to access to logged events.
+     * @deprecated Since 2.23.0, instead of relying on the buffering provided by {@code StatusLogger},
+     * users should register their own listeners to access to logged events.
      * @return a thread-safe read-only collection of buffered events
      */
     @Deprecated
@@ -704,7 +708,8 @@ public class StatusLogger extends AbstractLogger {
     /**
      * Clears the event buffer.
      *
-     * @deprecated Instead of relying on the buffering provided by {@code StatusLogger}, users should register their own listeners to access to logged events.
+     * @deprecated Since 2.23.0, instead of relying on the buffering provided by {@code StatusLogger},
+     * users should register their own listeners to access to logged events.
      */
     @Deprecated
     public void clear() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Activator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Activator.java
@@ -44,6 +44,7 @@ import org.osgi.framework.wiring.BundleWiring;
  * {@link org.apache.logging.log4j.spi.LoggerContextFactory} et al. that have corresponding
  * {@code META-INF/log4j-provider.properties} files. As with all OSGi BundleActivator classes, this class is not for
  * public use and is only useful in an OSGi framework environment.
+ * @since 2.0.1
  */
 @Header(name = Constants.BUNDLE_ACTIVATOR, value = "${@class}")
 @Header(name = Constants.BUNDLE_ACTIVATIONPOLICY, value = Constants.ACTIVATION_LAZY)

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
@@ -25,6 +25,8 @@ import org.apache.logging.log4j.status.StatusLogger;
 /**
  * Base64 encodes Strings. This utility is only necessary because the mechanism to do this changed in Java 8 and
  * the original method was removed in Java 9.
+ *
+ * @since 2.12.0
  */
 public final class Base64Util {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
@@ -56,6 +56,7 @@ public final class Base64Util {
 
     /**
      * This method does not specify an encoding for the {@code str} parameter and should not be used.
+     * @deprecated since 2.22.0, use {@link java.util.Base64} instead.
      */
     @Deprecated
     public static String encode(final String str) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Cast.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Cast.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.util;
 
+/**
+ * @since 2.22.0
+ */
 @InternalApi
 public final class Cast {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Chars.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Chars.java
@@ -35,7 +35,10 @@ public final class Chars {
     /** Line Feed. */
     public static final char LF = '\n';
 
-    /** NUL. */
+    /**
+     * NUL.
+     * @since 2.11.0
+     */
     public static final char NUL = 0;
 
     /** Single Quote [']. */

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Chars.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Chars.java
@@ -52,6 +52,7 @@ public final class Chars {
      *
      * @param digit a number 0 - 15
      * @return the hex character for that digit or '\0' if invalid
+     * @since 2.8.2
      */
     public static char getUpperCaseHex(final int digit) {
         if (digit < 0 || digit >= 16) {
@@ -65,6 +66,7 @@ public final class Chars {
      *
      * @param digit a number 0 - 15
      * @return the hex character for that digit or '\0' if invalid
+     * @since 2.8.2
      */
     public static char getLowerCaseHex(final int digit) {
         if (digit < 0 || digit >= 16) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Chars.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Chars.java
@@ -18,6 +18,7 @@ package org.apache.logging.log4j.util;
 
 /**
  * <em>Consider this class private.</em>
+ * @since 2.3
  */
 @InternalApi
 public final class Chars {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
@@ -78,7 +78,8 @@ public final class Constants {
      * The default value is 518, which allows the StringBuilder to resize three times from its initial size.
      * Users can override with system property "log4j.maxReusableMsgSize".
      * </p>
-     * @since 2.9
+     *
+     * @since 2.9.0
      */
     public static final int MAX_REUSABLE_MESSAGE_SIZE = size("log4j.maxReusableMsgSize", (128 * 2 + 2) * 2 + 2);
 
@@ -90,6 +91,8 @@ public final class Constants {
      * {@code <Configuration status="<level>" ...>} status attribute, as well as any value set for
      * system property {@code org.apache.logging.log4j.simplelog.StatusLogger.level}.
      * </p>
+     *
+     * @since 2.9.0
      */
     public static final String LOG4J2_DEBUG = "log4j2.debug";
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
@@ -116,11 +116,13 @@ public final class Constants {
 
     /**
      * The empty array.
+     * @since 2.15.0
      */
     public static final Object[] EMPTY_OBJECT_ARRAY = {};
 
     /**
      * The empty array.
+     * @since 2.15.0
      */
     public static final byte[] EMPTY_BYTE_ARRAY = {};
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Constants.java
@@ -67,6 +67,7 @@ public final class Constants {
 
     /**
      * Java major version.
+     * @since 2.8.1
      */
     public static final int JAVA_MAJOR_VERSION = getMajorVersion();
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/FilteredObjectInputStream.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/FilteredObjectInputStream.java
@@ -32,7 +32,7 @@ import org.apache.logging.log4j.util.internal.SerializationUtil;
  * Extends {@link ObjectInputStream} to only allow some built-in Log4j classes and caller-specified classes to be
  * deserialized.
  *
- * @since 2.8.2
+ * @since 2.11.0
  */
 public class FilteredObjectInputStream extends ObjectInputStream {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/InternalException.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/InternalException.java
@@ -19,6 +19,8 @@ package org.apache.logging.log4j.util;
 /**
  * Exception thrown when an error occurs while accessing internal resources. This is generally used to
  * convert checked exceptions to runtime exceptions.
+ *
+ * @since 2.22.0
  */
 public class InternalException extends RuntimeException {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LambdaUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LambdaUtil.java
@@ -81,6 +81,7 @@ public final class LambdaUtil {
      * @param supplier a lambda expression or {@code null}
      * @return the Message resulting from evaluating the lambda expression or the Message created by the factory for
      * supplied values that are not of type Message
+     * @since 2.6
      */
     public static Message getMessage(final Supplier<?> supplier, final MessageFactory messageFactory) {
         if (supplier == null) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LambdaUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LambdaUtil.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.message.MessageFactory;
 
 /**
  * Utility class for lambda support.
+ * @since 2.4
  */
 public final class LambdaUtil {
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Lazy.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Lazy.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
  * Provides a lazily-initialized value from a {@code Supplier<T>}.
  *
  * @param <T> type of value
+ * @since 2.22.0
  */
 public interface Lazy<T> extends Supplier<T> {
     /**

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LazyBoolean.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LazyBoolean.java
@@ -20,6 +20,9 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BooleanSupplier;
 
+/**
+ * @since 2.22.0
+ */
 public class LazyBoolean implements BooleanSupplier {
     private final BooleanSupplier supplier;
     private final Lock lock = new ReentrantLock();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
@@ -87,11 +87,15 @@ public final class LoaderUtil {
      * Returns the ClassLoader to use.
      *
      * @return the ClassLoader.
+     * @since 2.22.0
      */
     public static ClassLoader getClassLoader() {
         return getClassLoader(LoaderUtil.class, null);
     }
 
+    /**
+     * @since 2.22.0
+     */
     // TODO: this method could use some explanation
     public static ClassLoader getClassLoader(final Class<?> class1, final Class<?> class2) {
         PrivilegedAction<ClassLoader> action = () -> {
@@ -350,7 +354,7 @@ public final class LoaderUtil {
      * @throws IllegalAccessException      if the class can't be instantiated through a public constructor
      * @throws InstantiationException      if the provided class is abstract or an interface
      * @throws InvocationTargetException   if an exception is thrown by the constructor
-     * @since 2.22
+     * @since 2.22.0
      */
     public static <T> T newCheckedInstanceOfProperty(
             final String propertyName, final Class<T> clazz, final Supplier<T> defaultSupplier)

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/LoaderUtil.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.status.StatusLogger;
  * @see RuntimePermission
  * @see Thread#getContextClassLoader()
  * @see ClassLoader#getSystemClassLoader()
+ * @since 2.0.1
  */
 @InternalApi
 public final class LoaderUtil {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/OsgiServiceLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/OsgiServiceLocator.java
@@ -26,6 +26,9 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.wiring.BundleRevision;
 
+/**
+ * @since 2.18.0
+ */
 public class OsgiServiceLocator {
 
     private static final Logger LOGGER = StatusLogger.getLogger();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProcessIdUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProcessIdUtil.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Method;
 /**
  * Provides the PID of the current JVM.
  *
- * @since 2.9
+ * @since 2.9.0
  */
 public class ProcessIdUtil {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesPropertySource.java
@@ -38,6 +38,9 @@ public class PropertiesPropertySource implements PropertySource {
         this(properties, DEFAULT_PRIORITY);
     }
 
+    /**
+     * @since 2.18.0
+     */
     public PropertiesPropertySource(final Properties properties, final int priority) {
         this.properties = properties;
         this.priority = priority;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -596,6 +596,7 @@ public final class PropertiesUtil {
      * @param properties The Properties to evaluate.
      * @param prefix     The prefix to extract.
      * @return The subset of properties.
+     * @since 2.4
      */
     public static Properties extractSubset(final Properties properties, final String prefix) {
         final Properties subset = new Properties();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -160,6 +160,7 @@ public final class PropertiesUtil {
      *
      * @param name the name of the property to verify
      * @return {@code true} if the specified property is defined, regardless of its value
+     * @since 2.9.0
      */
     public boolean hasProperty(final String name) {
         return environment.containsKey(name);
@@ -196,6 +197,7 @@ public final class PropertiesUtil {
      * @param defaultValueIfAbsent  the default value to use if the property is undefined
      * @param defaultValueIfPresent the default value to use if the property is defined but not assigned
      * @return the boolean value of the property or {@code defaultValue} if undefined.
+     * @since 2.9.0
      */
     public boolean getBooleanProperty(
             final String name, final boolean defaultValueIfAbsent, final boolean defaultValueIfPresent) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -674,6 +674,7 @@ public final class PropertiesUtil {
      * Returns true if system properties tell us we are running on Windows.
      *
      * @return true if system properties tell us we are running on Windows.
+     * @since 2.5
      */
     public boolean isOsWindows() {
         return SystemPropertiesPropertySource.getSystemProperty("os.name", "").startsWith("Windows");

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -228,6 +228,7 @@ public final class PropertiesUtil {
      *
      * @param name the name of the property to look up
      * @return the Charset value of the property or {@link Charset#defaultCharset()} if undefined.
+     * @since 2.8
      */
     public Charset getCharsetProperty(final String name) {
         return getCharsetProperty(name, Charset.defaultCharset());
@@ -240,6 +241,7 @@ public final class PropertiesUtil {
      * @param name         the name of the property to look up
      * @param defaultValue the default value to use if the property is undefined
      * @return the Charset value of the property or {@code defaultValue} if undefined.
+     * @since 2.8
      */
     public Charset getCharsetProperty(final String name, final Charset defaultValue) {
         final String charsetName = getStringProperty(name);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertiesUtil.java
@@ -270,6 +270,7 @@ public final class PropertiesUtil {
      * @param name         the name of the property to look up
      * @param defaultValue the default value to use if the property is undefined
      * @return the parsed double value of the property or {@code defaultValue} if it was undefined or could not be parsed.
+     * @since 2.6
      */
     public double getDoubleProperty(final String name, final double defaultValue) {
         final String prop = getStringProperty(name);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyFilePropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertyFilePropertySource.java
@@ -37,6 +37,9 @@ public class PropertyFilePropertySource extends PropertiesPropertySource {
         this(fileName, true);
     }
 
+    /**
+     * @since 2.18.0
+     */
     public PropertyFilePropertySource(final String fileName, final boolean useTccl) {
         super(loadPropertiesFile(fileName, useTccl));
     }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/PropertySource.java
@@ -56,6 +56,7 @@ public interface PropertySource {
      * Returns the list of all property names.
      *
      * @return list of property names
+     * @since 2.18.0
      */
     default Collection<String> getPropertyNames() {
         return Collections.emptySet();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderActivator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderActivator.java
@@ -24,6 +24,8 @@ import org.osgi.framework.ServiceRegistration;
 
 /**
  * Utility class to register Log4j2 providers in an OSGI environment.
+ *
+ * @since 2.19.0
  */
 public abstract class ProviderActivator implements BundleActivator {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ServiceLoaderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ServiceLoaderUtil.java
@@ -47,6 +47,8 @@ import org.apache.logging.log4j.Logger;
  *     <li>skip faulty services, allowing for a partial retrieval of the good ones,</li>
  *     <li>allow to integrate other sources of services like OSGi services.</li>
  * </ol>
+ *
+ * @since 2.18.0
  */
 @InternalApi
 public final class ServiceLoaderUtil {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
@@ -109,6 +109,9 @@ public class SortedArrayStringMap implements IndexedStringMap {
         }
     }
 
+    /**
+     * @since 2.8
+     */
     public SortedArrayStringMap(final Map<String, ?> map) {
         resize(ceilingNextPowerOfTwo(map.size()));
         for (final Map.Entry<String, ?> entry : map.entrySet()) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -208,6 +208,9 @@ public final class StackLocator {
         return Object.class;
     }
 
+    /**
+     * @since 2.17.2
+     */
     // migrated from ThrowableProxy
     @PerformanceSensitive
     public Deque<Class<?>> getCurrentStackTrace() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -49,6 +49,8 @@ import org.apache.logging.log4j.status.StatusLogger;
  * environments may fall back to using {@link Throwable#getStackTrace()} which is significantly slower due to
  * examination of every virtual frame of execution.
  * </p>
+ *
+ * @since 2.9.0
  */
 @InternalApi
 public final class StackLocator {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
@@ -23,6 +23,8 @@ import org.apache.logging.log4j.status.StatusLogger;
 
 /**
  * <em>Consider this class private.</em> Provides various methods to determine the caller class.
+ *
+ * @since 2.9.0
  */
 @InternalApi
 public final class StackLocatorUtil {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
@@ -86,6 +86,7 @@ public final class StackLocatorUtil {
      * @param depth The stack frame count to walk.
      * @return A class or null.
      * @throws IndexOutOfBoundsException if depth is negative.
+     * @since 2.17.2
      */
     @PerformanceSensitive
     public static ClassLoader getCallerClassLoader(final int depth) {
@@ -112,6 +113,9 @@ public final class StackLocatorUtil {
         return stackLocator.getCallerClass(anchor);
     }
 
+    /**
+     * @since 2.17.2
+     */
     // migrated from ThrowableProxy
     @PerformanceSensitive
     public static Deque<Class<?>> getCurrentStackTrace() {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StackLocatorUtil.java
@@ -99,6 +99,7 @@ public final class StackLocatorUtil {
      * @param sentinelClass Sentinel class at which to begin searching
      * @param callerPredicate Predicate checked after the sentinelClass is found
      * @return the first matching class after <code>sentinelClass</code> is found.
+     * @since 2.15.0
      */
     @PerformanceSensitive
     public static Class<?> getCallerClass(final Class<?> sentinelClass, final Predicate<Class<?>> callerPredicate) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
@@ -214,7 +214,7 @@ public final class StringBuilders {
      *
      * @param stringBuilder the StringBuilder to check
      * @param maxSize the maximum number of characters the StringBuilder is allowed to have
-     * @since 2.9
+     * @since 2.9.0
      */
     public static void trimToMaxSize(final StringBuilder stringBuilder, final int maxSize) {
         if (stringBuilder != null && stringBuilder.capacity() > maxSize) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
@@ -101,6 +101,9 @@ public final class StringBuilders {
         }
     }
 
+    /**
+     * @since 2.10.0
+     */
     public static boolean appendSpecificTypes(final StringBuilder stringBuilder, final Object obj) {
         if (obj == null || obj instanceof String) {
             stringBuilder.append((String) obj);
@@ -223,6 +226,9 @@ public final class StringBuilders {
         }
     }
 
+    /**
+     * @since 2.10.0
+     */
     public static void escapeJson(final StringBuilder toAppendTo, final int start) {
         int escapeCount = 0;
         for (int i = start; i < toAppendTo.length(); i++) {
@@ -299,6 +305,9 @@ public final class StringBuilders {
         return lastPos;
     }
 
+    /**
+     * @since 2.10.0
+     */
     public static void escapeXml(final StringBuilder toAppendTo, final int start) {
         int escapeCount = 0;
         for (int i = start; i < toAppendTo.length(); i++) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
@@ -93,6 +93,7 @@ public final class StringBuilders {
      *
      * @param stringBuilder the StringBuilder to append the value to
      * @param obj the object whose text representation to append to the StringBuilder
+     * @since 2.7
      */
     public static void appendValue(final StringBuilder stringBuilder, final Object obj) {
         if (!appendSpecificTypes(stringBuilder, obj)) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
@@ -157,6 +157,7 @@ public final class StringBuilders {
      * @param rightOffset start index in the right CharSequence
      * @param rightLength length of the section in the right CharSequence
      * @return true if equal, false otherwise
+     * @since 2.8
      */
     public static boolean equals(
             final CharSequence left,
@@ -187,6 +188,7 @@ public final class StringBuilders {
      * @param rightOffset start index in the right CharSequence
      * @param rightLength length of the section in the right CharSequence
      * @return true if equal ignoring case, false otherwise
+     * @since 2.8
      */
     public static boolean equalsIgnoreCase(
             final CharSequence left,

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/StringBuilders.java
@@ -22,6 +22,7 @@ import java.util.Map.Entry;
 
 /**
  * <em>Consider this class private.</em>
+ * @since 2.3
  */
 @InternalApi
 public final class StringBuilders {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -51,6 +51,7 @@ public final class Strings {
     /**
      * OS-dependent line separator, defaults to {@code "\n"} if the system property {@code ""line.separator"} cannot be
      * read.
+     * @since 2.7
      */
     public static final String LINE_SEPARATOR = System.lineSeparator();
 
@@ -160,6 +161,7 @@ public final class Strings {
      * @param iterable  the {@code Iterable} providing the values to join together, may be null
      * @param separator  the separator character to use
      * @return the joined String, {@code null} if null iterator input
+     * @since 2.7
      */
     public static String join(final Iterable<?> iterable, final char separator) {
         if (iterable == null) {
@@ -178,6 +180,7 @@ public final class Strings {
      * @param iterator  the {@code Iterator} of values to join together, may be null
      * @param separator  the separator character to use
      * @return the joined String, {@code null} if null iterator input
+     * @since 2.7
      */
     public static String join(final Iterator<?> iterator, final char separator) {
 

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -310,6 +310,7 @@ public final class Strings {
      * @param str The string to lower case.
      * @return a new string
      * @see String#toLowerCase(Locale)
+     * @since 2.6
      */
     public static String toRootUpperCase(final String str) {
         return str.toUpperCase(Locale.ROOT);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -70,6 +70,7 @@ public final class Strings {
      *
      * @param s the String to check, may be {@code null}
      * @return {@code true} if the String is {@code null}, empty, or all characters are {@link Character#isWhitespace(char)}
+     * @since 2.0.1
      */
     public static boolean isBlank(final String s) {
         if (s == null || s.isEmpty()) {
@@ -118,6 +119,7 @@ public final class Strings {
      *
      * @param s the String to check, may be {@code null}
      * @return {@code true} if the String is non-{@code null} and has content after being trimmed.
+     * @since 2.0.1
      */
     public static boolean isNotBlank(final String s) {
         return !isBlank(s);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -214,6 +214,9 @@ public final class Strings {
         return buf.toString();
     }
 
+    /**
+     * @since 2.17.2
+     */
     public static String[] splitList(final String string) {
         return string != null ? string.split(COMMA_DELIMITED_RE) : new String[0];
     }
@@ -305,6 +308,7 @@ public final class Strings {
      * @param str The string to upper case.
      * @return a new string
      * @see String#toLowerCase(Locale)
+     * @since 2.17.2
      */
     public static String toRootLowerCase(final String str) {
         return str.toLowerCase(Locale.ROOT);

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -59,6 +59,7 @@ public final class Strings {
      *
      * @param str a String
      * @return {@code "str"}
+     * @since 2.3
      */
     public static String dquote(final String str) {
         return Chars.DQUOTE + str + Chars.DQUOTE;
@@ -255,6 +256,7 @@ public final class Strings {
      *
      * @param str a String
      * @return {@code 'str'}
+     * @since 2.3
      */
     public static String quote(final String str) {
         return Chars.QUOTE + str + Chars.QUOTE;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -45,6 +45,7 @@ public final class Strings {
 
     /**
      * The empty array.
+     * @since 2.15.0
      */
     public static final String[] EMPTY_ARRAY = {};
 
@@ -325,6 +326,7 @@ public final class Strings {
      * @param str1 the first string.
      * @param str2 the second string.
      * @return the concatenated String.
+     * @since 2.15.0
      */
     public static String concat(final String str1, final String str2) {
         if (isEmpty(str1)) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -347,6 +347,7 @@ public final class Strings {
      * @param count the repetition count
      * @return the new string
      * @throws IllegalArgumentException if either {@code str} is null or {@code count} is negative
+     * @since 2.14.0
      */
     public static String repeat(final String str, final int count) {
         Objects.requireNonNull(str, "str");

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Strings.java
@@ -240,6 +240,7 @@ public final class Strings {
      * @param str  the String to get the leftmost characters from, may be null
      * @param len  the length of the required String
      * @return the leftmost characters, {@code null} if null String input
+     * @since 2.11.2
      */
     public static String left(final String str, final int len) {
         if (str == null) {

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/SystemPropertiesPropertySource.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/SystemPropertiesPropertySource.java
@@ -49,6 +49,9 @@ public class SystemPropertiesPropertySource implements PropertySource {
         return INSTANCE;
     }
 
+    /**
+     * @since 2.20.0
+     */
     public static String getSystemProperty(final String key, final String defaultValue) {
         final String value = INSTANCE.getProperty(key);
         return value != null ? value : defaultValue;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Timer.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Timer.java
@@ -23,12 +23,17 @@ import java.text.DecimalFormat;
  * Primarily used in unit tests, but can be used to track elapsed time for a request or portion of any other operation
  * so long as all the timer methods are called on the same thread in which it was started. Calling start on
  * multiple threads will cause the times to be aggregated.
+ *
+ * @since 2.12.0
  */
 public class Timer implements Serializable, StringBuilderFormattable {
     private static final long serialVersionUID = 9175191792439630013L;
 
     private final String name; // The timer's name
 
+    /**
+     * @since 2.12.0
+     */
     public enum Status {
         Started,
         Stopped,


### PR DESCRIPTION
This PR uses [japicmp](https://siom79.github.io/japicmp/) to compare all 53 stable 2.x releases and document the changes in the public API of the `log4j-api` artifact.
The basic invocation of `japicmp` is:

```
java -jar japicmp.jar \
  --old-classpath org.osgi.core.jar -o log4j-api-<old_version>.jar \
  --new-classpath org.osgi.core.jar -n log4j-api-<new_version>.jar \
  -m
```

The resulting report was used to create or fix Javadoc `@since` tags.

Part of #1867