### PR TITLE
2791 Fix handling of `onMatch` and `onMismatch` attributes in the properties configuration format

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationConverter.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationConverter.java
@@ -32,7 +32,6 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import org.apache.logging.log4j.core.config.ConfigurationException;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.config.builder.impl.DefaultConfigurationBuilder;
 import org.apache.logging.log4j.core.tools.BasicCommandLineArguments;
 import org.apache.logging.log4j.core.tools.picocli.CommandLine;
@@ -160,8 +159,7 @@ public final class Log4j1ConfigurationConverter {
     }
 
     protected void convert(final InputStream input, final OutputStream output) throws IOException {
-        final ConfigurationBuilder<BuiltConfiguration> builder =
-                new Log4j1ConfigurationParser().buildConfigurationBuilder(input);
+        final ConfigurationBuilder<?> builder = new Log4j1ConfigurationParser().buildConfigurationBuilder(input);
         builder.writeXmlConfiguration(output);
     }
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationFactory.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationFactory.java
@@ -24,7 +24,6 @@ import org.apache.logging.log4j.core.config.ConfigurationException;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 
 /**
  * Experimental ConfigurationFactory for Log4j 1.2 properties configuration files.
@@ -40,7 +39,7 @@ public class Log4j1ConfigurationFactory extends ConfigurationFactory {
 
     @Override
     public Configuration getConfiguration(final LoggerContext loggerContext, final ConfigurationSource source) {
-        final ConfigurationBuilder<BuiltConfiguration> builder;
+        final ConfigurationBuilder<?> builder;
         try (final InputStream configStream = source.getInputStream()) {
             builder = new Log4j1ConfigurationParser().buildConfigurationBuilder(configStream);
         } catch (final IOException e) {

--- a/log4j-core-fuzz-test/src/main/java/org/apache/logging/log4j/core/fuzz/PatternLayoutFuzzer.java
+++ b/log4j-core-fuzz-test/src/main/java/org/apache/logging/log4j/core/fuzz/PatternLayoutFuzzer.java
@@ -34,7 +34,7 @@ public final class PatternLayoutFuzzer {
                 createLoggerContext(loggerContextName, EncodingAppender.PLUGIN_NAME, configBuilder -> configBuilder
                         .newLayout("PatternLayout")
                         // Enforce using a single message-based converter, i.e., `MessagePatternConverter`
-                        .addAttribute("pattern", "%m"))) {
+                        .setAttribute("pattern", "%m"))) {
             final ExtendedLogger logger = loggerContext.getLogger(PatternLayoutFuzzer.class);
             final LoggerFacade loggerFacade = new Log4jLoggerFacade(logger);
             fuzzLogger(loggerFacade, dataProvider);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/EventParameterMemoryLeakTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/EventParameterMemoryLeakTest.java
@@ -28,7 +28,6 @@ import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
 import org.apache.logging.log4j.core.config.builder.api.LayoutComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.RootLoggerComponentBuilder;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -88,10 +87,9 @@ class EventParameterMemoryLeakTest {
 
     @SuppressWarnings("SameParameterValue")
     private static Configuration createConfiguration(final String appenderName) {
-        final ConfigurationBuilder<BuiltConfiguration> configBuilder =
-                ConfigurationBuilderFactory.newConfigurationBuilder();
+        final ConfigurationBuilder<?> configBuilder = ConfigurationBuilderFactory.newConfigurationBuilder();
         final LayoutComponentBuilder layoutComponentBuilder =
-                configBuilder.newLayout("PatternLayout").addAttribute("pattern", "%m");
+                configBuilder.newLayout("PatternLayout").setAttribute("pattern", "%m");
         final AppenderComponentBuilder appenderComponentBuilder =
                 configBuilder.newAppender(appenderName, "List").add(layoutComponentBuilder);
         final RootLoggerComponentBuilder loggerComponentBuilder =

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/ReconfigureAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/ReconfigureAppenderTest.java
@@ -27,9 +27,7 @@ import org.apache.logging.log4j.core.appender.rolling.SizeBasedTriggeringPolicy;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.layout.PatternLayout;
-import org.apache.logging.log4j.core.util.Builder;
 import org.junit.jupiter.api.Test;
 
 class ReconfigureAppenderTest {
@@ -127,8 +125,7 @@ class ReconfigureAppenderTest {
     }
 
     private void createAndAddAppender() {
-        final ConfigurationBuilder<BuiltConfiguration> config_builder =
-                ConfigurationBuilderFactory.newConfigurationBuilder();
+        final ConfigurationBuilder<?> config_builder = ConfigurationBuilderFactory.newConfigurationBuilder();
 
         // All loggers must have a root logger. The default root logger logs ERRORs to the console.
         // Override this with a root logger that does not log anywhere as we leave it up the
@@ -141,10 +138,10 @@ class ReconfigureAppenderTest {
         // Retrieve the logger.
         final Logger logger = (Logger) LogManager.getLogger(this.getClass());
 
-        final Builder pattern_builder =
+        final PatternLayout.Builder pattern_builder =
                 PatternLayout.newBuilder().withPattern("[%d{dd-MM-yy HH:mm:ss}] %p %m %throwable %n");
 
-        final PatternLayout pattern_layout = (PatternLayout) pattern_builder.build();
+        final PatternLayout pattern_layout = pattern_builder.build();
 
         appender = RollingFileAppender.newBuilder()
                 .withLayout(pattern_layout)

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SocketAppenderReconnectTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SocketAppenderReconnectTest.java
@@ -42,7 +42,6 @@ import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder
 import org.apache.logging.log4j.core.config.builder.api.ComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.net.TcpSocketManager;
 import org.apache.logging.log4j.core.net.TcpSocketManager.HostResolver;
 import org.apache.logging.log4j.core.net.ssl.SslKeyStoreConstants;
@@ -219,24 +218,21 @@ class SocketAppenderReconnectTest {
             final int server1Port = server1.getServerSocket().getLocalPort();
 
             // Create the configuration transformer to add the `<Ssl>`, `<KeyStore>`, and `<TrustStore>` elements
-            final BiFunction<
-                            ConfigurationBuilder<BuiltConfiguration>,
-                            AppenderComponentBuilder,
-                            AppenderComponentBuilder>
+            final BiFunction<ConfigurationBuilder<?>, AppenderComponentBuilder, AppenderComponentBuilder>
                     appenderComponentBuilderTransformer = (configBuilder, appenderComponentBuilder) -> {
                         final ComponentBuilder<?> keyStoreComponentBuilder = configBuilder
                                 .newComponent("KeyStore")
-                                .addAttribute("type", keyStoreType)
-                                .addAttribute("location", keyStoreFilePath.toString())
-                                .addAttribute("passwordFile", keyStorePasswordFilePath);
+                                .setAttribute("type", keyStoreType)
+                                .setAttribute("location", keyStoreFilePath.toString())
+                                .setAttribute("passwordFile", keyStorePasswordFilePath);
                         final ComponentBuilder<?> trustStoreComponentBuilder = configBuilder
                                 .newComponent("TrustStore")
-                                .addAttribute("type", trustStoreType)
-                                .addAttribute("location", trustStoreFilePath.toString())
-                                .addAttribute("passwordFile", trustStorePasswordFilePath);
+                                .setAttribute("type", trustStoreType)
+                                .setAttribute("location", trustStoreFilePath.toString())
+                                .setAttribute("passwordFile", trustStorePasswordFilePath);
                         return appenderComponentBuilder.addComponent(configBuilder
                                 .newComponent("Ssl")
-                                .addAttribute("protocol", "TLS")
+                                .setAttribute("protocol", "TLS")
                                 .addComponent(keyStoreComponentBuilder)
                                 .addComponent(trustStoreComponentBuilder));
                     };
@@ -301,27 +297,23 @@ class SocketAppenderReconnectTest {
             final String host,
             final int port,
             @Nullable
-                    final BiFunction<
-                                    ConfigurationBuilder<BuiltConfiguration>,
-                                    AppenderComponentBuilder,
-                                    AppenderComponentBuilder>
+                    final BiFunction<ConfigurationBuilder<?>, AppenderComponentBuilder, AppenderComponentBuilder>
                             appenderComponentBuilderTransformer) {
 
         // Create the configuration builder
-        final ConfigurationBuilder<BuiltConfiguration> configBuilder =
-                ConfigurationBuilderFactory.newConfigurationBuilder()
-                        .setStatusLevel(Level.ERROR)
-                        .setConfigurationName(SocketAppenderReconnectTest.class.getSimpleName());
+        final ConfigurationBuilder<?> configBuilder = ConfigurationBuilderFactory.newConfigurationBuilder()
+                .setStatusLevel(Level.ERROR)
+                .setConfigurationName(SocketAppenderReconnectTest.class.getSimpleName());
 
         // Create the appender configuration
         final AppenderComponentBuilder appenderComponentBuilder = configBuilder
                 .newAppender(APPENDER_NAME, "Socket")
-                .addAttribute("host", host)
-                .addAttribute("port", port)
-                .addAttribute("ignoreExceptions", false)
-                .addAttribute("reconnectionDelayMillis", 10)
-                .addAttribute("immediateFlush", true)
-                .add(configBuilder.newLayout("PatternLayout").addAttribute("pattern", "%m%n"));
+                .setAttribute("host", host)
+                .setAttribute("port", port)
+                .setAttribute("ignoreExceptions", false)
+                .setAttribute("reconnectionDelayMillis", 10)
+                .setAttribute("immediateFlush", true)
+                .add(configBuilder.newLayout("PatternLayout").setAttribute("pattern", "%m%n"));
         final AppenderComponentBuilder transformedAppenderComponentBuilder = appenderComponentBuilderTransformer != null
                 ? appenderComponentBuilderTransformer.apply(configBuilder, appenderComponentBuilder)
                 : appenderComponentBuilder;
@@ -406,7 +398,7 @@ class SocketAppenderReconnectTest {
         // Verify the failure
         for (int i = 0; i < retryCount; i++) {
             try {
-                logger.info("should fail #" + i);
+                logger.info("should fail #{}", i);
                 fail("should have failed #" + i);
             } catch (final AppenderLoggingException ignored) {
                 assertThat(errorHandler.getBuffer()).hasSize(2 * (i + 1));

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SocketAppenderSslSocketOptionsTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SocketAppenderSslSocketOptionsTest.java
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder
 import org.apache.logging.log4j.core.config.builder.api.ComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.net.Rfc1349TrafficClass;
 import org.apache.logging.log4j.core.net.SocketOptions;
 import org.apache.logging.log4j.core.net.SocketPerformancePreferences;
@@ -134,10 +133,9 @@ class SocketAppenderSslSocketOptionsTest {
     private static Configuration createConfiguration(final Path tempDir, final int port) throws Exception {
 
         // Create the configuration builder
-        final ConfigurationBuilder<BuiltConfiguration> configBuilder =
-                ConfigurationBuilderFactory.newConfigurationBuilder()
-                        .setStatusLevel(Level.ERROR)
-                        .setConfigurationName(SocketAppenderReconnectTest.class.getSimpleName());
+        final ConfigurationBuilder<?> configBuilder = ConfigurationBuilderFactory.newConfigurationBuilder()
+                .setStatusLevel(Level.ERROR)
+                .setConfigurationName(SocketAppenderReconnectTest.class.getSimpleName());
 
         // Stage the key store password file
         final Path keyStorePasswordFilePath = tempDir.resolve("keyStorePassword");
@@ -150,47 +148,47 @@ class SocketAppenderSslSocketOptionsTest {
         // Create the `SocketOptions` element
         final ComponentBuilder<?> socketPerformancePreferencesComponentBuilder = configBuilder
                 .newComponent("SocketPerformancePreferences")
-                .addAttribute("bandwidth", SOCKET_PERFORMANCE_PREFERENCE_BANDWIDTH)
-                .addAttribute("connectionTime", SOCKET_PERFORMANCE_PREFERENCE_CONNECTION_TIME)
-                .addAttribute("latency", SOCKET_PERFORMANCE_PREFERENCE_LATENCY);
+                .setAttribute("bandwidth", SOCKET_PERFORMANCE_PREFERENCE_BANDWIDTH)
+                .setAttribute("connectionTime", SOCKET_PERFORMANCE_PREFERENCE_CONNECTION_TIME)
+                .setAttribute("latency", SOCKET_PERFORMANCE_PREFERENCE_LATENCY);
         final ComponentBuilder<?> socketOptionsComponentBuilder = configBuilder
                 .newComponent("SocketOptions")
-                .addAttribute("keepAlive", SOCKET_OPTION_KEEP_ALIVE)
-                .addAttribute("receiveBufferSize", SOCKET_OPTION_RECEIVE_BUFFER_SIZE)
-                .addAttribute("reuseAddress", SOCKET_OPTION_REUSE_ADDRESS)
-                .addAttribute("rfc1349TrafficClass", SOCKET_OPTION_RFC1349_TRAFFIC_CLASS)
-                .addAttribute("sendBufferSize", SOCKET_OPTION_SEND_BUFFER_SIZE)
-                .addAttribute("soLinger", SOCKET_OPTION_LINGER)
-                .addAttribute("soTimeout", SOCKET_OPTION_TIMEOUT)
-                .addAttribute("tcpNoDelay", SOCKET_OPTION_TCP_NO_DELAY)
+                .setAttribute("keepAlive", SOCKET_OPTION_KEEP_ALIVE)
+                .setAttribute("receiveBufferSize", SOCKET_OPTION_RECEIVE_BUFFER_SIZE)
+                .setAttribute("reuseAddress", SOCKET_OPTION_REUSE_ADDRESS)
+                .setAttribute("rfc1349TrafficClass", SOCKET_OPTION_RFC1349_TRAFFIC_CLASS)
+                .setAttribute("sendBufferSize", SOCKET_OPTION_SEND_BUFFER_SIZE)
+                .setAttribute("soLinger", SOCKET_OPTION_LINGER)
+                .setAttribute("soTimeout", SOCKET_OPTION_TIMEOUT)
+                .setAttribute("tcpNoDelay", SOCKET_OPTION_TCP_NO_DELAY)
                 .addComponent(socketPerformancePreferencesComponentBuilder);
 
         // Create the `Ssl` element
         final ComponentBuilder<?> keyStoreComponentBuilder = configBuilder
                 .newComponent("KeyStore")
-                .addAttribute("type", KEYSTORE_TYPE)
-                .addAttribute("location", KEYSTORE_LOCATION)
-                .addAttribute("passwordFile", keyStorePasswordFilePath);
+                .setAttribute("type", KEYSTORE_TYPE)
+                .setAttribute("location", KEYSTORE_LOCATION)
+                .setAttribute("passwordFile", keyStorePasswordFilePath);
         final ComponentBuilder<?> trustStoreComponentBuilder = configBuilder
                 .newComponent("TrustStore")
-                .addAttribute("type", TRUSTSTORE_TYPE)
-                .addAttribute("location", TRUSTSTORE_LOCATION)
-                .addAttribute("passwordFile", trustStorePasswordFilePath);
+                .setAttribute("type", TRUSTSTORE_TYPE)
+                .setAttribute("location", TRUSTSTORE_LOCATION)
+                .setAttribute("passwordFile", trustStorePasswordFilePath);
         final ComponentBuilder<?> sslComponentBuilder = configBuilder
                 .newComponent("Ssl")
-                .addAttribute("protocol", "TLS")
+                .setAttribute("protocol", "TLS")
                 .addComponent(keyStoreComponentBuilder)
                 .addComponent(trustStoreComponentBuilder);
 
         // Create the `Socket` element
         final AppenderComponentBuilder appenderComponentBuilder = configBuilder
                 .newAppender(APPENDER_NAME, "Socket")
-                .addAttribute("host", "localhost")
-                .addAttribute("port", port)
-                .addAttribute("ignoreExceptions", false)
-                .addAttribute("reconnectionDelayMillis", 10)
-                .addAttribute("immediateFlush", true)
-                .add(configBuilder.newLayout("PatternLayout").addAttribute("pattern", "%m%n"))
+                .setAttribute("host", "localhost")
+                .setAttribute("port", port)
+                .setAttribute("ignoreExceptions", false)
+                .setAttribute("reconnectionDelayMillis", 10)
+                .setAttribute("immediateFlush", true)
+                .add(configBuilder.newLayout("PatternLayout").setAttribute("pattern", "%m%n"))
                 .addComponent(socketOptionsComponentBuilder)
                 .addComponent(sslComponentBuilder);
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderInterruptedThreadTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderInterruptedThreadTest.java
@@ -30,7 +30,6 @@ import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.test.junit.CleanFolders;
 import org.junit.After;
 import org.junit.Before;
@@ -38,7 +37,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Tests https://issues.apache.org/jira/browse/LOG4J2-1798
+ * Tests <a href="https://issues.apache.org/jira/browse/LOG4J2-1798"/>.
  */
 public class RollingFileAppenderInterruptedThreadTest {
 
@@ -52,17 +51,17 @@ public class RollingFileAppenderInterruptedThreadTest {
 
     @Before
     public void setUp() {
-        final ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
+        final ConfigurationBuilder<?> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
         builder.setConfigurationName("LOG4J2-1798 test");
 
         builder.add(
-                builder.newAppender("consoleLog", "Console").addAttribute("target", ConsoleAppender.Target.SYSTEM_ERR));
+                builder.newAppender("consoleLog", "Console").setAttribute("target", ConsoleAppender.Target.SYSTEM_ERR));
 
         builder.add(builder.newAppender("fileAppender", "RollingFile")
-                .addAttribute("filePattern", ROLLING_APPENDER_FILES_DIR + "/file-%i.log")
-                .add(builder.newLayout("PatternLayout").addAttribute("pattern", "%msg%n"))
+                .setAttribute("filePattern", ROLLING_APPENDER_FILES_DIR + "/file-%i.log")
+                .add(builder.newLayout("PatternLayout").setAttribute("pattern", "%msg%n"))
                 .addComponent(builder.newComponent("SizeBasedTriggeringPolicy")
-                        .addAttribute("size", "20B"))); // relatively small amount to trigger rotation quickly
+                        .setAttribute("size", "20B"))); // relatively small amount to trigger rotation quickly
 
         builder.add(builder.newRootLogger(Level.INFO)
                 .add(builder.newAppenderRef("consoleLog"))

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderUpdateDataTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileAppenderUpdateDataTest.java
@@ -28,7 +28,6 @@ import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,26 +36,26 @@ import org.junit.jupiter.api.Test;
  */
 class RollingFileAppenderUpdateDataTest {
 
-    private ConfigurationBuilder<BuiltConfiguration> buildConfigA() {
+    private ConfigurationBuilder<?> buildConfigA() {
         return buildConfigurationBuilder("target/rolling-update-date/foo.log.%i");
     }
 
     // rebuild config with date based rollover
-    private ConfigurationBuilder<BuiltConfiguration> buildConfigB() {
+    private ConfigurationBuilder<?> buildConfigB() {
         return buildConfigurationBuilder("target/rolling-update-date/foo.log.%d{yyyy-MM-dd-HH:mm:ss}.%i");
     }
 
-    private ConfigurationBuilder<BuiltConfiguration> buildConfigurationBuilder(final String filePattern) {
-        final ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
+    private ConfigurationBuilder<?> buildConfigurationBuilder(final String filePattern) {
+        final ConfigurationBuilder<?> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
         builder.setConfigurationName("LOG4J2-1964 demo");
         builder.setStatusLevel(Level.ERROR);
         // @formatter:off
         builder.add(
-                builder.newAppender("consoleLog", "Console").addAttribute("target", ConsoleAppender.Target.SYSTEM_ERR));
+                builder.newAppender("consoleLog", "Console").setAttribute("target", ConsoleAppender.Target.SYSTEM_ERR));
         builder.add(builder.newAppender("fooAppender", "RollingFile")
-                .addAttribute("fileName", "target/rolling-update-date/foo.log")
-                .addAttribute("filePattern", filePattern)
-                .addComponent(builder.newComponent("SizeBasedTriggeringPolicy").addAttribute("size", "10MB")));
+                .setAttribute("fileName", "target/rolling-update-date/foo.log")
+                .setAttribute("filePattern", filePattern)
+                .addComponent(builder.newComponent("SizeBasedTriggeringPolicy").setAttribute("size", "10MB")));
         builder.add(builder.newRootLogger(Level.INFO)
                 .add(builder.newAppenderRef("consoleLog"))
                 .add(builder.newAppenderRef("fooAppender")));
@@ -82,15 +81,15 @@ class RollingFileAppenderUpdateDataTest {
     @Test
     void testClosingLoggerContext() {
         // initial config with indexed rollover
-        try (final LoggerContext loggerContext1 =
+        try (final LoggerContext tLoggerContext1 =
                 Configurator.initialize(buildConfigA().build())) {
-            validateAppender(loggerContext1, "target/rolling-update-date/foo.log.%i");
+            validateAppender(tLoggerContext1, "target/rolling-update-date/foo.log.%i");
         }
 
         // rebuild config with date based rollover
-        try (final LoggerContext loggerContext2 =
+        try (final LoggerContext tLoggerContext2 =
                 Configurator.initialize(buildConfigB().build())) {
-            validateAppender(loggerContext2, "target/rolling-update-date/foo.log.%d{yyyy-MM-dd-HH:mm:ss}.%i");
+            validateAppender(tLoggerContext2, "target/rolling-update-date/foo.log.%d{yyyy-MM-dd-HH:mm:ss}.%i");
         }
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/Configurator1Test.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/Configurator1Test.java
@@ -481,7 +481,7 @@ class Configurator1Test {
         builder.setStatusLevel(Level.ERROR);
         builder.setConfigurationName("BuilderTest");
         builder.add(builder.newScriptFile("filter.groovy", "target/test-classes/scripts/filter.groovy")
-                .addIsWatched(true));
+                .setIsWatchedAttribute(true));
         final AppenderComponentBuilder appenderBuilder =
                 builder.newAppender("Stdout", "CONSOLE").addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
         appenderBuilder.add(builder.newLayout("PatternLayout")

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/MissingLanguageTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/MissingLanguageTest.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.util.Constants;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
@@ -56,30 +55,30 @@ class MissingLanguageTest {
                         + "            } else {\n"
                         + "                return null;\n"
                         + "            }";
-        final ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
+        final ConfigurationBuilder<?> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
         builder.setStatusLevel(Level.ERROR);
         builder.setConfigurationName("BuilderTest");
         builder.add(builder.newScriptFile("filter.groovy", "target/test-classes/scripts/filter.groovy")
                 .setIsWatchedAttribute(true));
         final AppenderComponentBuilder appenderBuilder =
-                builder.newAppender("Stdout", "CONSOLE").addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
+                builder.newAppender("Stdout", "CONSOLE").setAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
         appenderBuilder.add(builder.newLayout("PatternLayout")
                 .addComponent(builder.newComponent("ScriptPatternSelector")
-                        .addAttribute("defaultPattern", "[%-5level] %c{1.} %C{1.}.%M.%L %msg%n")
+                        .setAttribute("defaultPattern", "[%-5level] %c{1.} %C{1.}.%M.%L %msg%n")
                         .addComponent(builder.newComponent("PatternMatch")
-                                .addAttribute("key", "NoLocation")
-                                .addAttribute("pattern", "[%-5level] %c{1.} %msg%n"))
+                                .setAttribute("key", "NoLocation")
+                                .setAttribute("pattern", "[%-5level] %c{1.} %msg%n"))
                         .addComponent(builder.newComponent("PatternMatch")
-                                .addAttribute("key", "FLOW")
-                                .addAttribute("pattern", "[%-5level] %c{1.} ====== %C{1.}.%M:%L %msg ======%n"))
+                                .setAttribute("key", "FLOW")
+                                .setAttribute("pattern", "[%-5level] %c{1.} ====== %C{1.}.%M:%L %msg ======%n"))
                         .addComponent(builder.newComponent("selectorScript", "Script", script)
-                                .addAttribute("language", "beanshell"))));
+                                .setAttribute("language", "beanshell"))));
         appenderBuilder.add(builder.newFilter("ScriptFilter", Filter.Result.DENY, Filter.Result.NEUTRAL)
-                .addComponent(builder.newComponent("ScriptRef").addAttribute("ref", "filter.groovy")));
+                .addComponent(builder.newComponent("ScriptRef").setAttribute("ref", "filter.groovy")));
         builder.add(appenderBuilder);
         builder.add(builder.newLogger("org.apache.logging.log4j", Level.DEBUG)
                 .add(builder.newAppenderRef("Stdout"))
-                .addAttribute("additivity", false));
+                .setAdditivityAttribute(false));
         builder.add(builder.newRootLogger(Level.ERROR).add(builder.newAppenderRef("Stdout")));
         ctx = Configurator.initialize(builder.build());
         final Configuration config = ctx.getConfiguration();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/MissingLanguageTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/MissingLanguageTest.java
@@ -60,7 +60,7 @@ class MissingLanguageTest {
         builder.setStatusLevel(Level.ERROR);
         builder.setConfigurationName("BuilderTest");
         builder.add(builder.newScriptFile("filter.groovy", "target/test-classes/scripts/filter.groovy")
-                .addIsWatched(true));
+                .setIsWatchedAttribute(true));
         final AppenderComponentBuilder appenderBuilder =
                 builder.newAppender("Stdout", "CONSOLE").addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
         appenderBuilder.add(builder.newLayout("PatternLayout")

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/NoLanguagesTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/NoLanguagesTest.java
@@ -57,7 +57,7 @@ class NoLanguagesTest {
         builder.setStatusLevel(Level.ERROR);
         builder.setConfigurationName("BuilderTest");
         builder.add(builder.newScriptFile("filter.groovy", "target/test-classes/scripts/filter.groovy")
-                .addIsWatched(true));
+                .setIsWatchedAttribute(true));
         final AppenderComponentBuilder appenderBuilder =
                 builder.newAppender("Stdout", "CONSOLE").addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
         appenderBuilder.add(builder.newLayout("PatternLayout")

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/NoLanguagesTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/NoLanguagesTest.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -53,30 +52,30 @@ class NoLanguagesTest {
                         + "            } else {\n"
                         + "                return null;\n"
                         + "            }";
-        final ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
+        final ConfigurationBuilder<?> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
         builder.setStatusLevel(Level.ERROR);
         builder.setConfigurationName("BuilderTest");
         builder.add(builder.newScriptFile("filter.groovy", "target/test-classes/scripts/filter.groovy")
                 .setIsWatchedAttribute(true));
         final AppenderComponentBuilder appenderBuilder =
-                builder.newAppender("Stdout", "CONSOLE").addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
+                builder.newAppender("Stdout", "CONSOLE").setAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
         appenderBuilder.add(builder.newLayout("PatternLayout")
                 .addComponent(builder.newComponent("ScriptPatternSelector")
-                        .addAttribute("defaultPattern", "[%-5level] %c{1.} %C{1.}.%M.%L %msg%n")
+                        .setAttribute("defaultPattern", "[%-5level] %c{1.} %C{1.}.%M.%L %msg%n")
                         .addComponent(builder.newComponent("PatternMatch")
-                                .addAttribute("key", "NoLocation")
-                                .addAttribute("pattern", "[%-5level] %c{1.} %msg%n"))
+                                .setAttribute("key", "NoLocation")
+                                .setAttribute("pattern", "[%-5level] %c{1.} %msg%n"))
                         .addComponent(builder.newComponent("PatternMatch")
-                                .addAttribute("key", "FLOW")
-                                .addAttribute("pattern", "[%-5level] %c{1.} ====== %C{1.}.%M:%L %msg ======%n"))
+                                .setAttribute("key", "FLOW")
+                                .setAttribute("pattern", "[%-5level] %c{1.} ====== %C{1.}.%M:%L %msg ======%n"))
                         .addComponent(builder.newComponent("selectorScript", "Script", script)
-                                .addAttribute("language", "beanshell"))));
+                                .setAttribute("language", "beanshell"))));
         appenderBuilder.add(builder.newFilter("ScriptFilter", Filter.Result.DENY, Filter.Result.NEUTRAL)
-                .addComponent(builder.newComponent("ScriptRef").addAttribute("ref", "filter.groovy")));
+                .addComponent(builder.newComponent("ScriptRef").setAttribute("ref", "filter.groovy")));
         builder.add(appenderBuilder);
         builder.add(builder.newLogger("org.apache.logging.log4j", Level.DEBUG)
                 .add(builder.newAppenderRef("Stdout"))
-                .addAttribute("additivity", false));
+                .setAdditivityAttribute(false));
         builder.add(builder.newRootLogger(Level.ERROR).add(builder.newAppenderRef("Stdout")));
         ctx = Configurator.initialize(builder.build());
         final Configuration config = ctx.getConfiguration();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/ConfigurationAssemblerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/ConfigurationAssemblerTest.java
