### PR TITLE
Fix(Documentation): Fixed ConfigurationStrSubstitutor dccumenation.

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/ConfigurationStrSubstitutor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/ConfigurationStrSubstitutor.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Properties;
 
 /**
- * {@link RuntimeStrSubstitutor} is a {@link StrSubstitutor} which only supports recursive evaluation of lookups.
+ * {@link ConfigurationStrSubstitutor} is a {@link StrSubstitutor} which only supports recursive evaluation of lookups.
  * This can be dangerous when combined with user-provided inputs, and should only be used on data directly from
  * a configuration.
  */


### PR DESCRIPTION
Fix for #3170 

Added a fix for changing `ConfigurationStrSubstitutor`  classes' documentation. 

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise NA 
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry) NA 
* Trivial change
* Tests for the changes are provided - NA
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
