### PR TITLE
Handle missing stack traces in ExtendedThreadInformation

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/message/ExtendedThreadInformation.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/message/ExtendedThreadInformation.java
@@ -119,7 +119,7 @@ class ExtendedThreadInformation implements ThreadInformation {
                 break;
             }
             case WAITING: {
-                final StackTraceElement element = info.getStackTrace()[0];
+                final StackTraceElement element = getStackTraceElement(info);
                 final String className = element.getClassName();
                 final String method = element.getMethodName();
                 if (className.equals("java.lang.Object") && method.equals("wait")) {
@@ -144,7 +144,7 @@ class ExtendedThreadInformation implements ThreadInformation {
                 break;
             }
             case TIMED_WAITING: {
-                final StackTraceElement element = info.getStackTrace()[0];
+                final StackTraceElement element = getStackTraceElement(info);
                 final String className = element.getClassName();
                 final String method = element.getMethodName();
                 if (className.equals("java.lang.Object") && method.equals("wait")) {
@@ -173,5 +173,15 @@ class ExtendedThreadInformation implements ThreadInformation {
             default:
                 break;
         }
+    }
+
+    private static StackTraceElement getStackTraceElement(final ThreadInfo info) {
+        final StackTraceElement[] stackTrace = info.getStackTrace();
+        if (stackTrace == null || stackTrace.length < 1) {
+            final String textualInfo = "Unknown";
+            return new StackTraceElement(textualInfo, textualInfo, textualInfo, -1);
+        }
+
+        return stackTrace[0];
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/message/ExtendedThreadInformation.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/message/ExtendedThreadInformation.java
@@ -23,6 +23,7 @@ import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import org.apache.logging.log4j.message.ThreadInformation;
 import org.apache.logging.log4j.util.StringBuilders;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Provides information on locks and monitors in the thread dump. This class requires Java 1.6 to compile and
@@ -119,17 +120,17 @@ class ExtendedThreadInformation implements ThreadInformation {
                 break;
             }
             case WAITING: {
-                final StackTraceElement element = getStackTraceElement(info);
-                final String className = element.getClassName();
-                final String method = element.getMethodName();
-                if (className.equals("java.lang.Object") && method.equals("wait")) {
+                final StackTraceElement element = getFirstStackTraceElement(info);
+                final String className = element != null ? element.getClassName() : null;
+                final String method = element != null ? element.getMethodName() : null;
+                if ("java.lang.Object".equals(className) && "wait".equals(method)) {
                     sb.append(" (on object monitor");
                     if (info.getLockOwnerName() != null) {
                         sb.append(" owned by \"");
                         sb.append(info.getLockOwnerName()).append("\" Id=").append(info.getLockOwnerId());
                     }
                     sb.append(')');
-                } else if (className.equals("java.lang.Thread") && method.equals("join")) {
+                } else if ("java.lang.Thread".equals(className) && "join".equals(method)) {
                     sb.append(" (on completion of thread ")
                             .append(info.getLockOwnerId())
                             .append(')');
@@ -144,19 +145,19 @@ class ExtendedThreadInformation implements ThreadInformation {
                 break;
             }
             case TIMED_WAITING: {
-                final StackTraceElement element = getStackTraceElement(info);
-                final String className = element.getClassName();
-                final String method = element.getMethodName();
-                if (className.equals("java.lang.Object") && method.equals("wait")) {
+                final StackTraceElement element = getFirstStackTraceElement(info);
+                final String className = element != null ? element.getClassName() : null;
+                final String method = element != null ? element.getMethodName() : null;
+                if ("java.lang.Object".equals(className) && "wait".equals(method)) {
                     sb.append(" (on object monitor");
                     if (info.getLockOwnerName() != null) {
                         sb.append(" owned by \"");
                         sb.append(info.getLockOwnerName()).append("\" Id=").append(info.getLockOwnerId());
                     }
                     sb.append(')');
-                } else if (className.equals("java.lang.Thread") && method.equals("sleep")) {
+                } else if ("java.lang.Thread".equals(className) && "sleep".equals(method)) {
                     sb.append(" (sleeping)");
-                } else if (className.equals("java.lang.Thread") && method.equals("join")) {
+                } else if ("java.lang.Thread".equals(className) && "join".equals(method)) {
                     sb.append(" (on completion of thread ")
                             .append(info.getLockOwnerId())
                             .append(')');
@@ -175,13 +176,9 @@ class ExtendedThreadInformation implements ThreadInformation {
         }
     }
 
-    private static StackTraceElement getStackTraceElement(final ThreadInfo info) {
+    @Nullable
+    private static StackTraceElement getFirstStackTraceElement(final ThreadInfo info) {
         final StackTraceElement[] stackTrace = info.getStackTrace();
-        if (stackTrace == null || stackTrace.length < 1) {
-            final String textualInfo = "Unknown";
-            return new StackTraceElement(textualInfo, textualInfo, textualInfo, -1);
-        }
-
-        return stackTrace[0];
+        return stackTrace != null && stackTrace.length > 0 ? stackTrace[0] : null;
     }
 }

--- a/src/changelog/.2.x.x/3655_handle_missing_stack_traces_in_ExtendedThreadInformation.xml
+++ b/src/changelog/.2.x.x/3655_handle_missing_stack_traces_in_ExtendedThreadInformation.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3655" link="https://github.com/apache/logging-log4j2/pull/3655"/>
+  <description format="asciidoc">
+    Fix `ArrayIndexOutOfBoundsException` on invocation of `Message.getFormattedMessage()` when any thread has no stack trace, which occurs on some JVM implementations.
+  </description>
+</entry>


### PR DESCRIPTION
Fix `ArrayIndexOutOfBoundsException` on invocation of `Message.getFormattedMessage()` when any thread has no stack trace, which occurs on some JVM implementations.

See issue: #3214 

The mentioned method retrieves detail information about all existing threads and collects it in a result string. One of the information are the stack traces. Some JVM implementations (such as OpenJ9) have an empty stack trace of threads in a specific state. This, in turn, results in a `ArrayIndexOutOfBoundsException` if the user tries to dump all thread information via `org.apache.logging.log4j.message.ThreadDumpMessage.ThreadDumpMessage(String)`.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
