### PR TITLE
Add references to Copernik.eu Log4j components

### DIFF
--- a/src/site/antora/modules/ROOT/pages/manual/lookups.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/lookups.adoc
@@ -966,7 +966,10 @@ include::partial$features/servlet-support.adoc[]
 [#third-party]
 == Third-party lookups
 
-The following additional lookups are available from third-party vendors:
+[IMPORTANT]
+====
+These lookups are provided by **third-party** vendors and are not maintained by the Apache Software Foundation.
+====
 
 [#KubernetesLookup]
 === Kubernetes Lookup
@@ -997,6 +1000,29 @@ for more details.
 ====
 The Spring Boot 3 Lookup conflicts with the <<#SpringBootLookup>>.
 If you are upgrading to Spring Boot 3, make sure to remove the latter from your classpath.
+====
+
+[#TomcatLookup]
+=== Tomcat Lookup
+
+[cols="1h,4"]
+|===
+| Syntax
+|
+`tomcat:<key>`
+
+where `key` is one of the
+https://oss.copernik.eu/tomcat/3.x/components/log4j-tomcat#TomcatLookup-keys[supported Tomcat Lookup keys]
+| Dependency | https://oss.copernik.eu/tomcat/3.x/components/log4j-tomcat#installation[`eu.copernik:log4j-tomcat`]
+|===
+
+The Tomcat Lookup allows retrieving the names of the currently active Tomcat engine, host and application context.
+See
+https://oss.copernik.eu/tomcat/3.x/components/log4j-tomcat#TomcatLookup[Copernik.eu Tomcat Lookup documentation] for more details.
+
+[TIP]
+====
+If you wish your custom lookup to appear on this page, use the ``[Edit]`` link at the top and submit a pull request.
 ====
 
 [#extending]

--- a/src/site/antora/modules/ROOT/pages/manual/lookups.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/lookups.adoc
@@ -968,7 +968,7 @@ include::partial$features/servlet-support.adoc[]
 
 [IMPORTANT]
 ====
-These lookups are provided by **third-party** vendors and are not maintained by the Apache Software Foundation.
+These lookups are provided by **third-party** vendors and are not maintained by the link:{logging-services-url}[Apache Logging Services] (Log4j, Log4cxx, Log4net) project.
 ====
 
 [#KubernetesLookup]
@@ -1019,11 +1019,6 @@ https://oss.copernik.eu/tomcat/3.x/components/log4j-tomcat#TomcatLookup-keys[sup
 The Tomcat Lookup allows retrieving the names of the currently active Tomcat engine, host and application context.
 See
 https://oss.copernik.eu/tomcat/3.x/components/log4j-tomcat#TomcatLookup[Copernik.eu Tomcat Lookup documentation] for more details.
-
-[TIP]
-====
-If you wish your custom lookup to appear on this page, use the ``[Edit]`` link at the top and submit a pull request.
-====
 
 [#extending]
 == Extending

--- a/src/site/antora/modules/ROOT/pages/manual/lookups.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/lookups.adoc
@@ -968,7 +968,9 @@ include::partial$features/servlet-support.adoc[]
 
 [IMPORTANT]
 ====
-These lookups are provided by **third-party** vendors and are not maintained by the link:{logging-services-url}[Apache Logging Services] (Log4j, Log4cxx, Log4net) project.
+These lookups are provided by **third-party** vendors and are not maintained by the
+link:{logging-services-url}[Apache Logging Services]
+(Log4j, Log4cxx, Log4net) project.
 ====
 
 [#KubernetesLookup]

--- a/src/site/antora/modules/ROOT/pages/manual/thread-context.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/thread-context.adoc
@@ -165,7 +165,9 @@ META-INF/services/org.apache.logging.log4j.core.util.ContextDataProvider
 
 [IMPORTANT]
 ====
-These context data providers are supplied by **third-party** vendors and are not maintained by the Apache Software Foundation.
+These context data providers are supplied by **third-party** vendors and are not maintained by the
+link:{logging-services-url}[Apache Logging Services]
+(Log4j, Log4cxx, Log4net) project.
 ====
 
 https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure[OpenTelemetry Context Data Provider]::

--- a/src/site/antora/modules/ROOT/pages/manual/thread-context.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/thread-context.adoc
@@ -159,7 +159,20 @@ You can provide a custom `ContextDataProvider` implementation as follows:
 ----
 META-INF/services/org.apache.logging.log4j.core.util.ContextDataProvider
 ----
-. Write the fully-qualified class name of your custom implementation (e.g., `com.mycompany.CustomContextDataProvider`) to the file created in the previous step
+. Write the fully-qualified class name of your custom implementation (e.g., `com.mycompany.CustomContextDataProvider`) to the file created in the previous step.
+
+==== Third-party custom thread context data providers
+
+[IMPORTANT]
+====
+These context data providers are supplied by **third-party** vendors and are not maintained by the Apache Software Foundation.
+====
+
+https://github.com/open-telemetry/opentelemetry-java-instrumentation/tree/main/instrumentation/log4j/log4j-context-data/log4j-context-data-2.17/library-autoconfigure[OpenTelemetry Context Data Provider]::
+Injects trace context data into log events.
+
+https://oss.copernik.eu/tomcat/3.x/components/log4j-tomcat#TomcatContextDataProvider[Copernik.eu Tomcat Context Data Provider]::
+Injects the name of the currently active Tomcat engine, host and web application into log events.
 
 [#custom-ThreadContextMap]
 === Custom thread context map

--- a/src/site/antora/modules/ROOT/partials/manual/systemproperties/properties-context-selector.adoc
+++ b/src/site/antora/modules/ROOT/partials/manual/systemproperties/properties-context-selector.adoc
@@ -56,3 +56,16 @@ Creates a separate logger context per OSGi bundle and synchronous loggers
 
 link:../javadoc/log4j-core/org/apache/logging/log4j/core/selector/JndiContextSelector.html[`org.apache.logging.log4j.core.selector.JndiContextSelector`]::
 Creates loggers contexts based on a JNDI lookup and synchronous loggers See xref:jakarta.adoc#jndi-configuration[Web application] for details.
+
+There are also third-party context selector implementations:
+
+[IMPORTANT]
+====
+These context selectors are provided by **third-party** vendors and are not maintained by the Apache Software Foundation.
+====
+
+https://oss.copernik.eu/tomcat/3.x/components/log4j-tomcat#TomcatContextSelector[`eu.copernik.log4j.tomcat.TomcatContextSelector`]::
+Selects the currently active Tomcat web application and creates synchronous loggers.
+
+https://oss.copernik.eu/tomcat/3.x/components/log4j-tomcat#TomcatContextSelector[`eu.copernik.log4j.tomcat.TomcatAsyncContextSelector`]::
+Selects the currently active Tomcat web application and creates xref:manual/async.adoc[asynchronous loggers].

--- a/src/site/antora/modules/ROOT/partials/manual/systemproperties/properties-context-selector.adoc
+++ b/src/site/antora/modules/ROOT/partials/manual/systemproperties/properties-context-selector.adoc
@@ -61,7 +61,9 @@ There are also third-party context selector implementations:
 
 [IMPORTANT]
 ====
-These context selectors are provided by **third-party** vendors and are not maintained by the Apache Software Foundation.
+These context selectors are provided by **third-party** vendors and are not maintained by the
+link:{logging-services-url}[Apache Logging Services]
+(Log4j, Log4cxx, Log4net) project.
 ====
 
 https://oss.copernik.eu/tomcat/3.x/components/log4j-tomcat#TomcatContextSelector[`eu.copernik.log4j.tomcat.TomcatContextSelector`]::


### PR DESCRIPTION
This change adds references to the Log4j plugins from my personal ["Extensions for Log4j and Tomcat"](https://oss.copernik.eu/tomcat/3.x/) project to the Log4j documentation.

To prevent confusion between original Log4j plugins and third-party plugins an appropriate note is added to each section.
