### PR TITLE
Enforce explicit names for global scripts and refine script id handling

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ScriptsPluginTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ScriptsPluginTest.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.core.config;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -28,18 +27,18 @@ import org.junit.jupiter.api.Test;
 class ScriptsPluginTest {
 
     @Test
-    public void testCreateScriptsNullInput() {
-        assertNull(ScriptsPlugin.createScripts(null), "Should return null");
+    void testCreateScriptsNullInput() {
+        assertThrows(NullPointerException.class, () -> ScriptsPlugin.createScripts(null));
     }
 
     @Test
-    public void testCreateScriptsEmptyInput() {
+    void testCreateScriptsEmptyInput() {
         AbstractScript[] emptyArray = new AbstractScript[0];
         assertSame(emptyArray, ScriptsPlugin.createScripts(emptyArray), "Should return empty array");
     }
 
     @Test
-    public void testCreateScriptsAllExplicitNames() {
+    void testCreateScriptsAllExplicitNames() {
         AbstractScript script1 = new MockScript("script1", "JavaScript", "text");
         AbstractScript script2 = new MockScript("script2", "Groovy", "text");
         AbstractScript[] input = {script1, script2};
@@ -49,21 +48,21 @@ class ScriptsPluginTest {
     }
 
     @Test
-    public void testCreateScriptsImplicitName() {
+    void testCreateScriptsImplicitName() {
         AbstractScript script = new MockScript(null, "JavaScript", "text");
         AbstractScript[] input = {script};
         assertThrows(ConfigurationException.class, () -> ScriptsPlugin.createScripts(input));
     }
 
     @Test
-    public void testCreateScriptsBlankName() {
+    void testCreateScriptsBlankName() {
         AbstractScript script = new MockScript("  ", "JavaScript", "text");
         AbstractScript[] input = {script};
         assertThrows(ConfigurationException.class, () -> ScriptsPlugin.createScripts(input));
     }
 
     @Test
-    public void testCreateScriptsMixedExplicitAndImplicitNames() {
+    void testCreateScriptsMixedExplicitAndImplicitNames() {
         AbstractScript explicitScript = new MockScript("script", "Python", "text");
         AbstractScript implicitScript = new MockScript(null, "JavaScript", "text");
         AbstractScript[] input = {explicitScript, implicitScript};

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ScriptsPluginTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ScriptsPluginTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.config;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.logging.log4j.core.script.AbstractScript;
+import org.junit.jupiter.api.Test;
+
+class ScriptsPluginTest {
+
+    @Test
+    public void testCreateScriptsNullInput() {
+        assertNull(ScriptsPlugin.createScripts(null), "Should return null");
+    }
+
+    @Test
+    public void testCreateScriptsEmptyInput() {
+        AbstractScript[] emptyArray = new AbstractScript[0];
+        assertSame(emptyArray, ScriptsPlugin.createScripts(emptyArray), "Should return empty array");
+    }
+
+    @Test
+    public void testCreateScriptsAllExplicitNames() {
+        AbstractScript script1 = new MockScript("script1", "JavaScript", "text");
+        AbstractScript script2 = new MockScript("script2", "Groovy", "text");
+        AbstractScript[] input = {script1, script2};
+        AbstractScript[] result = ScriptsPlugin.createScripts(input);
+        assertEquals(2, result.length, "Should return 2 scripts");
+        assertArrayEquals(input, result, "Should contain all valid scripts");
+    }
+
+    @Test
+    public void testCreateScriptsImplicitName() {
+        AbstractScript script = new MockScript(null, "JavaScript", "text");
+        AbstractScript[] input = {script};
+        assertThrows(ConfigurationException.class, () -> ScriptsPlugin.createScripts(input));
+    }
+
+    @Test
+    public void testCreateScriptsBlankName() {
+        AbstractScript script = new MockScript("  ", "JavaScript", "text");
+        AbstractScript[] input = {script};
+        assertThrows(ConfigurationException.class, () -> ScriptsPlugin.createScripts(input));
+    }
+
+    @Test
+    public void testCreateScriptsMixedExplicitAndImplicitNames() {
+        AbstractScript explicitScript = new MockScript("script", "Python", "text");
+        AbstractScript implicitScript = new MockScript(null, "JavaScript", "text");
+        AbstractScript[] input = {explicitScript, implicitScript};
+        assertThrows(ConfigurationException.class, () -> ScriptsPlugin.createScripts(input));
+    }
+
+    private class MockScript extends AbstractScript {
+
+        public MockScript(String name, String language, String scriptText) {
+            super(name, language, scriptText);
+        }
+    }
+}

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/script/AbstractScriptTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/script/AbstractScriptTest.java
@@ -17,6 +17,7 @@
 package org.apache.logging.log4j.core.script;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ import org.junit.jupiter.api.Test;
 class AbstractScriptTest {
 
     @Test
-    public void testConstructorAndGettersWithExplicitName() {
+    void testConstructorAndGettersWithExplicitName() {
         final String lang = "JavaScript";
         final String text = "text";
         final String name = "script";
@@ -37,7 +38,7 @@ class AbstractScriptTest {
     }
 
     @Test
-    public void testConstructorAndGettersWithImplicitName() {
+    void testConstructorAndGettersWithImplicitName() {
         final String lang = "JavaScript";
         final String text = "text";
         final AbstractScript script = new MockScript(null, lang, text);
@@ -45,11 +46,11 @@ class AbstractScriptTest {
         assertEquals(lang, script.getLanguage(), "Language should match");
         assertEquals(text, script.getScriptText(), "Script text should match");
         assertNull(script.getName(), "Name should be null");
-        assertEquals(script.toString(), script.getId(), "Id should match its toString()");
+        assertNotNull(script.getId(), "Id should not be null");
     }
 
     @Test
-    public void testConstructorAndGettersWithBlankName() {
+    void testConstructorAndGettersWithBlankName() {
         final String lang = "JavaScript";
         final String text = "text";
         final String name = "  ";
@@ -58,7 +59,7 @@ class AbstractScriptTest {
         assertEquals(lang, script.getLanguage(), "Language should match");
         assertEquals(text, script.getScriptText(), "Script text should match");
         assertEquals(name, script.getName(), "Name should be blank");
-        assertEquals(script.toString(), script.getId(), "Id should match its toString()");
+        assertNotNull(script.getId(), "Id should not be null");
     }
 
     private class MockScript extends AbstractScript {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/script/AbstractScriptTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/script/AbstractScriptTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.script;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+class AbstractScriptTest {
+
+    @Test
+    public void testConstructorAndGettersWithExplicitName() {
+        final String lang = "JavaScript";
+        final String text = "text";
+        final String name = "script";
+        final AbstractScript script = new MockScript(name, lang, text);
+
+        assertEquals(lang, script.getLanguage(), "Language should match");
+        assertEquals(text, script.getScriptText(), "Script text should match");
+        assertEquals(name, script.getName(), "Name should match the provided name");
+        assertEquals(name, script.getId(), "Id should match the provided name");
+    }
+
+    @Test
+    public void testConstructorAndGettersWithImplicitName() {
+        final String lang = "JavaScript";
+        final String text = "text";
+        final AbstractScript script = new MockScript(null, lang, text);
+
+        assertEquals(lang, script.getLanguage(), "Language should match");
+        assertEquals(text, script.getScriptText(), "Script text should match");
+        assertNull(script.getName(), "Name should be null");
+        assertEquals(script.toString(), script.getId(), "Id should match its toString()");
+    }
+
+    @Test
+    public void testConstructorAndGettersWithBlankName() {
+        final String lang = "JavaScript";
+        final String text = "text";
+        final String name = "  ";
+        final AbstractScript script = new MockScript(name, lang, text);
+
+        assertEquals(lang, script.getLanguage(), "Language should match");
+        assertEquals(text, script.getScriptText(), "Script text should match");
+        assertEquals(name, script.getName(), "Name should be blank");
+        assertEquals(script.toString(), script.getId(), "Id should match its toString()");
+    }
+
+    private class MockScript extends AbstractScript {
+
+        public MockScript(String name, String language, String scriptText) {
+            super(name, language, scriptText);
+        }
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ScriptAppenderSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ScriptAppenderSelector.java
@@ -94,9 +94,9 @@ public class ScriptAppenderSelector extends AbstractAppender {
                     "ScriptAppenderSelector '{}' executing {} '{}': {}",
                     name,
                     script.getLanguage(),
-                    script.getName(),
+                    script.getId(),
                     script.getScriptText());
-            final Object object = scriptManager.execute(script.getName(), bindings);
+            final Object object = scriptManager.execute(script.getId(), bindings);
             final String actualAppenderName = Objects.toString(object, null);
             LOGGER.debug("ScriptAppenderSelector '{}' selected '{}'", name, actualAppenderName);
             return appenderSet.createAppender(actualAppenderName, name);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/ScriptCondition.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/ScriptCondition.java
@@ -73,7 +73,7 @@ public class ScriptCondition {
         bindings.put("configuration", configuration);
         bindings.put("substitutor", configuration.getStrSubstitutor());
         bindings.put("statusLogger", LOGGER);
-        final Object object = configuration.getScriptManager().execute(script.getName(), bindings);
+        final Object object = configuration.getScriptManager().execute(script.getId(), bindings);
         return (List<PathWithAttributes>) object;
     }
 
@@ -110,8 +110,8 @@ public class ScriptCondition {
             return null;
         }
         if (script instanceof ScriptRef) {
-            if (configuration.getScriptManager().getScript(script.getName()) == null) {
-                LOGGER.error("ScriptCondition: No script with name {} has been declared.", script.getName());
+            if (configuration.getScriptManager().getScript(script.getId()) == null) {
+                LOGGER.error("ScriptCondition: No script with name {} has been declared.", script.getId());
                 return null;
             }
         } else {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/Routes.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/Routes.java
@@ -180,7 +180,7 @@ public final class Routes {
             final Bindings bindings = scriptManager.createBindings(patternScript);
             bindings.put(STATIC_VARIABLES_KEY, scriptStaticVariables);
             bindings.put(LOG_EVENT_KEY, event);
-            final Object object = scriptManager.execute(patternScript.getName(), bindings);
+            final Object object = scriptManager.execute(patternScript.getId(), bindings);
             bindings.remove(LOG_EVENT_KEY);
             return Objects.toString(object, null);
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/routing/RoutingAppender.java
@@ -202,7 +202,7 @@ public final class RoutingAppender extends AbstractAppender {
                 final ScriptManager scriptManager = configuration.getScriptManager();
                 final Bindings bindings = scriptManager.createBindings(defaultRouteScript);
                 bindings.put(STATIC_VARIABLES_KEY, scriptStaticVariables);
-                final Object object = scriptManager.execute(defaultRouteScript.getName(), bindings);
+                final Object object = scriptManager.execute(defaultRouteScript.getId(), bindings);
                 final Route route = routes.getRoute(Objects.toString(object, null));
                 if (route != null) {
                     defaultRoute = route;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ScriptsPlugin.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ScriptsPlugin.java
@@ -18,16 +18,19 @@ package org.apache.logging.log4j.core.config;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.script.AbstractScript;
 import org.apache.logging.log4j.util.Strings;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * A  container of Scripts.
  */
+@NullMarked
 @Plugin(name = "Scripts", category = Core.CATEGORY_NAME)
 public final class ScriptsPlugin {
 
@@ -40,7 +43,8 @@ public final class ScriptsPlugin {
      */
     @PluginFactory
     public static AbstractScript[] createScripts(@PluginElement("Scripts") final AbstractScript[] scripts) {
-        if (scripts == null || scripts.length == 0) {
+        Objects.requireNonNull(scripts, "Scripts array cannot be null");
+        if (scripts.length == 0) {
             return scripts;
         }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ScriptsPlugin.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ScriptsPlugin.java
@@ -16,11 +16,14 @@
  */
 package org.apache.logging.log4j.core.config;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.script.AbstractScript;
+import org.apache.logging.log4j.util.Strings;
 
 /**
  * A  container of Scripts.
@@ -37,7 +40,18 @@ public final class ScriptsPlugin {
      */
     @PluginFactory
     public static AbstractScript[] createScripts(@PluginElement("Scripts") final AbstractScript[] scripts) {
+        if (scripts == null || scripts.length == 0) {
+            return scripts;
+        }
 
-        return scripts;
+        final List<AbstractScript> validScripts = new ArrayList<>(scripts.length);
+        for (final AbstractScript script : scripts) {
+            if (Strings.isBlank(script.getName())) {
+                throw new ConfigurationException("A script defined in <Scripts> lacks an explicit 'name' attribute");
+            } else {
+                validScripts.add(script);
+            }
+        }
+        return validScripts.toArray(new AbstractScript[0]);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/ScriptArbiter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/arbiters/ScriptArbiter.java
@@ -57,7 +57,7 @@ public class ScriptArbiter implements Arbiter {
         final SimpleBindings bindings = new SimpleBindings();
         bindings.putAll(configuration.getProperties());
         bindings.put("substitutor", configuration.getStrSubstitutor());
-        final Object object = configuration.getScriptManager().execute(script.getName(), bindings);
+        final Object object = configuration.getScriptManager().execute(script.getId(), bindings);
         return Boolean.parseBoolean(object.toString());
     }
 
@@ -114,8 +114,8 @@ public class ScriptArbiter implements Arbiter {
                 return null;
             }
             if (script instanceof ScriptRef) {
-                if (configuration.getScriptManager().getScript(script.getName()) == null) {
-                    LOGGER.error("No script with name {} has been declared.", script.getName());
+                if (configuration.getScriptManager().getScript(script.getId()) == null) {
+                    LOGGER.error("No script with name {} has been declared.", script.getId());
                     return null;
                 }
             } else {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/ScriptFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/ScriptFilter.java
@@ -69,7 +69,7 @@ public final class ScriptFilter extends AbstractFilter {
         bindings.put("throwable", null);
         bindings.putAll(configuration.getProperties());
         bindings.put("substitutor", configuration.getStrSubstitutor());
-        final Object object = configuration.getScriptManager().execute(script.getName(), bindings);
+        final Object object = configuration.getScriptManager().execute(script.getId(), bindings);
         return object == null || !Boolean.TRUE.equals(object) ? onMismatch : onMatch;
     }
 
@@ -85,7 +85,7 @@ public final class ScriptFilter extends AbstractFilter {
         bindings.put("throwable", t);
         bindings.putAll(configuration.getProperties());
         bindings.put("substitutor", configuration.getStrSubstitutor());
-        final Object object = configuration.getScriptManager().execute(script.getName(), bindings);
+        final Object object = configuration.getScriptManager().execute(script.getId(), bindings);
         return object == null || !Boolean.TRUE.equals(object) ? onMismatch : onMatch;
     }
 
@@ -101,7 +101,7 @@ public final class ScriptFilter extends AbstractFilter {
         bindings.put("throwable", t);
         bindings.putAll(configuration.getProperties());
         bindings.put("substitutor", configuration.getStrSubstitutor());
-        final Object object = configuration.getScriptManager().execute(script.getName(), bindings);
+        final Object object = configuration.getScriptManager().execute(script.getId(), bindings);
         return object == null || !Boolean.TRUE.equals(object) ? onMismatch : onMatch;
     }
 
@@ -111,13 +111,13 @@ public final class ScriptFilter extends AbstractFilter {
         bindings.put("logEvent", event);
         bindings.putAll(configuration.getProperties());
         bindings.put("substitutor", configuration.getStrSubstitutor());
-        final Object object = configuration.getScriptManager().execute(script.getName(), bindings);
+        final Object object = configuration.getScriptManager().execute(script.getId(), bindings);
         return object == null || !Boolean.TRUE.equals(object) ? onMismatch : onMatch;
     }
 
     @Override
     public String toString() {
-        return script.getName();
+        return script.getId();
     }
 
     /**
@@ -146,8 +146,8 @@ public final class ScriptFilter extends AbstractFilter {
             return null;
         }
         if (script instanceof ScriptRef) {
-            if (configuration.getScriptManager().getScript(script.getName()) == null) {
-                logger.error("No script with name {} has been declared.", script.getName());
+            if (configuration.getScriptManager().getScript(script.getId()) == null) {
+                logger.error("No script with name {} has been declared.", script.getId());
                 return null;
             }
         } else {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/ScriptPatternSelector.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/ScriptPatternSelector.java
@@ -89,8 +89,8 @@ public class ScriptPatternSelector implements PatternSelector, LocationAware {
                 return null;
             }
             if (script instanceof ScriptRef) {
-                if (configuration.getScriptManager().getScript(script.getName()) == null) {
-                    LOGGER.error("No script with name {} has been declared.", script.getName());
+                if (configuration.getScriptManager().getScript(script.getId()) == null) {
+                    LOGGER.error("No script with name {} has been declared.", script.getId());
                     return null;
                 }
             } else {
@@ -262,7 +262,7 @@ public class ScriptPatternSelector implements PatternSelector, LocationAware {
         bindings.putAll(configuration.getProperties());
         bindings.put("substitutor", configuration.getStrSubstitutor());
         bindings.put("logEvent", event);
-        final Object object = configuration.getScriptManager().execute(script.getName(), bindings);
+        final Object object = configuration.getScriptManager().execute(script.getId(), bindings);
         if (object == null) {
             return defaultFormatters;
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/script/AbstractScript.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/script/AbstractScript.java
@@ -18,6 +18,7 @@ package org.apache.logging.log4j.core.script;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Strings;
 
 /**
  * Container for the language and body of a script.
@@ -30,11 +31,13 @@ public abstract class AbstractScript {
     private final String language;
     private final String scriptText;
     private final String name;
+    private final String id;
 
     public AbstractScript(final String name, final String language, final String scriptText) {
         this.language = language;
         this.scriptText = scriptText;
-        this.name = name == null ? this.toString() : name;
+        this.name = name;
+        this.id = Strings.isBlank(name) ? this.toString() : name;
     }
 
     public String getLanguage() {
@@ -47,5 +50,9 @@ public abstract class AbstractScript {
 
     public String getName() {
         return this.name;
+    }
+
+    public String getId() {
+        return this.id;
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/script/AbstractScript.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/script/AbstractScript.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.core.script;
 
+import java.util.Objects;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
@@ -37,7 +38,7 @@ public abstract class AbstractScript {
         this.language = language;
         this.scriptText = scriptText;
         this.name = name;
-        this.id = Strings.isBlank(name) ? this.toString() : name;
+        this.id = Strings.isBlank(name) ? Integer.toHexString(Objects.hashCode(this)) : name;
     }
 
     public String getLanguage() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/script/ScriptFile.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/script/ScriptFile.java
@@ -123,8 +123,8 @@ public class ScriptFile extends AbstractScript {
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
-        if (!(getName().equals(filePath.toString()))) {
-            sb.append("name=").append(getName()).append(", ");
+        if (!(getId().equals(filePath.toString()))) {
+            sb.append("name=").append(getId()).append(", ");
         }
         sb.append("path=").append(filePath);
         if (getLanguage() != null) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/script/ScriptManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/script/ScriptManager.java
@@ -147,9 +147,9 @@ public class ScriptManager implements FileWatcher {
                 return false;
             }
             if (engine.getFactory().getParameter(KEY_THREADING) == null) {
-                scriptRunners.put(script.getName(), new ThreadLocalScriptRunner(script));
+                scriptRunners.put(script.getId(), new ThreadLocalScriptRunner(script));
             } else {
-                scriptRunners.put(script.getName(), new MainScriptRunner(engine, script));
+                scriptRunners.put(script.getId(), new MainScriptRunner(engine, script));
             }
 
             if (script instanceof ScriptFile) {
@@ -162,7 +162,7 @@ public class ScriptManager implements FileWatcher {
         } else {
             logger.error(
                     "Unable to add script {}, {} has not been configured as an allowed language",
-                    script.getName(),
+                    script.getId(),
                     script.getLanguage());
             return false;
         }
@@ -173,8 +173,8 @@ public class ScriptManager implements FileWatcher {
         return getScriptRunner(script).createBindings();
     }
 
-    public AbstractScript getScript(final String name) {
-        final ScriptRunner runner = scriptRunners.get(name);
+    public AbstractScript getScript(final String id) {
+        final ScriptRunner runner = scriptRunners.get(id);
         return runner != null ? runner.getScript() : null;
     }
 
@@ -188,16 +188,16 @@ public class ScriptManager implements FileWatcher {
         final ScriptEngine engine = runner.getScriptEngine();
         final AbstractScript script = runner.getScript();
         if (engine.getFactory().getParameter(KEY_THREADING) == null) {
-            scriptRunners.put(script.getName(), new ThreadLocalScriptRunner(script));
+            scriptRunners.put(script.getId(), new ThreadLocalScriptRunner(script));
         } else {
-            scriptRunners.put(script.getName(), new MainScriptRunner(engine, script));
+            scriptRunners.put(script.getId(), new MainScriptRunner(engine, script));
         }
     }
 
-    public Object execute(final String name, final Bindings bindings) {
-        final ScriptRunner scriptRunner = scriptRunners.get(name);
+    public Object execute(final String id, final Bindings bindings) {
+        final ScriptRunner scriptRunner = scriptRunners.get(id);
         if (scriptRunner == null) {
-            logger.warn("No script named {} could be found", name);
+            logger.warn("No script named {} could be found", id);
             return null;
         }
         return AccessController.doPrivileged((PrivilegedAction<Object>) () -> scriptRunner.execute(bindings));
@@ -224,7 +224,7 @@ public class ScriptManager implements FileWatcher {
             this.scriptEngine = scriptEngine;
             CompiledScript compiled = null;
             if (scriptEngine instanceof Compilable) {
-                logger.debug("Script {} is compilable", script.getName());
+                logger.debug("Script {} is compilable", script.getId());
                 compiled = AccessController.doPrivileged((PrivilegedAction<CompiledScript>) () -> {
                     try {
                         return ((Compilable) scriptEngine).compile(script.getScriptText());
@@ -252,14 +252,14 @@ public class ScriptManager implements FileWatcher {
                 try {
                     return compiledScript.eval(bindings);
                 } catch (final ScriptException ex) {
-                    logger.error("Error running script " + script.getName(), ex);
+                    logger.error("Error running script " + script.getId(), ex);
                     return null;
                 }
             }
             try {
                 return scriptEngine.eval(script.getScriptText(), bindings);
             } catch (final ScriptException ex) {
-                logger.error("Error running script " + script.getName(), ex);
+                logger.error("Error running script " + script.getId(), ex);
                 return null;
             }
         }
@@ -302,6 +302,6 @@ public class ScriptManager implements FileWatcher {
     }
 
     private ScriptRunner getScriptRunner(final AbstractScript script) {
-        return scriptRunners.get(script.getName());
+        return scriptRunners.get(script.getId());
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/script/ScriptRef.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/script/ScriptRef.java
@@ -38,13 +38,13 @@ public class ScriptRef extends AbstractScript {
 
     @Override
     public String getLanguage() {
-        final AbstractScript script = this.scriptManager.getScript(getName());
+        final AbstractScript script = this.scriptManager.getScript(getId());
         return script != null ? script.getLanguage() : null;
     }
 
     @Override
     public String getScriptText() {
-        final AbstractScript script = this.scriptManager.getScript(getName());
+        final AbstractScript script = this.scriptManager.getScript(getId());
         return script != null ? script.getScriptText() : null;
     }
 
@@ -62,6 +62,6 @@ public class ScriptRef extends AbstractScript {
 
     @Override
     public String toString() {
-        return "ref=" + getName();
+        return "ref=" + getId();
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/script/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/script/package-info.java
@@ -18,7 +18,7 @@
  * Log4j 2 Script support.
  */
 @Export
-@Version("2.20.2")
+@Version("2.25.0")
 package org.apache.logging.log4j.core.script;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/script/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/script/package-info.java
@@ -18,7 +18,7 @@
  * Log4j 2 Script support.
  */
 @Export
-@Version("2.25.0")
+@Version("2.26.0")
 package org.apache.logging.log4j.core.script;
 
 import org.osgi.annotation.bundle.Export;

--- a/src/changelog/.2.x.x/3176_validate_scripts_in_ScriptsPlugin.xml
+++ b/src/changelog/.2.x.x/3176_validate_scripts_in_ScriptsPlugin.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+    <issue id="3176" link="https://github.com/apache/logging-log4j2/issues/3176"/>
+    <description format="asciidoc">
+      Ensured scripts in global `Scripts container` have explicit names by throwing a `ConfigurationException` for unnamed ones.
+      Refined script identification with `AbstractScript.getId()` and clarified `AbstractScript.getName()`.
+    </description>
+</entry>


### PR DESCRIPTION
This PR addresses issue #3176 by ensuring scripts defined in the global `<Scripts>` container have explicit, non-blank names. It also introduces a clearer distinction between user-defined names and internal script identifiers.

**Key Changes:**
* `AbstractScript` now provides `getName()` strictly for user-configured names, which can be null or blank. It also introduces `getId()` to consistently return a non-blank internal identifier, falling back to `toString()` if no explicit name is set.
* `ScriptsPlugin` now throws a `ConfigurationException` if any script defined directly under the global `<Scripts>` element lacks an explicit name.
* `ScriptManager` and various script-using components were updated. They now utilize the `script.getId()` for internal referencing.
* Added unit tests for `AbstractScript` and `ScriptsPlugin`.