### PR TITLE
StatusLogger: Write to stderr by default

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/status/StatusLoggerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StatusLoggerTest {
+    private final PrintStream origOut = System.out;
+    private final PrintStream origErr = System.err;
+    private ByteArrayOutputStream outBuf;
+    private ByteArrayOutputStream errBuf;
+
+    @BeforeEach
+    void setupStreams() {
+        outBuf = new ByteArrayOutputStream();
+        errBuf = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(outBuf));
+        System.setErr(new PrintStream(errBuf));
+    }
+
+    @AfterEach
+    void resetStreams() {
+        System.setOut(origOut);
+        System.setErr(origErr);
+    }
+
+    @Test
+    void status_logger_writes_to_stderr_by_default() {
+        StatusLogger statusLogger = new StatusLogger();
+        statusLogger.error("Test message");
+
+        assertEquals("", outBuf.toString());
+        assertThat(errBuf.toString()).contains("Test message");
+    }
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/status/StatusLogger.java
@@ -531,7 +531,7 @@ public class StatusLogger extends AbstractLogger {
                 StatusLogger.class.getSimpleName(),
                 ParameterizedNoReferenceMessageFactory.INSTANCE,
                 Config.getInstance(),
-                new StatusConsoleListener(requireNonNull(Config.getInstance().fallbackListenerLevel)));
+                new StatusConsoleListener(requireNonNull(Config.getInstance().fallbackListenerLevel), System.err));
     }
 
     /**

--- a/src/changelog/.2.x.x/3665_fix_StatusLogger_writing_to_stdout.xml
+++ b/src/changelog/.2.x.x/3665_fix_StatusLogger_writing_to_stdout.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3665" link="https://github.com/apache/logging-log4j2/issues/3665"/>
+  <description format="asciidoc">
+    StatusLogger now writes to standard error by default. This fixes a regression introduced in 2.23.0.
+  </description>
+</entry>


### PR DESCRIPTION
`StatusLogger` messages used to be written to stderr by default. Since 2.23.0, they are being written to stdout. This is a significant regression. As a rule, stderr is for humans, and stdout is for programs. The pipe operator redirects stdout by default, and a CLI utility can have its output corrupted because Log4j2 emitted a status message to stdout. For example, consider a program that emits JSON and has its output piped to `jq`: after upgrading to Log4j 2.23.0 or later, this program will cease to work correctly unless the StatusLogger is reconfigured to not emit anything, or is explicitly configured to write to stderr.

This regression can be fixed by calling the two-parameter constructor variant of `StatusConsoleListener` from `StatusLogger`. A simple test case has been added that captures stdout/stderr and ensures that the default `StatusLogger` is not emitting anything to stdout.

Fixes #3665.