### PR TITLE
[main] Create `DefaultLayout` independent of `PatternLayout`

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java
@@ -43,7 +43,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.Filter;
-import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -54,7 +53,6 @@ import org.apache.logging.log4j.core.config.arbiters.Arbiter;
 import org.apache.logging.log4j.core.config.arbiters.SelectArbiter;
 import org.apache.logging.log4j.core.filter.AbstractFilterable;
 import org.apache.logging.log4j.core.impl.CoreProperties.ConfigurationProperties;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.lookup.ConfigurationStrSubstitutor;
 import org.apache.logging.log4j.core.lookup.Interpolator;
 import org.apache.logging.log4j.core.lookup.InterpolatorFactory;
@@ -790,11 +788,7 @@ public abstract class AbstractConfiguration extends AbstractFilterable implement
     protected void setToDefault() {
         // LOG4J2-1176 facilitate memory leak investigation
         setName(DefaultConfiguration.DEFAULT_NAME + "@" + Integer.toHexString(hashCode()));
-        final Layout layout = PatternLayout.newBuilder()
-                .setPattern(DefaultConfiguration.DEFAULT_PATTERN)
-                .setConfiguration(this)
-                .build();
-        final Appender appender = ConsoleAppender.createDefaultAppenderForLayout(layout);
+        final Appender appender = ConsoleAppender.createDefaultAppenderForLayout(DefaultLayout.INSTANCE);
         appender.start();
         addAppender(appender);
         final LoggerConfig rootLoggerConfig = getRootLogger();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/DefaultLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/DefaultLayout.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.config;
+
+import java.nio.charset.Charset;
+import java.util.Map;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.StringLayout;
+import org.apache.logging.log4j.core.layout.ByteBufferDestination;
+import org.apache.logging.log4j.status.StatusData;
+
+/**
+ * A simple layout used only by {@link DefaultConfiguration}
+ * <p>
+ *   This layout allows to create applications that don't contain {@link org.apache.logging.log4j.core.layout.PatternLayout}
+ *   and all its patterns, e.g. GraalVM applications.
+ * </p>
+ *
+ * @since 2.25.0
+ */
+final class DefaultLayout implements StringLayout {
+
+    static final StringLayout INSTANCE = new DefaultLayout();
+
+    private DefaultLayout() {}
+
+    @Override
+    public String toSerializable(LogEvent event) {
+        return new StatusData(
+                        event.getSource(),
+                        event.getLevel(),
+                        event.getMessage(),
+                        event.getThrown(),
+                        event.getThreadName())
+                .getFormattedStatus();
+    }
+
+    @Override
+    public byte[] toByteArray(LogEvent event) {
+        return toSerializable(event).getBytes(Charset.defaultCharset());
+    }
+
+    @Override
+    public void encode(LogEvent event, ByteBufferDestination destination) {
+        final byte[] data = toByteArray(event);
+        destination.writeBytes(data, 0, data.length);
+    }
+
+    @Override
+    public String getContentType() {
+        return "text/plain";
+    }
+
+    @Override
+    public Charset getCharset() {
+        return Charset.defaultCharset();
+    }
+
+    @Override
+    public byte[] getFooter() {
+        return null;
+    }
+
+    @Override
+    public byte[] getHeader() {
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getContentFormat() {
+        return Map.of();
+    }
+}

--- a/src/changelog/.3.x.x/3118_default_layout.xml
+++ b/src/changelog/.3.x.x/3118_default_layout.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="3118" link="https://github.com/apache/logging-log4j2/pull/3118"/>
+  <description format="asciidoc">
+    Changes the layout used by the
+    https://logging.apache.org/log4j/2.x/manual/configuration.html#automatic-configuration[default configuration].
+  </description>
+</entry>


### PR DESCRIPTION
Currently, `PatternLayout` and all its patterns are a required element of Log4j Core, since `DefaultConfiguration` uses it. The default configuration is used in all Log4j Core installation as failsafe to handle logging between the time a logger context is created and the real configuration starts (a couple of ms).

This PR creates a simple hardcoded layout to use with `DefaultConfiguration`, based on the `StatusData` formatter.

(cherry picked from commit e8d5ffc9cd876f740ad39dc18c70089664609b49)

