### PR TITLE
Fix Sponsors buttons

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -19,5 +19,7 @@
 # For details see:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
 #
+# WARNING: the `github` key accepts only 4 GitHub user ids, so we can not use this feature.
+#
 custom: "https://logging.apache.org/support.html#sponsors"
 tidelift: "maven/org.apache.logging.log4j:log4j-core"

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -19,12 +19,5 @@
 # For details see:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
 #
-# This list includes in the same order, committers of Log4j listed on:
-# https://logging.apache.org/support.html#sponsors
-github:
-  - carterkozak
-  - garydgregory
-  - jvz
-  - ppkarwasz
-  - rgoers
-  - vy
+custom: "https://logging.apache.org/support.html#sponsors"
+tidelift: "maven/org.apache.logging.log4j:log4j-core"


### PR DESCRIPTION
Due to limitations in the number of GitHub Sponsors buttons (there can be only up to 4 buttons), part of the team is ignored.

This replaces the buttons with our "Sponsorship" page and a button to sponsor `log4j-core` via Tidelift.
The end result can be seen [on my fork](https://github.com/ppkarwasz/logging-log4j2).
