### PR TITLE
Fix formatting of `s` pattern

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatterTest.java
@@ -100,6 +100,9 @@ class InstantPatternDynamicFormatterTest {
         testCases.add(Arguments.of(
                 "HH:mm:ss.SSSSSS", ChronoUnit.MINUTES, asList(pDyn("HH':'mm':'", ChronoUnit.MINUTES), pSec(".", 6))));
 
+        // Seconds without padding
+        testCases.add(Arguments.of("s.SSS", ChronoUnit.SECONDS, asList(pDyn("s'.'", ChronoUnit.SECONDS), pMilliSec())));
+
         return testCases;
     }
 
@@ -352,7 +355,9 @@ class InstantPatternDynamicFormatterTest {
                         "yyyy-MM-dd'T'HH:mm:ss.SSS",
                         "yyyy-MM-dd'T'HH:mm:ss.SSSSSS",
                         "dd/MM/yy HH:mm:ss.SSS",
-                        "dd/MM/yyyy HH:mm:ss.SSS")
+                        "dd/MM/yyyy HH:mm:ss.SSS",
+                        // seconds without padding
+                        "s.SSS")
                 .flatMap(InstantPatternDynamicFormatterTest::formatterInputs);
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatterTest.java
@@ -65,13 +65,13 @@ class InstantPatternDynamicFormatterTest {
         testCases.add(Arguments.of(
                 "yyyyMMddHHmmssSSSX",
                 ChronoUnit.HOURS,
-                asList(pDyn("yyyyMMddHH", ChronoUnit.HOURS), pDyn("mm"), pSec("", 3), pDyn("X"))));
+                asList(pDyn("yyyyMMddHH", ChronoUnit.HOURS), pDyn("mm"), pSec(2, "", 3), pDyn("X"))));
 
         // `yyyyMMddHHmmssSSSX` instant cache updated per minute
         testCases.add(Arguments.of(
                 "yyyyMMddHHmmssSSSX",
                 ChronoUnit.MINUTES,
-                asList(pDyn("yyyyMMddHHmm", ChronoUnit.MINUTES), pSec("", 3), pDyn("X"))));
+                asList(pDyn("yyyyMMddHHmm", ChronoUnit.MINUTES), pSec(2, "", 3), pDyn("X"))));
 
         // ISO9601 instant cache updated daily
         final String iso8601InstantPattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
@@ -81,27 +81,29 @@ class InstantPatternDynamicFormatterTest {
                 asList(
                         pDyn("yyyy'-'MM'-'dd'T'", ChronoUnit.DAYS),
                         pDyn("HH':'mm':'", ChronoUnit.MINUTES),
-                        pSec(".", 3),
+                        pSec(2, ".", 3),
                         pDyn("X"))));
 
         // ISO9601 instant cache updated per minute
         testCases.add(Arguments.of(
                 iso8601InstantPattern,
                 ChronoUnit.MINUTES,
-                asList(pDyn("yyyy'-'MM'-'dd'T'HH':'mm':'", ChronoUnit.MINUTES), pSec(".", 3), pDyn("X"))));
+                asList(pDyn("yyyy'-'MM'-'dd'T'HH':'mm':'", ChronoUnit.MINUTES), pSec(2, ".", 3), pDyn("X"))));
 
         // ISO9601 instant cache updated per second
         testCases.add(Arguments.of(
                 iso8601InstantPattern,
                 ChronoUnit.SECONDS,
-                asList(pDyn("yyyy'-'MM'-'dd'T'HH':'mm':'", ChronoUnit.MINUTES), pSec(".", 3), pDyn("X"))));
+                asList(pDyn("yyyy'-'MM'-'dd'T'HH':'mm':'", ChronoUnit.MINUTES), pSec(2, ".", 3), pDyn("X"))));
 
         // Seconds and micros
         testCases.add(Arguments.of(
-                "HH:mm:ss.SSSSSS", ChronoUnit.MINUTES, asList(pDyn("HH':'mm':'", ChronoUnit.MINUTES), pSec(".", 6))));
+                "HH:mm:ss.SSSSSS",
+                ChronoUnit.MINUTES,
+                asList(pDyn("HH':'mm':'", ChronoUnit.MINUTES), pSec(2, ".", 6))));
 
         // Seconds without padding
-        testCases.add(Arguments.of("s.SSS", ChronoUnit.SECONDS, asList(pDyn("s'.'", ChronoUnit.SECONDS), pMilliSec())));
+        testCases.add(Arguments.of("s.SSS", ChronoUnit.SECONDS, singletonList(pSec(1, ".", 3))));
 
         return testCases;
     }
@@ -114,12 +116,12 @@ class InstantPatternDynamicFormatterTest {
         return new DynamicPatternSequence(pattern, precision);
     }
 
