### PR TITLE
Adjust GcpLayout JSON to latest format

### DIFF
--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/GcpLayoutTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/GcpLayoutTest.java
@@ -152,7 +152,7 @@ class GcpLayoutTest {
                         .contains("at org.junit.platform.engine");
 
             } else {
-                assertThat(accessor.getString("exception")).isEmpty();
+                assertThat(accessor.getString("exception")).isNull();
             }
 
             // Verify thread name.

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/GcpLayoutTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/GcpLayoutTest.java
@@ -159,8 +159,7 @@ class GcpLayoutTest {
                         .contains("at org.junit.platform.engine");
 
             } else {
-                assertThat(accessor.getString("exception"))
-                        .isEmpty();
+                assertThat(accessor.getString("exception")).isEmpty();
             }
 
             // Verify thread name.

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/GcpLayoutTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/GcpLayoutTest.java
@@ -148,9 +148,6 @@ class GcpLayoutTest {
                         .isEmpty();
             }
 
-            // Verify insert id.
-            assertThat(accessor.getString("logging.googleapis.com/insertId")).matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
-
             // Verify exception.
             if (exception != null) {
 

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/GcpLayoutTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/GcpLayoutTest.java
@@ -149,40 +149,28 @@ class GcpLayoutTest {
             }
 
             // Verify insert id.
-            assertThat(accessor.getString("logging.googleapis.com/insertId")).matches("[-]?[0-9]+");
+            assertThat(accessor.getString("logging.googleapis.com/insertId")).matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
 
             // Verify exception.
             if (exception != null) {
 
-                // Verify exception class.
-                assertThat(accessor.getString(new String[] {"_exception", "class"}))
-                        .isEqualTo(exception.getClass().getCanonicalName());
-
-                // Verify exception message.
-                assertThat(accessor.getString(new String[] {"_exception", "message"}))
-                        .isEqualTo(exception.getMessage());
-
                 // Verify exception stack trace.
-                assertThat(accessor.getString(new String[] {"_exception", "stackTrace"}))
+                assertThat(accessor.getString("exception"))
                         .contains(exception.getLocalizedMessage())
                         .contains("at org.apache.logging.log4j.layout.template.json")
                         .contains("at " + JAVA_BASE_PREFIX + "java.lang.reflect.Method")
                         .contains("at org.junit.platform.engine");
 
             } else {
-                assertThat(accessor.getObject(new String[] {"_exception", "class"}))
-                        .isNull();
-                assertThat(accessor.getObject(new String[] {"_exception", "message"}))
-                        .isNull();
-                assertThat(accessor.getString(new String[] {"_exception", "stackTrace"}))
+                assertThat(accessor.getString("exception"))
                         .isEmpty();
             }
 
             // Verify thread name.
-            assertThat(accessor.getString("_thread")).isEqualTo(logEvent.getThreadName());
+            assertThat(accessor.getString("thread")).isEqualTo(logEvent.getThreadName());
 
             // Verify logger name.
-            assertThat(accessor.getString("_logger")).isEqualTo(logEvent.getLoggerName());
+            assertThat(accessor.getString("logger")).isEqualTo(logEvent.getLoggerName());
         });
     }
 

--- a/log4j-layout-template-json/src/main/resources/GcpLayout.json
+++ b/log4j-layout-template-json/src/main/resources/GcpLayout.json
@@ -51,8 +51,11 @@
   },
   "logging.googleapis.com/trace_sampled": true,
   "exception": {
-    "$resolver": "pattern",
-    "pattern": "%xEx"
+    "$resolver": "exception",
+    "field": "stackTrace",
+    "stackTrace": {
+      "stringified": true
+    }
   },
   "thread": {
     "$resolver": "thread",

--- a/log4j-layout-template-json/src/main/resources/GcpLayout.json
+++ b/log4j-layout-template-json/src/main/resources/GcpLayout.json
@@ -12,7 +12,7 @@
       "unit": "secs.nanos"
     }
   },
