### PR TITLE
Have org.apache.logging.log4j.util.Base64Util invoke java.util.Base64…

### DIFF
--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Base64Util.java
@@ -16,11 +16,8 @@
  */
 package org.apache.logging.log4j.util;
 
-import java.lang.reflect.Method;
 import java.nio.charset.Charset;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LoggingException;
-import org.apache.logging.log4j.status.StatusLogger;
+import java.util.Base64;
 
 /**
  * Base64 encodes Strings. This utility is only necessary because the mechanism to do this changed in Java 8 and
@@ -30,27 +27,7 @@ import org.apache.logging.log4j.status.StatusLogger;
  */
 public final class Base64Util {
 
-    private static final Logger LOGGER = StatusLogger.getLogger();
-
-    private static Method encodeMethod = null;
-    private static Object encoder = null;
-
-    static {
-        try {
-            final Class<?> clazz = LoaderUtil.loadClass("java.util.Base64");
-            final Class<?> encoderClazz = LoaderUtil.loadClass("java.util.Base64$Encoder");
-            final Method method = clazz.getMethod("getEncoder");
-            encoder = method.invoke(null);
-            encodeMethod = encoderClazz.getMethod("encodeToString", byte[].class);
-        } catch (Exception ex) {
-            try {
-                final Class<?> clazz = LoaderUtil.loadClass("javax.xml.bind.DataTypeConverter");
-                encodeMethod = clazz.getMethod("printBase64Binary");
-            } catch (Exception ex2) {
-                LOGGER.error("Unable to create a Base64 Encoder", ex2);
-            }
-        }
-    }
+    private static final Base64.Encoder ENCODER = Base64.getEncoder();
 
     private Base64Util() {}
 
@@ -60,17 +37,6 @@ public final class Base64Util {
      */
     @Deprecated
     public static String encode(final String str) {
-        if (str == null) {
-            return null;
-        }
-        final byte[] data = str.getBytes(Charset.defaultCharset());
-        if (encodeMethod != null) {
-            try {
-                return (String) encodeMethod.invoke(encoder, data);
-            } catch (Exception ex) {
-                throw new LoggingException("Unable to encode String", ex);
-            }
-        }
-        throw new LoggingException("No Encoder, unable to encode string");
+        return str != null ? ENCODER.encodeToString(str.getBytes(Charset.defaultCharset())) : null;
     }
 }

--- a/src/changelog/.2.x.x/3686_invoke_java_util_base64_directly_instead_of_reflectively.xml
+++ b/src/changelog/.2.x.x/3686_invoke_java_util_base64_directly_instead_of_reflectively.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="3686" link="https://github.com/apache/logging-log4j2/issues/3686"/>
+  <description format="asciidoc">Have org.apache.logging.log4j.util.Base64Util invoke java.util.Base64 directly instead of reflectively.</description>
+</entry>


### PR DESCRIPTION
… directly instead of reflectively (#3686)

This pull request fixes issue #3686 by having `org.apache.logging.log4j.util.Base64Util` invoke `java.util.Base64` directly instead of reflectively. This avoids the need to use `javax.xml.bind.DataTypeConverter` as a fallback, which has been problematic because it is not Jakarta EE9 compliant.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds (if it fails due to code formatting issues reported by Spotless, simply run `./mvnw spotless:apply` and retry)
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests for the changes are provided
* [Commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (optional, but highly recommended)
