### PR TITLE
Fix log4j2.properties sample

### DIFF
--- a/src/site/antora/modules/ROOT/pages/manual/installation.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/installation.adoc
@@ -483,7 +483,7 @@ log4j2.properties::
 ----
 appender.0.type = Console
 appender.0.name = CONSOLE
-appender.0.layout = PatternLayout # <1>
+appender.0.layout.type = PatternLayout # <1>
 appender.0.layout.pattern = %d [%t] %5p %c{1.} - %m%n
 rootLogger.level = INFO
 rootLogger.appenderRef.0.ref = CONSOLE


### PR DESCRIPTION
Attempt to use the original log4j2.properties results in
org.apache.logging.log4j.core.config.ConfigurationException: No type attribute provided for Layout on Appender CONSOLE

Apparently `.type` is missing on respective line. This commit fixes that documentation error.