-  "logging.googleapis.com/severity": {
+  "severity": {
     "$resolver": "pattern",
     "pattern": "%level{WARN=WARNING, TRACE=DEBUG, FATAL=EMERGENCY}",
     "stackTraceEnabled": false
@@ -40,11 +40,6 @@
       "pattern": "%replace{%C.%M}{^\\?\\.$}{}",
       "stackTraceEnabled": false
     }
-  },
-  "logging.googleapis.com/insertId": {
-    "$resolver": "pattern",
-    "pattern": "%uuid{TIME}",
-    "stackTraceEnabled": false
   },
   "logging.googleapis.com/trace": {
     "$resolver": "mdc",

--- a/log4j-layout-template-json/src/main/resources/GcpLayout.json
+++ b/log4j-layout-template-json/src/main/resources/GcpLayout.json
@@ -1,13 +1,18 @@
 {
-  "timestamp": {
+  "timestampSeconds": {
     "$resolver": "timestamp",
-    "pattern": {
-      "format": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-      "timeZone": "UTC",
-      "locale": "en_US"
+    "epoch": {
+      "unit": "secs",
+      "rounded": true
     }
   },
-  "severity": {
+  "timestampNanos": {
+    "$resolver": "timestamp",
+    "epoch": {
+      "unit": "secs.nanos"
+    }
+  },
+  "logging.googleapis.com/severity": {
     "$resolver": "pattern",
     "pattern": "%level{WARN=WARNING, TRACE=DEBUG, FATAL=EMERGENCY}",
     "stackTraceEnabled": false
@@ -37,8 +42,9 @@
     }
   },
   "logging.googleapis.com/insertId": {
-    "$resolver": "counter",
-    "stringified": true
+    "$resolver": "pattern",
+    "pattern": "%uuid{TIME}",
+    "stackTraceEnabled": false
   },
   "logging.googleapis.com/trace": {
     "$resolver": "mdc",
@@ -49,25 +55,15 @@
     "key": "span_id"
   },
   "logging.googleapis.com/trace_sampled": true,
-  "_exception": {
-    "class": {
-      "$resolver": "exception",
-      "field": "className"
-    },
-    "message": {
-      "$resolver": "exception",
-      "field": "message"
-    },
-    "stackTrace": {
-      "$resolver": "pattern",
-      "pattern": "%xEx"
-    }
+  "exception": {
+    "$resolver": "pattern",
+    "pattern": "%xEx"
   },
-  "_thread": {
+  "thread": {
     "$resolver": "thread",
     "field": "name"
   },
-  "_logger": {
+  "logger": {
     "$resolver": "logger",
     "field": "name"
   }

--- a/src/changelog/.2.x.x/3586_improve_GcpLayout.xml
+++ b/src/changelog/.2.x.x/3586_improve_GcpLayout.xml
@@ -5,6 +5,6 @@
        type="changed">
   <issue id="3586" link="https://github.com/apache/logging-log4j2/pull/3586"/>
   <description format="asciidoc">
-    Adjust GcpLayout JSON template to support automatic timestamp recognition by the Google Cloud Logging. This also changes `exception`, `thread`, `logger` fields a bit, and removes `insertId` field.
+    Update `GcpLayout.json` JSON Template Layout event template to support automatic timestamp recognition by the Google Cloud Logging. This also changes `exception`, `thread`, `logger` fields, and removes `insertId` field.
   </description>
 </entry>

--- a/src/changelog/.2.x.x/3586_improve_GcpLayout.xml
+++ b/src/changelog/.2.x.x/3586_improve_GcpLayout.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="3586" link="https://github.com/apache/logging-log4j2/pull/3586"/>
+  <description format="asciidoc">
+    Adjust GcpLayout JSON template to support automatic timestamp recognition by the Google Cloud Logging. This also changes `exception`, `thread`, `logger` fields a bit, and removes `insertId` field.
+  </description>
+</entry>


### PR DESCRIPTION
This is my first contribution to Log4J so I'm not 100% sure if I did everything right, but here it goes.

This PR adjusts GcpLayout JSON formatting to match what is expected by GCP.

First, it formats the log timestamp field to the correct format recognized by Fluent-Bit (component of Google Cloud Logging) and Google Ops Agent. I'm not sure how it worked before, probably it didn't, but Google Cloud Logging [expects timestampSecond + timestampNanos format](https://cloud.google.com/logging/docs/agent/logging/configuration#timestamp-processing). Ops Agent, which also can be used to feed the logs from external Log4J environment via Socket or RollingFile into GCP, [also expects the same format](https://cloud.google.com/logging/docs/agent/ops-agent/configuration#special-fields). More over, the same [timestamp format is always used in Spring GCP libraries](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/cabb7a59fa6d49d280dd311a7f59ec4d922300e7/spring-cloud-gcp-logging/src/main/java/com/google/cloud/spring/logging/StackdriverJsonLayout.java#L270-L278).

Secondly, severity field now must be prefixed with `logging.googleapis.com`. I'm not 100% sure regarding this, because Spring GCP libraries are still using just `severity` field name. However Ops Agent (link above) already uses `logging.googleapis.com/severity`, and simple `severity` name is only described in legacy logging agent which is deprecated.

Third, counter cannot be used for `logging.googleapis.com/insertId` as it is duplicated on different threads. I've chosen to use time-based UUID, but if that increases garbage collection issues it safely can be removed. GCP will generate their own IDs anyway.

And the last but not the least, I have renamed `exception`, `thread` and `logger` fields. I saw the PR discussion in https://github.com/apache/logging-log4j2/pull/543, however these fields are pretty standard when logging via [Logback's JSON layout](https://github.com/qos-ch/logback-contrib/blob/c68c2e5ddc0ed589b0f1e24bac7b9300a0ea5153/json/classic/src/main/java/ch/qos/logback/contrib/json/classic/JsonLayout.java#L105-L113) and then they are reused in Google's Spring GCP libraries. Sadly, I didn't find how to completely remove `exception` field from JSON output if it's empty. Looks like all empty fields are removed except for `pattern` type. I also found https://issues.apache.org/jira/browse/LOG4J2-3053 regarding that, but not sure about its state. This is not a big issue but is preferable for GCP.
By the way, Log4J docs are a little bit incorrect. If `message` field exist, having separate `exception` does nothing to catch the error in Google Error Reporting. According to [Google docs](https://cloud.google.com/error-reporting/docs/formatting-error-messages#format-log-entry), if `message` field exist it must contain stack trace and only that stack trace is used in the Error Reporting UI. I tested this extensively. But I left separate `exception` field if one wants to filter it in the logs.

All in all, this should provide much better JSON field mapping experience on GCP. If you think this PR is usable I then will go ahead and fix tests for timestamp processing.
