### PR TITLE
Update pattern logger precision  example and description

### DIFF
--- a/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
@@ -912,7 +912,7 @@ A logger conversion specifier can be optionally followed by a _precision specifi
 If the number is positive, the layout prints the corresponding number of the rightmost logger name components.
 If negative, the layout removes the corresponding number of leftmost logger name components.
 * If the precision contains periods then the number before the period identifies the length to be printed from items that precede the matching period in the logger name.
-An asterix can be used as a wildecard to print the whole logger name component before a period. 
+An asterisk can be used as a wildcard to print the whole logger name component before a period. 
 * If the precision contains any non-integer characters, then the layout abbreviates the name based on the pattern.
 If the precision integer is less than one, the layout still prints the right-most token in full.
 

--- a/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
@@ -911,8 +911,8 @@ A logger conversion specifier can be optionally followed by a _precision specifi
 * When the precision specifier is an integer value, it reduces the size of the logger name.
 If the number is positive, the layout prints the corresponding number of the rightmost logger name components.
 If negative, the layout removes the corresponding number of leftmost logger name components.
-* If the precision contains periods then the number before the first period identifies the length to be printed from items that precede tokens in the rest of the pattern.
-If the number after the first period is followed by an asterisk it indicates how many of the rightmost tokens will be printed in full.
+* If the precision contains periods then the number before the period identifies the length to be printed from items that precede the matching period in the logger name.
+An asterix can be used as a wildecard to print the whole logger name component before a period. 
 * If the precision contains any non-integer characters, then the layout abbreviates the name based on the pattern.
 If the precision integer is less than one, the layout still prints the right-most token in full.
 
@@ -966,15 +966,19 @@ See the table below for abbreviation examples:
 
 |%c{1.2.*}
 |org.apache.commons.test.Foo
-|o.a.c.test.Foo
+|o.ap.common.test.Foo
 
 |%c{1.3.*}
 |org.apache.commons.test.Foo
-|o.a.commons.test.Foo
+|o.apa.commons.test.Foo
 
 |%c{1.8.*}
 |org.apache.commons.test.Foo
+|o.apache.commons.test.Foo
+
+|%c{1.*.1}
 |org.apache.commons.test.Foo
+|o.apache.c.test.Foo
 |===
 
 [#converter-marker]


### PR DESCRIPTION
The description of the logger precision using periods was confusing and the examples were wrong. This commit fixes the description, the wrong examples and adds one more example for clarification.


I was confused by the examples and after trying them in my own implementation it turns out that using periods in the precision pattern for the logger is straight forward but differs from the examples documented here. I did not test every precision value, only periods with asteri

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
