### PR TITLE
Uniformize API of `StackLocator` versions

### DIFF
--- a/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/StackLocator.java
+++ b/log4j-api-java9/src/main/java/org/apache/logging/log4j/util/StackLocator.java
@@ -53,10 +53,6 @@ public final class StackLocator {
                 .orElse(null));
     }
 
-    public Class<?> getCallerClass(final String fqcn) {
-        return getCallerClass(fqcn, "");
-    }
-
     public Class<?> getCallerClass(final String fqcn, final String pkg) {
         return WALKER.walk(s -> s.dropWhile(f -> !f.getClassName().equals(fqcn))
                         .dropWhile(f -> f.getClassName().equals(fqcn))

--- a/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/StackLocatorTest.java
+++ b/log4j-api-java9/src/test/java/org/apache/logging/log4j/util/java9/StackLocatorTest.java
@@ -73,7 +73,7 @@ class StackLocatorTest {
         private static void assertCallerClassViaName() {
             final Class<?> expected = StackLocatorTest.class;
             final StackLocator stackLocator = StackLocator.getInstance();
-            final Class<?> actual = stackLocator.getCallerClass(Inner.class.getName());
+            final Class<?> actual = stackLocator.getCallerClass(Inner.class.getName(), "");
             assertSame(expected, actual);
         }
 


### PR DESCRIPTION
The Java 9 version of `StackLocator` has an additional public `getCallerClass(String)` method. This method makes the Java 8 and 9 versions of `StackLocator` expose different APIs to the user. To prevent API compatibility problems, we remove the additional method.

This incompatibility was accidentally discovered during the work in #3339: `japicmp` did randomly compare a `StackLocator` class from the old version with a `StackLocator` class from the new version.

This is part of #1867.