@@ -41,7 +41,6 @@ import org.apache.logging.log4j.core.config.CustomLevelConfig;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.core.layout.GelfLayout;
 import org.apache.logging.log4j.core.layout.PatternLayout;
@@ -55,8 +54,7 @@ class ConfigurationAssemblerTest {
         try {
             System.setProperty(
                     Constants.LOG4J_CONTEXT_SELECTOR, "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector");
-            final ConfigurationBuilder<BuiltConfiguration> builder =
-                    ConfigurationBuilderFactory.newConfigurationBuilder();
+            final ConfigurationBuilder<?> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
             CustomConfigurationFactory.addTestFixtures("config name", builder);
             final Configuration configuration = builder.build();
             try (final LoggerContext ctx = Configurator.initialize(configuration)) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/ConfigurationBuilderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/ConfigurationBuilderTest.java
@@ -38,7 +38,7 @@ class ConfigurationBuilderTest {
         builder.setStatusLevel(Level.ERROR);
         builder.setShutdownTimeout(5000, TimeUnit.MILLISECONDS);
         builder.add(builder.newScriptFile("target/test-classes/scripts/filter.groovy")
-                .addIsWatched(true));
+                .setIsWatchedAttribute(true));
         builder.add(builder.newFilter("ThresholdFilter", Filter.Result.ACCEPT, Filter.Result.NEUTRAL)
                 .addAttribute("level", Level.DEBUG));
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/ConfigurationBuilderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/ConfigurationBuilderTest.java
@@ -25,7 +25,6 @@ import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.junit.jupiter.api.Test;
 
 class ConfigurationBuilderTest {
@@ -33,38 +32,37 @@ class ConfigurationBuilderTest {
     private static final String INDENT = "  ";
     private static final String EOL = System.lineSeparator();
 
-    private void addTestFixtures(final String name, final ConfigurationBuilder<BuiltConfiguration> builder) {
+    private void addTestFixtures(final String name, final ConfigurationBuilder<?> builder) {
         builder.setConfigurationName(name);
         builder.setStatusLevel(Level.ERROR);
         builder.setShutdownTimeout(5000, TimeUnit.MILLISECONDS);
         builder.add(builder.newScriptFile("target/test-classes/scripts/filter.groovy")
                 .setIsWatchedAttribute(true));
         builder.add(builder.newFilter("ThresholdFilter", Filter.Result.ACCEPT, Filter.Result.NEUTRAL)
-                .addAttribute("level", Level.DEBUG));
+                .setAttribute("level", Level.DEBUG));
 
         final AppenderComponentBuilder appenderBuilder =
-                builder.newAppender("Stdout", "CONSOLE").addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
+                builder.newAppender("Stdout", "CONSOLE").setAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
         appenderBuilder.add(
-                builder.newLayout("PatternLayout").addAttribute("pattern", "%d [%t] %-5level: %msg%n%throwable"));
+                builder.newLayout("PatternLayout").setAttribute("pattern", "%d [%t] %-5level: %msg%n%throwable"));
         appenderBuilder.add(builder.newFilter("MarkerFilter", Filter.Result.DENY, Filter.Result.NEUTRAL)
-                .addAttribute("marker", "FLOW"));
+                .setAttribute("marker", "FLOW"));
         builder.add(appenderBuilder);
 
         final AppenderComponentBuilder appenderBuilder2 =
-                builder.newAppender("Kafka", "Kafka").addAttribute("topic", "my-topic");
+                builder.newAppender("Kafka", "Kafka").setAttribute("topic", "my-topic");
         appenderBuilder2.addComponent(builder.newProperty("bootstrap.servers", "localhost:9092"));
         appenderBuilder2.add(builder.newLayout("GelfLayout")
-                .addAttribute("host", "my-host")
+                .setAttribute("host", "my-host")
                 .addComponent(builder.newKeyValuePair("extraField", "extraValue")));
         builder.add(appenderBuilder2);
 
         builder.add(builder.newLogger("org.apache.logging.log4j", Level.DEBUG, true)
                 .add(builder.newAppenderRef("Stdout"))
-                .addAttribute("additivity", false));
+                .setAdditivityAttribute(false));
         builder.add(builder.newLogger("org.apache.logging.log4j.core").add(builder.newAppenderRef("Stdout")));
         builder.add(builder.newRootLogger(Level.ERROR).add(builder.newAppenderRef("Stdout")));
-
-        builder.addProperty("MyKey", "MyValue");
+        builder.add(builder.newProperty("MyKey", "MyValue"));
         builder.add(builder.newCustomLevel("Panic", 17));
         builder.setPackages("foo,bar");
     }
@@ -113,7 +111,7 @@ class ConfigurationBuilderTest {
 
     @Test
     void testXmlConstructing() {
-        final ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
+        final ConfigurationBuilder<?> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
         addTestFixtures("config name", builder);
         final String xmlConfiguration = builder.toXmlConfiguration();
         assertEquals(expectedXml, xmlConfiguration);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/CustomConfigurationFactory.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/CustomConfigurationFactory.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 
 /**
  * Normally this would be a plugin. However, we don't want it used for everything so it will be defined
@@ -36,33 +35,33 @@ import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 // @Order(50)
 public class CustomConfigurationFactory extends ConfigurationFactory {
 
-    static Configuration addTestFixtures(final String name, final ConfigurationBuilder<BuiltConfiguration> builder) {
+    static Configuration addTestFixtures(final String name, final ConfigurationBuilder<?> builder) {
         builder.setConfigurationName(name);
         builder.setStatusLevel(Level.ERROR);
         builder.add(builder.newScriptFile("target/test-classes/scripts/filter.groovy")
                 .setIsWatchedAttribute(true));
         builder.add(builder.newFilter("ThresholdFilter", Filter.Result.ACCEPT, Filter.Result.NEUTRAL)
-                .addAttribute("level", Level.DEBUG));
+                .setAttribute("level", Level.DEBUG));
 
         final AppenderComponentBuilder appenderBuilder =
-                builder.newAppender("Stdout", "CONSOLE").addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
+                builder.newAppender("Stdout", "CONSOLE").setAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
         appenderBuilder.add(
-                builder.newLayout("PatternLayout").addAttribute("pattern", "%d [%t] %-5level: %msg%n%throwable"));
+                builder.newLayout("PatternLayout").setAttribute("pattern", "%d [%t] %-5level: %msg%n%throwable"));
         appenderBuilder.add(builder.newFilter("MarkerFilter", Filter.Result.DENY, Filter.Result.NEUTRAL)
-                .addAttribute("marker", "FLOW"));
+                .setAttribute("marker", "FLOW"));
         builder.add(appenderBuilder);
 
         final AppenderComponentBuilder appenderBuilder2 =
-                builder.newAppender("Kafka", "Kafka").addAttribute("topic", "my-topic");
+                builder.newAppender("Kafka", "Kafka").setAttribute("topic", "my-topic");
         appenderBuilder2.addComponent(builder.newProperty("bootstrap.servers", "localhost:9092"));
         appenderBuilder2.add(builder.newLayout("GelfLayout")
-                .addAttribute("host", "my-host")
+                .setAttribute("host", "my-host")
                 .addComponent(builder.newKeyValuePair("extraField", "extraValue")));
         builder.add(appenderBuilder2);
 
         builder.add(builder.newLogger("org.apache.logging.log4j", Level.DEBUG, true)
                 .add(builder.newAppenderRef("Stdout"))
-                .addAttribute("additivity", false));
+                .setAdditivityAttribute(false));
         builder.add(builder.newRootLogger(Level.ERROR).add(builder.newAppenderRef("Stdout")));
 
         builder.add(builder.newCustomLevel("Panic", 17));
@@ -78,7 +77,7 @@ public class CustomConfigurationFactory extends ConfigurationFactory {
     @Override
     public Configuration getConfiguration(
             final LoggerContext loggerContext, final String name, final URI configLocation) {
-        final ConfigurationBuilder<BuiltConfiguration> builder = newConfigurationBuilder();
+        final ConfigurationBuilder<?> builder = newConfigurationBuilder();
         return addTestFixtures(name, builder);
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/CustomConfigurationFactory.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/CustomConfigurationFactory.java
@@ -40,7 +40,7 @@ public class CustomConfigurationFactory extends ConfigurationFactory {
         builder.setConfigurationName(name);
         builder.setStatusLevel(Level.ERROR);
         builder.add(builder.newScriptFile("target/test-classes/scripts/filter.groovy")
-                .addIsWatched(true));
+                .setIsWatchedAttribute(true));
         builder.add(builder.newFilter("ThresholdFilter", Filter.Result.ACCEPT, Filter.Result.NEUTRAL)
                 .addAttribute("level", Level.DEBUG));
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/impl/DefaultComponentBuilderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/impl/DefaultComponentBuilderTest.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.config.builder.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LifeCycle.State;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests: {@link DefaultComponentBuilder}.
+ */
+@SuppressWarnings("DataFlowIssue")
+class DefaultComponentBuilderTest {
+
+    private final DefaultComponentBuilder<?, ?> builder =
+            new DefaultComponentBuilder<>(ConfigurationBuilderFactory.newConfigurationBuilder(), "test");
+
+    @BeforeEach
+    void setup() {
+        builder.clear();
+    }
+
+    @Test
+    void testAddAttribute_DuplicateKey() {
+
+        final String key = "k1";
+        final String lastValue = "foobar";
+
+        builder.addAttribute(key, Level.ERROR);
+        builder.addAttribute(key, State.INITIALIZING);
+        builder.addAttribute(key, lastValue);
+
+        assertEquals(
+                lastValue,
+                builder.getAttribute(key),
+                "addAttribute(String, String) should have set the attribute value.");
+        assertEquals(
+                1,
+                builder.getAttributes().size(),
+                "addAttribute(String, String) should have added the attribute only once.");
+    }
+
+    @Test
+    void testAddAttribute_Bool_OK() {
+
+        final String key = "k1";
+        final boolean booleanValue = true;
+
+        builder.addAttribute(key, booleanValue);
+
+        assertEquals(
+                Boolean.toString(booleanValue),
+                builder.getAttribute(key),
+                "addAttribute(String, boolean) should have set the attribute value.");
+    }
+
+    @Test
+    void testAddAttribute_Bool_NullKey() {
+
+        assertThrows(
+                NullPointerException.class,
+                () -> builder.addAttribute((String) null, true),
+                "addAttribute(String, boolean) should throw an exception with null key");
+    }
+
+    @Test
+    void testAddAttribute_Int_OK() {
+
+        final String key = "k1";
+        final int value = 5;
+
+        builder.addAttribute(key, value);
+
+        assertEquals(
+                Integer.toString(value),
+                builder.getAttribute(key),
+                "addAttribute(String, int) should have set the attribute value.");
+    }
+
+    @Test
+    void testAddAttribute_Int_NullKey() {
+
+        assertThrows(
+                NullPointerException.class,
+                () -> builder.addAttribute((String) null, 5),
+                "addAttribute(String, int) should throw an exception with null key");
+    }
+
+    @Test
+    void testAddAttribute_Enum_OK() {
+
+        final String key = "k1";
+        final State enumValue = State.INITIALIZING;
+
+        builder.addAttribute(key, enumValue);
+
+        assertEquals(
+                enumValue.name(),
+                builder.getAttribute(key),
+                "addAttribute(String, Enum) should have set the attribute value.");
+    }
+
+    @Test
+    void testAddAttribute_Enum_NullKey() {
+
+        assertThrows(
+                NullPointerException.class,
+                () -> builder.addAttribute((String) null, State.INITIALIZING),
+                "addAttribute(String, Enum) should throw an exception with null key");
+    }
+
+    @Test
+    void testAddAttribute_Enum_NullValue() {
+
+        final String key = "k1";
+
+        builder.addAttribute(key, "foobar");
+        builder.addAttribute(key, (State) null);
+
+        assertFalse(
+                builder.getAttributes().containsKey(key),
+                "addAttribute(String, Enum) should remove the attribute with a null value");
+    }
+
+    @Test
+    void testAddAttribute_Level_OK() {
+
+        final String key = "k1";
+        final Level levelValue = Level.ERROR;
+
+        builder.addAttribute(key, levelValue);
+
+        assertEquals(
+                levelValue.toString(),
+                builder.getAttribute(key),
+                "addAttribute(String, Level) should have set the attribute value.");
+    }
+
+    @Test
+    void testAddAttribute_Level_NullKey() {
+
+        assertThrows(
+                NullPointerException.class,
+                () -> builder.addAttribute((String) null, Level.ERROR),
+                "addAttribute(String, Level) should throw an exception with null key");
+    }
+
+    @Test
+    void testAddAttribute_Level_NullValue() {
+
+        final String key = "k1";
+
+        builder.addAttribute(key, "foobar");
+        builder.addAttribute(key, (Level) null);
+
+        assertFalse(
+                builder.getAttributes().containsKey(key),
+                "addAttribute(String, Level) should remove the attribute with a null value");
+    }
+
+    @Test
+    void testAddAttribute_Object_OK() {
+
+        final String key = "k1";
+        final Long objectValue = 50L;
+
+        builder.addAttribute(key, objectValue);
+
+        assertEquals(
+                objectValue.toString(),
+                builder.getAttribute(key),
+                "addAttribute(String, Object) should have set the attribute value.");
+    }
+
+    @Test
+    void testAddAttribute_Object_NullKey() {
+
+        assertThrows(
+                NullPointerException.class,
+                () -> builder.addAttribute((String) null, 50L),
+                "addAttribute(String, Object) should throw an exception with null key");
+    }
+
+    @Test
+    void testAddAttribute_Object_NullValue() {
+
+        final String key = "k1";
+
+        builder.addAttribute(key, "foobar");
+        builder.addAttribute(key, (Long) null);
+
+        assertFalse(
+                builder.getAttributes().containsKey(key),
+                "addAttribute(String, Object) should remove the attribute with a null value");
+    }
+
+    @Test
+    void testAddAttribute_String_OK() {
+
+        final String key = "k1";
+        final String stringValue = "foobar";
+
+        builder.addAttribute(key, stringValue);
+
+        assertEquals(
+                stringValue,
+                builder.getAttribute(key),
+                "addAttribute(String, String) should have set the attribute value.");
+    }
+
+    @Test
+    void testAddAttribute_String_NullKey() {
+
+        assertThrows(
+                NullPointerException.class,
+                () -> builder.addAttribute((String) null, "foobar"),
+                "addAttribute(String, Enum) should throw an exception with null key");
+    }
+
+    @Test
+    void testAddAttribute_String_NullValue() {
+
+        final String key = "k1";
+
+        builder.addAttribute(key, "foobar");
+        builder.addAttribute(key, (String) null);
+
+        assertFalse(
+                builder.getAttributes().containsKey(key),
+                "addAttribute(String, Enum) should remove the attribute with a null value");
+    }
+
+    @Test
+    void testConstructor_NullBuilder() {
+        assertThrows(NullPointerException.class, () -> new DefaultComponentBuilder<>(null, "test"));
+    }
+
+    @Test
+    void testConstructor_NullType() {
+
+        ConfigurationBuilder<?> configurationBuilder = ConfigurationBuilderFactory.newConfigurationBuilder();
+
+        assertThrows(NullPointerException.class, () -> new DefaultComponentBuilder<>(configurationBuilder, null));
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/impl/DefaultComponentBuilderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/impl/DefaultComponentBuilderTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit tests: {@link DefaultComponentBuilder}.
  */
-@SuppressWarnings("DataFlowIssue")
+@SuppressWarnings({"DataFlowIssue", "RedundantCast"})
 class DefaultComponentBuilderTest {
 
     private final DefaultComponentBuilder<?, ?> builder =

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/impl/DefaultComponentBuilderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/impl/DefaultComponentBuilderTest.java
@@ -47,9 +47,9 @@ class DefaultComponentBuilderTest {
         final String key = "k1";
         final String lastValue = "foobar";
 
-        builder.addAttribute(key, Level.ERROR);
-        builder.addAttribute(key, State.INITIALIZING);
-        builder.addAttribute(key, lastValue);
+        builder.setAttribute(key, Level.ERROR);
+        builder.setAttribute(key, State.INITIALIZING);
+        builder.setAttribute(key, lastValue);
 
         assertEquals(
                 lastValue,
@@ -67,7 +67,7 @@ class DefaultComponentBuilderTest {
         final String key = "k1";
         final boolean booleanValue = true;
 
-        builder.addAttribute(key, booleanValue);
+        builder.setAttribute(key, booleanValue);
 
         assertEquals(
                 Boolean.toString(booleanValue),
@@ -80,7 +80,7 @@ class DefaultComponentBuilderTest {
 
         assertThrows(
                 NullPointerException.class,
-                () -> builder.addAttribute((String) null, true),
+                () -> builder.setAttribute((String) null, true),
                 "addAttribute(String, boolean) should throw an exception with null key");
     }
 
@@ -90,7 +90,7 @@ class DefaultComponentBuilderTest {
         final String key = "k1";
         final int value = 5;
 
-        builder.addAttribute(key, value);
+        builder.setAttribute(key, value);
 
         assertEquals(
                 Integer.toString(value),
@@ -103,7 +103,7 @@ class DefaultComponentBuilderTest {
 
         assertThrows(
                 NullPointerException.class,
-                () -> builder.addAttribute((String) null, 5),
+                () -> builder.setAttribute((String) null, 5),
                 "addAttribute(String, int) should throw an exception with null key");
     }
 
@@ -113,7 +113,7 @@ class DefaultComponentBuilderTest {
         final String key = "k1";
         final State enumValue = State.INITIALIZING;
 
-        builder.addAttribute(key, enumValue);
+        builder.setAttribute(key, enumValue);
 
         assertEquals(
                 enumValue.name(),
@@ -126,7 +126,7 @@ class DefaultComponentBuilderTest {
 
         assertThrows(
                 NullPointerException.class,
-                () -> builder.addAttribute((String) null, State.INITIALIZING),
+                () -> builder.setAttribute((String) null, State.INITIALIZING),
                 "addAttribute(String, Enum) should throw an exception with null key");
     }
 
@@ -135,8 +135,8 @@ class DefaultComponentBuilderTest {
 
         final String key = "k1";
 
-        builder.addAttribute(key, "foobar");
-        builder.addAttribute(key, (State) null);
+        builder.setAttribute(key, "foobar");
+        builder.setAttribute(key, (State) null);
 
         assertFalse(
                 builder.getAttributes().containsKey(key),
@@ -149,7 +149,7 @@ class DefaultComponentBuilderTest {
         final String key = "k1";
         final Level levelValue = Level.ERROR;
 
-        builder.addAttribute(key, levelValue);
+        builder.setAttribute(key, levelValue);
 
         assertEquals(
                 levelValue.toString(),
@@ -162,7 +162,7 @@ class DefaultComponentBuilderTest {
 
         assertThrows(
                 NullPointerException.class,
-                () -> builder.addAttribute((String) null, Level.ERROR),
+                () -> builder.setAttribute((String) null, Level.ERROR),
                 "addAttribute(String, Level) should throw an exception with null key");
     }
 
@@ -171,8 +171,8 @@ class DefaultComponentBuilderTest {
 
         final String key = "k1";
 
-        builder.addAttribute(key, "foobar");
-        builder.addAttribute(key, (Level) null);
+        builder.setAttribute(key, "foobar");
+        builder.setAttribute(key, (Level) null);
 
         assertFalse(
                 builder.getAttributes().containsKey(key),
@@ -185,7 +185,7 @@ class DefaultComponentBuilderTest {
         final String key = "k1";
         final Long objectValue = 50L;
 
-        builder.addAttribute(key, objectValue);
+        builder.setAttribute(key, objectValue);
 
         assertEquals(
                 objectValue.toString(),
@@ -198,7 +198,7 @@ class DefaultComponentBuilderTest {
 
         assertThrows(
                 NullPointerException.class,
-                () -> builder.addAttribute((String) null, 50L),
+                () -> builder.setAttribute((String) null, 50L),
                 "addAttribute(String, Object) should throw an exception with null key");
     }
 
@@ -207,8 +207,8 @@ class DefaultComponentBuilderTest {
 
         final String key = "k1";
 
-        builder.addAttribute(key, "foobar");
-        builder.addAttribute(key, (Long) null);
+        builder.setAttribute(key, "foobar");
+        builder.setAttribute(key, (Long) null);
 
         assertFalse(
                 builder.getAttributes().containsKey(key),
@@ -221,7 +221,7 @@ class DefaultComponentBuilderTest {
         final String key = "k1";
         final String stringValue = "foobar";
 
-        builder.addAttribute(key, stringValue);
+        builder.setAttribute(key, stringValue);
 
         assertEquals(
                 stringValue,
@@ -234,7 +234,7 @@ class DefaultComponentBuilderTest {
 
         assertThrows(
                 NullPointerException.class,
-                () -> builder.addAttribute((String) null, "foobar"),
+                () -> builder.setAttribute((String) null, "foobar"),
                 "addAttribute(String, Enum) should throw an exception with null key");
     }
 
@@ -243,8 +243,8 @@ class DefaultComponentBuilderTest {
 
         final String key = "k1";
 
-        builder.addAttribute(key, "foobar");
-        builder.addAttribute(key, (String) null);
+        builder.setAttribute(key, "foobar");
+        builder.setAttribute(key, (String) null);
 
         assertFalse(
                 builder.getAttributes().containsKey(key),

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/MessagePatternConverterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/MessagePatternConverterTest.java
@@ -22,7 +22,8 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
-import org.apache.logging.log4j.core.config.builder.impl.DefaultConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -80,8 +81,9 @@ class MessagePatternConverterTest {
 
     @Test
     void testDefaultDisabledLookup() {
-        final Configuration config =
-                new DefaultConfigurationBuilder().addProperty("foo", "bar").build(true);
+        final ConfigurationBuilder<?> configurationBuilder = ConfigurationBuilderFactory.newConfigurationBuilder();
+        configurationBuilder.add(configurationBuilder.newProperty("foo", "bar"));
+        final Configuration config = configurationBuilder.build(true);
         final MessagePatternConverter converter = MessagePatternConverter.newInstance(config, null);
         final Message msg = new ParameterizedMessage("${foo}");
         final LogEvent event = Log4jLogEvent.newBuilder() //
@@ -96,8 +98,9 @@ class MessagePatternConverterTest {
 
     @Test
     void testDisabledLookup() {
-        final Configuration config =
-                new DefaultConfigurationBuilder().addProperty("foo", "bar").build(true);
+        final ConfigurationBuilder<?> configurationBuilder = ConfigurationBuilderFactory.newConfigurationBuilder();
+        configurationBuilder.add(configurationBuilder.newProperty("foo", "bar"));
+        final Configuration config = configurationBuilder.build(true);
         final MessagePatternConverter converter =
                 MessagePatternConverter.newInstance(config, new String[] {"nolookups"});
         final Message msg = new ParameterizedMessage("${foo}");
@@ -113,8 +116,9 @@ class MessagePatternConverterTest {
 
     @Test
     void testLookup() {
-        final Configuration config =
-                new DefaultConfigurationBuilder().addProperty("foo", "bar").build(true);
+        final ConfigurationBuilder<?> configurationBuilder = ConfigurationBuilderFactory.newConfigurationBuilder();
+        configurationBuilder.add(configurationBuilder.newProperty("foo", "bar"));
+        final Configuration config = configurationBuilder.build(true);
         final MessagePatternConverter converter = MessagePatternConverter.newInstance(config, new String[] {"lookups"});
         final Message msg = new ParameterizedMessage("${foo}");
         final LogEvent event = Log4jLogEvent.newBuilder() //

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/AppenderComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/AppenderComponentBuilder.java
@@ -16,23 +16,33 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.apache.logging.log4j.core.Appender;
+import org.osgi.annotation.versioning.ProviderType;
+
 /**
- * Builder for constructing Appender Components.
+ * A builder interface for constructing and configuring {@link Appender} components in a Log4j configuration.
+ *
+ * <p>
+ *   Instances of this builder are designed for single-threaded use and are not thread-safe. Developers
+ *   should avoid sharing instances between threads.
+ * </p>
+ *
  * @since 2.4
  */
+@ProviderType
 public interface AppenderComponentBuilder extends FilterableComponentBuilder<AppenderComponentBuilder> {
 
     /**
-     * Adds a Layout to the Appender component.
-     * @param builder The LayoutComponentBuilder with all of its attributes set.
-     * @return this builder.
+     * Adds a {@link LayoutComponentBuilder} to this Appender component builder.
+     * <p>
+     *   Note: the provided {@code builder} will be built by this method; therefore, it must be fully configured
+     *   <i>before</i> calling this method.  Changes to the builder after calling this method will not have
+     *   any effect.
+     * </p>
+     *
+     * @param builder The {@code LayoutComponentBuilder} with all of its attributes set.
+     * @return this component builder (for chaining)
+     * @throws NullPointerException if the given {@code builder} argument is {@code null}
      */
     AppenderComponentBuilder add(LayoutComponentBuilder builder);
-
-    /**
-     * Returns the name of the Appender.
-     * @return the name of the Appender.
-     */
-    @Override
-    String getName();
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/AppenderRefComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/AppenderRefComponentBuilder.java
@@ -16,8 +16,58 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.AppenderRef;
+import org.jspecify.annotations.Nullable;
+
 /**
- * Assembler for constructing AppenderRef Components.
+ * A builder interface for constructing and configuring {@link AppenderRef} components in a Log4j configuration.
+ *
+ * <p>
+ *   Instances of this builder are designed for single-threaded use and are not thread-safe. Developers
+ *   should avoid sharing instances between threads.
+ * </p>
+ *
  * @since 2.4
  */
-public interface AppenderRefComponentBuilder extends FilterableComponentBuilder<AppenderRefComponentBuilder> {}
+public interface AppenderRefComponentBuilder extends FilterableComponentBuilder<AppenderRefComponentBuilder> {
+
+    /**
+     * Sets the "{@code level}" attribute on the appender-reference component.
+     * <p>
+     *   If the given {@code level} is {@code null}, the attribute will be removed from the component.
+     * </p>
+     *
+     * @param level the level
+     * @return this builder (for chaining)
+     */
+    default AppenderRefComponentBuilder setLevelAttribute(@Nullable String level) {
+        return setAttribute("level", level);
+    }
+
+    /**
+     * Sets the "{@code level}" attribute on the appender reference component.
+     * <p>
+     *   If the given {@code level} is {@code null}, the attribute will be removed from the component.
+     * </p>
+     *
+     * @param level the level
+     * @return this builder (for chaining)
+     */
+    default AppenderRefComponentBuilder setLevelAttribute(@Nullable Level level) {
+        return setAttribute("level", level);
+    }
+
+    /**
+     * Sets the "{@code ref}" attribute on the appender reference component.
+     * <p>
+     *   If the given {@code refAppenderName} is {@code null}, the attribute will be removed from the component.
+     * </p>
+     *
+     * @param refAppenderName the name of the appender being referenced
+     * @return this builder (for chaining)
+     */
+    default AppenderRefComponentBuilder setRefAttribute(@Nullable String refAppenderName) {
+        return setAttribute("ref", refAppenderName);
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/Component.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/Component.java
@@ -20,45 +20,65 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * Container for building Configurations. This class is not normally directly manipulated by users
  * of the Assembler API.
  * @since 2.4
  */
+@ProviderType
 public class Component {
 
     private final Map<String, String> attributes = new LinkedHashMap<>();
     private final List<Component> components = new ArrayList<>();
     private final String pluginType;
-    private final String value;
+    private final @Nullable String value;
+
+    /**
+     * Default constructor.
+     *
+     * @deprecated - use {@link Component(String)} - a non-{@code null} '{@code pluginType}' must be specified
+     */
+    @Deprecated
+    public Component() {
+        this.pluginType = "";
+        this.value = null;
+    }
 
     public Component(final String pluginType) {
         this(pluginType, null, null);
     }
 
-    public Component(final String pluginType, final String name) {
+    public Component(final String pluginType, final @Nullable String name) {
         this(pluginType, name, null);
     }
 
-    public Component(final String pluginType, final String name, final String value) {
+    public Component(final String pluginType, @Nullable final String name, @Nullable final String value) {
         this.pluginType = pluginType;
         this.value = value;
-        if (name != null && name.length() > 0) {
+        if (name != null && !name.isEmpty()) {
             attributes.put("name", name);
         }
     }
 
-    public Component() {
-        this.pluginType = null;
-        this.value = null;
-    }
-
-    public String addAttribute(final String key, final String newValue) {
-        return attributes.put(key, newValue);
+    /**
+     * Puts the given key/value pair to the attribute map.
+     * <p>
+     *   If the new value is {@code null}, than any existing entry with the given {@code key} is ejected from the map.
+     * </p>
+     * @param key the key
+     * @param newValue the new value
+     * @return the previous value or {@code null} if none was set
+     */
+    public @Nullable String addAttribute(final String key, final @Nullable String newValue) {
+        return putAttribute(key, newValue);
     }
 
     public void addComponent(final Component component) {
+        Objects.requireNonNull(component, "The 'component' argument cannot be null.");
         components.add(component);
     }
 
@@ -74,7 +94,27 @@ public class Component {
         return pluginType;
     }
 
-    public String getValue() {
+    public @Nullable String getValue() {
         return value;
+    }
+
+    /**
+     * Puts the given key/value pair to the attribute map.
+     * <p>
+     *   If the new value is {@code null}, than any existing entry with the given {@code key} is ejected from the map.
+     * </p>
+     * @param key the key
+     * @param newValue the new value
+     * @return the previous value or {@code null} if none was set
+     */
+    protected @Nullable String putAttribute(final String key, final @Nullable String newValue) {
+
+        Objects.requireNonNull(key, "The 'key' argument cannot be null.");
+
+        if (newValue == null) {
+            return attributes.remove(key);
+        } else {
+            return attributes.put(key, newValue);
+        }
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ComponentBuilder.java
@@ -19,6 +19,8 @@ package org.apache.logging.log4j.core.config.builder.api;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.util.Builder;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Builds arbitrary components and is the base type for the provided components.
@@ -35,9 +37,11 @@ public interface ComponentBuilder<T extends ComponentBuilder<T>> extends Builder
      * </p>
      * @param key The attribute key.
      * @param value The value of the attribute.
-     * @return This ComponentBuilder.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
      */
-    T addAttribute(String key, String value);
+    @NonNull
+    T addAttribute(@NonNull String key, @Nullable String value);
 
     /**
      * Adds a logging Level attribute.
@@ -47,9 +51,11 @@ public interface ComponentBuilder<T extends ComponentBuilder<T>> extends Builder
      * </p>
      * @param key The attribute key.
      * @param level The logging Level.
-     * @return This ComponentBuilder.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
      */
-    T addAttribute(String key, Level level);
+    @NonNull
+    T addAttribute(@NonNull String key, @Nullable Level level);
 
     /**
      * Adds an enumeration attribute.
@@ -59,25 +65,31 @@ public interface ComponentBuilder<T extends ComponentBuilder<T>> extends Builder
      * </p>
      * @param key The attribute key.
      * @param value The enumeration.
-     * @return This ComponentBuilder.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
      */
-    T addAttribute(String key, Enum<?> value);
+    @NonNull
+    T addAttribute(@NonNull String key, @Nullable Enum<?> value);
 
     /**
      * Adds an integer attribute.
      * @param key The attribute key.
      * @param value The integer value.
-     * @return This ComponentBuilder.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
      */
-    T addAttribute(String key, int value);
+    @NonNull
+    T addAttribute(@NonNull String key, int value);
 
     /**
      * Adds a boolean attribute.
      * @param key The attribute key.
      * @param value The boolean value.
-     * @return This ComponentBuilder.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
      */
-    T addAttribute(String key, boolean value);
+    @NonNull
+    T addAttribute(@NonNull String key, boolean value);
 
     /**
      * Adds an Object attribute.
@@ -87,26 +99,32 @@ public interface ComponentBuilder<T extends ComponentBuilder<T>> extends Builder
      * </p>
      * @param key The attribute key.
      * @param value The object value.
-     * @return This ComponentBuilder.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
      */
-    T addAttribute(String key, Object value);
+    @NonNull
+    T addAttribute(@NonNull String key, @Nullable Object value);
 
     /**
      * Adds a sub component.
      * @param builder The Assembler for the subcomponent with all of its attributes and sub-components set.
-     * @return This ComponentBuilder (<em>not</em> the argument).
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code builder} is {@code null}
      */
-    T addComponent(ComponentBuilder<?> builder);
+    @NonNull
+    T addComponent(@NonNull ComponentBuilder<?> builder);
 
     /**
-     * Returns the name of the component, if any.
-     * @return The component's name or null if it doesn't have one.
+     * Returns the name of the component.
+     * @return The component's name or {@code null} if it doesn't have one.
      */
+    @Nullable
     String getName();
 
     /**
-     * Retrieves the ConfigurationBuilder.
+     * Retrieves the {@code ConfigurationBuilder}.
      * @return The ConfigurationBuilder.
      */
+    @NonNull
     ConfigurationBuilder<? extends Configuration> getBuilder();
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ComponentBuilder.java
@@ -19,100 +19,16 @@ package org.apache.logging.log4j.core.config.builder.api;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.util.Builder;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * Builds arbitrary components and is the base type for the provided components.
  * @param <T> The ComponentBuilder's own type for fluent APIs.
  * @since 2.4
  */
+@ProviderType
 public interface ComponentBuilder<T extends ComponentBuilder<T>> extends Builder<Component> {
-
-    /**
-     * Adds a String attribute.
-     * <p>
-     *   If the given {@code level} value is {@code null}, the component attribute with the given key
-     *   will be removed (if present).
-     * </p>
-     * @param key The attribute key.
-     * @param value The value of the attribute.
-     * @return this builder (for chaining)
-     * @throws NullPointerException if the given {@code key} is {@code null}
-     */
-    @NonNull
-    T addAttribute(@NonNull String key, @Nullable String value);
-
-    /**
-     * Adds a logging Level attribute.
-     * <p>
-     *   If the given {@code level} value is {@code null}, the component attribute with the given key
-     *   will be removed (if present).
-     * </p>
-     * @param key The attribute key.
-     * @param level The logging Level.
-     * @return this builder (for chaining)
-     * @throws NullPointerException if the given {@code key} is {@code null}
-     */
-    @NonNull
-    T addAttribute(@NonNull String key, @Nullable Level level);
-
-    /**
-     * Adds an enumeration attribute.
-     * <p>
-     *   If the given {@code level} value is {@code null}, the component attribute with the given key
-     *   will be removed (if present).
-     * </p>
-     * @param key The attribute key.
-     * @param value The enumeration.
-     * @return this builder (for chaining)
-     * @throws NullPointerException if the given {@code key} is {@code null}
-     */
-    @NonNull
-    T addAttribute(@NonNull String key, @Nullable Enum<?> value);
-
-    /**
-     * Adds an integer attribute.
-     * @param key The attribute key.
-     * @param value The integer value.
-     * @return this builder (for chaining)
-     * @throws NullPointerException if the given {@code key} is {@code null}
-     */
-    @NonNull
-    T addAttribute(@NonNull String key, int value);
-
-    /**
-     * Adds a boolean attribute.
-     * @param key The attribute key.
-     * @param value The boolean value.
-     * @return this builder (for chaining)
-     * @throws NullPointerException if the given {@code key} is {@code null}
-     */
-    @NonNull
-    T addAttribute(@NonNull String key, boolean value);
-
-    /**
-     * Adds an Object attribute.
-     * <p>
-     *   If the given {@code value} is {@code null}, the component attribute with the given key
-     *   will be removed (if present).
-     * </p>
-     * @param key The attribute key.
-     * @param value The object value.
-     * @return this builder (for chaining)
-     * @throws NullPointerException if the given {@code key} is {@code null}
-     */
-    @NonNull
-    T addAttribute(@NonNull String key, @Nullable Object value);
-
-    /**
-     * Adds a sub component.
-     * @param builder The Assembler for the subcomponent with all of its attributes and sub-components set.
-     * @return this builder (for chaining)
-     * @throws NullPointerException if the given {@code builder} is {@code null}
-     */
-    @NonNull
-    T addComponent(@NonNull ComponentBuilder<?> builder);
 
     /**
      * Returns the name of the component.
@@ -125,6 +41,177 @@ public interface ComponentBuilder<T extends ComponentBuilder<T>> extends Builder
      * Retrieves the {@code ConfigurationBuilder}.
      * @return The ConfigurationBuilder.
      */
-    @NonNull
     ConfigurationBuilder<? extends Configuration> getBuilder();
+
+    /**
+     * Adds a sub component.
+     * @param builder The Assembler for the subcomponent with all of its attributes and sub-components set.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code builder} is {@code null}
+     */
+    T addComponent(ComponentBuilder<?> builder);
+
+    /**
+     * Sets a String attribute.
+     * <p>
+     *   If the given {@code level} value is {@code null}, the component attribute with the given key
+     *   will be removed (if present).
+     * </p>
+     * @param key The attribute key.
+     * @param value The value of the attribute.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
+     */
+    T setAttribute(String key, @Nullable String value);
+
+    /**
+     * Sets a logging Level attribute.
+     * <p>
+     *   If the given {@code level} value is {@code null}, the component attribute with the given key
+     *   will be removed (if present).
+     * </p>
+     * @param key The attribute key.
+     * @param level The logging Level.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
+     */
+    T setAttribute(String key, @Nullable Level level);
+
+    /**
+     * Sets an enumeration attribute.
+     * <p>
+     *   If the given {@code level} value is {@code null}, the component attribute with the given key
+     *   will be removed (if present).
+     * </p>
+     * @param key The attribute key.
+     * @param value The enumeration.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
+     */
+    T setAttribute(String key, @Nullable Enum<?> value);
+
+    /**
+     * Sets an integer attribute.
+     * @param key The attribute key.
+     * @param value The integer value.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
+     */
+    T setAttribute(String key, int value);
+
+    /**
+     * Sets a boolean attribute.
+     * @param key The attribute key.
+     * @param value The boolean value.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
+     */
+    T setAttribute(String key, boolean value);
+
+    /**
+     * Sets an Object attribute.
+     * <p>
+     *   If the given {@code value} is {@code null}, the component attribute with the given key
+     *   will be removed (if present).
+     * </p>
+     * @param key The attribute key.
+     * @param value The object value.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
+     */
+    T setAttribute(String key, @Nullable Object value);
+
+    /**
+     * Adds a String attribute.
+     * <p>
+     *   If the given {@code level} value is {@code null}, the component attribute with the given key
+     *   will be removed (if present).
+     * </p>
+     * @param key The attribute key.
+     * @param value The value of the attribute.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
+     * @deprecated use {@link #setAttribute(String, int)}
+     */
+    @Deprecated
+    default T addAttribute(String key, @Nullable String value) {
+        return setAttribute(key, value);
+    }
+
+    /**
+     * Adds a logging Level attribute.
+     * <p>
+     *   If the given {@code level} value is {@code null}, the component attribute with the given key
+     *   will be removed (if present).
+     * </p>
+     * @param key The attribute key.
+     * @param level The logging Level.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
+     * @deprecated use {@link #setAttribute(String, Level)}
+     */
+    @Deprecated
+    default T addAttribute(String key, @Nullable Level level) {
+        return setAttribute(key, level);
+    }
+
+    /**
+     * Adds an enumeration attribute.
+     * <p>
+     *   If the given {@code level} value is {@code null}, the component attribute with the given key
+     *   will be removed (if present).
+     * </p>
+     * @param key The attribute key.
+     * @param value The enumeration.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
+     * @deprecated use {@link #setAttribute(String, Enum)}
+     */
+    @Deprecated
+    default T addAttribute(String key, @Nullable Enum<?> value) {
+        return setAttribute(key, value);
+    }
+
+    /**
+     * Adds an integer attribute.
+     * @param key The attribute key.
+     * @param value The integer value.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
+     * @deprecated use {@link #setAttribute(String, int)}
+     */
+    @Deprecated
+    default T addAttribute(String key, int value) {
+        return setAttribute(key, value);
+    }
+
+    /**
+     * Adds a boolean attribute.
+     * @param key The attribute key.
+     * @param value The boolean value.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
+     * @deprecated use {@link #setAttribute(String, boolean)}
+     */
+    @Deprecated
+    default T addAttribute(String key, boolean value) {
+        return setAttribute(key, value);
+    }
+
+    /**
+     * Adds an Object attribute.
+     * <p>
+     *   If the given {@code value} is {@code null}, the component attribute with the given key
+     *   will be removed (if present).
+     * </p>
+     * @param key The attribute key.
+     * @param value The object value.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code key} is {@code null}
+     * @deprecated use {@link #setAttribute(String, Object)}
+     */
+    @Deprecated
+    default T addAttribute(String key, @Nullable Object value) {
+        return setAttribute(key, value);
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ComponentBuilder.java
@@ -29,6 +29,10 @@ public interface ComponentBuilder<T extends ComponentBuilder<T>> extends Builder
 
     /**
      * Adds a String attribute.
+     * <p>
+     *   If the given {@code level} value is {@code null}, the component attribute with the given key
+     *   will be removed (if present).
+     * </p>
      * @param key The attribute key.
      * @param value The value of the attribute.
      * @return This ComponentBuilder.
@@ -37,6 +41,10 @@ public interface ComponentBuilder<T extends ComponentBuilder<T>> extends Builder
 
     /**
      * Adds a logging Level attribute.
+     * <p>
+     *   If the given {@code level} value is {@code null}, the component attribute with the given key
+     *   will be removed (if present).
+     * </p>
      * @param key The attribute key.
      * @param level The logging Level.
      * @return This ComponentBuilder.
@@ -45,6 +53,10 @@ public interface ComponentBuilder<T extends ComponentBuilder<T>> extends Builder
 
     /**
      * Adds an enumeration attribute.
+     * <p>
+     *   If the given {@code level} value is {@code null}, the component attribute with the given key
+     *   will be removed (if present).
+     * </p>
      * @param key The attribute key.
      * @param value The enumeration.
      * @return This ComponentBuilder.
@@ -69,6 +81,10 @@ public interface ComponentBuilder<T extends ComponentBuilder<T>> extends Builder
 
     /**
      * Adds an Object attribute.
+     * <p>
+     *   If the given {@code value} is {@code null}, the component attribute with the given key
+     *   will be removed (if present).
+     * </p>
      * @param key The attribute key.
      * @param value The object value.
      * @return This ComponentBuilder.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/CompositeFilterComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/CompositeFilterComponentBuilder.java
@@ -16,9 +16,71 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.apache.logging.log4j.core.Filter.Result;
+import org.apache.logging.log4j.core.filter.CompositeFilter;
+import org.jspecify.annotations.Nullable;
+
 /**
- * Wraps multiple Filter Component builders.
+ * A builder interface for constructing and configuring {@link CompositeFilter} components in a Log4j configuration.
+ *
+ * <p>
+ *   Instances of this builder are designed for single-threaded use and are not thread-safe. Developers
+ *   should avoid sharing instances between threads.
+ * </p>
  *
  * @since 2.4
  */
-public interface CompositeFilterComponentBuilder extends FilterableComponentBuilder<CompositeFilterComponentBuilder> {}
+public interface CompositeFilterComponentBuilder extends FilterableComponentBuilder<CompositeFilterComponentBuilder> {
+
+    /**
+     * Adds the 'onMatch' attribute to the filter component.
+     * <p>
+     *   If the given {@code onMatch} argument is {@code} the attribute will be removed (if present).
+     * </p>
+     *
+     * @param onMatch the attribute value
+     * @return this builder (for chaining)
+     */
+    default CompositeFilterComponentBuilder setOnMatchAttribute(@Nullable String onMatch) {
+        return setAttribute("onMatch", onMatch);
+    }
+
+    /**
+     * Sets the 'onMatch' attribute on the filter component.
+     * <p>
+     *   If the given {@code onMatch} argument is {@code} the attribute will be removed (if present).
+     * </p>
+     *
+     * @param onMatch the attribute value
+     * @return this builder (for chaining)
+     */
+    default CompositeFilterComponentBuilder setOnMatchAttribute(@Nullable Result onMatch) {
+        return setAttribute("onMatch", onMatch);
+    }
+
+    /**
+     * Sets the 'onMismatch' attribute on the filter component.
+     * <p>
+     *   If the given {@code onMismatch} argument is {@code} the attribute will be removed (if present).
+     * </p>
+     *
+     * @param onMismatch the attribute value
+     * @return this builder (for chaining)
+     */
+    default CompositeFilterComponentBuilder setOnMismatchAttribute(@Nullable String onMismatch) {
+        return setAttribute("onMismatch", onMismatch);
+    }
+
+    /**
+     * Sets the 'onMismatch' attribute on the filter component.
+     * <p>
+     *   If the given {@code onMismatch} argument is {@code} the attribute will be removed (if present).
+     * </p>
+     *
+     * @param onMismatch the attribute value
+     * @return this builder (for chaining)
+     */
+    default CompositeFilterComponentBuilder setOnMismatchAttribute(@Nullable Result onMismatch) {
+        return setAttribute("onMismatch", onMismatch);
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ConfigurationBuilder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import aQute.bnd.annotation.baseline.BaselineIgnore;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.concurrent.TimeUnit;
@@ -509,7 +510,8 @@ public interface ConfigurationBuilder<T extends Configuration> extends Builder<T
      * Sets the logger context.
      * @param loggerContext the logger context.
      */
-    void setLoggerContext(@Nullable LoggerContext loggerContext);
+    @BaselineIgnore("2.25.0")
+    ConfigurationBuilder<T> setLoggerContext(@Nullable LoggerContext loggerContext);
 
     /**
      * Sets the configuration's "monitorInterval" attribute.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ConfigurationBuilder.java
@@ -20,426 +20,581 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Filter.Result;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.async.AsyncLogger;
+import org.apache.logging.log4j.core.config.AppenderRef;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.config.CustomLevels;
+import org.apache.logging.log4j.core.config.LoggerConfig.RootLogger;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.script.Script;
+import org.apache.logging.log4j.core.script.ScriptFile;
 import org.apache.logging.log4j.core.util.Builder;
+import org.apache.logging.log4j.core.util.KeyValuePair;
+import org.jspecify.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * Interface for building logging configurations.
  * @param <T> The Configuration type created by this builder.
  * @since 2.4
  */
+@ProviderType
 public interface ConfigurationBuilder<T extends Configuration> extends Builder<T> {
 
     /**
-     * Adds a ScriptComponent.
-     * @param builder The ScriptComponentBuilder with all of its attributes and sub components set.
-     * @return this builder instance.
+     * Adds the {@link Script} component built by the given {@code ScriptComponentBuilder} to this builder.
+     * <p>
+     *   Note: the provided {@code builder} will be built by this method; therefore, it must be fully configured
+     *   <i>before</i> calling this method.  Changes to the builder after calling this method will not have
+     *   any effect.
+     * </p>
+     *
+     * @param builder The {@code ScriptComponentBuilder} to add with all of its attributes and subcomponents set.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code builder} is {@code null}
      */
     ConfigurationBuilder<T> add(ScriptComponentBuilder builder);
 
     /**
-     * Adds a ScriptFileComponent.
-     * @param builder The ScriptFileComponentBuilder with all of its attributes and sub components set.
-     * @return this builder instance.
+     * Adds the {@link ScriptFile} component built by the given {@code ScriptFileComponentBuilder} to this builder.
+     * <p>
+     *   Note: the provided {@code builder} will be built by this method; therefore, it must be fully configured
+     *   <i>before</i> calling this method.  Changes to the builder after calling this method will not have
+     *   any effect.
+     * </p>
+     *
+     * @param builder The {@code ScriptFileComponentBuilder} to add with all of its attributes and subcomponents set.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code builder} is {@code null}
      */
     ConfigurationBuilder<T> add(ScriptFileComponentBuilder builder);
 
     /**
-     * Adds an AppenderComponent.
-     * @param builder The AppenderComponentBuilder with all of its attributes and sub components set.
-     * @return this builder instance.
+     * Adds the {@link Appender} component built by the given {@code AppenderComponentBuilder} to this builder.
+     * <p>
+     *   Note: the provided {@code builder} will be built by this method; therefore, it must be fully configured
+     *   <i>before</i> calling this method.  Changes to the builder after calling this method will not have
+     *   any effect.
+     * </p>
+     *
+     * @param builder The {@code AppenderComponentBuilder} to add with all of its attributes and subcomponents set.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code builder} is {@code null}
      */
     ConfigurationBuilder<T> add(AppenderComponentBuilder builder);
 
     /**
-     * Adds a CustomLevel component.
-     * @param builder The CustomLevelComponentBuilder with all of its attributes set.
-     * @return this builder instance.
+     * Adds the {@link CustomLevels} component built by the given {@code CustomLevelComponentBuilder} to this builder.
+     * <p>
+     *   Note: the provided {@code builder} will be built by this method; therefore, it must be fully configured
+     *   <i>before</i> calling this method.  Changes to the builder after calling this method will not have
+     *   any effect.
+     * </p>
+     *
+     * @param builder The {@code CustomLevelComponentBuilder} with all of its attributes and subcomponents set.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code builder} is {@code null}
      */
     ConfigurationBuilder<T> add(CustomLevelComponentBuilder builder);
 
     /**
-     * Adds a Filter component.
-     * @param builder the FilterComponentBuilder with all of its attributes and sub components set.
-     * @return this builder instance.
+     * Adds the {@link Filter} component built by the given {@code FilterComponentBuilder} to this builder.
+     * <p>
+     *   Note: the provided {@code builder} will be built by this method; therefore, it must be fully configured
+     *   <i>before</i> calling this method.  Changes to the builder after calling this method will not have
+     *   any effect.
+     * </p>
+     *
+     * @param builder The {@code FilterComponentBuilder} with all of its attributes and subcomponents set.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code builder} is {@code null}
      */
     ConfigurationBuilder<T> add(FilterComponentBuilder builder);
 
     /**
-     * Adds a Logger component.
-     * @param builder The LoggerComponentBuilder with all of its attributes and sub components set.
-     * @return this builder instance.
+     * Adds the {@link Logger} component built by the given {@code LoggerComponentBuilder} to this builder.
+     * <p>
+     *   Note: the provided {@code builder} will be built by this method; therefore, it must be fully configured
+     *   <i>before</i> calling this method.  Changes to the builder after calling this method will not have
+     *   any effect.
+     * </p>
+     *
+     * @param builder The {@code LoggerComponentBuilder} with all of its attributes and subcomponents set.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code builder} is {@code null}
      */
     ConfigurationBuilder<T> add(LoggerComponentBuilder builder);
 
     /**
-     * Adds the root Logger component.
-     * @param builder The RootLoggerComponentBuilder with all of its attributes and sub components set.
-     * @return this builder instance.
+     * Adds the {@link RootLogger} component built by the given {@code RootLoggerComponentBuilder}
+     * to this builder.
+     * <p>
+     *   Note: the provided {@code builder} will be built by this method; therefore, it must be fully configured
+     *   <i>before</i> calling this method.  Changes to the builder after calling this method will not have
+     *   any effect.
+     * </p>
+     *
+     * @param builder The {@code RootLoggerComponentBuilder} with all of its attributes and subcomponents set.
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code builder} is {@code null}
      */
     ConfigurationBuilder<T> add(RootLoggerComponentBuilder builder);
 
     /**
-     * Adds a Property key and value.
-     * @param key The property key.
-     * @param value The property value.
-     * @return this builder instance.
+     * Adds a the {@link Property} component built by the given {@link PropertyComponentBuilder}.
+     * @param builder the {@code PropertyComponentBuilder} to add
+     * @return this builder (for chaining)
      */
-    ConfigurationBuilder<T> addProperty(String key, String value);
+    ConfigurationBuilder<T> add(PropertyComponentBuilder builder);
 
     /**
-     * Returns a builder for creating Async Loggers.
-     * @param name The name of the Logger.
-     * @param language The script language
-     * @param text The script to execute.
-     * @return A new ScriptComponentBuilder.
+     * Adds a {@link Property} component with the given {@code key} and {@code value}.
+     *
+     * @param name the property name
+     * @param value the property value
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code builder} is {@code null}
+     * @deprecated use {@link #add(PropertyComponentBuilder)}
      */
-    ScriptComponentBuilder newScript(String name, String language, String text);
+    @Deprecated
+    ConfigurationBuilder<T> addProperty(@Nullable String name, @Nullable String value);
 
     /**
-     * Returns a builder for creating Async Loggers.
-     * @param path The location of the script file.
-     * @return A new ScriptFileComponentBuilder.
+     * Returns a {@link ScriptComponentBuilder} for creating a {@link Script} component.
+     * @param name the script name
+     * @param language the script language
+     * @param text the script to execute
+     * @return the new component builder instance
      */
-    ScriptFileComponentBuilder newScriptFile(String path);
+    ScriptComponentBuilder newScript(@Nullable String name, @Nullable String language, @Nullable String text);
 
     /**
-     * Returns a builder for creating Async Loggers.
-     * @param name The name of the script file.
-     * @param path The location of the script file.
-     * @return A new ScriptFileComponentBuilder.
+     * Returns a {@link ScriptFileComponentBuilder} for creating a {@link ScriptFile} component.
+     * @param path the script file path
+     * @return the new component builder instance
      */
-    ScriptFileComponentBuilder newScriptFile(String name, String path);
+    ScriptFileComponentBuilder newScriptFile(@Nullable String path);
 
     /**
-     * Returns a builder for creating Appenders.
-     * @param name The name of the Appender.
-     * @param pluginName The Plugin type of the Appender.
-     * @return A new AppenderComponentBuilder.
+     * Returns a {@link ScriptFileComponentBuilder} for creating a {@link ScriptFile} component.
+     * @param name the script file name
+     * @param path the script file path
+     * @return the new component builder instance
      */
-    AppenderComponentBuilder newAppender(String name, String pluginName);
+    ScriptFileComponentBuilder newScriptFile(@Nullable String name, @Nullable String path);
 
     /**
-     * Returns a builder for creating AppenderRefs.
-     * @param ref The name of the Appender being referenced.
-     * @return A new AppenderRefComponentBuilder.
+     * Returns a {@link AppenderComponentBuilder} for creating an {@link Appender} component.
+     * @param name the appender name
+     * @param pluginName the appender plugin-type
+     * @return the new component builder instance
      */
-    AppenderRefComponentBuilder newAppenderRef(String ref);
+    AppenderComponentBuilder newAppender(@Nullable String name, String pluginName);
 
     /**
-     * Returns a builder for creating Async Loggers.
-     * @param name The name of the Logger.
-     * @return A new LoggerComponentBuilder.
+     * Returns a {@link AppenderRefComponentBuilder} for creating an {@link AppenderRef} component.
+     * @param ref the name of the {@code Appender} being referenced
+     * @return the new component builder instance
      */
-    LoggerComponentBuilder newAsyncLogger(String name);
+    AppenderRefComponentBuilder newAppenderRef(@Nullable String ref);
 
     /**
-     * Returns a builder for creating Async Loggers.
-     * @param name The name of the Logger.
-     * @param includeLocation If true include location information.
-     * @return A new LoggerComponentBuilder.
+     * Returns a {@link LoggerComponentBuilder} builder for creating an {@link AsyncLogger} component.
+     * @param name the logger name
+     * @return the new component builder instance
      */
-    LoggerComponentBuilder newAsyncLogger(String name, boolean includeLocation);
+    LoggerComponentBuilder newAsyncLogger(@Nullable String name);
 
     /**
-     * Returns a builder for creating Async Loggers.
-     * @param name The name of the Logger.
-     * @param level The logging Level to be assigned to the Logger.
-     * @return A new LoggerComponentBuilder.
+     * Returns a {@link LoggerComponentBuilder} for creating an {@link AsyncLogger} component.
+     * @param name the logger name
+     * @param includeLocation {@code true} to include location information; otherwise, {@code false}
+     * @return the new component builder instance
      */
-    LoggerComponentBuilder newAsyncLogger(String name, Level level);
+    LoggerComponentBuilder newAsyncLogger(@Nullable String name, boolean includeLocation);
 
     /**
-     * Returns a builder for creating Async Loggers.
-     * @param name The name of the Logger.
-     * @param level The logging Level to be assigned to the Logger.
-     * @param includeLocation If true include location information.
-     * @return A new LoggerComponentBuilder.
-     */
-    LoggerComponentBuilder newAsyncLogger(String name, Level level, boolean includeLocation);
-
-    /**
-     * Returns a builder for creating Async Loggers.
+     * Returns a {@link LoggerComponentBuilder} for creating an {@link AsyncLogger} component.
      * @param name The name of the Logger.
      * @param level The logging Level to be assigned to the Logger.
      * @return A new LoggerComponentBuilder.
      */
-    LoggerComponentBuilder newAsyncLogger(String name, String level);
+    LoggerComponentBuilder newAsyncLogger(@Nullable String name, @Nullable Level level);
 
     /**
-     * Returns a builder for creating Async Loggers.
-     * @param name The name of the Logger.
-     * @param level The logging Level to be assigned to the Logger.
-     * @param includeLocation If true include location information.
-     * @return A new LoggerComponentBuilder.
+     * Returns a {@link LoggerComponentBuilder} for creating an {@link AsyncLogger} component.
+     * @param name the logger name
+     * @param level the logger level
+     * @param includeLocation {@code true} to include location information; otherwise, {@code false}
+     * @return the new component builder instance
      */
-    LoggerComponentBuilder newAsyncLogger(String name, String level, boolean includeLocation);
+    LoggerComponentBuilder newAsyncLogger(@Nullable String name, @Nullable Level level, boolean includeLocation);
 
     /**
-     * Returns a builder for creating the async root Logger.
-     * @return A new RootLoggerComponentBuilder.
+     * Returns a {@link LoggerComponentBuilder} for creating an {@link AsyncLogger} component
+     * @param name the logger name
+     * @param level the logger level
+     * @return the new component builder instance
+     */
+    LoggerComponentBuilder newAsyncLogger(@Nullable String name, @Nullable String level);
+
+    /**
+     * Returns a {@link LoggerComponentBuilder} for creating an {@link AsyncLogger} component.
+     * @param name the logger name
+     * @param level the logger level
+     * @param includeLocation {@code true} to include location inforrmation; otherwise, {@code false}
+     * @return the new component builder instance
+     */
+    LoggerComponentBuilder newAsyncLogger(@Nullable String name, @Nullable String level, boolean includeLocation);
+
+    /**
+     * Returns a {@link RootLoggerComponentBuilder} for creating a root {@link AsyncLogger} component.
+     * @return the new component builder instance
      */
     RootLoggerComponentBuilder newAsyncRootLogger();
 
     /**
-     * Returns a builder for creating the async root Logger.
-     * @param includeLocation If true include location information.
-     * @return A new RootLoggerComponentBuilder.
+     * Returns a {@link RootLoggerComponentBuilder} for creating a root {@link AsyncLogger} component.
+     * @param includeLocation {@code true} to include location information; otherwise, {@code false}
+     * @return the new component builder instance
      */
     RootLoggerComponentBuilder newAsyncRootLogger(boolean includeLocation);
 
     /**
-     * Returns a builder for creating the async root Logger.
-     * @param level The logging Level to be assigned to the root Logger.
-     * @return A new RootLoggerComponentBuilder.
+     * Returns a {@link RootLoggerComponentBuilder} for creating a root {@link AsyncLogger} component.
+     * @param level the logger level
+     * @return the new component builder instance
      */
-    RootLoggerComponentBuilder newAsyncRootLogger(Level level);
+    RootLoggerComponentBuilder newAsyncRootLogger(@Nullable Level level);
 
     /**
-     * Returns a builder for creating the async root Logger.
-     * @param level The logging Level to be assigned to the root Logger.
-     * @param includeLocation If true include location information.
-     * @return A new RootLoggerComponentBuilder.
+     * Returns a {@link RootLoggerComponentBuilder} for creating a root {@link AsyncLogger} component.
+     * @param level the logger level
+     * @param includeLocation {@code true} to include location information; otherwise, {@code false}
+     * @return the new component builder instance
      */
-    RootLoggerComponentBuilder newAsyncRootLogger(Level level, boolean includeLocation);
+    RootLoggerComponentBuilder newAsyncRootLogger(@Nullable Level level, boolean includeLocation);
 
     /**
-     * Returns a builder for creating the async root Logger.
-     * @param level The logging Level to be assigned to the root Logger.
-     * @return A new RootLoggerComponentBuilder.
+     * Returns a {@link RootLoggerComponentBuilder} for creating a root {@link AsyncLogger} component.
+     * @param level the logger level
+     * @return the new component builder instance
      */
-    RootLoggerComponentBuilder newAsyncRootLogger(String level);
+    RootLoggerComponentBuilder newAsyncRootLogger(@Nullable String level);
 
     /**
-     * Returns a builder for creating the async root Logger.
-     * @param level The logging Level to be assigned to the root Logger.
-     * @param includeLocation If true include location information.
-     * @return A new RootLoggerComponentBuilder.
+     * Returns a {@link RootLoggerComponentBuilder} for creating a root {@link AsyncLogger} component.
+     * @param level the logger level
+     * @param includeLocation {@code true} to include location information; otherwise, {@code false}
+     * @return the new component builder instance
      */
-    RootLoggerComponentBuilder newAsyncRootLogger(String level, boolean includeLocation);
+    RootLoggerComponentBuilder newAsyncRootLogger(@Nullable String level, boolean includeLocation);
 
     /**
-     * Returns a builder for creating generic components.
-     * @param <B> ComponentBuilder target type
-     * @param pluginName The Plugin type of the component.
-     * @return A new ComponentBuilder.
+     * Returns a new {@link ComponentBuilder} for creating a generic {@link Component}.
+     * @param <B> the {@code ComponentBuilder} target type
+     * @param pluginType the component plugin type
+     * @return the new component builder instance
      */
-    <B extends ComponentBuilder<B>> ComponentBuilder<B> newComponent(String pluginName);
+    <B extends ComponentBuilder<B>> ComponentBuilder<B> newComponent(String pluginType);
 
     /**
-     * Returns a builder for creating generic components.
-     * @param <B> ComponentBuilder target type
-     * @param name The name of the component (may be null).
-     * @param pluginName The Plugin type of the component.
-     * @return A new ComponentBuilder.
+     * Returns a new {@link ComponentBuilder} for creating a generic {@link Component}.
+     * @param <B> the {@code ComponentBuilder} target type
+     * @param name the component name
+     * @param pluginType the component plugin type
+     * @return the new component builder instance
      */
-    <B extends ComponentBuilder<B>> ComponentBuilder<B> newComponent(String name, String pluginName);
+    <B extends ComponentBuilder<B>> ComponentBuilder<B> newComponent(@Nullable String name, String pluginType);
 
     /**
-     * Returns a builder for creating generic components.
-     * @param <B> ComponentBuilder target type
-     * @param name The name of the component (may be null).
-     * @param pluginName The Plugin type of the component.
-     * @param value The value of the component.
-     * @return A new ComponentBuilder.
+     * Returns a new {@link ComponentBuilder} for creating a generic {@link Component}.
+     * @param <B> the {@code ComponentBuilder} target type
+     * @param name the component name
+     * @param pluginType the component plugin type
+     * @param value the component value
+     * @return the new component builder instance
      */
-    <B extends ComponentBuilder<B>> ComponentBuilder<B> newComponent(String name, String pluginName, String value);
+    <B extends ComponentBuilder<B>> ComponentBuilder<B> newComponent(
+            @Nullable String name, String pluginType, @Nullable String value);
 
     /**
-     * Returns a builder for creating Property:s
-     * @param name The name of the property.
-     * @param value The value of the component.
-     * @return A new PropertyComponentBuilder.
+     * Returns a new {@link PropertyComponentBuilder} for creating a {@link Property} component.
+     * @param name the property name
+     * @param value the property value
+     * @return the new component builder instance
      */
-    PropertyComponentBuilder newProperty(String name, String value);
+    PropertyComponentBuilder newProperty(@Nullable String name, @Nullable String value);
 
     /**
-     * Returns a builder for creating KeyValuePair:s
-     * @param key The name
-     * @param value The value
-     * @return A new KeyValuePairComponentBuilder.
+     * Returns a new {@link PropertyComponentBuilder} for creating a {@link KeyValuePair} component.
+     * @param key the key
+     * @param value the value
+     * @return the new component builder instance
      */
-    KeyValuePairComponentBuilder newKeyValuePair(String key, String value);
+    KeyValuePairComponentBuilder newKeyValuePair(@Nullable String key, @Nullable String value);
 
     /**
-     * Returns a builder for creating CustomLevels
-     * @param name The name of the custom level.
-     * @param level The integer value to be assigned to the level.
-     * @return A new CustomLevelComponentBuilder.
+     * Returns a new {@link CustomLevelComponentBuilder} for creating a {@link CustomLevels} component.
+     * @param name the custom level name
+     * @param intLevel the integer value to be assigned to the level
+     * @return the new component builder instance
      */
-    CustomLevelComponentBuilder newCustomLevel(String name, int level);
+    CustomLevelComponentBuilder newCustomLevel(@Nullable String name, int intLevel);
 
     /**
-     * Returns a builder for creating Filters.
-     * @param pluginName The Plugin type of the Filter.
+     * Returns a new {@link FilterComponentBuilder} for creating a {@link Filter} component.
+     * @param pluginType the plugin type of the filter
+     * @return the new component builder instance
+     */
+    FilterComponentBuilder newFilter(String pluginType);
+
+    /**
+     * Returns a new {@link FilterComponentBuilder} for creating a {@code Filter} component.
+     * @param pluginType The Plugin type of the Filter.
      * @param onMatch "ACCEPT", "DENY", or "NEUTRAL"
      * @param onMismatch "ACCEPT", "DENY", or "NEUTRAL"
-     * @return A new FilterComponentBuilder.
+     * @return the new component builder instance
      */
-    FilterComponentBuilder newFilter(String pluginName, Filter.Result onMatch, Filter.Result onMismatch);
+    FilterComponentBuilder newFilter(String pluginType, @Nullable Result onMatch, @Nullable Result onMismatch);
 
     /**
-     * Returns a builder for creating Filters.
-     * @param pluginName The Plugin type of the Filter.
+     * Returns a new {@link FilterComponentBuilder} for creating a {@link Filter} component.
+     * @param pluginType the plugin type of the filter
      * @param onMatch "ACCEPT", "DENY", or "NEUTRAL"
      * @param onMismatch "ACCEPT", "DENY", or "NEUTRAL"
-     * @return A new FilterComponentBuilder.
+     * @return the new component builder instance
      */
-    FilterComponentBuilder newFilter(String pluginName, String onMatch, String onMismatch);
+    FilterComponentBuilder newFilter(String pluginType, @Nullable String onMatch, @Nullable String onMismatch);
 
     /**
-     * Returns a builder for creating Layouts.
-     * @param pluginName The Plugin type of the Layout.
-     * @return A new LayoutComponentBuilder.
+     * Returns a new {@link LayoutComponentBuilder} for creating a {@link Layout} component.
+     * @param pluginType the plugin type of the layout
+     * @return the new component builder instance
      */
-    LayoutComponentBuilder newLayout(String pluginName);
+    LayoutComponentBuilder newLayout(String pluginType);
 
     /**
-     * Returns a builder for creating Loggers.
-     * @param name The name of the Logger.
-     * @return A new LoggerComponentBuilder.
+     * Returns a new {@link LayoutComponentBuilder} for creating a {@link Layout} component.
+     * @param name the logger name
+     * @return the new component builder instance
      */
-    LoggerComponentBuilder newLogger(String name);
+    LoggerComponentBuilder newLogger(@Nullable String name);
 
     /**
-     * Returns a builder for creating Loggers.
-     * @param name The name of the Logger.
-     * @param includeLocation If true include location information.
-     * @return A new LoggerComponentBuilder.
+     * Returns a new {@link LoggerComponentBuilder} for creating a {@link Logger} component.
+     * @param name the logger name
+     * @param includeLocation {@code true} to include location information; otherwise, {@code false}
+     * @return the new component builder instance
      */
-    LoggerComponentBuilder newLogger(String name, boolean includeLocation);
+    LoggerComponentBuilder newLogger(@Nullable String name, boolean includeLocation);
 
     /**
-     * Returns a builder for creating Loggers.
-     * @param name The name of the Logger.
-     * @param level The logging Level to be assigned to the Logger.
-     * @return A new LoggerComponentBuilder.
+     * Returns a new {@link LoggerComponentBuilder} for creating a {@link Logger} component.
+     * @param name the logger name
+     * @param level the logger level
+     * @return the new component builder instance
      */
-    LoggerComponentBuilder newLogger(String name, Level level);
+    LoggerComponentBuilder newLogger(@Nullable String name, @Nullable Level level);
 
     /**
-     * Returns a builder for creating Loggers.
-     * @param name The name of the Logger.
-     * @param level The logging Level to be assigned to the Logger.
-     * @param includeLocation If true include location information.
-     * @return A new LoggerComponentBuilder.
+     * Returns a new {@link LoggerComponentBuilder} for creating a {@link Logger} component.
+     * @param name the logger name
+     * @param level the logger level
+     * @param includeLocation {@code true} to include location information; otherwise, {@code false}
+     * @return the new component builder instance
      */
-    LoggerComponentBuilder newLogger(String name, Level level, boolean includeLocation);
+    LoggerComponentBuilder newLogger(@Nullable String name, @Nullable Level level, boolean includeLocation);
 
     /**
-     * Returns a builder for creating Loggers.
-     * @param name The name of the Logger.
-     * @param level The logging Level to be assigned to the Logger.
-     * @return A new LoggerComponentBuilder.
+     * Returns a new {@link LoggerComponentBuilder} for creating a {@link Logger} component.
+     * @param name the logger name
+     * @param level the logger level
+     * @return the new component builder instance
      */
-    LoggerComponentBuilder newLogger(String name, String level);
+    LoggerComponentBuilder newLogger(@Nullable String name, @Nullable String level);
 
     /**
-     * Returns a builder for creating Loggers.
-     * @param name The name of the Logger.
-     * @param level The logging Level to be assigned to the Logger.
-     * @param includeLocation If true include location information.
-     * @return A new LoggerComponentBuilder.
+     * Returns a new {@link LoggerComponentBuilder} for creating a {@link Logger} component.
+     * @param name the logger name
+     * @param level the logger level
+     * @param includeLocation {@code true} to include location information; otherwise, {@code false}
+     * @return the new component builder instance
      */
-    LoggerComponentBuilder newLogger(String name, String level, boolean includeLocation);
+    LoggerComponentBuilder newLogger(@Nullable String name, @Nullable String level, boolean includeLocation);
 
     /**
-     * Returns a builder for creating the root Logger.
-     * @return A new RootLoggerComponentBuilder.
+     * Returns a new {@link RootLoggerComponentBuilder} for creating a {@link RootLogger} component.
+     * @return the new component builder instance
      */
     RootLoggerComponentBuilder newRootLogger();
 
     /**
-     * Returns a builder for creating the root Logger.
-     * @param includeLocation If true include location information.
-     * @return A new RootLoggerComponentBuilder.
+     * Returns a new {@link RootLoggerComponentBuilder} for creating a {@link RootLogger} component.
+     * @param includeLocation {@code true} to include location information; otherwise, {@code false}
+     * @return the new component builder instancec
      */
     RootLoggerComponentBuilder newRootLogger(boolean includeLocation);
 
     /**
-     * Returns a builder for creating the root Logger.
-     * @param level The logging Level to be assigned to the root Logger.
-     * @return A new RootLoggerComponentBuilder.
+     * Returns a new {@link RootLoggerComponentBuilder} for creating a {@link RootLogger} component.
+     * @param level the logger level
+     * @return the new component builder instance
      */
-    RootLoggerComponentBuilder newRootLogger(Level level);
+    RootLoggerComponentBuilder newRootLogger(@Nullable Level level);
 
     /**
-     * Returns a builder for creating the root Logger.
-     * @param level The logging Level to be assigned to the root Logger.
-     * @param includeLocation If true include location information.
-     * @return A new RootLoggerComponentBuilder.
+     * Returns a new {@link RootLoggerComponentBuilder} for creating a {@link RootLogger} component.
+     * @param level the logger level
+     * @param includeLocation {@code true} to include location information; otherwise, {@code false}
+     * @return the new component builder instance
      */
-    RootLoggerComponentBuilder newRootLogger(Level level, boolean includeLocation);
+    RootLoggerComponentBuilder newRootLogger(@Nullable Level level, boolean includeLocation);
 
     /**
-     * Returns a builder for creating the root Logger.
-     * @param level The logging Level to be assigned to the root Logger.
-     *
-     * @return A new RootLoggerComponentBuilder.
+     * Returns a new {@link RootLoggerComponentBuilder} for creating a {@link RootLogger} component.
+     * @param level the logger level
+     * @return the new component builder instance
      */
-    RootLoggerComponentBuilder newRootLogger(String level);
+    RootLoggerComponentBuilder newRootLogger(@Nullable String level);
 
     /**
-     * Returns a builder for creating the root Logger.
-     * @param level The logging Level to be assigned to the root Logger.
-     *
-     * @return A new RootLoggerComponentBuilder.
+     * Returns a new {@link RootLoggerComponentBuilder} for creating a {@link RootLogger} component.
+     * @param level the logger level
+     * @param includeLocation {@code true} to include location information; otherwise, {@code false}
+     * @return the new component builder instance
      */
-    RootLoggerComponentBuilder newRootLogger(String level, boolean includeLocation);
+    RootLoggerComponentBuilder newRootLogger(@Nullable String level, boolean includeLocation);
 
     /**
      * Set the Advertiser Plugin name.
      * @param advertiser The Advertiser Plugin name.
      * @return this builder instance.
      */
-    ConfigurationBuilder<T> setAdvertiser(String advertiser);
+    ConfigurationBuilder<T> setAdvertiser(@Nullable String advertiser);
 
     /**
      * Sets the name of the configuration.
      * @param name the name of the {@link Configuration}. By default is {@code "Constructed"}.
      * @return this builder instance.
      */
-    ConfigurationBuilder<T> setConfigurationName(String name);
+    ConfigurationBuilder<T> setConfigurationName(@Nullable String name);
 
     /**
-     * Sets the configuration source, if one exists.
-     * @param configurationSource the ConfigurationSource.
+     * Sets the configuration source.
+     * @param configurationSource the configuration source
+     * @return this builder instance (for chaining)
+     */
+    ConfigurationBuilder<T> setConfigurationSource(@Nullable ConfigurationSource configurationSource);
+
+    /**
+     * Specifies the destination for StatusLogger events. This can be {@code out} (default) for using
+     * {@link System#out standard out}, {@code err} for using {@link System#err standard error}, or a file URI to
+     * which log events will be written. If the provided URI is invalid, then the default destination of standard
+     * out will be used.
+     *
+     * @param destination where status log messages should be output.
      * @return this builder instance.
      */
-    ConfigurationBuilder<T> setConfigurationSource(ConfigurationSource configurationSource);
+    ConfigurationBuilder<T> setDestination(@Nullable String destination);
 
     /**
-     * Sets the interval at which the configuration file should be checked for changes.
-     * @param intervalSeconds The number of seconds that should pass between checks of the configuration file.
-     * @return this builder instance.
+     * Sets the logger context.
+     * @param loggerContext the logger context.
+     */
+    void setLoggerContext(@Nullable LoggerContext loggerContext);
+
+    /**
+     * Sets the configuration's "monitorInterval" attribute.
+     * <p>
+     *   The monitor interval specifies the number of seconds between checks for changes to the configuration source.
+     * </p>
+     * @param intervalSeconds the number of seconds that should pass between checks of the configuration source
+     * @return this builder instance
+     */
+    ConfigurationBuilder<T> setMonitorInterval(int intervalSeconds);
+
+    /**
+     * Sets the configuration's "monitorInterval" attribute.
+     * <p>
+     *   The monitor interval specifies the number of seconds between checks for changes to the configuration source.
+     * </p>
+     * @param intervalSeconds the number of seconds that should pass between checks of the configuration source
+     * @return this builder instance
+     * @throws NumberFormatException if the {@code intervalSeconds} argument is not a valid integer representation
      */
     ConfigurationBuilder<T> setMonitorInterval(String intervalSeconds);
 
     /**
-     * Sets the list of packages to search for plugins.
-     * @param packages The comma separated list of packages.
-     * @return this builder instance.
+     * Sets the configuration's list of packages to search for Log4j plugins.
+     * @param packages a comma separated list of packages
+     * @return this builder (for chaining)
      */
-    ConfigurationBuilder<T> setPackages(String packages);
+    ConfigurationBuilder<T> setPackages(@Nullable String packages);
 
     /**
-     * Sets whether the shutdown hook should be disabled.
+     * Sets the configuration's "shutdownHook" attribute.
      * @param flag "disable" will prevent the shutdown hook from being set.
-     * @return this builder instance.
+     * @return this builder (for chaining)
      */
-    ConfigurationBuilder<T> setShutdownHook(String flag);
+    ConfigurationBuilder<T> setShutdownHook(@Nullable String flag);
 
     /**
-     * How long appenders and background tasks will get to shutdown when the JVM shuts down.
-     * Default is zero which mean that each appender uses its default timeout, and don't wait for background
-     * tasks. Not all appenders will honor this, it is a hint and not an absolute guarantee that the shutdown
-     * procedure will not take longer. Setting this too low increase the risk of losing outstanding log events
-     * not yet written to the final destination. (Not used if {@link #setShutdownHook(String)} is set to "disable".)
-     * @return this builder instance.
+     * Sets the configuration's "shutdownTimeout" attribute.
+     * <p>
+     *   The shutdown-timeout specifies how long appenders and background tasks will get to shut down when the
+     *   JVM is shutting down.
+     * </p>
+     * <p>
+     *   The default is zero which means that each appender uses its default timeout, and doesn't wait for background
+     *   tasks. Not all appenders will honor this, it is a hint and not an absolute guarantee that the shutdown
+     *   procedure will not take longer.
+     * </p>
+     * <p>
+     *   Setting the shutdown-timeout too low increase the risk of losing outstanding log events that have not yet
+     *   been written to the final destination.
+     * </p>
+     * <p>
+     *   This setting is ignored if {@link #setShutdownHook(String)} has been set to "disable".
+     * </p>
      *
+     * @param shutdownTimeoutMillis the shutdown timeout in milliseconds
+     * @return this builder (for chaining)
+     * @throws IllegalArgumentException if the {@code shutdownTimeoutMillis} argument is less than 0
+     * @see LoggerContext#stop(long, TimeUnit)
+     */
+    ConfigurationBuilder<T> setShutdownTimeout(long shutdownTimeoutMillis);
+
+    /**
+     * Sets the configuration's "shutdownTimeout" attribute.
+     * <p>
+     *   The shutdown-timeout specifies how long appenders and background tasks will get to shut down when the
+     *   JVM is shutting down.
+     * </p>
+     * <p>
+     *   The default is zero which means that each appender uses its default timeout, and doesn't wait for background
+     *   tasks. Not all appenders will honor this, it is a hint and not an absolute guarantee that the shutdown
+     *   procedure will not take longer.
+     * </p>
+     * <p>
+     *   Setting the shutdown-timeout too low increase the risk of losing outstanding log events that have not yet
+     *   been written to the final destination.
+     * </p>
+     * <p>
+     *   This setting is ignored if {@link #setShutdownHook(String)} has been set to "disable".
+     * </p>
+     *
+     * @param timeout the timeout (in the given {@code TimeUnit}
+     * @param timeUnit the time-unit used to convert the timeout to milliseconds
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the given {@code timeUnit} argument is {@code null}
      * @see LoggerContext#stop(long, TimeUnit)
      */
     ConfigurationBuilder<T> setShutdownTimeout(long timeout, TimeUnit timeUnit);
@@ -452,35 +607,29 @@ public interface ConfigurationBuilder<T extends Configuration> extends Builder<T
     ConfigurationBuilder<T> setStatusLevel(Level level);
 
     /**
+     * Set a property with the given {@code key} and {@code value} on the root node.
+     * @param key the property key
+     * @param value the property value
+     * @return this builder (for chaining)
+     * @throws NullPointerException if the {@code key} argument is {@code null}
+     */
+    ConfigurationBuilder<T> setRootProperty(String key, @Nullable String value);
+
+    /**
      * Sets whether the logging should include constructing Plugins.
      * @param verbosity "disable" will hide messages from plugin construction.
      * @return this builder instance.
      */
-    ConfigurationBuilder<T> setVerbosity(String verbosity);
+    ConfigurationBuilder<T> setVerbosity(@Nullable String verbosity);
 
     /**
-     * Specifies the destination for StatusLogger events. This can be {@code out} (default) for using
-     * {@link System#out standard out}, {@code err} for using {@link System#err standard error}, or a file URI to
-     * which log events will be written. If the provided URI is invalid, then the default destination of standard
-     * out will be used.
-     *
-     * @param destination where status log messages should be output.
-     * @return this builder instance.
+     * Add a property with the given key and value to the configuration's root node.
+     * @param key the property key
+     * @param value the property value
+     * @return this builder (for chaining)
+     * @deprecated use {@link #setRootProperty(String, String)}
      */
-    ConfigurationBuilder<T> setDestination(String destination);
-
-    /**
-     * Sets the logger context.
-     * @param loggerContext the logger context.
-     */
-    void setLoggerContext(LoggerContext loggerContext);
-
-    /**
-     * Add the properties for the root node.
-     * @param key The property key.
-     * @param value The property value.
-     * @return this builder instance.
-     */
+    @Deprecated
     ConfigurationBuilder<T> addRootProperty(String key, String value);
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ConfigurationBuilderFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ConfigurationBuilderFactory.java
@@ -20,19 +20,31 @@ import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.config.builder.impl.DefaultConfigurationBuilder;
 
 /**
- * Provides methods to create ConfigurationBuilders.
+ * A {@link ConfigurationBuilder} factory which generates configuration-builders that build
+ * a {@link BuiltConfiguration} or a derivative thereof.
+ *
  * @since 2.4
  */
 public abstract class ConfigurationBuilderFactory {
 
     /**
-     * Returns a new default ConfigurationBuilder to construct Log4j configurations.
-     * @return A new ConfigurationBuilder.
+     * Returns a new default {@link ConfigurationBuilder} of type {@link BuiltConfiguration}
+     * to construct Log4j configurations.
+     *
+     * @return the new configuration builder instance
      */
     public static ConfigurationBuilder<BuiltConfiguration> newConfigurationBuilder() {
         return new DefaultConfigurationBuilder<>();
     }
 
+    /**
+     * Returns a new default {@link ConfigurationBuilder} which builds a specific implementation of
+     * {@link BuiltConfiguration}.
+     *
+     * @param <T> the {@code BuiltConfiguration} implementation type
+     * @param clazz the class of the built-configuration implementation which should be built
+     * @return the new configuration builder instance
+     */
     public static <T extends BuiltConfiguration> ConfigurationBuilder<T> newConfigurationBuilder(final Class<T> clazz) {
         return new DefaultConfigurationBuilder<>(clazz);
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/CustomLevelComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/CustomLevelComponentBuilder.java
@@ -16,8 +16,30 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.apache.logging.log4j.core.config.CustomLevels;
+
 /**
- * Assembler for constructing CustomLevel Components.
+ * A builder interface for constructing and configuring {@link CustomLevels} components in a Log4j configuration.
+ *
+ * <p>
+ *   Instances of this builder are designed for single-threaded use and are not thread-safe. Developers
+ *   should avoid sharing instances between threads.
+ * </p>
+ *
  * @since 2.4
  */
-public interface CustomLevelComponentBuilder extends ComponentBuilder<CustomLevelComponentBuilder> {}
+public interface CustomLevelComponentBuilder extends ComponentBuilder<CustomLevelComponentBuilder> {
+
+    /**
+     * Sets the 'intLevel' attribute on the custom-level component.
+     * <p>
+     *   If the given {@code onMismatch} argument is {@code} the attribute will be removed (if present).
+     * </p>
+     *
+     * @param intLevel the integer level value
+     * @return this builder (for chaining)
+     */
+    default CustomLevelComponentBuilder setIntLevelAttribute(int intLevel) {
+        return setAttribute("intLevel", intLevel);
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/FilterComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/FilterComponentBuilder.java
@@ -16,8 +16,71 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Filter.Result;
+import org.jspecify.annotations.Nullable;
+
 /**
- * Assembler for constructing Filter Components.
+ * A builder interface for constructing and configuring {@link Filter} components in a Log4j configuration.
+ *
+ * <p>
+ *   Instances of this builder are designed for single-threaded use and are not thread-safe. Developers
+ *   should avoid sharing instances between threads.
+ * </p>
+ *
  * @since 2.4
  */
-public interface FilterComponentBuilder extends ComponentBuilder<FilterComponentBuilder> {}
+public interface FilterComponentBuilder extends ComponentBuilder<FilterComponentBuilder> {
+
+    /**
+     * Sets the 'onMatch' attribute on the filter component.
+     * <p>
+     *   If the given {@code onMatch} argument is {@code} the attribute will be removed (if present).
+     * </p>
+     *
+     * @param onMatch the attribute value
+     * @return this builder (for chaining)
+     */
+    default FilterComponentBuilder setOnMatchAttribute(@Nullable String onMatch) {
+        return setAttribute("onMatch", onMatch);
+    }
+
+    /**
+     * Sets the 'onMatch' attribute on the filter component.
+     * <p>
+     *   If the given {@code onMatch} argument is {@code} the attribute will be removed (if present).
+     * </p>
+     *
+     * @param onMatch the attribute value
+     * @return this builder (for chaining)
+     */
+    default FilterComponentBuilder setOnMatchAttribute(@Nullable Result onMatch) {
+        return setAttribute("onMatch", onMatch);
+    }
+
+    /**
+     * Sets the 'onMismatch' attribute on the filter component.
+     * <p>
+     *   If the given {@code onMismatch} argument is {@code} the attribute will be removed (if present).
+     * </p>
+     *
+     * @param onMismatch the attribute value
+     * @return this builder (for chaining)
+     */
+    default FilterComponentBuilder setOnMismatchAttribute(@Nullable String onMismatch) {
+        return setAttribute("onMismatch", onMismatch);
+    }
+
+    /**
+     * Sets the 'onMismatch' attribute on the filter component.
+     * <p>
+     *   If the given {@code onMismatch} argument is {@code} the attribute will be removed (if present).
+     * </p>
+     *
+     * @param onMismatch the attribute value
+     * @return this builder (for chaining)
+     */
+    default FilterComponentBuilder setOnMismatchAttribute(@Nullable Result onMismatch) {
+        return setAttribute("onMismatch", onMismatch);
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/FilterableComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/FilterableComponentBuilder.java
@@ -25,9 +25,15 @@ public interface FilterableComponentBuilder<T extends ComponentBuilder<T>> exten
 
     /**
      * Adds a Filter to the component.
+     * <p>
+     *   Note: the provided {@code builder} will be built by this method; therefore, it must be fully configured
+     *   <i>before</i> calling this method.  Changes to the builder after calling this method will not have
+     *   any effect.
+     * </p>
      *
-     * @param assembler The FilterComponentBuilder with all of its attributes and sub components set.
-     * @return this Assembler.
+     * @param builder The {@code FilterComponentBuilder} with all of its attributes and subcomponents set.
+     * @return this component builder (for chaining)
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
      */
-    T add(FilterComponentBuilder assembler);
+    T add(FilterComponentBuilder builder);
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/KeyValuePairComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/KeyValuePairComponentBuilder.java
@@ -16,8 +16,44 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.apache.logging.log4j.core.util.KeyValuePair;
+import org.jspecify.annotations.Nullable;
+
 /**
- * Assembler for constructing KeyValuePair Components.
+ * A builder interface for constructing and configuring {@link KeyValuePair} components in a Log4j configuration.
+ *
+ * <p>
+ *   Instances of this builder are designed for single-threaded use and are not thread-safe. Developers
+ *   should avoid sharing instances between threads.
+ * </p>
+ *
  * @since 2.9
  */
-public interface KeyValuePairComponentBuilder extends ComponentBuilder<KeyValuePairComponentBuilder> {}
+public interface KeyValuePairComponentBuilder extends ComponentBuilder<KeyValuePairComponentBuilder> {
+
+    /**
+     * Sets the 'key' attribute to the key-value pair component.
+     * <p>
+     *   If the given {@code key} argument is {@code} the attribute will be removed (if present).
+     * </p>
+     *
+     * @param key the attribute value
+     * @return this builder (for chaining)
+     */
+    default KeyValuePairComponentBuilder setKeyAttribute(final @Nullable String key) {
+        return setAttribute("key", key);
+    }
+
+    /**
+     * Sets the 'value' attribute to the key-value pair component.
+     * <p>
+     *   If the given {@code value} argument is {@code} the attribute will be removed (if present).
+     * </p>
+     *
+     * @param value the attribute value
+     * @return this builder (for chaining)
+     */
+    default KeyValuePairComponentBuilder setValueAttribute(final @Nullable String value) {
+        return setAttribute("value", value);
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/LayoutComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/LayoutComponentBuilder.java
@@ -16,8 +16,16 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.apache.logging.log4j.core.Layout;
+
 /**
- * Assembler for constructing Layout Components.
+ * A builder interface for constructing and configuring {@link Layout} components in a Log4j configuration.
+ *
+ * <p>
+ *   Instances of this builder are designed for single-threaded use and are not thread-safe. Developers
+ *   should avoid sharing instances between threads.
+ * </p>
+ *
  * @since 2.4
  */
 public interface LayoutComponentBuilder extends ComponentBuilder<LayoutComponentBuilder> {}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/LoggableComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/LoggableComponentBuilder.java
@@ -16,17 +16,97 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.config.LoggerConfig.RootLogger;
+import org.jspecify.annotations.Nullable;
+
 /**
- * Common component builder for Logger and RootLogger elements.
+ * A common builder interface for constructing and configuring {@link Logger} and {@link RootLogger}
+ * components in a Log4j configuration.
+ *
+ * <p>
+ *   Instances of this builder are designed for single-threaded use and are not thread-safe. Developers
+ *   should avoid sharing instances between threads.
+ * </p>
  *
  * @since 2.6
  */
 public interface LoggableComponentBuilder<T extends ComponentBuilder<T>> extends FilterableComponentBuilder<T> {
+
     /**
-     * Add an Appender reference to the Logger component.
+     * Add an {@link AppenderRefComponentBuilder} to this logger component builder.
+     * <p>
+     *   Note: the provided {@code builder} will be built by this method; therefore, it must be fully configured
+     *   <i>before</i> calling this method.  Changes to the builder after calling this method will not have
+     *   any effect.
+     * </p>
      *
-     * @param assembler The AppenderRefComponentBuilder with all of its attributes and sub-components set.
-     * @return this Assembler.
+     * @param builder The {@code AppenderRefComponentBuilder} with all of its attributes and subcomponents set.
+     * @return this component builder (for chaining)
+     * @throws NullPointerException if the given {@code builder} argument is {@code null}
      */
-    T add(AppenderRefComponentBuilder assembler);
+    T add(AppenderRefComponentBuilder builder);
+
+    /**
+     * Sets the "{@code additivity}" attribute on the logger component.
+     *
+     * @param additivity {@code true} if additive; otherwise, {@code false}
+     * @return this builder (for chaining)
+     */
+    default T setAdditivityAttribute(boolean additivity) {
+        return setAttribute("additivity", additivity);
+    }
+
+    /**
+     * Sets the "{@code additivity}" attribute on the logger component.
+     * <p>
+     *   If the given {@code additivity} is {@code null}, the attribute will be removed from the component.
+     * </p>
+     *
+     * @param additivity "{@code true}" if additive; otherwise, {@code false}
+     * @return this builder (for chaining)
+     */
+    default T setAdditivityAttribute(String additivity) {
+        return setAttribute("additivity", additivity);
+    }
+
+    /**
+     * Sets the "{@code includeLocation}" attribute on the loggable component.
+     * <p>
+     *   If the given {@code includeLocation} is {@code null}, the attribute will be removed from the component.
+     * </p>
+     *
+     * @param includeLocation {@code true} to include location information; otherwise, {@code false}
+     * @return this builder (for chaining)
+     */
+    default T setIncludeLocationAttribute(boolean includeLocation) {
+        return setAttribute("includeLocation", includeLocation);
+    }
+
+    /**
+     * Sets the "{@code level}" attribute on the loggable component.
+     * <p>
+     *   If the given {@code level} is {@code null}, the attribute will be removed from the component.
+     * </p>
+     *
+     * @param level the level
+     * @return this builder (for chaining)
+     */
+    default T setLevelAttribute(@Nullable String level) {
+        return setAttribute("level", level);
+    }
+
+    /**
+     * Sets the "{@code level}" attribute on the loggable component.
+     * <p>
+     *   If the given {@code level} is {@code null}, the attribute will be removed from the component.
+     * </p>
+     *
+     * @param level the level
+     * @return this builder (for chaining)
+     */
+    default T setLevelAttribute(@Nullable Level level) {
+        return setAttribute("level", level);
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/LoggerComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/LoggerComponentBuilder.java
@@ -16,8 +16,16 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.apache.logging.log4j.core.Logger;
+
 /**
- * Assembler for constructing Logger Components.
+ * A builder interface for constructing and configuring {@link Logger} components in a Log4j configuration.
+ *
+ * <p>
+ *   Instances of this builder are designed for single-threaded use and are not thread-safe. Developers
+ *   should avoid sharing instances between threads.
+ * </p>
+ *
  * @since 2.4
  */
 public interface LoggerComponentBuilder extends LoggableComponentBuilder<LoggerComponentBuilder> {}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/PropertyComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/PropertyComponentBuilder.java
@@ -16,8 +16,16 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.apache.logging.log4j.core.config.Property;
+
 /**
- * Assembler for constructing Property Components.
+ * A builder interface for constructing and configuring {@link Property} components in a Log4j configuration.
+ *
+ * <p>
+ *   Instances of this builder are designed for single-threaded use and are not thread-safe. Developers
+ *   should avoid sharing instances between threads.
+ * </p>
+ *
  * @since 2.9
  */
 public interface PropertyComponentBuilder extends ComponentBuilder<PropertyComponentBuilder> {}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/RootLoggerComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/RootLoggerComponentBuilder.java
@@ -16,8 +16,17 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.apache.logging.log4j.core.config.LoggerConfig.RootLogger;
+
 /**
- * Assembler for constructing the root Logger Components.
+ * A builder interface for constructing and configuring {@link RootLogger} components in a Log4j
+ * configuration.
+ *
+ * <p>
+ *   Instances of this builder are designed for single-threaded use and are not thread-safe. Developers
+ *   should avoid sharing instances between threads.
+ * </p>
+ *
  * @since 2.4
  */
 public interface RootLoggerComponentBuilder extends LoggableComponentBuilder<RootLoggerComponentBuilder> {}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ScriptComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ScriptComponentBuilder.java
@@ -16,8 +16,44 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.apache.logging.log4j.core.script.Script;
+import org.jspecify.annotations.Nullable;
+
 /**
- * Assembler for constructing Layout Components.
+ * A builder interface for constructing and configuring {@link Script} components in a Log4j configuration.
+ *
+ * <p>
+ *   Instances of this builder are designed for single-threaded use and are not thread-safe. Developers
+ *   should avoid sharing instances between threads.
+ * </p>
+ *
  * @since 2.5
  */
-public interface ScriptComponentBuilder extends ComponentBuilder<ScriptComponentBuilder> {}
+public interface ScriptComponentBuilder extends ComponentBuilder<ScriptComponentBuilder> {
+
+    /**
+     * Sets the 'language' attribute on the script component.
+     * <p>
+     *   If the given {@code language} argument is {@code} the attribute will be removed (if present).
+     * </p>
+     *
+     * @param language the script language
+     * @return this builder (for chaining)
+     */
+    default ScriptComponentBuilder setLanguageAttribute(final @Nullable String language) {
+        return setAttribute("language", language);
+    }
+
+    /**
+     * Sets the 'test' attribute on the script component.
+     * <p>
+     *   If the given {@code onMatch} argument is {@code} the attribute will be removed (if present).
+     * </p>
+     *
+     * @param text the script text
+     * @return this builder (for chaining)
+     */
+    default ScriptComponentBuilder setTextAttribute(final @Nullable String text) {
+        return setAttribute("text", text);
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ScriptFileComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/ScriptFileComponentBuilder.java
@@ -16,17 +16,131 @@
  */
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.apache.logging.log4j.core.script.ScriptFile;
+import org.jspecify.annotations.Nullable;
+
 /**
- * Assembler for constructing ScriptFile Components.
+ * A builder interface for constructing and configuring {@link ScriptFile} components in a Log4j configuration.
+ *
+ * <p>
+ *   Instances of this builder are designed for single-threaded use and are not thread-safe. Developers
+ *   should avoid sharing instances between threads.
+ * </p>
+ *
  * @since 2.5
  */
 public interface ScriptFileComponentBuilder extends ComponentBuilder<ScriptFileComponentBuilder> {
 
-    ScriptFileComponentBuilder addLanguage(String language);
+    /**
+     * Sets the '{@code language}' attribute for the script-file component.
+     * <p>
+     *   If the {@code language} argument is {@code null} the attribute will be removed.
+     * </p>
+     * @param language the language
+     * @return this builder (for chaining)
+     */
+    default ScriptFileComponentBuilder setLanguageAttribute(@Nullable String language) {
+        return setAttribute("language", language);
+    }
 
-    ScriptFileComponentBuilder addIsWatched(boolean isWatched);
+    /**
+     * Sets the '{@code isWatched}' attribute for the script-file component.
+     * @param isWatched {@code true} to watch the script file; otherwise, {@code false}
+     * @return this builder (for chaining)
+     */
+    default ScriptFileComponentBuilder setIsWatchedAttribute(boolean isWatched) {
+        return setAttribute("isWatched", isWatched);
+    }
 
-    ScriptFileComponentBuilder addIsWatched(String isWatched);
+    /**
+     * Sets the '{@code isWatched}' attribute for the script-file component.
+     * <p>
+     *   If the {@code isWatched} argument is {@code null} the attribute will be removed.
+     * </p>
+     * @param isWatched the string value of the flag
+     * @return this builder (for chaining)
+     */
+    default ScriptFileComponentBuilder setIsWatchedAttribute(@Nullable String isWatched) {
+        return setAttribute("isWatched", isWatched);
+    }
 
-    ScriptFileComponentBuilder addCharset(String charset);
+    /**
+     * Sets the '{@code charset}' attribute for the script-file component.
+     * <p>
+     *   If the {@code charset} argument is {@code null} the attribute will be removed.
+     * </p>
+     * @param charset the charset
+     * @return this builder (for chaining)
+     */
+    default ScriptFileComponentBuilder setCharsetAttribute(@Nullable String charset) {
+        return setAttribute("charset", charset);
+    }
+
+    /**
+     * Sets the '{@code path}' attribute for the script-file component.
+     * <p>
+     *   If the {@code path} argument is {@code null} the attribute will be removed.
+     * </p>
+     * @param path the script file path
+     * @return this builder (for chaining)
+     */
+    default ScriptFileComponentBuilder setPathAttribute(@Nullable String path) {
+        return setAttribute("path", path);
+    }
+
+    /**
+     * Adds the '{@code language}' attribute for the script-file component.
+     * <p>
+     *   If the {@code language} argument is {@code null} the attribute will be removed.
+     * </p>
+     * @param language the language
+     * @return this builder (for chaining)
+     * @deprecated use {@link #setLanguageAttribute(String)}
+     */
+    @Deprecated
+    default ScriptFileComponentBuilder addLanguage(@Nullable String language) {
+        return setLanguageAttribute(language);
+    }
+
+    /**
+     * Adds the '{@code isWatched}' attribute for the script-file component.
+     * <p>
+     *   If the {@code isWatched} argument is {@code null} the attribute will be removed.
+     * </p>
+     * @param isWatched the string value of the flag
+     * @return this builder (for chaining)
+     * @deprecated use {@link #setIsWatchedAttribute(boolean)} (String)}
+     */
+    @Deprecated
+    default ScriptFileComponentBuilder addIsWatched(boolean isWatched) {
+        return setIsWatchedAttribute(isWatched);
+    }
+
+    /**
+     * Adds the '{@code isWatched}' attribute for the script-file component.
+     * <p>
+     *   If the {@code isWatched} argument is {@code null} the attribute will be removed.
+     * </p>
+     * @param isWatched the string value of the flag
+     * @return this builder (for chaining)
+     * @deprecated use {@link #setIsWatchedAttribute(String)}
+     */
+    @Deprecated
+    default ScriptFileComponentBuilder addIsWatched(String isWatched) {
+        return setIsWatchedAttribute(isWatched);
+    }
+
+    /**
+     * Sets the '{@code charset}' attribute for the script-file component.
+     * <p>
+     *   If the {@code charset} argument is {@code null} the attribute will be removed.
+     * </p>
+     * @param charset the charset
+     * @return this builder (for chaining)
+     * @deprecated use {@link #setCharsetAttribute(String)}
+     */
+    @Deprecated
+    default ScriptFileComponentBuilder addCharset(String charset) {
+        return setCharsetAttribute(charset);
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/api/package-info.java
@@ -20,8 +20,10 @@
  * @since 2.4
  */
 @Export
-@Version("2.20.1")
+@NullMarked
+@Version("2.25.0")
 package org.apache.logging.log4j.core.config.builder.api;
 
+import org.jspecify.annotations.NullMarked;
 import org.osgi.annotation.bundle.Export;
 import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultAppenderComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultAppenderComponentBuilder.java
@@ -16,29 +16,58 @@
  */
 package org.apache.logging.log4j.core.config.builder.impl;
 
+import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.FilterComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.LayoutComponentBuilder;
+import org.jspecify.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * Holds the Appender Component attributes and subcomponents.
+ * A default implementation of the {@link AppenderComponentBuilder} interface for building
+ * an {@link Appender} component for a Log4j configuration.
+ *
+ * <p>
+ *   Note: This builder is not thread-safe. Instances should not be shared between threads.
+ * </p>
  *
  * @since 2.4
  */
+@ProviderType
 class DefaultAppenderComponentBuilder extends DefaultComponentAndConfigurationBuilder<AppenderComponentBuilder>
         implements AppenderComponentBuilder {
 
+    /**
+     * Constructs a new component builder instance.
+     *
+     * @param builder    the configuration builder
+     * @param pluginType the plugin-type of the appender component to build
+     * @param name       the appender name
+     * @throws NullPointerException if tthe {@code builder} argument is {@code null}
+     */
     public DefaultAppenderComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder, final String name, final String type) {
-        super(builder, name, type);
+            final DefaultConfigurationBuilder<? extends Configuration> builder,
+            final String pluginType,
+            final @Nullable String name) {
+        super(builder, pluginType, name);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
     @Override
     public AppenderComponentBuilder add(final LayoutComponentBuilder builder) {
         return addComponent(builder);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
     @Override
     public AppenderComponentBuilder add(final FilterComponentBuilder builder) {
         return addComponent(builder);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultAppenderRefComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultAppenderRefComponentBuilder.java
@@ -16,24 +16,40 @@
  */
 package org.apache.logging.log4j.core.config.builder.impl;
 
+import org.apache.logging.log4j.core.config.AppenderRef;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.builder.api.AppenderRefComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.FilterComponentBuilder;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * Holds the Appender Component attributes and subcomponents.
+ * A default implementation of the {@link AppenderRefComponentBuilder} interface for building
+ * an {@link AppenderRef} component for a Log4j configuration.
+ *
+ * <p>
+ *   Note: This builder is not thread-safe. Instances should not be shared between threads.
+ * </p>
  *
  * @since 2.4
  */
+@ProviderType
 class DefaultAppenderRefComponentBuilder extends DefaultComponentAndConfigurationBuilder<AppenderRefComponentBuilder>
         implements AppenderRefComponentBuilder {
 
-    public DefaultAppenderRefComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder, final String ref) {
+    /**
+     * Constructs a new component builder instance.
+     * @param builder the configuration builder
+     * @throws NullPointerException if tthe {@code builder} argument is {@code null}
+     */
+    public DefaultAppenderRefComponentBuilder(final DefaultConfigurationBuilder<? extends Configuration> builder) {
         super(builder, "AppenderRef");
-        addAttribute("ref", ref);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
     @Override
     public AppenderRefComponentBuilder add(final FilterComponentBuilder builder) {
         return addComponent(builder);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultComponentAndConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultComponentAndConfigurationBuilder.java
@@ -18,32 +18,64 @@ package org.apache.logging.log4j.core.config.builder.impl;
 
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.builder.api.ComponentBuilder;
+import org.jspecify.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * Extends {@code DefaultComponentBuilder} to specify
- * {@code DefaultConfigurationBuilder<? extends Configuration>} as the
- * {@code ConfigurationBuilder} type.
+ * Extends {@code DefaultComponentBuilder} to specify {@code DefaultConfigurationBuilder<? extends Configuration>}
+ * as the {@code ConfigurationBuilder} type.
+ *
+ * <p>
+ *   Note: This builder is not thread-safe. Instances should not be shared between threads.
+ * </p>
  *
  * @since 2.4
  */
-class DefaultComponentAndConfigurationBuilder<T extends ComponentBuilder<T>>
+@ProviderType
+abstract class DefaultComponentAndConfigurationBuilder<T extends ComponentBuilder<T>>
         extends DefaultComponentBuilder<T, DefaultConfigurationBuilder<? extends Configuration>> {
 
-    DefaultComponentAndConfigurationBuilder(
+    /**
+     * Constructs a new instance with the given plugin-type and {@code null} name and value.
+     * @param builder the configuration-builder
+     * @param pluginType the plugin-type of the component being built
+     * @throws NullPointerException if either the {@code builder} or {@code pluginType} arguments are {@code null}
+     */
+    protected DefaultComponentAndConfigurationBuilder(
+            final DefaultConfigurationBuilder<? extends Configuration> builder, final String pluginType) {
+
+        this(builder, pluginType, null, null);
+    }
+
+    /**
+     * Constructs a new instance with the given plugin-type, name and {@code null} value.
+     * @param builder the configuration-builder
+     * @param pluginType the plugin-type of the component being built
+     * @param name the component name
+     * @throws NullPointerException if either the {@code builder} or {@code pluginType} arguments are {@code null}
+     */
+    protected DefaultComponentAndConfigurationBuilder(
             final DefaultConfigurationBuilder<? extends Configuration> builder,
-            final String name,
-            final String type,
-            final String value) {
-        super(builder, name, type, value);
+            final String pluginType,
+            final @Nullable String name) {
+
+        this(builder, pluginType, name, null);
     }
 
-    DefaultComponentAndConfigurationBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder, final String name, final String type) {
-        super(builder, name, type);
-    }
+    /**
+     * Constructs a new instance with the given plugin-type, name and value.
+     * @param builder the configuration-builder
+     * @param pluginType the plugin-type of the component being built
+     * @param name the component name
+     * @param value the component value
+     * @throws NullPointerException if either the {@code builder} or {@code pluginType} arguments are {@code null}
+     */
+    protected DefaultComponentAndConfigurationBuilder(
+            final DefaultConfigurationBuilder<? extends Configuration> builder,
+            final String pluginType,
+            final @Nullable String name,
+            final @Nullable String value) {
 
-    public DefaultComponentAndConfigurationBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder, final String type) {
-        super(builder, type);
+        super(builder, pluginType, name, value);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultComponentBuilder.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.builder.api.Component;
@@ -57,36 +59,43 @@ class DefaultComponentBuilder<T extends ComponentBuilder<T>, CB extends Configur
         this.value = value;
     }
 
+    /** {@inheritDoc} */
     @Override
     public T addAttribute(final String key, final boolean value) {
         return put(key, Boolean.toString(value));
     }
 
+    /** {@inheritDoc} */
     @Override
     public T addAttribute(final String key, final Enum<?> value) {
-        return put(key, value.name());
+        return put(key, Optional.ofNullable(value).map(Enum::name).orElse(null));
     }
 
+    /** {@inheritDoc} */
     @Override
     public T addAttribute(final String key, final int value) {
         return put(key, Integer.toString(value));
     }
 
+    /** {@inheritDoc} */
     @Override
     public T addAttribute(final String key, final Level level) {
-        return put(key, level.toString());
+        return put(key, Optional.ofNullable(level).map(Level::toString).orElse(null));
     }
 
+    /** {@inheritDoc} */
     @Override
     public T addAttribute(final String key, final Object value) {
-        return put(key, value.toString());
+        return put(key, Optional.ofNullable(value).map(Object::toString).orElse(null));
     }
 
+    /** {@inheritDoc} */
     @Override
     public T addAttribute(final String key, final String value) {
         return put(key, value);
     }
 
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public T addComponent(final ComponentBuilder<?> builder) {
@@ -94,6 +103,7 @@ class DefaultComponentBuilder<T extends ComponentBuilder<T>, CB extends Configur
         return (T) this;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Component build() {
         final Component component = new Component(type, name, value);
@@ -102,19 +112,37 @@ class DefaultComponentBuilder<T extends ComponentBuilder<T>, CB extends Configur
         return component;
     }
 
+    /** {@inheritDoc} */
     @Override
     public CB getBuilder() {
         return builder;
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getName() {
         return name;
     }
 
+    /**
+     * Puts the given key/value pair to the attribute map.
+     * <p>
+     *   If the value is {@code null} the component attribute with the given {@code key} will
+     *   instead be removed from the map.
+     * </p>
+     * @param key the key
+     * @param value the value
+     * @return this builder (for chaining)
+     */
     @SuppressWarnings("unchecked")
     protected T put(final String key, final String value) {
-        attributes.put(key, value);
+
+        if (value != null) {
+            attributes.put(key, value);
+        } else {
+            attributes.remove(key);
+        }
+
         return (T) this;
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultComponentBuilder.java
@@ -91,37 +91,38 @@ class DefaultComponentBuilder<T extends ComponentBuilder<T>, CB extends Configur
     /** {@inheritDoc} */
     @Override
     public @NonNull T addAttribute(final @NonNull String key, final boolean value) {
-        return put(key, Boolean.toString(value));
+        return putAttribute(key, Boolean.toString(value));
     }
 
     /** {@inheritDoc} */
     @Override
     public @NonNull T addAttribute(final @NonNull String key, final int value) {
-        return put(key, Integer.toString(value));
+        return putAttribute(key, Integer.toString(value));
     }
 
     /** {@inheritDoc} */
     @Override
     public @NonNull T addAttribute(final @NonNull String key, final @Nullable Enum<?> value) {
-        return put(key, Optional.ofNullable(value).map(Enum::name).orElse(null));
+        return putAttribute(key, Optional.ofNullable(value).map(Enum::name).orElse(null));
     }
 
     /** {@inheritDoc} */
     @Override
     public @NonNull T addAttribute(final @NonNull String key, final @Nullable Level level) {
-        return put(key, Optional.ofNullable(level).map(Level::toString).orElse(null));
+        return putAttribute(key, Optional.ofNullable(level).map(Level::toString).orElse(null));
     }
 
     /** {@inheritDoc} */
     @Override
     public @NonNull T addAttribute(final @NonNull String key, final @Nullable Object value) {
-        return put(key, Optional.ofNullable(value).map(Object::toString).orElse(null));
+        return putAttribute(
+                key, Optional.ofNullable(value).map(Object::toString).orElse(null));
     }
 
     /** {@inheritDoc} */
     @Override
     public @NonNull T addAttribute(final @NonNull String key, final @Nullable String value) {
-        return put(key, value);
+        return putAttribute(key, value);
     }
 
     /**
@@ -188,7 +189,7 @@ class DefaultComponentBuilder<T extends ComponentBuilder<T>, CB extends Configur
      * @return this builder (for chaining)
      * @throws NullPointerException if the given {@code key} argument is {@code null}
      */
-    private @NonNull T put(final @NonNull String key, final @Nullable String value) {
+    private @NonNull T putAttribute(final @NonNull String key, final @Nullable String value) {
 
         Objects.requireNonNull(key, "The 'key' argument must not be null.");
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultCompositeFilterComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultCompositeFilterComponentBuilder.java
@@ -19,24 +19,38 @@ package org.apache.logging.log4j.core.config.builder.impl;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.builder.api.CompositeFilterComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.FilterComponentBuilder;
-import org.apache.logging.log4j.core.filter.AbstractFilter.AbstractFilterBuilder;
+import org.apache.logging.log4j.core.filter.CompositeFilter;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
+ * A default implementation of the {@link CompositeFilterComponentBuilder} interface for building
+ * a {@link CompositeFilter} component for a Log4j configuration.
+ *
+ * <p>
+ *   Note: This builder is not thread-safe. Instances should not be shared between threads.
+ * </p>
+ *
  * @since 2.4
  */
+@ProviderType
 class DefaultCompositeFilterComponentBuilder
         extends DefaultComponentAndConfigurationBuilder<CompositeFilterComponentBuilder>
         implements CompositeFilterComponentBuilder {
 
-    public DefaultCompositeFilterComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder,
-            final String onMatch,
-            final String onMismatch) {
+    /**
+     * Constructs a new instance with the given configurration builder and default plugin-type "{@code Filters}".
+     * @param builder the configuration builder
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
+    public DefaultCompositeFilterComponentBuilder(final DefaultConfigurationBuilder<? extends Configuration> builder) {
         super(builder, "Filters");
-        addAttribute(AbstractFilterBuilder.ATTR_ON_MATCH, onMatch);
-        addAttribute(AbstractFilterBuilder.ATTR_ON_MISMATCH, onMismatch);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
     @Override
     public CompositeFilterComponentBuilder add(final FilterComponentBuilder builder) {
         return addComponent(builder);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultConfigurationBuilder.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.core.config.builder.impl;
 
+import aQute.bnd.annotation.baseline.BaselineIgnore;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -698,8 +699,10 @@ public class DefaultConfigurationBuilder<T extends BuiltConfiguration> implement
 
     /** {@inheritDoc} */
     @Override
-    public void setLoggerContext(final @Nullable LoggerContext loggerContext) {
+    @BaselineIgnore("2.25.0")
+    public ConfigurationBuilder<T> setLoggerContext(final @Nullable LoggerContext loggerContext) {
         this.loggerContext = loggerContext;
+        return this;
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultConfigurationBuilder.java
@@ -24,24 +24,22 @@ import java.io.StringWriter;
 import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.OutputKeys;
-import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Filter.Result;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationException;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.LoggerConfig;
@@ -59,57 +57,81 @@ import org.apache.logging.log4j.core.config.builder.api.PropertyComponentBuilder
 import org.apache.logging.log4j.core.config.builder.api.RootLoggerComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ScriptComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ScriptFileComponentBuilder;
-import org.apache.logging.log4j.core.util.Integers;
 import org.apache.logging.log4j.core.util.Throwables;
+import org.jspecify.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
+ * A {@link ConfigurationBuilder} implementation for building a {@link BuiltConfiguration} or a custom
+ * implementation thereof.
+ *
  * @param <T> The BuiltConfiguration type.
  * @since 2.4
  */
+@ProviderType
 public class DefaultConfigurationBuilder<T extends BuiltConfiguration> implements ConfigurationBuilder<T> {
 
     private static final String INDENT = "  ";
 
-    private final Component root = new Component();
-    private Component loggers;
-    private Component appenders;
-    private Component filters;
-    private Component properties;
-    private Component customLevels;
-    private Component scripts;
+    private final Component root = new Component("root");
+    private final Component loggers;
+    private final Component appenders;
+    private final Component filters;
+    private final Component properties;
+    private final Component customLevels;
+    private final Component scripts;
     private final Class<T> clazz;
-    private ConfigurationSource source;
-    private int monitorInterval;
-    private Level level;
-    private String destination;
-    private String packages;
-    private String shutdownFlag;
-    private long shutdownTimeoutMillis;
-    private String advertiser;
-    private LoggerContext loggerContext;
-    private String name;
+    private @Nullable ConfigurationSource configurationSource = null;
+    private int monitorInterval = 0;
+    private @Nullable Level statusLevel;
+    private @Nullable String destination;
+    private @Nullable String packages;
+    private @Nullable String shutdownFlag;
+    private long shutdownTimeoutMillis = 0L;
+    private @Nullable String advertiser;
+    private @Nullable LoggerContext loggerContext;
+    private @Nullable String configurationName;
 
+    /* static initialization */
     @SuppressFBWarnings(
             value = {"XXE_DTD_TRANSFORM_FACTORY", "XXE_XSLT_TRANSFORM_FACTORY"},
             justification = "This method only uses internally generated data.")
-    public static void formatXml(final Source source, final Result result)
-            throws TransformerConfigurationException, TransformerFactoryConfigurationError, TransformerException {
+    public static void formatXml(final Source source, final javax.xml.transform.Result result)
+            throws TransformerFactoryConfigurationError, TransformerException {
         final Transformer transformer = TransformerFactory.newInstance().newTransformer();
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", Integer.toString(INDENT.length()));
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.transform(source, result);
     }
 
+    /**
+     * Constructs a new configuration builder using the default {@link BuiltConfiguration} as
+     * a target configuration type.
+     */
     @SuppressWarnings("unchecked")
     public DefaultConfigurationBuilder() {
         this((Class<T>) BuiltConfiguration.class);
         root.addAttribute("name", "Built");
     }
 
+    /**
+     * Constructs a new configuration builder with the given target {@link BuiltConfiguration} implementation class.
+     * <p>
+     *   Note the implementation will be instantiated per reflection and must have a constructor with the following
+     *   parameters:
+     * </p>
+     * <pre>{@code
+     *   public BuiltConfigurationClazz(LogggerContext, ConfigurationSource, Component) {
+     *     ...
+     *   }
+     * }</pre>
+     *
+     * @param clazz the {@code BuiltConfiguration} implementation class
+     */
     public DefaultConfigurationBuilder(final Class<T> clazz) {
-        if (clazz == null) {
-            throw new IllegalArgumentException("A Configuration class must be provided");
-        }
+
+        Objects.requireNonNull(clazz, "The 'clazz' argument must not be null.");
+
         this.clazz = clazz;
         final List<Component> components = root.getComponents();
         properties = new Component("Properties");
@@ -126,41 +148,51 @@ public class DefaultConfigurationBuilder<T extends BuiltConfiguration> implement
         components.add(loggers);
     }
 
-    protected ConfigurationBuilder<T> add(final Component parent, final ComponentBuilder<?> builder) {
-        parent.getComponents().add(builder.build());
-        return this;
-    }
-
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
     @Override
     public ConfigurationBuilder<T> add(final AppenderComponentBuilder builder) {
         return add(appenders, builder);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
     @Override
     public ConfigurationBuilder<T> add(final CustomLevelComponentBuilder builder) {
         return add(customLevels, builder);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
     @Override
     public ConfigurationBuilder<T> add(final FilterComponentBuilder builder) {
         return add(filters, builder);
     }
 
-    @Override
-    public ConfigurationBuilder<T> add(final ScriptComponentBuilder builder) {
-        return add(scripts, builder);
-    }
-
-    @Override
-    public ConfigurationBuilder<T> add(final ScriptFileComponentBuilder builder) {
-        return add(scripts, builder);
-    }
-
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
     @Override
     public ConfigurationBuilder<T> add(final LoggerComponentBuilder builder) {
         return add(loggers, builder);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
     @Override
     public ConfigurationBuilder<T> add(final RootLoggerComponentBuilder builder) {
         for (final Component c : loggers.getComponents()) {
@@ -171,33 +203,94 @@ public class DefaultConfigurationBuilder<T extends BuiltConfiguration> implement
         return add(loggers, builder);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
     @Override
-    public ConfigurationBuilder<T> addProperty(final String key, final String value) {
-        properties.addComponent(newComponent(key, "Property", value).build());
+    public ConfigurationBuilder<T> add(final PropertyComponentBuilder builder) {
+        return add(properties, builder);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
+    @Override
+    public ConfigurationBuilder<T> add(final ScriptComponentBuilder builder) {
+        return add(scripts, builder);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
+    @Override
+    public ConfigurationBuilder<T> add(final ScriptFileComponentBuilder builder) {
+        return add(scripts, builder);
+    }
+
+    /**
+     * Adds the {@code Component} built by the given {@code builder} as a child of the given {@code parent} component.
+     * @param parent the parent component
+     * @param builder the builder used to build the child componentt
+     * @return this builder (for chaining)
+     */
+    protected ConfigurationBuilder<T> add(final Component parent, final ComponentBuilder<?> builder) {
+        Objects.requireNonNull(parent, "The 'parent' argument must not be null.");
+        Objects.requireNonNull(builder, "The 'builder' argument must not be null.");
+        parent.getComponents().add(builder.build());
         return this;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated use {@link #add(PropertyComponentBuilder)}
+     */
+    @Override
+    @Deprecated
+    public ConfigurationBuilder<T> addProperty(@Nullable String name, @Nullable String value) {
+        return add(newProperty(name, value));
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated use {@link #setRootProperty(String, String)}
+     */
+    @Override
+    @Deprecated
+    public ConfigurationBuilder<T> addRootProperty(String key, String value) {
+        return setRootProperty(key, value);
+    }
+
+    /** {@inheritDoc} */
     @Override
     public T build() {
         return build(true);
     }
 
+    /** {@inheritDoc} */
     @Override
     public T build(final boolean initialize) {
         T configuration;
         try {
-            if (source == null) {
-                source = ConfigurationSource.NULL_SOURCE;
+            if (configurationSource == null) {
+                configurationSource = ConfigurationSource.NULL_SOURCE;
             }
             final Constructor<T> constructor =
                     clazz.getConstructor(LoggerContext.class, ConfigurationSource.class, Component.class);
-            configuration = constructor.newInstance(loggerContext, source, root);
+            configuration = constructor.newInstance(loggerContext, configurationSource, root);
             configuration.getRootNode().getAttributes().putAll(root.getAttributes());
-            if (name != null) {
-                configuration.setName(name);
+            if (configurationName != null) {
+                configuration.setName(configurationName);
             }
-            if (level != null) {
-                configuration.getStatusConfiguration().withStatus(level);
+            if (statusLevel != null) {
+                configuration.getStatusConfiguration().withStatus(statusLevel);
             }
             if (destination != null) {
                 configuration.getStatusConfiguration().withDestination(destination);
@@ -212,7 +305,7 @@ public class DefaultConfigurationBuilder<T extends BuiltConfiguration> implement
                 configuration.setShutdownTimeoutMillis(shutdownTimeoutMillis);
             }
             if (advertiser != null) {
-                configuration.createAdvertiser(advertiser, source);
+                configuration.createAdvertiser(advertiser, configurationSource);
             }
             configuration.setMonitorInterval(monitorInterval);
         } catch (final Exception ex) {
@@ -225,8 +318,503 @@ public class DefaultConfigurationBuilder<T extends BuiltConfiguration> implement
         return configuration;
     }
 
-    private String formatXml(final String xml)
-            throws TransformerConfigurationException, TransformerException, TransformerFactoryConfigurationError {
+    /** {@inheritDoc} */
+    @Override
+    public ScriptComponentBuilder newScript(
+            final @Nullable String name, final @Nullable String language, final @Nullable String text) {
+        return new DefaultScriptComponentBuilder(this, name)
+                .setLanguageAttribute(language)
+                .setTextAttribute(text);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ScriptFileComponentBuilder newScriptFile(final @Nullable String path) {
+        return new DefaultScriptFileComponentBuilder(this, path).setPathAttribute(path);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ScriptFileComponentBuilder newScriptFile(final @Nullable String name, final @Nullable String path) {
+        return new DefaultScriptFileComponentBuilder(this, (name != null) ? name : path).setPathAttribute(path);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public AppenderComponentBuilder newAppender(final @Nullable String name, final String type) {
+        return new DefaultAppenderComponentBuilder(this, type, name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public AppenderRefComponentBuilder newAppenderRef(final @Nullable String ref) {
+        return new DefaultAppenderRefComponentBuilder(this).setRefAttribute(ref);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public LoggerComponentBuilder newAsyncLogger(final @Nullable String name) {
+        return new DefaultLoggerComponentBuilder(this, "AsyncLogger", name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public LoggerComponentBuilder newAsyncLogger(final @Nullable String name, final boolean includeLocation) {
+        return this.newAsyncLogger(name).setIncludeLocationAttribute(includeLocation);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public LoggerComponentBuilder newAsyncLogger(final @Nullable String name, final @Nullable Level level) {
+        return this.newAsyncLogger(name).setLevelAttribute(level);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public LoggerComponentBuilder newAsyncLogger(
+            final @Nullable String name, final @Nullable Level level, final boolean includeLocation) {
+        return this.newAsyncLogger(name)
+                .setIncludeLocationAttribute(includeLocation)
+                .setLevelAttribute(level);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public LoggerComponentBuilder newAsyncLogger(final @Nullable String name, final @Nullable String level) {
+        return this.newAsyncLogger(name).setLevelAttribute(level);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public LoggerComponentBuilder newAsyncLogger(
+            final @Nullable String name, final @Nullable String level, final boolean includeLocation) {
+        return this.newAsyncLogger(name).setLevelAttribute(level).setIncludeLocationAttribute(includeLocation);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public RootLoggerComponentBuilder newAsyncRootLogger() {
+        return new DefaultRootLoggerComponentBuilder(this, "AsyncRoot");
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public RootLoggerComponentBuilder newAsyncRootLogger(final boolean includeLocation) {
+        return newAsyncRootLogger().setIncludeLocationAttribute(includeLocation);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public RootLoggerComponentBuilder newAsyncRootLogger(final @Nullable Level level) {
+        return newAsyncRootLogger().setLevelAttribute(level);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public RootLoggerComponentBuilder newAsyncRootLogger(final @Nullable Level level, final boolean includeLocation) {
+        return newAsyncRootLogger().setLevelAttribute(level).setIncludeLocationAttribute(includeLocation);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public RootLoggerComponentBuilder newAsyncRootLogger(final @Nullable String level) {
+        return newAsyncRootLogger().setLevelAttribute(level);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public RootLoggerComponentBuilder newAsyncRootLogger(final @Nullable String level, final boolean includeLocation) {
+        return newAsyncRootLogger().setLevelAttribute(level).setIncludeLocationAttribute(includeLocation);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <B extends ComponentBuilder<B>> ComponentBuilder<B> newComponent(final String pluginType) {
+        return newComponent(null, pluginType, null);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <B extends ComponentBuilder<B>> ComponentBuilder<B> newComponent(
+            final @Nullable String name, final String pluginType) {
+        return this.newComponent(name, pluginType, null);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public <B extends ComponentBuilder<B>> ComponentBuilder<B> newComponent(
+            final @Nullable String name, final String pluginType, final @Nullable String value) {
+        return new DefaultComponentBuilder<>(this, pluginType, name, value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public PropertyComponentBuilder newProperty(final @Nullable String name, final @Nullable String value) {
+        return new DefaultPropertyComponentBuilder(this, name, value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public KeyValuePairComponentBuilder newKeyValuePair(final @Nullable String key, final @Nullable String value) {
+        return new DefaultKeyValuePairComponentBuilder(this)
+                .setKeyAttribute(key)
+                .setValueAttribute(value);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public CustomLevelComponentBuilder newCustomLevel(final @Nullable String name, final int intLevel) {
+        return new DefaultCustomLevelComponentBuilder(this, name).setIntLevelAttribute(intLevel);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code pluginType} argument is {@code null}
+     */
+    @Override
+    public FilterComponentBuilder newFilter(final String pluginType) {
+        return new DefaultFilterComponentBuilder(this, pluginType);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code pluginType} argument is {@code null}
+     */
+    @Override
+    public FilterComponentBuilder newFilter(
+            final String pluginType, final @Nullable Result onMatch, final @Nullable Result onMismatch) {
+        return newFilter(pluginType).setOnMatchAttribute(onMatch).setOnMismatchAttribute(onMismatch);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code pluginType} argument is {@code null}
+     */
+    @Override
+    public FilterComponentBuilder newFilter(
+            final String pluginType, final @Nullable String onMatch, final @Nullable String onMismatch) {
+        return newFilter(pluginType).setOnMatchAttribute(onMatch).setOnMismatchAttribute(onMismatch);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code pluginType} argument is {@code null}
+     */
+    @Override
+    public LayoutComponentBuilder newLayout(final String pluginType) {
+        return new DefaultLayoutComponentBuilder(this, pluginType);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public LoggerComponentBuilder newLogger(final @Nullable String name) {
+        return new DefaultLoggerComponentBuilder(this, name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public LoggerComponentBuilder newLogger(final @Nullable String name, final boolean includeLocation) {
+        return newLogger(name).setIncludeLocationAttribute(includeLocation);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public LoggerComponentBuilder newLogger(final @Nullable String name, final @Nullable Level level) {
+        return newLogger(name).setLevelAttribute(level);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public LoggerComponentBuilder newLogger(
+            final @Nullable String name, final @Nullable Level level, final boolean includeLocation) {
+        return newLogger(name).setLevelAttribute(level).setIncludeLocationAttribute(includeLocation);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public LoggerComponentBuilder newLogger(final @Nullable String name, final @Nullable String level) {
+        return newLogger(name).setLevelAttribute(level);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public LoggerComponentBuilder newLogger(
+            final @Nullable String name, final @Nullable String level, final boolean includeLocation) {
+        return newLogger(name).setIncludeLocationAttribute(includeLocation).setLevelAttribute(level);
+    }
+
+    @Override
+    public RootLoggerComponentBuilder newRootLogger() {
+        return new DefaultRootLoggerComponentBuilder(this);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public RootLoggerComponentBuilder newRootLogger(final boolean includeLocation) {
+        return newRootLogger().setIncludeLocationAttribute(includeLocation);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public RootLoggerComponentBuilder newRootLogger(final @Nullable Level level) {
+        return newRootLogger().setLevelAttribute(level);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public RootLoggerComponentBuilder newRootLogger(final @Nullable Level level, final boolean includeLocation) {
+        return newRootLogger().setLevelAttribute(level).setIncludeLocationAttribute(includeLocation);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public RootLoggerComponentBuilder newRootLogger(final @Nullable String level) {
+        return newRootLogger().setLevelAttribute(level);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public RootLoggerComponentBuilder newRootLogger(final @Nullable String level, final boolean includeLocation) {
+        return newRootLogger().setLevelAttribute(level).setIncludeLocationAttribute(includeLocation);
+    }
+
+    /**
+     * Returns the advertiser.
+     * @return the advertiser or {@code null} if undefined
+     */
+    protected @Nullable String getAdvertiser() {
+        return this.advertiser;
+    }
+
+    /**
+     * Returns the configuration name.
+     * @return the configuration name or {@code null} if undefined
+     */
+    protected @Nullable String getConfigurationName() {
+        return this.configurationName;
+    }
+
+    /**
+     * Returns the configuration source.
+     *
+     * @return the configuration source or {@code null} if undefined
+     */
+    protected @Nullable ConfigurationSource getConfigurationSource() {
+        return this.configurationSource;
+    }
+
+    /**
+     * Returns the configuration's destination.
+     * @return the destination or {@code null} if undefined
+     */
+    protected @Nullable String getDestination() {
+        return this.destination;
+    }
+
+    /**
+     * Returns the configuration's logger-context.
+     * @return the logger-context or {@code null} if undefined
+     */
+    protected @Nullable LoggerContext getLoggerContext() {
+        return this.loggerContext;
+    }
+
+    /**
+     * Returns the configuration's monitor interval in seconds.
+     * @return the monitor interval (in seconds)
+     */
+    protected int getMonitorInterval() {
+        return this.monitorInterval;
+    }
+
+    /**
+     * Returns the comma-separated of package-names to search for plugins.
+     * @return the packages or {@code null} if undefined
+     */
+    protected @Nullable String getPackages() {
+        return this.packages;
+    }
+
+    /**
+     * Returns the root property with the given key.
+     * @param key the key
+     * @return the property value or {@code null} if undefined
+     * @throws NullPointerException if the given {@code key} argument is {@code null}
+     */
+    protected @Nullable String getRootProperty(String key) {
+
+        Objects.requireNonNull(key, "The 'key' argument must not be null.");
+
+        return this.root.getAttributes().get(key);
+    }
+
+    /**
+     * Returns the configuration's shutdown timeout in milliseconds.
+     * @return the shutdown timeout (in millis)
+     */
+    protected long getShutdownTimeout() {
+        return this.shutdownTimeoutMillis;
+    }
+
+    /**
+     * Returns the configuration's status logger level.
+     * @return the status logger level or {@code null} if undefined
+     */
+    protected @Nullable Level getStatusLevel() {
+        return this.statusLevel;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ConfigurationBuilder<T> setAdvertiser(final @Nullable String advertiser) {
+        this.advertiser = advertiser;
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ConfigurationBuilder<T> setConfigurationName(final @Nullable String name) {
+        this.configurationName = name;
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ConfigurationBuilder<T> setConfigurationSource(final @Nullable ConfigurationSource configurationSource) {
+        this.configurationSource = configurationSource;
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ConfigurationBuilder<T> setDestination(final @Nullable String destination) {
+        this.destination = destination;
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setLoggerContext(final @Nullable LoggerContext loggerContext) {
+        this.loggerContext = loggerContext;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NumberFormatException if the {@code intervalSeconds} argument is not a valid integer representation
+     */
+    @Override
+    public ConfigurationBuilder<T> setMonitorInterval(final int intervalSeconds) {
+        if (intervalSeconds >= 0) {
+            monitorInterval = intervalSeconds;
+        } else {
+            throw new IllegalArgumentException("The monitor interval must be greater than or equal to 0.");
+        }
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NumberFormatException if the {@code intervalSeconds} argument is not a valid integer representation
+     */
+    @Override
+    public ConfigurationBuilder<T> setMonitorInterval(final @Nullable String intervalSeconds) {
+        return setMonitorInterval(intervalSeconds != null ? Integer.parseInt(intervalSeconds) : 0);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ConfigurationBuilder<T> setPackages(final @Nullable String packages) {
+        this.packages = packages;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code key} argument is {@code null}
+     */
+    @Override
+    public ConfigurationBuilder<T> setRootProperty(final String key, final @Nullable String value) {
+
+        Objects.requireNonNull(key, "The 'key' argument must not be null.");
+
+        if (value != null) {
+            root.getAttributes().put(key, value);
+        } else {
+            root.getAttributes().remove(key);
+        }
+
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ConfigurationBuilder<T> setShutdownHook(final @Nullable String flag) {
+        this.shutdownFlag = flag;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if the {@code shutdownTimeoutMillis} argument is invalid
+     */
+    @Override
+    public ConfigurationBuilder<T> setShutdownTimeout(final long shutdownTimeoutMillis) {
+        if (shutdownTimeoutMillis >= 0) {
+            this.shutdownTimeoutMillis = shutdownTimeoutMillis;
+        } else {
+            throw new IllegalArgumentException(
+                    "The 'shutdownTimeoutMillis' argument must be greater than " + "or equal to 0.");
+        }
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the given {@code timeUnit} argument is {@code null}
+     */
+    @Override
+    public ConfigurationBuilder<T> setShutdownTimeout(final long shutdownTimeout, final TimeUnit timeUnit) {
+        Objects.requireNonNull(timeUnit, "The 'timeUnit' argument must not be null.");
+        this.shutdownTimeoutMillis = timeUnit.toMillis(shutdownTimeout);
+        return this;
+    }
+
+    /**
+     * Sets the status level.
+     * @param level the configuration status logging level
+     * @return this builder (for chaining)
+     */
+    @Override
+    public ConfigurationBuilder<T> setStatusLevel(final @Nullable Level level) {
+        this.statusLevel = level;
+        return this;
+    }
+
+    /**
+     * Sets the verbosity.
+     * @param verbosity the configuration verbosity
+     * @return this component builder (for chaining)
+     * @deprecated This method is ineffective and only kept for binary backward compatibility.
+     */
+    @Override
+    @Deprecated
+    public ConfigurationBuilder<T> setVerbosity(final @Nullable String verbosity) {
+        return this;
+    }
+
+    // XML generation
+
+    private String formatXml(final String xml) throws TransformerException, TransformerFactoryConfigurationError {
+        Objects.requireNonNull(xml, "The 'xml' argument must not be null.");
         final StringWriter writer = new StringWriter();
         formatXml(new StreamSource(new StringReader(xml)), new StreamResult(writer));
         return writer.toString();
@@ -234,6 +822,7 @@ public class DefaultConfigurationBuilder<T extends BuiltConfiguration> implement
 
     @Override
     public void writeXmlConfiguration(final OutputStream output) throws IOException {
+        Objects.requireNonNull(output, "The 'output' argument must not be null.");
         try {
             final XMLStreamWriter xmlWriter = XMLOutputFactory.newInstance().createXMLStreamWriter(output);
             writeXmlConfiguration(xmlWriter);
@@ -261,13 +850,14 @@ public class DefaultConfigurationBuilder<T extends BuiltConfiguration> implement
     }
 
     private void writeXmlConfiguration(final XMLStreamWriter xmlWriter) throws XMLStreamException {
+        Objects.requireNonNull(xmlWriter, "The 'xmlWriter' argument must not be null.");
         xmlWriter.writeStartDocument();
         xmlWriter.writeStartElement("Configuration");
-        if (name != null) {
-            xmlWriter.writeAttribute("name", name);
+        if (configurationName != null) {
+            xmlWriter.writeAttribute("name", configurationName);
         }
-        if (level != null) {
-            xmlWriter.writeAttribute("status", level.name());
+        if (statusLevel != null) {
+            xmlWriter.writeAttribute("status", statusLevel.name());
         }
         if (destination != null) {
             xmlWriter.writeAttribute("dest", destination);
@@ -304,6 +894,8 @@ public class DefaultConfigurationBuilder<T extends BuiltConfiguration> implement
     }
 
     private void writeXmlSection(final XMLStreamWriter xmlWriter, final Component component) throws XMLStreamException {
+        Objects.requireNonNull(xmlWriter, "The 'xmlWriter' argument must not be null.");
+        Objects.requireNonNull(component, "The 'component' argument must not be null.");
         if (!component.getAttributes().isEmpty()
                 || !component.getComponents().isEmpty()
                 || component.getValue() != null) {
@@ -313,6 +905,8 @@ public class DefaultConfigurationBuilder<T extends BuiltConfiguration> implement
 
     private void writeXmlComponent(final XMLStreamWriter xmlWriter, final Component component)
             throws XMLStreamException {
+        Objects.requireNonNull(xmlWriter, "The 'xmlWriter' argument must not be null.");
+        Objects.requireNonNull(component, "The 'component' argument must not be null.");
         if (!component.getComponents().isEmpty() || component.getValue() != null) {
             xmlWriter.writeStartElement(component.getPluginType());
             writeXmlAttributes(xmlWriter, component);
@@ -331,287 +925,11 @@ public class DefaultConfigurationBuilder<T extends BuiltConfiguration> implement
 
     private void writeXmlAttributes(final XMLStreamWriter xmlWriter, final Component component)
             throws XMLStreamException {
+        Objects.requireNonNull(xmlWriter, "The 'xmlWriter' argument must not be null.");
+        Objects.requireNonNull(component, "The 'component' argument must not be null.");
         for (final Map.Entry<String, String> attribute :
                 component.getAttributes().entrySet()) {
             xmlWriter.writeAttribute(attribute.getKey(), attribute.getValue());
         }
-    }
-
-    @Override
-    public ScriptComponentBuilder newScript(final String name, final String language, final String text) {
-        return new DefaultScriptComponentBuilder(this, name, language, text);
-    }
-
-    @Override
-    public ScriptFileComponentBuilder newScriptFile(final String path) {
-        return new DefaultScriptFileComponentBuilder(this, path, path);
-    }
-
-    @Override
-    public ScriptFileComponentBuilder newScriptFile(final String name, final String path) {
-        return new DefaultScriptFileComponentBuilder(this, name, path);
-    }
-
-    @Override
-    public AppenderComponentBuilder newAppender(final String name, final String type) {
-        return new DefaultAppenderComponentBuilder(this, name, type);
-    }
-
-    @Override
-    public AppenderRefComponentBuilder newAppenderRef(final String ref) {
-        return new DefaultAppenderRefComponentBuilder(this, ref);
-    }
-
-    @Override
-    public LoggerComponentBuilder newAsyncLogger(final String name) {
-        return new DefaultLoggerComponentBuilder(this, name, null, "AsyncLogger");
-    }
-
-    @Override
-    public LoggerComponentBuilder newAsyncLogger(final String name, final boolean includeLocation) {
-        return new DefaultLoggerComponentBuilder(this, name, null, "AsyncLogger", includeLocation);
-    }
-
-    @Override
-    public LoggerComponentBuilder newAsyncLogger(final String name, final Level level) {
-        return new DefaultLoggerComponentBuilder(this, name, level.toString(), "AsyncLogger");
-    }
-
-    @Override
-    public LoggerComponentBuilder newAsyncLogger(final String name, final Level level, final boolean includeLocation) {
-        return new DefaultLoggerComponentBuilder(this, name, level.toString(), "AsyncLogger", includeLocation);
-    }
-
-    @Override
-    public LoggerComponentBuilder newAsyncLogger(final String name, final String level) {
-        return new DefaultLoggerComponentBuilder(this, name, level, "AsyncLogger");
-    }
-
-    @Override
-    public LoggerComponentBuilder newAsyncLogger(final String name, final String level, final boolean includeLocation) {
-        return new DefaultLoggerComponentBuilder(this, name, level, "AsyncLogger", includeLocation);
-    }
-
-    @Override
-    public RootLoggerComponentBuilder newAsyncRootLogger() {
-        return new DefaultRootLoggerComponentBuilder(this, "AsyncRoot");
-    }
-
-    @Override
-    public RootLoggerComponentBuilder newAsyncRootLogger(final boolean includeLocation) {
-        return new DefaultRootLoggerComponentBuilder(this, null, "AsyncRoot", includeLocation);
-    }
-
-    @Override
-    public RootLoggerComponentBuilder newAsyncRootLogger(final Level level) {
-        return new DefaultRootLoggerComponentBuilder(this, level.toString(), "AsyncRoot");
-    }
-
-    @Override
-    public RootLoggerComponentBuilder newAsyncRootLogger(final Level level, final boolean includeLocation) {
-        return new DefaultRootLoggerComponentBuilder(this, level.toString(), "AsyncRoot", includeLocation);
-    }
-
-    @Override
-    public RootLoggerComponentBuilder newAsyncRootLogger(final String level) {
-        return new DefaultRootLoggerComponentBuilder(this, level, "AsyncRoot");
-    }
-
-    @Override
-    public RootLoggerComponentBuilder newAsyncRootLogger(final String level, final boolean includeLocation) {
-        return new DefaultRootLoggerComponentBuilder(this, level, "AsyncRoot", includeLocation);
-    }
-
-    @Override
-    public <B extends ComponentBuilder<B>> ComponentBuilder<B> newComponent(final String type) {
-        return new DefaultComponentBuilder<>(this, type);
-    }
-
-    @Override
-    public <B extends ComponentBuilder<B>> ComponentBuilder<B> newComponent(final String name, final String type) {
-        return new DefaultComponentBuilder<>(this, name, type);
-    }
-
-    @Override
-    public <B extends ComponentBuilder<B>> ComponentBuilder<B> newComponent(
-            final String name, final String type, final String value) {
-        return new DefaultComponentBuilder<>(this, name, type, value);
-    }
-
-    @Override
-    public PropertyComponentBuilder newProperty(final String name, final String value) {
-        return new DefaultPropertyComponentBuilder(this, name, value);
-    }
-
-    @Override
-    public KeyValuePairComponentBuilder newKeyValuePair(final String key, final String value) {
-        return new DefaultKeyValuePairComponentBuilder(this, key, value);
-    }
-
-    @Override
-    public CustomLevelComponentBuilder newCustomLevel(final String name, final int level) {
-        return new DefaultCustomLevelComponentBuilder(this, name, level);
-    }
-
-    @Override
-    public FilterComponentBuilder newFilter(
-            final String type, final Filter.Result onMatch, final Filter.Result onMismatch) {
-        return new DefaultFilterComponentBuilder(this, type, onMatch.name(), onMismatch.name());
-    }
-
-    @Override
-    public FilterComponentBuilder newFilter(final String type, final String onMatch, final String onMismatch) {
-        return new DefaultFilterComponentBuilder(this, type, onMatch, onMismatch);
-    }
-
-    @Override
-    public LayoutComponentBuilder newLayout(final String type) {
-        return new DefaultLayoutComponentBuilder(this, type);
-    }
-
-    @Override
-    public LoggerComponentBuilder newLogger(final String name) {
-        return new DefaultLoggerComponentBuilder(this, name, null);
-    }
-
-    @Override
-    public LoggerComponentBuilder newLogger(final String name, final boolean includeLocation) {
-        return new DefaultLoggerComponentBuilder(this, name, null, includeLocation);
-    }
-
-    @Override
-    public LoggerComponentBuilder newLogger(final String name, final Level level) {
-        return new DefaultLoggerComponentBuilder(this, name, level.toString());
-    }
-
-    @Override
-    public LoggerComponentBuilder newLogger(final String name, final Level level, final boolean includeLocation) {
-        return new DefaultLoggerComponentBuilder(this, name, level.toString(), includeLocation);
-    }
-
-    @Override
-    public LoggerComponentBuilder newLogger(final String name, final String level) {
-        return new DefaultLoggerComponentBuilder(this, name, level);
-    }
-
-    @Override
-    public LoggerComponentBuilder newLogger(final String name, final String level, final boolean includeLocation) {
-        return new DefaultLoggerComponentBuilder(this, name, level, includeLocation);
-    }
-
-    @Override
-    public RootLoggerComponentBuilder newRootLogger() {
-        return new DefaultRootLoggerComponentBuilder(this, null);
-    }
-
-    @Override
-    public RootLoggerComponentBuilder newRootLogger(final boolean includeLocation) {
-        return new DefaultRootLoggerComponentBuilder(this, null, includeLocation);
-    }
-
-    @Override
-    public RootLoggerComponentBuilder newRootLogger(final Level level) {
-        return new DefaultRootLoggerComponentBuilder(this, level.toString());
-    }
-
-    @Override
-    public RootLoggerComponentBuilder newRootLogger(final Level level, final boolean includeLocation) {
-        return new DefaultRootLoggerComponentBuilder(this, level.toString(), includeLocation);
-    }
-
-    @Override
-    public RootLoggerComponentBuilder newRootLogger(final String level) {
-        return new DefaultRootLoggerComponentBuilder(this, level);
-    }
-
-    @Override
-    public RootLoggerComponentBuilder newRootLogger(final String level, final boolean includeLocation) {
-        return new DefaultRootLoggerComponentBuilder(this, level, includeLocation);
-    }
-
-    @Override
-    public ConfigurationBuilder<T> setAdvertiser(final String advertiser) {
-        this.advertiser = advertiser;
-        return this;
-    }
-
-    /**
-     * Set the name of the configuration.
-     *
-     * @param name the name of the {@link Configuration}. By default is {@code "Assembled"}.
-     * @return this builder instance
-     */
-    @Override
-    public ConfigurationBuilder<T> setConfigurationName(final String name) {
-        this.name = name;
-        return this;
-    }
-
-    /**
-     * Set the ConfigurationSource.
-     *
-     * @param configurationSource the {@link ConfigurationSource}
-     * @return this builder instance
-     */
-    @Override
-    public ConfigurationBuilder<T> setConfigurationSource(final ConfigurationSource configurationSource) {
-        source = configurationSource;
-        return this;
-    }
-
-    @Override
-    public ConfigurationBuilder<T> setMonitorInterval(final String intervalSeconds) {
-        monitorInterval = Integers.parseInt(intervalSeconds);
-        return this;
-    }
-
-    @Override
-    public ConfigurationBuilder<T> setPackages(final String packages) {
-        this.packages = packages;
-        return this;
-    }
-
-    @Override
-    public ConfigurationBuilder<T> setShutdownHook(final String flag) {
-        this.shutdownFlag = flag;
-        return this;
-    }
-
-    @Override
-    public ConfigurationBuilder<T> setShutdownTimeout(final long timeout, final TimeUnit timeUnit) {
-        this.shutdownTimeoutMillis = timeUnit.toMillis(timeout);
-        return this;
-    }
-
-    @Override
-    public ConfigurationBuilder<T> setStatusLevel(final Level level) {
-        this.level = level;
-        return this;
-    }
-
-    /**
-     * @deprecated This method is ineffective and only kept for binary backward compatibility.
-     */
-    @Override
-    @Deprecated
-    public ConfigurationBuilder<T> setVerbosity(final String verbosity) {
-        return this;
-    }
-
-    @Override
-    public ConfigurationBuilder<T> setDestination(final String destination) {
-        this.destination = destination;
-        return this;
-    }
-
-    @Override
-    public void setLoggerContext(final LoggerContext loggerContext) {
-        this.loggerContext = loggerContext;
-    }
-
-    @Override
-    public ConfigurationBuilder<T> addRootProperty(final String key, final String value) {
-        root.getAttributes().put(key, value);
-        return this;
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultCustomLevelComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultCustomLevelComponentBuilder.java
@@ -17,17 +17,34 @@
 package org.apache.logging.log4j.core.config.builder.impl;
 
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.CustomLevelConfig;
 import org.apache.logging.log4j.core.config.builder.api.CustomLevelComponentBuilder;
+import org.jspecify.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
+ * A default implementation of the {@link CustomLevelComponentBuilder} interface for building
+ * a {@link CustomLevelConfig} component for a Log4j configuration.
+ *
+ * <p>
+ *   Note: This builder is not thread-safe. Instances should not be shared between threads.
+ * </p>
+ *
  * @since 2.4
  */
+@ProviderType
 class DefaultCustomLevelComponentBuilder extends DefaultComponentAndConfigurationBuilder<CustomLevelComponentBuilder>
         implements CustomLevelComponentBuilder {
 
+    /**
+     * Constructs a new component builder instance.
+     * @param builder the configuration builder
+     * @param name the component name
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
     public DefaultCustomLevelComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder, final String name, final int level) {
-        super(builder, name, "CustomLevel");
-        addAttribute("intLevel", level);
+            final DefaultConfigurationBuilder<? extends Configuration> builder, final @Nullable String name) {
+
+        super(builder, "CustomLevel", name);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultFilterComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultFilterComponentBuilder.java
@@ -16,23 +16,34 @@
  */
 package org.apache.logging.log4j.core.config.builder.impl;
 
+import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.builder.api.FilterComponentBuilder;
-import org.apache.logging.log4j.core.filter.AbstractFilter.AbstractFilterBuilder;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
+ * A default implementation of the {@link FilterComponentBuilder} interface for building
+ * a {@link Filter} component for a Log4j configuration.
+ *
+ * <p>
+ *   Note: This builder is not thread-safe. Instances should not be shared between threads.
+ * </p>
+ *
  * @since 2.4
  */
+@ProviderType
 class DefaultFilterComponentBuilder extends DefaultComponentAndConfigurationBuilder<FilterComponentBuilder>
         implements FilterComponentBuilder {
 
+    /**
+     * Create a new filter component builder instance with the given plugin-type.
+     * @param builder the configuration builder.
+     * @param pluginType the plugin-type of the filter component to build
+     * @throws NullPointerException if either the {@code builder} or {@code pluginType} argument is {@code null}
+     */
     public DefaultFilterComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder,
-            final String type,
-            final String onMatch,
-            final String onMismatch) {
-        super(builder, type);
-        addAttribute(AbstractFilterBuilder.ATTR_ON_MATCH, onMatch);
-        addAttribute(AbstractFilterBuilder.ATTR_ON_MISMATCH, onMismatch);
+            final DefaultConfigurationBuilder<? extends Configuration> builder, final String pluginType) {
+
+        super(builder, pluginType);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultKeyValuePairComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultKeyValuePairComponentBuilder.java
@@ -18,17 +18,29 @@ package org.apache.logging.log4j.core.config.builder.impl;
 
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.builder.api.KeyValuePairComponentBuilder;
+import org.apache.logging.log4j.core.util.KeyValuePair;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
+ * A default implementation of the {@link KeyValuePairComponentBuilder} interface for building
+ * a {@link KeyValuePair} component for a Log4j configuration.
+ *
+ * <p>
+ *   Note: This builder is not thread-safe. Instances should not be shared between threads.
+ * </p>
+ *
  * @since 2.9
  */
+@ProviderType
 class DefaultKeyValuePairComponentBuilder extends DefaultComponentAndConfigurationBuilder<KeyValuePairComponentBuilder>
         implements KeyValuePairComponentBuilder {
 
-    public DefaultKeyValuePairComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder, final String key, final String value) {
+    /**
+     * Create a new key-value pair component builder instance with the default plugin-type "{@code KeyValuePair}".
+     * @param builder the configuration builder
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
+    public DefaultKeyValuePairComponentBuilder(final DefaultConfigurationBuilder<? extends Configuration> builder) {
         super(builder, "KeyValuePair");
-        addAttribute("key", key);
-        addAttribute("value", value);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultLayoutComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultLayoutComponentBuilder.java
@@ -16,17 +16,34 @@
  */
 package org.apache.logging.log4j.core.config.builder.impl;
 
+import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.builder.api.LayoutComponentBuilder;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
+ * A default implementation of the {@link LayoutComponentBuilder} interface for building
+ * a {@link Layout} component in a Log4j configuration.
+ *
+ * <p>
+ *   Note: This builder is not thread-safe. Instances should not be shared between threads.
+ * </p>
+ *
  * @since 2.4
  */
+@ProviderType
 class DefaultLayoutComponentBuilder extends DefaultComponentAndConfigurationBuilder<LayoutComponentBuilder>
         implements LayoutComponentBuilder {
 
+    /**
+     * Create a new layout component builder instance with the given plugin-type.
+     *
+     * @param builder the configuration builder
+     * @param pluginType the target plugin-type of the logger component
+     * @throws NullPointerException if either the {@code builder} or {@code pluginType} argument is {@code null}
+     */
     public DefaultLayoutComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder, final String type) {
-        super(builder, type);
+            final DefaultConfigurationBuilder<? extends Configuration> builder, final String pluginType) {
+        super(builder, pluginType);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultLoggerComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultLoggerComponentBuilder.java
@@ -16,94 +16,67 @@
  */
 package org.apache.logging.log4j.core.config.builder.impl;
 
+import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.builder.api.AppenderRefComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.FilterComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.LoggerComponentBuilder;
+import org.jspecify.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
+ * A default implementation of the {@link LoggerComponentBuilder} interface for building
+ * a {@link Logger} component for a Log4j configuration.
+ *
+ * <p>
+ *   Note: This builder is not thread-safe. Instances should not be shared between threads.
+ * </p>
+ *
  * @since 2.4
  */
+@ProviderType
 class DefaultLoggerComponentBuilder extends DefaultComponentAndConfigurationBuilder<LoggerComponentBuilder>
         implements LoggerComponentBuilder {
 
     /**
-     * Configure a logger.
-     * @param builder
-     * @param name
-     * @param level
+     * Create a new logger component builder instance with the default plugin-type "{@code Logger}".
+     * @param builder the configuration builder
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
      */
     public DefaultLoggerComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder, final String name, final String level) {
-        super(builder, name, "Logger");
-        if (level != null) {
-            addAttribute("level", level);
-        }
+            final DefaultConfigurationBuilder<? extends Configuration> builder, final @Nullable String name) {
+        this(builder, "Logger", name);
     }
 
     /**
-     * Configure a logger.
-     * @param builder
-     * @param name
-     * @param level
-     * @param includeLocation
+     * Create a new logger component builder instance with the given plugin-type.
+     *
+     * @param builder    the configuration builder
+     * @param pluginType the target plugin-type of the logger component
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
      */
     public DefaultLoggerComponentBuilder(
             final DefaultConfigurationBuilder<? extends Configuration> builder,
-            final String name,
-            final String level,
-            final boolean includeLocation) {
-        super(builder, name, "Logger");
-        if (level != null) {
-            addAttribute("level", level);
-        }
-        addAttribute("includeLocation", includeLocation);
+            final String pluginType,
+            final @Nullable String name) {
+        super(builder, pluginType, name);
     }
 
     /**
-     * Configure a logger.
-     * @param builder
-     * @param name
-     * @param level
-     * @param type
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} is {@code null}
      */
-    public DefaultLoggerComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder,
-            final String name,
-            final String level,
-            final String type) {
-        super(builder, name, type);
-        if (level != null) {
-            addAttribute("level", level);
-        }
-    }
-
-    /**
-     * Configure a logger.
-     * @param builder
-     * @param name
-     * @param level
-     * @param type
-     * @param includeLocation
-     */
-    public DefaultLoggerComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder,
-            final String name,
-            final String level,
-            final String type,
-            final boolean includeLocation) {
-        super(builder, name, type);
-        if (level != null) {
-            addAttribute("level", level);
-        }
-        addAttribute("includeLocation", includeLocation);
-    }
-
     @Override
     public LoggerComponentBuilder add(final AppenderRefComponentBuilder builder) {
         return addComponent(builder);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the {@code builder} is {@code null}
+     */
     @Override
     public LoggerComponentBuilder add(final FilterComponentBuilder builder) {
         return addComponent(builder);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultPropertyComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultPropertyComponentBuilder.java
@@ -17,16 +17,37 @@
 package org.apache.logging.log4j.core.config.builder.impl;
 
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.config.builder.api.PropertyComponentBuilder;
+import org.jspecify.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
+ * A default implementation of the {@link PropertyComponentBuilder} interface for constructing
+ * a {@link Property} component for a Log4j configuration.
+ *
+ * <p>
+ *   Note: This builder is not thread-safe. Instances should not be shared between threads.
+ * </p>
+ *
  * @since 2.9
  */
+@ProviderType
 class DefaultPropertyComponentBuilder extends DefaultComponentAndConfigurationBuilder<PropertyComponentBuilder>
         implements PropertyComponentBuilder {
 
+    /**
+     * Constructs a new component builder instance.
+     * @param builder the configuration builder
+     * @param name the property name
+     * @param value the property value
+     * @throws NullPointerException if the given {@code builder} is {@code}
+     */
     public DefaultPropertyComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder, final String name, final String value) {
-        super(builder, name, "Property", value);
+            final DefaultConfigurationBuilder<? extends Configuration> builder,
+            final @Nullable String name,
+            final @Nullable String value) {
+
+        super(builder, "Property", name, value);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultRootLoggerComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultRootLoggerComponentBuilder.java
@@ -16,84 +16,61 @@
  */
 package org.apache.logging.log4j.core.config.builder.impl;
 
+import static org.apache.logging.log4j.core.config.LoggerConfig.RootLogger;
+
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.builder.api.AppenderRefComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.FilterComponentBuilder;
 import org.apache.logging.log4j.core.config.builder.api.RootLoggerComponentBuilder;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
+ * A default implementation of the {@link RootLoggerComponentBuilder} interface for building
+ * a {@link RootLogger} component for a Log4j configuration.
+ *
+ * <p>
+ *   Note: This builder is not thread-safe. Instances should not be shared between threads.
+ * </p>
+ *
  * @since 2.4
  */
+@ProviderType
 class DefaultRootLoggerComponentBuilder extends DefaultComponentAndConfigurationBuilder<RootLoggerComponentBuilder>
         implements RootLoggerComponentBuilder {
 
     /**
-     * Configure the root logger.
-     * @param builder
-     * @param level
+     * Create a new root logger component builder instance with the default plugin-type "{@code Root}".
+     * @param builder the configuration builder.
      */
-    public DefaultRootLoggerComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder, final String level) {
-        super(builder, "", "Root");
-        if (level != null) {
-            addAttribute("level", level);
-        }
+    public DefaultRootLoggerComponentBuilder(final DefaultConfigurationBuilder<? extends Configuration> builder) {
+        this(builder, "Root");
     }
 
     /**
-     * Configure the root logger.
-     * @param builder
-     * @param level
-     * @param includeLocation
+     * Create a new root logger component builder instance with the given plugin-type.
+     * @param builder the configuration builder
+     * @param pluginType the target plugin-type of the logger component
      */
     public DefaultRootLoggerComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder,
-            final String level,
-            final boolean includeLocation) {
-        super(builder, "", "Root");
-        if (level != null) {
-            addAttribute("level", level);
-        }
-        addAttribute("includeLocation", includeLocation);
+            final DefaultConfigurationBuilder<? extends Configuration> builder, final String pluginType) {
+        super(builder, pluginType, "");
     }
 
     /**
-     * Configure the root logger.
-     * @param builder
-     * @param level
-     * @param type
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the given {@code builder} is {@code null}
      */
-    public DefaultRootLoggerComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder, final String level, final String type) {
-        super(builder, "", type);
-        if (level != null) {
-            addAttribute("level", level);
-        }
-    }
-
-    /**
-     * Configure the root logger.
-     * @param builder
-     * @param level
-     * @param type
-     */
-    public DefaultRootLoggerComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder,
-            final String level,
-            final String type,
-            final boolean includeLocation) {
-        super(builder, "", type);
-        if (level != null) {
-            addAttribute("level", level);
-        }
-        addAttribute("includeLocation", includeLocation);
-    }
-
     @Override
     public RootLoggerComponentBuilder add(final AppenderRefComponentBuilder builder) {
         return addComponent(builder);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NullPointerException if the given {@code builder} is {@code null}
+     */
     @Override
     public RootLoggerComponentBuilder add(final FilterComponentBuilder builder) {
         return addComponent(builder);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultScriptComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultScriptComponentBuilder.java
@@ -18,24 +18,32 @@ package org.apache.logging.log4j.core.config.builder.impl;
 
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.builder.api.ScriptComponentBuilder;
+import org.apache.logging.log4j.core.script.Script;
+import org.jspecify.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
+ * A default implementation of the {@link ScriptComponentBuilder} interface for building a {@link Script} component
+ * for a Log4j configuration.
+ *
+ * <p>
+ *   Note: This builder is not thread-safe. Instances should not be shared between threads.
+ * </p>
+ *
  * @since 2.5
  */
+@ProviderType
 class DefaultScriptComponentBuilder extends DefaultComponentAndConfigurationBuilder<ScriptComponentBuilder>
         implements ScriptComponentBuilder {
 
+    /**
+     * Constructs a new component builder instance.
+     * @param builder the configuration builder
+     * @param name the script name
+     * @throws NullPointerException if the {@code builder} argument is {@code null}
+     */
     public DefaultScriptComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder,
-            final String name,
-            final String language,
-            final String text) {
-        super(builder, name, "Script");
-        if (language != null) {
-            addAttribute("language", language);
-        }
-        if (text != null) {
-            addAttribute("text", text);
-        }
+            final DefaultConfigurationBuilder<? extends Configuration> builder, final @Nullable String name) {
+        super(builder, "Script", name);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultScriptFileComponentBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/DefaultScriptFileComponentBuilder.java
@@ -18,42 +18,32 @@ package org.apache.logging.log4j.core.config.builder.impl;
 
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.builder.api.ScriptFileComponentBuilder;
+import org.apache.logging.log4j.core.script.ScriptFile;
+import org.jspecify.annotations.Nullable;
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * Creates a ScriptFile ComponentBuilder.
+ * A default implementation of the {@link ScriptFileComponentBuilder} interface for building
+ * an {@link ScriptFile} component for a Log4j configuration.
+ *
+ * <p>
+ *   Note: This builder is not thread-safe. Instances should not be shared between threads.
+ * </p>
  *
  * @since 2.5
  */
+@ProviderType
 class DefaultScriptFileComponentBuilder extends DefaultComponentAndConfigurationBuilder<ScriptFileComponentBuilder>
         implements ScriptFileComponentBuilder {
 
+    /**
+     * Create a new filter component builder instance with the given plugin-type.
+     * @param builder the configuration builder.
+     * @param name the script component name
+     * @throws NullPointerException if either the {@code builder} or {@code pluginType} argument is {@code null}
+     */
     public DefaultScriptFileComponentBuilder(
-            final DefaultConfigurationBuilder<? extends Configuration> builder, final String name, final String path) {
-        super(builder, name != null ? name : path, "ScriptFile");
-        addAttribute("path", path);
-    }
-
-    @Override
-    public DefaultScriptFileComponentBuilder addLanguage(final String language) {
-        addAttribute("language", language);
-        return this;
-    }
-
-    @Override
-    public DefaultScriptFileComponentBuilder addIsWatched(final boolean isWatched) {
-        addAttribute("isWatched", Boolean.toString(isWatched));
-        return this;
-    }
-
-    @Override
-    public DefaultScriptFileComponentBuilder addIsWatched(final String isWatched) {
-        addAttribute("isWatched", isWatched);
-        return this;
-    }
-
-    @Override
-    public DefaultScriptFileComponentBuilder addCharset(final String charset) {
-        addAttribute("charset", charset);
-        return this;
+            final DefaultConfigurationBuilder<? extends Configuration> builder, @Nullable final String name) {
+        super(builder, "ScriptFile", name);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/builder/impl/package-info.java
@@ -20,8 +20,10 @@
  * @since 2.4
  */
 @Export
-@Version("2.20.2")
+@NullMarked
+@Version("2.25.0")
 package org.apache.logging.log4j.core.config.builder.impl;
 
+import org.jspecify.annotations.NullMarked;
 import org.osgi.annotation.bundle.Export;
 import org.osgi.annotation.versioning.Version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
@@ -334,7 +334,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
             final ComponentBuilder<?> parent, final String key, final Properties properties) {
         final String name = (String) properties.remove(CONFIG_NAME);
         final String type = (String) properties.remove(CONFIG_TYPE);
-        if (Strings.isEmpty(type)) {
+        if (type == null || Strings.isEmpty(type)) {
             throw new ConfigurationException("No type attribute provided for component " + key);
         }
         final ComponentBuilder<B> componentBuilder = parent.getBuilder().newComponent(name, type);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
@@ -84,7 +84,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
     public PropertiesConfiguration build() {
         for (final String key : rootProperties.stringPropertyNames()) {
             if (!key.contains(".")) {
-                builder.addRootProperty(key, rootProperties.getProperty(key));
+                builder.setRootProperty(key, rootProperties.getProperty(key));
             }
         }
         builder.setStatusLevel(Level.toLevel(rootProperties.getProperty(STATUS_KEY), Level.ERROR))
@@ -99,7 +99,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
 
         final Properties propertyPlaceholders = PropertiesUtil.extractSubset(rootProperties, "property");
         for (final String key : propertyPlaceholders.stringPropertyNames()) {
-            builder.addProperty(key, propertyPlaceholders.getProperty(key));
+            builder.add(builder.newProperty(key, propertyPlaceholders.getProperty(key)));
         }
 
         final Map<String, Properties> scripts =
@@ -118,7 +118,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
         }
 
         final Properties levelProps = PropertiesUtil.extractSubset(rootProperties, "customLevel");
-        if (levelProps.size() > 0) {
+        if (!levelProps.isEmpty()) {
             for (final String key : levelProps.stringPropertyNames()) {
                 builder.add(builder.newCustomLevel(key, Integers.parseInt(levelProps.getProperty(key))));
             }
@@ -183,7 +183,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
             props.setProperty("", rootProp);
             rootProperties.remove("rootLogger");
         }
-        if (props.size() > 0) {
+        if (!props.isEmpty()) {
             builder.add(createRootLogger(props));
         }
 
@@ -219,7 +219,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
         final AppenderComponentBuilder appenderBuilder = builder.newAppender(name, type);
         addFiltersToComponent(appenderBuilder, properties);
         final Properties layoutProps = PropertiesUtil.extractSubset(properties, "layout");
-        if (layoutProps.size() > 0) {
+        if (!layoutProps.isEmpty()) {
             appenderBuilder.add(createLayout(name, layoutProps));
         }
 
@@ -245,7 +245,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
         final AppenderRefComponentBuilder appenderRefBuilder = builder.newAppenderRef(ref);
         final String level = Strings.trimToNull((String) properties.remove("level"));
         if (!Strings.isEmpty(level)) {
-            appenderRefBuilder.addAttribute("level", level);
+            appenderRefBuilder.setLevelAttribute(level);
         }
         return addFiltersToComponent(appenderRefBuilder, properties);
     }
@@ -282,10 +282,10 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
         addFiltersToComponent(loggerBuilder, properties);
         final String additivity = (String) properties.remove("additivity");
         if (!Strings.isEmpty(additivity)) {
-            loggerBuilder.addAttribute("additivity", additivity);
+            loggerBuilder.setAdditivityAttribute(additivity);
         }
         if (levelAndRefs != null) {
-            loggerBuilder.addAttribute("levelAndRefs", levelAndRefs);
+            loggerBuilder.setAttribute("levelAndRefs", levelAndRefs);
         }
         return loggerBuilder;
     }
@@ -316,7 +316,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
         }
         addLoggersToComponent(loggerBuilder, properties);
         if (levelAndRefs != null) {
-            loggerBuilder.addAttribute("levelAndRefs", levelAndRefs);
+            loggerBuilder.setAttribute("levelAndRefs", levelAndRefs);
         }
         return addFiltersToComponent(loggerBuilder, properties);
     }
@@ -343,7 +343,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
 
     private static <B extends ComponentBuilder<?>> B processRemainingProperties(
             final B builder, final Properties properties) {
-        while (properties.size() > 0) {
+        while (!properties.isEmpty()) {
             final String propertyName =
                     properties.stringPropertyNames().iterator().next();
             final int index = propertyName.indexOf('.');
@@ -352,7 +352,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
                 final Properties componentProperties = PropertiesUtil.extractSubset(properties, prefix);
                 builder.addComponent(createComponent(builder, prefix, componentProperties));
             } else {
-                builder.addAttribute(propertyName, properties.getProperty(propertyName));
+                builder.setAttribute(propertyName, properties.getProperty(propertyName));
                 properties.remove(propertyName);
             }
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
@@ -187,9 +187,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
             builder.add(createRootLogger(props));
         }
 
-        builder.setLoggerContext(loggerContext);
-
-        return builder.build(false);
+        return builder.setLoggerContext(loggerContext).build(false);
     }
 
     private ScriptComponentBuilder createScript(final Properties properties) {

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutConcurrentEncodeTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutConcurrentEncodeTest.java
@@ -113,15 +113,15 @@ class JsonTemplateLayoutConcurrentEncodeTest {
         final Configuration config = configBuilder
                 .add(configBuilder
                         .newAppender(appenderName, "File")
-                        .addAttribute(
+                        .setAttribute(
                                 "fileName", appenderFilepath.toAbsolutePath().toString())
-                        .addAttribute("append", false)
-                        .addAttribute("immediateFlush", false)
-                        .addAttribute("ignoreExceptions", false)
+                        .setAttribute("append", false)
+                        .setAttribute("immediateFlush", false)
+                        .setAttribute("ignoreExceptions", false)
                         .add(configBuilder
                                 .newLayout("JsonTemplateLayout")
-                                .addAttribute("eventTemplate", eventTemplateJson)
-                                .addAttribute("recyclerFactory", recyclerFactory)))
+                                .setAttribute("eventTemplate", eventTemplateJson)
+                                .setAttribute("recyclerFactory", recyclerFactory)))
                 .add(configBuilder.newRootLogger(Level.ALL).add(configBuilder.newAppenderRef(appenderName)))
                 .build(false);
 

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/JsonTemplateLayoutTest.java
@@ -57,6 +57,7 @@ import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.SocketAppender;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
@@ -291,9 +292,9 @@ class JsonTemplateLayoutTest {
 
         // Create the layout with property.
         final String propertyValue = "propertyValue";
-        final Configuration config = ConfigurationBuilderFactory.newConfigurationBuilder()
-                .addProperty(propertyName, propertyValue)
-                .build();
+        final ConfigurationBuilder<?> configurationBuilder = ConfigurationBuilderFactory.newConfigurationBuilder();
+        configurationBuilder.add(configurationBuilder.newProperty(propertyName, propertyValue));
+        final Configuration config = configurationBuilder.build();
         final JsonTemplateLayout layout = JsonTemplateLayout.newBuilder()
                 .setConfiguration(config)
                 .setEventTemplate(eventTemplate)

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/TestHelpers.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/TestHelpers.java
@@ -29,7 +29,6 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.layout.template.json.util.JsonReader;
 import org.apache.logging.log4j.layout.template.json.util.JsonWriter;
@@ -114,10 +113,9 @@ public final class TestHelpers {
             final BiConsumer<LoggerContext, ListAppender> consumer) {
 
         // Create the configuration builder.
-        final ConfigurationBuilder<BuiltConfiguration> configBuilder =
-                ConfigurationBuilderFactory.newConfigurationBuilder()
-                        .setStatusLevel(Level.ERROR)
-                        .setConfigurationName(configName);
+        final ConfigurationBuilder<?> configBuilder = ConfigurationBuilderFactory.newConfigurationBuilder()
+                .setStatusLevel(Level.ERROR)
+                .setConfigurationName(configName);
 
         // Create the configuration.
         final String eventTemplateJson = writeJson(eventTemplate);
@@ -125,10 +123,10 @@ public final class TestHelpers {
         final Configuration config = configBuilder
                 .add(configBuilder
                         .newAppender(appenderName, "List")
-                        .addAttribute("raw", true)
+                        .setAttribute("raw", true)
                         .add(configBuilder
                                 .newLayout("JsonTemplateLayout")
-                                .addAttribute("eventTemplate", eventTemplateJson)))
+                                .setAttribute("eventTemplate", eventTemplateJson)))
                 .add(configBuilder.newRootLogger(Level.ALL).add(configBuilder.newAppenderRef(appenderName)))
                 .build(false);
 

--- a/src/changelog/.2.x.x/2791_fix_DefaultComponenBuilder_null_value_attributes.xml
+++ b/src/changelog/.2.x.x/2791_fix_DefaultComponenBuilder_null_value_attributes.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="2791" link="https://github.com/apache/logging-log4j2/issues/2791"/>
+  <description format="asciidoc">
+    Fix problem when null attribute values are set on DefaultComponentBuilder.
+    GitHub issue #2791.
+  </description>
+</entry>

--- a/src/changelog/.2.x.x/2791_rework_ComponentBuilder_API.xml
+++ b/src/changelog/.2.x.x/2791_rework_ComponentBuilder_API.xml
@@ -5,7 +5,8 @@
        type="changed">
   <issue id="2791" link="https://github.com/apache/logging-log4j2/issues/2791"/>
   <description format="asciidoc">
-    Fix problem when null attribute values are set on DefaultComponentBuilder.
-    GitHub issue #2791.
+    Fix problem when null attribute values are set on DefaultComponentBuilder. GitHub issue #2791.
+    Added JVerify annotations to config.builder.* packages.
+    Updated Builder APIs and Default***Builder implementations.
   </description>
 </entry>


### PR DESCRIPTION
#2791
---
+ Updated DefaultComponentBuilder `put(String, String)` to remove attributte if value is null
+ Updated DefaultComponentBuilder guarded `putAttribute(...)` implementations with object values against NPE
+ updated javadoc
+ added changelog

(edit)
+ per @ppkarwasz review added JVerify annotations to `config.builder` and `config.builder.api` packages
+ optimized builder APIs and Default***ComponentBuilder implementations
+ changed (deprecated) 'addAttribute' methods to 'setAttribute' to better match other builder APIs
+ added convencience APIs for setting general attributes on ***ComponentBuilder interfaces
+ javadoc'd both packages 100%
+ updated callers of now deprecated APIs
+ updated changelog