### PR TITLE
Fix duplicate Dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -45,7 +45,6 @@ updates:
 
   - package-ecosystem: maven
     directories:
-      - "/"
       - "/log4j-1.2-api"
       - "/log4j-api-test"
       - "/log4j-api"
@@ -164,7 +163,6 @@ updates:
   - package-ecosystem: maven
     directories:
       - "/log4j-mongodb4"
-      - "/log4j-slf4j-impl"
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
@@ -175,9 +173,6 @@ updates:
       # MongoDB 4.x should only upgrade to 4.x
       - dependency-name: "org.mongodb:*"
         versions: [ "[5,)" ]
-      # SLF4J 1.7.x should only upgrade to 1.7.x and
-      - dependency-name: "org.slf4j:slf4j-api"
-        versions: [ "[1,)" ]
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
Since Dependabot cannot handle multiple versions of the same artifact at once, our Dependabot configuration for `2.x` is split into two runs:

- One Dependabot run handles the dependency upgrades for the `log4j-slf4j-impl` (based on SLF4J 1.x) and `log4j-mongodb4` (based on MongoDB client 4.x).
- A second Dependabot run handles the dependency upgrades for the remaining modules (which use SLF4J 2.x and MongoDB client 5.x).

Unfortunately, due to the way Maven multi-module support is implemented in Dependabot (see dependabot/dependabot-core#222), the second Dependabot configuration also tries to upgrade the dependencies of `log4j-slf4j-impl` and `log4j-mongodb4`. This is due to the inclusion of the aggregator POM `/pom.xml`, which causes Dependabot to also include all the remaining Log4j modules. The easiest solution to this problem is to remove "/" from the second configuration.

Pros:

- 99% of our managed dependencies are in "/log4j-parent" or the individual modules, so we will not miss many upgrades.
- No more duplicate PRs.

Cons:

- "pom.xml" contains some dummy managed dependencies to upgrade the version number of `commons-csv` and similar artifacts for **site-only** purposes. IMHO we should find a different way to upgrade these.

