### PR TITLE
doc(architecture): update the ordering of vertical and horizontal headers in the statement

### DIFF
--- a/src/site/antora/modules/ROOT/pages/manual/architecture.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/architecture.adoc
@@ -281,8 +281,8 @@ it doesn't have a LoggerConfig with a name that exactly matches. It too
 inherits its logging level from LoggerConfig X.
 
 The table below illustrates how Level filtering works. In the table,
-the vertical header shows the Level of the LogEvent, while the horizontal
-header shows the Level associated with the appropriate LoggerConfig. The
+the vertical header shows the Level associated with the appropriate LoggerConfig, while the horizontal
+header shows the Level of the LogEvent. The
 intersection identifies whether the LogEvent would be allowed to pass
 for further processing (Yes) or discarded (No).
 


### PR DESCRIPTION
The line [here](https://logging.apache.org/log4j/3.x/manual/architecture.html#:~:text=In%20the%20table%2C%20the%20vertical%20header%20shows%20the%20Level%20of%20the%20LogEvent%2C%20while%20the%20horizontal%20header%20shows%20the%20Level%20associated%20with%20the%20appropriate%20LoggerConfig.) seems to be incorrect since according to the table vertical headers denote **LoggerConfig** Level while horizontal ones denote **LogEvent** Level.

This MR updates the ordering to correctly explain the table beneath it.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
