### PR TITLE
Prevent NPE with rootLogger shorthand when no appenders are specified

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/LoggerConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/LoggerConfigTest.java
@@ -17,9 +17,11 @@
 package org.apache.logging.log4j.core.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -32,6 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.config.properties.PropertiesConfiguration;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent.Builder;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.junit.jupiter.api.Test;
@@ -136,5 +139,19 @@ class LoggerConfigTest {
         config.log(FQCN, FQCN, null, Level.INFO, new SimpleMessage(), null);
         verify(appender, times(1)).append(any());
         verify(filter, times(1)).filter(any());
+    }
+
+    @Test
+    void testLevelAndRefsWithoutAppenderRef() {
+        final Configuration configuration = mock(PropertiesConfiguration.class);
+        final LoggerConfig.Builder builder = LoggerConfig.newBuilder()
+                .withLoggerName(FQCN)
+                .withConfig(configuration)
+                .withLevelAndRefs(Level.INFO.name());
+
+        final LoggerConfig loggerConfig = builder.build();
+
+        assertNotNull(loggerConfig.getAppenderRefs());
+        assertTrue(loggerConfig.getAppenderRefs().isEmpty());
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -1009,13 +1009,13 @@ public class LoggerConfig extends AbstractFilterable implements LocationAware {
                 }
                 final String[] parts = Strings.splitList(levelAndRefs);
                 result.level = Level.getLevel(parts[0]);
+                final List<AppenderRef> refList = new ArrayList<>();
                 if (parts.length > 1) {
-                    final List<AppenderRef> refList = new ArrayList<>();
                     Arrays.stream(parts)
                             .skip(1)
                             .forEach((ref) -> refList.add(AppenderRef.createAppenderRef(ref, null, null)));
-                    result.refs = refList;
                 }
+                result.refs = refList;
             } else {
                 LOGGER.warn("levelAndRefs are only allowed in a properties configuration. The value is ignored.");
                 result.level = level;

--- a/src/changelog/.2.x.x/3206_fix_rootLogger_shorthand_npe.xml
+++ b/src/changelog/.2.x.x/3206_fix_rootLogger_shorthand_npe.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3206" link="https://github.com/apache/logging-log4j2/issues/3206"/>
+  <description format="asciidoc">
+    Fix NullPointerException when using `rootLogger = LEVEL` shorthand in properties without appender.
+  </description>
+</entry>


### PR DESCRIPTION
This pull request addresses issue #3206, which could lead to a `NullPointerException` when using the shorthand notation for the root logger (e.g., rootLogger = INFO) in `log4j2.properties` without explicitly defining any appender references.

To resolve this, the static helper method `LoggerConfig.getLevelAndRefs()` has been updated to ensure that the `LevelAndRefs` container always holds a non-null list of `AppenderRef` objects. When no appenders are specified in the shorthand string, the method has been updated to return an empty list instead of `null`.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
