### PR TITLE
docsImprove String concatenation best practice

### DIFF
--- a/src/site/antora/modules/ROOT/pages/manual/api.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/api.adoc
@@ -78,6 +78,8 @@ include::partial$manual/api-best-practice-exception-as-last-argument.adoc[]
 
 include::partial$manual/api-best-practice-dont-use-string-concat.adoc[]
 
+include::partial$manual/api-best-practice-dont-mix-concat-and-params.adoc[]
+
 [#best-practice-supplier]
 === Use ``Supplier``s to pass computationally expensive arguments
 

--- a/src/site/antora/modules/ROOT/pages/manual/getting-started.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/getting-started.adoc
@@ -121,6 +121,8 @@ include::partial$manual/api-best-practice-exception-as-last-argument.adoc[]
 
 include::partial$manual/api-best-practice-dont-use-string-concat.adoc[]
 
+include::partial$manual/api-best-practice-dont-mix-concat-and-params.adoc[]
+
 [#install-app]
 == How do I install Log4j Core to run my **application**?
 

--- a/src/site/antora/modules/ROOT/partials/manual/api-best-practice-dont-mix-concat-and-params.adoc
+++ b/src/site/antora/modules/ROOT/partials/manual/api-best-practice-dont-mix-concat-and-params.adoc
@@ -15,24 +15,20 @@
     limitations under the License.
 ////
 
-* [ ] Don't use `String` concatenation to format arguments:
-the log message will be formatted, even if the logger is not enabled, and you will suffer a performance penalty!
+If you are mixing `String` concatenation and parameterized logging, you are doing something very wrong and dangerous!
+
+* [ ] The format string of a parameterized statement should be a compile time constant!
+An attacker could mangle your logs by inserting `{}` placeholders in the values!
+Try these examples with `userId="{}\nbadUser"` and `reason="root logged in successfully"`
 +
 [source,java]
 ----
-/* BAD! */ LOGGER.info("failed for user ID: " + userId);
+/* BAD! */ LOGGER.info("User " + userId + " logged out: {}", reason);
 ----
 
 * [x] Use message parameters
 +
 [source,java]
 ----
-/* GOOD */ LOGGER.info("failed for user ID `{}`", userId);
-----
-
-* [x] Use message lambdas
-+
-[source,java]
-----
-/* GOOD */ LOGGER.info(() -> "failed for user ID: " + userId);
+/* GOOD */ LOGGER.info("User {} logged out: {}", userId, reason);
 ----


### PR DESCRIPTION
This change splits the "don't use String concatenation" best practice into two parts:

- A recommendation concerning performance: string concatenation is not efficient if the logger is off.
- A security recommendation: format string must be constants to prevent `{}` placeholder injection.

The `${dangerousLookup}` part of the example is removed, since lookups are not executed since version `2.15.0`
