### PR TITLE
Fix typo in `Filter.java`

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/Filter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/Filter.java
@@ -46,7 +46,7 @@ public interface Filter extends LifeCycle {
     String ELEMENT_TYPE = "filter";
 
     /**
-     * The result that can returned from a filter method call.
+     * The result that can be returned from a filter method call.
      */
     enum Result {
         /**


### PR DESCRIPTION
The result that can returned from a filter method call -> The result that can **be** returned from a filter method call