### PR TITLE
Publish build scans to develocity.apache.org

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     uses: apache/logging-parent/.github/workflows/build-reusable.yaml@rel/11.3.0
     secrets:
-      DV_ACCESS_TOKEN: ${{ startsWith(github.ref_name, 'release/') && '' || secrets.GE_ACCESS_TOKEN }}
+      DV_ACCESS_TOKEN: ${{ startsWith(github.ref_name, 'release/') && '' || secrets.DEVELOCITY_ACCESS_KEY }}
     with:
       java-version: |
         8

--- a/.github/workflows/develocity-publish-build-scans.yaml
+++ b/.github/workflows/develocity-publish-build-scans.yaml
@@ -39,4 +39,4 @@ jobs:
         uses: gradle/develocity-actions/maven-publish-build-scan@b8d3a572314ffff3b940a2c1b7b384d4983d422d   # 1.3
         with:
           develocity-url: 'https://develocity.apache.org'
-          develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}

--- a/.github/workflows/develocity-publish-build-scans.yaml
+++ b/.github/workflows/develocity-publish-build-scans.yaml
@@ -38,5 +38,5 @@ jobs:
       - name: Publish Build Scans
         uses: gradle/develocity-actions/maven-publish-build-scan@b8d3a572314ffff3b940a2c1b7b384d4983d422d   # 1.3
         with:
-          develocity-url: 'https://ge.apache.org'
+          develocity-url: 'https://develocity.apache.org'
           develocity-access-key: ${{ secrets.GE_ACCESS_TOKEN }}

--- a/.github/workflows/merge-dependabot.yaml
+++ b/.github/workflows/merge-dependabot.yaml
@@ -32,7 +32,7 @@ jobs:
     if: github.repository == 'apache/logging-log4j2' && github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
     uses: apache/logging-parent/.github/workflows/build-reusable.yaml@rel/11.3.0
     secrets:
-      DV_ACCESS_TOKEN: ${{ secrets.GE_ACCESS_TOKEN }}
+      DV_ACCESS_TOKEN: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     with:
       java-version: |
         8

--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -2,7 +2,7 @@
 <develocity>
     <projectId>logging-log4j2</projectId>
     <server>
-        <url>https://ge.apache.org</url>
+        <url>https://develocity.apache.org</url>
     </server>
     <buildScan>
         <capture>

--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@
     <log4j.docgen.pluginDescriptorsDir.phase1>${maven.multiModuleProjectDirectory}/target/plugin-descriptors/phase1</log4j.docgen.pluginDescriptorsDir.phase1>
     <log4j.docgen.pluginDescriptorsDir.phase2>${maven.multiModuleProjectDirectory}/target/plugin-descriptors/phase2</log4j.docgen.pluginDescriptorsDir.phase2>
 
-    <!-- Downgrade temporarily Maven Surefire, since it breaks tests statistics on `ge.apache.org` -->
+    <!-- Downgrade temporarily Maven Surefire, since it breaks tests statistics on `develocity.apache.org` -->
     <version.maven-surefire>3.2.5</version.maven-surefire>
   </properties>
 


### PR DESCRIPTION
This PR migrates the Log4j project to publish Build Scans to the the new Develocity instance at develocity.apache.org.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
