### PR TITLE
Removes deprecated `github.del_branch_on_merge` setting

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -40,7 +40,6 @@ github:
     issues: true
     discussions: true
     projects: true
-  del_branch_on_merge: true
   autolink_jira:
     - LOG4J2
   labels:


### PR DESCRIPTION
The `github.del_branch_on_merge` setting was renamed to `github.pull_requests.del_branch_on_merge`, which causes an error message:

> An error occurred while processing the github feature in .asf.yaml: 
>
> found legacy setting 'github.del_branch_on_merge' while 'github.pull_requests' is present. Move setting to 'github.pull_requests'