### PR TITLE
Add transitive compileOnlyApi (requires static) dependencies

### DIFF
--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -154,6 +154,16 @@
     <httpcore.version>4.4.16</httpcore.version>
     <jna.version>5.17.0</jna.version>
 
+    <!-- Add 'requires static' for annotation library dependencies (defined as <scope>provided</scope> in this file)
+         to allow them to be visible at compile time to make the '-Xlint:classfile' check of javac pass.
+         Overrides parent's 'bnd-jpms-module-info' and hence re-defines '$[bnd-module-name];access=0' -->
+    <bnd-jpms-module-info>$[bnd-module-name];access=0;modules="
+      biz.aQute.bnd.annotation,
+      com.google.errorprone.annotations,
+      com.github.spotbugs.annotations,
+      org.osgi.annotation.bundle,
+      org.osgi.annotation.versioning
+      "</bnd-jpms-module-info>
   </properties>
 
   <dependencyManagement>
@@ -1084,6 +1094,58 @@
               ]]></script>
               </scripts>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Add annotation library dependencies (defined as <scope>provided</scope> in this file) as compileOnlyApi
+           dependencies for Gradle consumers. This makes the Jars automatically available at compile time to make
+           the '-Xlint:classfile' check of javac pass.-->
+      <plugin>
+        <groupId>org.gradlex</groupId>
+        <artifactId>gradle-module-metadata-maven-plugin</artifactId>
+        <version>1.0.1</version>
+        <configuration>
+          <compileOnlyApiDependencies>
+            <dependency>
+              <groupId>org.jspecify</groupId>
+              <artifactId>jspecify</artifactId>
+              <version>${jspecify.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>biz.aQute.bnd</groupId>
+              <artifactId>biz.aQute.bnd.annotation</artifactId>
+              <version>${bnd.annotation.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_annotations</artifactId>
+              <version>${error-prone.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.osgi</groupId>
+              <!-- Note: 'org.osgi.annotation.bundle' and 'osgi.annotation' overlap. We do not want to add
+                   both. As 'org.osgi.annotation.bundle' has an Automatic-Module-Name, it is preferred. -->
+              <artifactId>org.osgi.annotation.bundle</artifactId>
+              <version>${osgi.annotation.bundle.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.osgi</groupId>
+              <artifactId>org.osgi.annotation.versioning</artifactId>
+              <version>${osgi.annotation.versioning.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>com.github.spotbugs</groupId>
+              <artifactId>spotbugs-annotations</artifactId>
+              <version>${spotbugs-annotations.version}</version>
+            </dependency>
+          </compileOnlyApiDependencies>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>gmm</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/src/changelog/.2.x.x/3437_transtive_compile_only_dependencies.xml
+++ b/src/changelog/.2.x.x/3437_transtive_compile_only_dependencies.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3437" link="https://github.com/apache/logging-log4j2/issues/3437"/>
+  <description format="asciidoc">
+    Make annotation libraries visible transitively at compile time for Gradle users through Gradle Module Metadata
+    and for JPMS users through `requires static` directives in `module-info.java` files.
+  </description>
+</entry>


### PR DESCRIPTION
This pull requests adds `compileOnlyApi` dependencies (Gradle Module Metadata) and `requires static` (module-info) for all annotation libraries used in Log4j. See #3437 for details.

The following example can be used to test the effects of the change in a Gradle build on a locally built snapshot:
https://github.com/jjohannes/gradle-demos/tree/main/log4j-metadata

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
