### PR TITLE
Enabled GH discussions and projects

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,6 +38,7 @@ github:
   features:
     issues: true
     discussions: true
+    projects: true
   del_branch_on_merge: true
   autolink_jira:
     - LOG4J2

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,6 +31,7 @@ notifications:
   pullrequests: notifications@logging.apache.org
   pullrequests_bot_dependabot: robots@logging.apache.org
   jira_options: link label worklog
+  discussions: dev@logging.apache.org
 
 github:
   description: "Apache Log4j is a versatile, feature-rich, efficient logging API and backend for Java."

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -37,6 +37,7 @@ github:
   homepage: https://logging.apache.org/log4j/2.x
   features:
     issues: true
+    discussions: true
   del_branch_on_merge: true
   autolink_jira:
     - LOG4J2


### PR DESCRIPTION
A recent change made it necessary to enable GH discussions on .asf.yml:
https://github.com/apache/infrastructure-asfyaml?tab=readme-ov-file#repository-features

If we want to continue "discussions", we need to switch the flag.