### PR TITLE
Fix `SEI MET07-J` violations

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -75,9 +75,9 @@ github:
         checks:
           # The GitHub Actions app: 15368
           - app_id: 15368
-            context: "build"
+            context: "build / build (ubuntu-latest)"
           - app_id: 15368
-            context: "codeql-analysis"
+            context: "analyze / Analyze"
       # At least one positive review must be present
       required_pull_request_reviews:
         required_approving_review_count: 1

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/Hierarchy.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/Hierarchy.java
@@ -16,6 +16,7 @@
  */
 package org.apache.log4j;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Vector;
@@ -79,10 +80,16 @@ public class Hierarchy implements LoggerRepository, RendererSupport, ThrowableRe
     private static class PrivateLogManager extends org.apache.logging.log4j.LogManager {
         private static final String FQCN = Hierarchy.class.getName();
 
+        @SuppressFBWarnings(
+                value = "HSM_HIDING_METHOD",
+                justification = "The class is private, no confusion can arise.")
         public static LoggerContext getContext() {
             return getContext(FQCN, false);
         }
 
+        @SuppressFBWarnings(
+                value = "HSM_HIDING_METHOD",
+                justification = "The class is private, no confusion can arise.")
         public static org.apache.logging.log4j.Logger getLogger(final String name) {
             return getLogger(FQCN, name);
         }

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/LogEventAdapter.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/bridge/LogEventAdapter.java
@@ -37,7 +37,7 @@ import org.apache.logging.log4j.util.Strings;
  */
 public class LogEventAdapter extends LoggingEvent {
 
-    private static final long JVM_START_TIME = initStartTime();
+    public static final long JVM_START_TIME = initStartTime();
 
     private final LogEvent event;
 
@@ -50,7 +50,7 @@ public class LogEventAdapter extends LoggingEvent {
      * elapsed since 01.01.1970.
      * @return the time when the JVM started.
      */
-    public static long getStartTime() {
+    public static long getJvmStartTime() {
         return JVM_START_TIME;
     }
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/UtilLoggingLevel.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/UtilLoggingLevel.java
@@ -18,6 +18,7 @@ package org.apache.log4j.helpers;
 
 import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.log4j.Level;
@@ -157,6 +158,7 @@ public class UtilLoggingLevel extends Level {
      * @param val numeric value.
      * @return matching level or UtilLoggerLevel.FINEST if no match.
      */
+    @SuppressFBWarnings(value = "HSM_HIDING_METHOD", justification = "Legacy code")
     public static Level toLevel(final int val) {
         return toLevel(val, FINEST);
     }
@@ -184,6 +186,7 @@ public class UtilLoggingLevel extends Level {
      * @param s symbolic name.
      * @return matching level or Level.DEBUG if no match.
      */
+    @SuppressFBWarnings(value = "HSM_HIDING_METHOD", justification = "Legacy code")
     public static Level toLevel(final String s) {
         return toLevel(s, Level.DEBUG);
     }
@@ -195,6 +198,7 @@ public class UtilLoggingLevel extends Level {
      * @param defaultLevel level to return if no match.
      * @return matching level or defaultLevel if no match.
      */
+    @SuppressFBWarnings(value = "HSM_HIDING_METHOD", justification = "Legacy code")
     public static Level toLevel(final String sArg, final Level defaultLevel) {
         if (sArg == null) {
             return defaultLevel;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/helpers/package-info.java
@@ -18,7 +18,7 @@
  * Log4j 1.x compatibility layer.
  */
 @Export
-@Version("2.20.2")
+@Version("2.20.3")
 package org.apache.log4j.helpers;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/spi/LoggingEvent.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/spi/LoggingEvent.java
@@ -35,7 +35,7 @@ public class LoggingEvent {
      * @return the JVM start time.
      */
     public static long getStartTime() {
-        return LogEventAdapter.getStartTime();
+        return LogEventAdapter.getJvmStartTime();
     }
 
     /**

--- a/log4j-appserver/src/main/java/org/apache/logging/log4j/appserver/jetty/Log4j2Logger.java
+++ b/log4j-appserver/src/main/java/org/apache/logging/log4j/appserver/jetty/Log4j2Logger.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.appserver.jetty;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.spi.ExtendedLogger;
@@ -51,6 +52,7 @@ public class Log4j2Logger extends AbstractLogger {
      */
     private static class PrivateManager extends LogManager {
 
+        @SuppressFBWarnings("HSM_HIDING_METHOD")
         public static LoggerContext getContext() {
             final ClassLoader cl = AbstractLogger.class.getClassLoader();
             return getContext(PARENT_FQCN, cl, false);

--- a/log4j-appserver/src/main/java/org/apache/logging/log4j/appserver/tomcat/TomcatLogger.java
+++ b/log4j-appserver/src/main/java/org/apache/logging/log4j/appserver/tomcat/TomcatLogger.java
@@ -18,6 +18,7 @@ package org.apache.logging.log4j.appserver.tomcat;
 
 import aQute.bnd.annotation.Resolution;
 import aQute.bnd.annotation.spi.ServiceProvider;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -163,6 +164,7 @@ public class TomcatLogger implements Log {
      */
     private static class PrivateManager extends LogManager {
 
+        @SuppressFBWarnings("HSM_HIDING_METHOD")
         public static LoggerContext getContext() {
             final ClassLoader cl = TomcatLogger.class.getClassLoader();
             URI uri = null;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/AsyncLoggerConfig.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.core.async;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -90,7 +91,7 @@ public class AsyncLoggerConfig extends LoggerConfig {
                     isAdditivity(),
                     getProperties(),
                     getConfig(),
-                    includeLocation(getIncludeLocation()));
+                    shouldIncludeLocation(getIncludeLocation()));
         }
     }
 
@@ -273,7 +274,14 @@ public class AsyncLoggerConfig extends LoggerConfig {
         final boolean additive = Booleans.parseBoolean(additivity, true);
 
         return new AsyncLoggerConfig(
-                name, appenderRefs, filter, level, additive, properties, config, includeLocation(includeLocation));
+                name,
+                appenderRefs,
+                filter,
+                level,
+                additive,
+                properties,
+                config,
+                shouldIncludeLocation(includeLocation));
     }
 
     /**
@@ -291,6 +299,7 @@ public class AsyncLoggerConfig extends LoggerConfig {
      * @since 3.0
      */
     @Deprecated
+    @SuppressFBWarnings("HSM_HIDING_METHOD")
     public static LoggerConfig createLogger(
             @PluginAttribute(value = "additivity", defaultBoolean = true) final boolean additivity,
             @PluginAttribute("level") final Level level,
@@ -310,11 +319,20 @@ public class AsyncLoggerConfig extends LoggerConfig {
                 additivity,
                 properties,
                 config,
-                includeLocation(includeLocation));
+                shouldIncludeLocation(includeLocation));
+    }
+
+    /**
+     * @deprecated since 2.25.0. The method will become private in version 3.0.
+     */
+    @Deprecated
+    @SuppressFBWarnings(value = "HSM_HIDING_METHOD", justification = "Should be private.")
+    protected static boolean includeLocation(final String includeLocationConfigValue) {
+        return shouldIncludeLocation(includeLocationConfigValue);
     }
 
     // Note: for asynchronous loggers, includeLocation default is FALSE
-    protected static boolean includeLocation(final String includeLocationConfigValue) {
+    private static boolean shouldIncludeLocation(final String includeLocationConfigValue) {
         return Boolean.parseBoolean(includeLocationConfigValue);
     }
 
@@ -343,7 +361,7 @@ public class AsyncLoggerConfig extends LoggerConfig {
                         isAdditivity(),
                         getProperties(),
                         getConfig(),
-                        AsyncLoggerConfig.includeLocation(getIncludeLocation()));
+                        shouldIncludeLocation(getIncludeLocation()));
             }
         }
 
@@ -376,7 +394,7 @@ public class AsyncLoggerConfig extends LoggerConfig {
                     additive,
                     properties,
                     config,
-                    AsyncLoggerConfig.includeLocation(includeLocation));
+                    shouldIncludeLocation(includeLocation));
         }
 
         /**
@@ -402,7 +420,7 @@ public class AsyncLoggerConfig extends LoggerConfig {
                     additive,
                     properties,
                     config,
-                    AsyncLoggerConfig.includeLocation(includeLocation));
+                    shouldIncludeLocation(includeLocation));
         }
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/MainMapLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/MainMapLookup.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.core.lookup;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
@@ -74,6 +75,9 @@ public class MainMapLookup extends MapLookup {
      * @param args
      *        An application's {@code public static main(String[])} arguments.
      */
+    @SuppressFBWarnings(
+            value = "HSM_HIDING_METHOD",
+            justification = "The MapLookup.setMainArguments() method hidden by this one is deprecated.")
     public static void setMainArguments(final String... args) {
         if (args == null) {
             return;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/package-info.java
@@ -21,7 +21,7 @@
  * {@link org.apache.logging.log4j.core.lookup.StrLookup#CATEGORY Lookup}.
  */
 @Export
-@Version("2.24.0")
+@Version("2.24.1")
 package org.apache.logging.log4j.core.lookup;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/ExceptionResolver.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/ExceptionResolver.java
@@ -387,10 +387,6 @@ public class ExceptionResolver implements EventResolver {
         return logEvent.getThrown();
     }
 
-    static String getName() {
-        return "exception";
-    }
-
     @Override
     public boolean isResolvable() {
         return stackTraceEnabled;

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/ExceptionResolverFactory.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/ExceptionResolverFactory.java
@@ -36,7 +36,7 @@ public final class ExceptionResolverFactory implements EventResolverFactory {
 
     @Override
     public String getName() {
-        return ExceptionResolver.getName();
+        return "exception";
     }
 
     @Override

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/ExceptionRootCauseResolver.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/ExceptionRootCauseResolver.java
@@ -36,10 +36,6 @@ public final class ExceptionRootCauseResolver extends ExceptionResolver {
         super(context, config);
     }
 
-    static String getName() {
-        return "exceptionRootCause";
-    }
-
     @Override
     Throwable extractThrowable(final LogEvent logEvent) {
         final Throwable thrown = logEvent.getThrown();

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/ExceptionRootCauseResolverFactory.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/resolver/ExceptionRootCauseResolverFactory.java
@@ -36,7 +36,7 @@ public final class ExceptionRootCauseResolverFactory implements EventResolverFac
 
     @Override
     public String getName() {
-        return ExceptionRootCauseResolver.getName();
+        return "exceptionRootCause";
     }
 
     @Override

--- a/src/changelog/.2.x.x/3601_deprecate_or_remove_hiding_methods.xml
+++ b/src/changelog/.2.x.x/3601_deprecate_or_remove_hiding_methods.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3601" link="https://github.com/apache/logging-log4j2/issues/3601"/>
+  <description format="asciidoc">
+    Deprecate or remove static hiding methods.
+  </description>
+</entry>


### PR DESCRIPTION
This change:

- Deprecates public/protected hiding methods.
- Removes package-private hiding methods.
- For legacy modules that will disappear in 3.x, just suppresses the warning.

Closes #3601

