### PR TITLE
Add Max Base as collaborator

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -55,6 +55,9 @@ github:
     - logger
     - api
     - syslog
+  # People helping with triaging and Project Management
+  collaborators:
+    - basemax
 
   # Enforce squashing while merging PRs.
   # Otherwise, the git log gets polluted severely.


### PR DESCRIPTION
I propose to add @basemax as collaborator, to help with bug triage and project management.
Max is a very prolific Open Source contributor and have helped many projects (see [his profile](https://github.com/basemax)).

**Note**: To prevent misunderstandings, "contributor" is not the same thing as "committer" and IMHO this PR does not require a PMC vote.
