### PR TITLE
Enforce RTC style on `logging-log4j2`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -66,12 +66,16 @@ github:
   # Enforce Review-then-Commit
   protected_branches:
     2.x: &default_protection
-      # All reviews must be addressed before merging
-      required_conversation_resolution: true
-      # Use "Squash and merge" or equivalent
-      required_linear_history: true
       # All commits must be signed
       required_signatures: true
+      # All reviews must be addressed before merging
+      required_conversation_resolution: true
+      # Require the `build` to pass before merging
+      required_status_checks:
+        checks:
+          # The GitHub Actions app
+          - app_id: ~
+            check: "build"
       # At least one positive review must be present
       required_pull_request_reviews:
         required_approving_review_count: 1

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -70,12 +70,14 @@ github:
       required_signatures: true
       # All reviews must be addressed before merging
       required_conversation_resolution: true
-      # Require the `build` to pass before merging
+      # Require checks to pass before merging
       required_status_checks:
         checks:
           # The GitHub Actions app
           - app_id: ~
             check: "build"
+          - app_id: ~
+            check: "codeql-analysis"
       # At least one positive review must be present
       required_pull_request_reviews:
         required_approving_review_count: 1

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,7 +16,7 @@
 #
 
 # `.asf.yaml` is a branch-specific YAML configuration file for Git repositories to control features such as notifications, GitHub settings, etc.
-# See its documentation for details: https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
+# See its documentation for details: https://github.com/apache/infrastructure-asfyaml
 
 # Bare minimum `notifications` to
 #
@@ -63,8 +63,17 @@ github:
     merge:   false
     rebase:  false
 
+  # Enforce Review-then-Commit
   protected_branches:
+    2.x: &default_protection
+      # All reviews must be addressed before merging
+      required_conversation_resolution: true
+      # Use "Squash and merge" or equivalent
+      required_linear_history: true
+      # All commits must be signed
+      required_signatures: true
+      # At least one positive review must be present
+      required_pull_request_reviews:
+        required_approving_review_count: 1
     main:
-      required_signatures: true
-    2.x:
-      required_signatures: true
+      *default_protection


### PR DESCRIPTION
Following the [PMC discussion in September 2024](https://lists.apache.org/thread/6gbos0rn3k4y3wjb1hcgnnols4ogqckl), this PR changes the branch protection rules for the `logging-log4j2` repository:

- It requires all changes to `2.x` and `main` to be submitted as PRs.
- It requires all PRs to have at least one positive review to be merged.
- It requires all conversations to be marked as resolved, before a PR is merged.

The current features offered by GitHub do not allow introducing exceptions on the size of the PR or other criteria, so let's try to review 100% of the PRs. Smaller teams manage to do it, so we should be able too.
