### PR TITLE
Expunge stale entries in InternalLoggerRegistry

### DIFF
--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/util/InternalLoggerRegistryGCTest.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/util/InternalLoggerRegistryGCTest.java
@@ -16,7 +16,12 @@
  */
 package org.apache.logging.log4j.core.test.util;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.CountDownLatch;

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/util/InternalLoggerRegistryGCTest.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/util/InternalLoggerRegistryGCTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.test.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.util.internal.InternalLoggerRegistry;
+import org.apache.logging.log4j.message.MessageFactory;
+import org.apache.logging.log4j.message.SimpleMessageFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InternalLoggerRegistryTest {
+    private InternalLoggerRegistry registry;
+    private MessageFactory messageFactory;
+
+    @BeforeEach
+    void setUp() {
+        registry = new InternalLoggerRegistry();
+        messageFactory = new SimpleMessageFactory();
+    }
+
+    @Test
+    void testGetLoggerReturnsNullForNonExistentLogger() {
+        assertNull(registry.getLogger("nonExistent", messageFactory));
+    }
+
+    @Test
+    void testComputeIfAbsentCreatesLogger() {
+        Logger logger =
+                registry.computeIfAbsent("testLogger", messageFactory, (name, factory) -> LoggerContext.getContext()
+                        .getLogger(name, factory));
+        assertNotNull(logger);
+        assertEquals("testLogger", logger.getName());
+    }
+
+    @Test
+    void testGetLoggerRetrievesExistingLogger() {
+        Logger logger =
+                registry.computeIfAbsent("testLogger", messageFactory, (name, factory) -> LoggerContext.getContext()
+                        .getLogger(name, factory));
+        assertSame(logger, registry.getLogger("testLogger", messageFactory));
+    }
+
+    @Test
+    void testHasLoggerReturnsCorrectStatus() {
+        assertFalse(registry.hasLogger("testLogger", messageFactory));
+        registry.computeIfAbsent("testLogger", messageFactory, (name, factory) -> LoggerContext.getContext()
+                .getLogger(name, factory));
+        assertTrue(registry.hasLogger("testLogger", messageFactory));
+    }
+
+    @Test
+    void testExpungeStaleEntriesRemovesGarbageCollectedLoggers() throws InterruptedException {
+        Logger logger =
+                registry.computeIfAbsent("testLogger", messageFactory, (name, factory) -> LoggerContext.getContext()
+                        .getLogger(name, factory));
+
+        WeakReference<Logger> weakRef = new WeakReference<>(logger);
+        logger = null; // Dereference to allow GC
+
+        // Retry loop to give GC time to collect
+        for (int i = 0; i < 10; i++) {
+            System.gc();
+            Thread.sleep(100);
+            if (weakRef.get() == null) {
+                break;
+            }
+        }
+
+        // Access the registry to potentially trigger cleanup
+        registry.computeIfAbsent("tempLogger", messageFactory, (name, factory) -> LoggerContext.getContext()
+                .getLogger(name, factory));
+
+        assertNull(weakRef.get(), "Logger should have been garbage collected");
+        assertNull(
+                registry.getLogger("testLogger", messageFactory), "Stale logger should be removed from the registry");
+    }
+
+    @Test
+    void testConcurrentAccess() throws InterruptedException {
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                registry.computeIfAbsent("testLogger", messageFactory, (name, factory) -> LoggerContext.getContext()
+                        .getLogger(name, factory));
+                latch.countDown();
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        // Verify logger was created and is accessible after concurrent creation
+        assertNotNull(
+                registry.getLogger("testLogger", messageFactory),
+                "Logger should be accessible after concurrent creation");
+    }
+}

--- a/src/changelog/.2.x.x/3430_InternalLoggerRegistry_stale_entry_expunge.xml
+++ b/src/changelog/.2.x.x/3430_InternalLoggerRegistry_stale_entry_expunge.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <issue id="3430" link="https://github.com/apache/logging-log4j2/issues/3430"/>
+    <issue id="3681" link="https://github.com/apache/logging-log4j2/pull/3681"/>
+    <description format="asciidoc">
+        Improved expunging of stale entries in `InternalLoggerRegistry` to prevent potential memory leaks
+    </description>
+</entry>


### PR DESCRIPTION
This pull request addresses issue #3430 by implementing a mechanism to expunge stale entries in `InternalLoggerRegistry`. 

It builds upon PR #3474 and incorporates feedback from @vy and @ppkarwasz.

Key changes include:
*   **Enabled stale entry detection via `ReferenceQueue`**: When a `Logger` is GC'd, its `WeakReference` is enqueued. Subsequent calls to methods like `getLogger()` or `computeIfAbsent()` trigger `expungeStaleEntries()` to process it.
*   **Implemented `expungeStaleEntries` logic**: If the `ReferenceQueue` is not empty, a write lock is acquired, the queue is drained, and map entries are scanned once to remove `WeakReferences` with null referents and clean up any empty maps. No action or locking occurs if the queue is initially empty.
*   **Added unit tests**: Verified the expunging mechanism under various conditions, including GC scenarios and concurrent access.

@vy, `ReferenceQueue` has no `peek()`/`isEmpty()`, so I couldn’t do a proper double-check and used an initial `poll()` instead. Feedback is welcome if there's a better way or if I missed something. Thanks!

Fixes #3430