-    private static SecondPatternSequence pSec(String separator, int fractionalDigits) {
-        return new SecondPatternSequence(true, separator, fractionalDigits);
+    private static SecondPatternSequence pSec(int secondDigits, String separator, int fractionalDigits) {
+        return new SecondPatternSequence(secondDigits, separator, fractionalDigits);
     }
 
     private static SecondPatternSequence pMilliSec() {
-        return new SecondPatternSequence(false, "", 3);
+        return new SecondPatternSequence(0, "", 3);
     }
 
     @ParameterizedTest
@@ -369,7 +371,7 @@ class InstantPatternDynamicFormatterTest {
             Arrays.stream(TimeZone.getAvailableIDs()).map(TimeZone::getTimeZone).toArray(TimeZone[]::new);
 
     static Stream<Arguments> formatterInputs(final String pattern) {
-        return IntStream.range(0, 500).mapToObj(ignoredIndex -> {
+        return IntStream.range(0, 100).mapToObj(ignoredIndex -> {
             final Locale locale = LOCALES[RANDOM.nextInt(LOCALES.length)];
             final TimeZone timeZone = TIME_ZONES[RANDOM.nextInt(TIME_ZONES.length)];
             final MutableInstant instant = randomInstant();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
@@ -702,11 +702,19 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
             super(
                     createPattern(secondDigits, separator, fractionalDigits),
                     determinePrecision(secondDigits, fractionalDigits));
-            if (secondDigits < 0 || secondDigits > 2) {
-                throw new IllegalArgumentException("Unsupported number of `s` pattern letters.");
+            final int maxSecondDigits = 2;
+            if (secondDigits > maxSecondDigits) {
+                final String message = String.format(
+                        "More than %d `s` pattern letters are not supported, found: %d",
+                        maxSecondDigits, secondDigits);
+                throw new IllegalArgumentException(message);
             }
-            if (fractionalDigits > 9) {
-                throw new IllegalArgumentException("Unsupported number of `S` pattern letters.");
+            final int maxFractionalDigits = 9;
+            if (fractionalDigits > maxFractionalDigits) {
+                final String message = String.format(
+                        "More than %d `S` pattern letters are not supported, found: %d",
+                        maxFractionalDigits, fractionalDigits);
+                throw new IllegalArgumentException(message);
             }
             this.secondDigits = secondDigits;
             this.separator = separator;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
@@ -705,8 +705,7 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
             final int maxSecondDigits = 2;
             if (secondDigits > maxSecondDigits) {
                 final String message = String.format(
-                        "More than %d `s` pattern letters are not supported, found: %d",
-                        maxSecondDigits, secondDigits);
+                        "More than %d `s` pattern letters are not supported, found: %d", maxSecondDigits, secondDigits);
                 throw new IllegalArgumentException(message);
             }
             final int maxFractionalDigits = 9;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
@@ -726,15 +726,8 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
             return secondDigits > 0 ? ChronoUnit.SECONDS : ChronoUnit.FOREVER;
         }
 
-        private void formatSeconds(StringBuilder buffer, Instant instant) {
-            switch (secondDigits) {
-                case 1:
-                    buffer.append(instant.getEpochSecond() % 60L);
-                    break;
-                case 2:
-                    formatPaddedSeconds(buffer, instant);
-                    break;
-            }
+        private static void formatUnpaddedSeconds(StringBuilder buffer, Instant instant) {
+            buffer.append(instant.getEpochSecond() % 60L);
         }
 
         private static void formatPaddedSeconds(StringBuilder buffer, Instant instant) {
@@ -768,8 +761,9 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
 
         @Override
         InstantPatternFormatter createFormatter(Locale locale, TimeZone timeZone) {
-            final BiConsumer<StringBuilder, Instant> secondDigitsFormatter =
-                    secondDigits == 2 ? SecondPatternSequence::formatPaddedSeconds : this::formatSeconds;
+            final BiConsumer<StringBuilder, Instant> secondDigitsFormatter = secondDigits == 2
+                    ? SecondPatternSequence::formatPaddedSeconds
+                    : SecondPatternSequence::formatUnpaddedSeconds;
             final BiConsumer<StringBuilder, Instant> fractionDigitsFormatter =
                     fractionalDigits == 3 ? SecondPatternSequence::formatMillis : this::formatFractionalDigits;
             if (secondDigits == 0) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternDynamicFormatter.java
@@ -239,7 +239,11 @@ final class InstantPatternDynamicFormatter implements InstantPatternFormatter {
                 final PatternSequence sequence;
                 switch (c) {
                     case 's':
-                        sequence = new SecondPatternSequence(true, "", 0);
+                        if (sequenceContent.length() == 2) {
+                            sequence = new SecondPatternSequence(true, "", 0);
+                        } else {
+                            sequence = new DynamicPatternSequence(sequenceContent);
+                        }
                         break;
                     case 'S':
                         sequence = new SecondPatternSequence(false, "", sequenceContent.length());


### PR DESCRIPTION
The specialized `SecondPatternSequence` formatter is optimized to format the `ss.?S*` patterns, where seconds are padded. For the not padded (and uncommon) `s` pattern, we should use the usual `DynamicPatternSequence`.

This is the main reason for the failing #3468 test.
