### PR TITLE
Add `collectionName` and `databaseName` attributes to `MongoDbProvider`

### DIFF
--- a/log4j-mongodb/pom.xml
+++ b/log4j-mongodb/pom.xml
@@ -141,7 +141,6 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <build>
@@ -150,9 +149,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
+
         <dependencies>
 
           <dependency>

--- a/log4j-mongodb/src/main/java/org/apache/logging/log4j/mongodb/MongoDbConnection.java
+++ b/log4j-mongodb/src/main/java/org/apache/logging/log4j/mongodb/MongoDbConnection.java
@@ -16,7 +16,6 @@
  */
 package org.apache.logging.log4j.mongodb;
 
-import com.mongodb.ConnectionString;
 import com.mongodb.MongoException;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
@@ -59,20 +58,17 @@ public final class MongoDbConnection extends AbstractNoSqlConnection<Document, M
         }
     }
 
-    private final ConnectionString connectionString;
     private final MongoCollection<Document> collection;
     private final MongoClient mongoClient;
 
     public MongoDbConnection(
-            final ConnectionString connectionString,
             final MongoClient mongoClient,
             final MongoDatabase mongoDatabase,
+            final String collectionName,
             final boolean isCapped,
             final Long sizeInBytes) {
-        this.connectionString = connectionString;
         this.mongoClient = mongoClient;
-        this.collection =
-                getOrCreateMongoCollection(mongoDatabase, connectionString.getCollection(), isCapped, sizeInBytes);
+        this.collection = getOrCreateMongoCollection(mongoDatabase, collectionName, isCapped, sizeInBytes);
     }
 
     @Override
@@ -106,8 +102,6 @@ public final class MongoDbConnection extends AbstractNoSqlConnection<Document, M
 
     @Override
     public String toString() {
-        return String.format(
-                "Mongo4Connection [connectionString=%s, collection=%s, mongoClient=%s]",
-                connectionString, collection, mongoClient);
+        return String.format("Mongo4Connection [collection=%s, mongoClient=%s]", collection, mongoClient);
     }
 }

--- a/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbCollectionNameIT.java
+++ b/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbCollectionNameIT.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.mongodb;
+
+import com.mongodb.client.MongoClient;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.test.junit.UsingStatusListener;
+import org.junit.jupiter.api.Test;
+
+@UsingMongoDb
+@LoggerContextSource("MongoDbCollectionNameIT.xml")
+// Print debug status logger output upon failure
+@UsingStatusListener
+class MongoDbCollectionNameIT extends AbstractMongoDbCappedIT {
+
+    @Test
+    @Override
+    protected void test(final LoggerContext ctx, final MongoClient mongoClient) {
+        super.test(ctx, mongoClient);
+    }
+}

--- a/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbDatabaseAndCollectionNameIT.java
+++ b/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbDatabaseAndCollectionNameIT.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.mongodb;
+
+import com.mongodb.client.MongoClient;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.test.junit.UsingStatusListener;
+import org.junit.jupiter.api.Test;
+
+@UsingMongoDb
+@LoggerContextSource("MongoDbDatabaseAndCollectionNameIT.xml")
+// Print debug status logger output upon failure
+@UsingStatusListener
+class MongoDbDatabaseAndCollectionNameIT extends AbstractMongoDbCappedIT {
+
+    @Test
+    @Override
+    protected void test(final LoggerContext ctx, final MongoClient mongoClient) {
+        super.test(ctx, mongoClient);
+    }
+}

--- a/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbProviderTest.java
+++ b/log4j-mongodb/src/test/java/org/apache/logging/log4j/mongodb/MongoDbProviderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.mongodb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.MongoCollection;
+import java.lang.reflect.Field;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+class MongoDbProviderTest {
+
+    private static final String CS_WO_DB = "mongodb://localhost:27017";
+    private static final String CS_W_DB = "mongodb://localhost:27017/logging";
+    private static final String CS_W_DB_N_COLL = "mongodb://localhost:27017/logging.logs";
+
+    private static final String COLL_NAME = "logsTest";
+    private static final String DB_NAME = "loggingTest";
+
+    @Test
+    void createProviderWithDatabaseAndCollectionProvidedViaConfig() {
+        final MongoDbProvider provider = MongoDbProvider.newBuilder()
+                .setConnectionStringSource(CS_WO_DB)
+                .setDatabaseName(DB_NAME)
+                .setCollectionName(COLL_NAME)
+                .build();
+        assertNotNull(provider);
+        final MongoNamespace namespace = getNamespace(provider.getConnection());
+        assertEquals(COLL_NAME, namespace.getCollectionName());
+        assertEquals(DB_NAME, namespace.getDatabaseName());
+    }
+
+    @Test
+    void createProviderWithoutDatabaseName() {
+        final MongoDbProvider provider =
+                MongoDbProvider.newBuilder().setConnectionStringSource(CS_WO_DB).build();
+        assertNull(provider);
+    }
+
+    @Test
+    void createProviderWithoutDatabaseNameWithCollectionName() {
+        final MongoDbProvider provider = MongoDbProvider.newBuilder()
+                .setConnectionStringSource(CS_WO_DB)
+                .setCollectionName(COLL_NAME)
+                .build();
+        assertNull(provider);
+    }
+
+    @Test
+    void createProviderWithoutCollectionName() {
+        final MongoDbProvider provider = MongoDbProvider.newBuilder()
+                .setConnectionStringSource(CS_WO_DB)
+                .setDatabaseName(DB_NAME)
+                .build();
+        assertNull(provider);
+    }
+
+    @Test
+    void createProviderWithDatabaseOnConnectionString() {
+        final MongoDbProvider provider = MongoDbProvider.newBuilder()
+                .setConnectionStringSource(CS_W_DB)
+                .setCollectionName(COLL_NAME)
+                .build();
+        assertNotNull(provider);
+        final MongoNamespace namespace = getNamespace(provider.getConnection());
+        assertEquals(COLL_NAME, namespace.getCollectionName());
+        assertEquals("logging", namespace.getDatabaseName());
+    }
+
+    @Test
+    void createProviderConfigOverridesConnectionString() {
+        final MongoDbProvider provider = MongoDbProvider.newBuilder()
+                .setConnectionStringSource(CS_W_DB_N_COLL)
+                .setCollectionName(COLL_NAME)
+                .setDatabaseName(DB_NAME)
+                .build();
+        assertNotNull(provider);
+        final MongoNamespace namespace = getNamespace(provider.getConnection());
+        assertEquals(COLL_NAME, namespace.getCollectionName());
+        assertEquals(DB_NAME, namespace.getDatabaseName());
+    }
+
+    private static MongoNamespace getNamespace(final MongoDbConnection connection) {
+        try {
+            final Field collectionField = MongoDbConnection.class.getDeclaredField("collection");
+            collectionField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            final MongoCollection<Document> collection = (MongoCollection<Document>) collectionField.get(connection);
+            return collection.getNamespace();
+        } catch (final Exception exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+}

--- a/log4j-mongodb/src/test/resources/MongoDbAdditionalFields.xml
+++ b/log4j-mongodb/src/test/resources/MongoDbAdditionalFields.xml
@@ -22,7 +22,10 @@
                    https://logging.apache.org/xml/ns/log4j-config-3.xsd">
   <Appenders>
     <NoSql name="MONGO">
-      <MongoDb connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}/testDb.MongoDbAdditionalFieldsIT"/>
+      <MongoDb
+        connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}"
+        databaseName="testDb"
+        collectionName="MongoDbAdditionalFieldsIT"/>
       <KeyValuePair key="A" value="1"/>
       <KeyValuePair key="B" value="2"/>
       <KeyValuePair key="env1" value="${env:PATH}"/>

--- a/log4j-mongodb/src/test/resources/MongoDbAuthFailureIT.xml
+++ b/log4j-mongodb/src/test/resources/MongoDbAuthFailureIT.xml
@@ -23,7 +23,9 @@
   <Appenders>
     <NoSql name="MONGO">
       <MongoDb
-        connection="mongodb://log4jUser:12345678@localhost:${sys:log4j.mongo.port:-27017}/testDb.MongoDbAuthFailureIT" />
+        connection="mongodb://log4jUser:12345678@localhost:${sys:log4j.mongo.port:-27017}"
+        databaseName="testDb"
+        collectionName="MongoDbAuthFailureIT" />
     </NoSql>
   </Appenders>
   <Loggers>

--- a/log4j-mongodb/src/test/resources/MongoDbCappedIntIT.xml
+++ b/log4j-mongodb/src/test/resources/MongoDbCappedIntIT.xml
@@ -23,7 +23,9 @@
   <Appenders>
     <NoSql name="MONGO">
       <MongoDb
-        connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}/testDb.MongoDbCappedIntIT"
+        connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}"
+        databaseName="testDb"
+        collectionName="MongoDbCappedIntIT"
         capped="true"
         collectionSize="1073741824"/>
     </NoSql>

--- a/log4j-mongodb/src/test/resources/MongoDbCollectionNameIT.xml
+++ b/log4j-mongodb/src/test/resources/MongoDbCollectionNameIT.xml
@@ -22,18 +22,16 @@
                    https://logging.apache.org/xml/ns/log4j-config-3.xsd">
   <Appenders>
     <NoSql name="MONGO">
-      <!-- collectionSize="2147483657" is max int + 10 -->
       <MongoDb
-        connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}"
-        databaseName="testDb"
-        collectionName="MongoDbCappedLongIT"
+        connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}/testDb"
         capped="true"
-        collectionSize="2147483657"/>
+        collectionSize="1073741824"
+        collectionName="MongoDbCollectionNameIT"/>
     </NoSql>
   </Appenders>
   <Loggers>
     <Root level="ALL">
-      <AppenderRef ref="MONGO" />
+      <AppenderRef ref="MONGO"/>
     </Root>
   </Loggers>
 </Configuration>

--- a/log4j-mongodb/src/test/resources/MongoDbDatabaseAndCollectionNameIT.xml
+++ b/log4j-mongodb/src/test/resources/MongoDbDatabaseAndCollectionNameIT.xml
@@ -22,18 +22,17 @@
                    https://logging.apache.org/xml/ns/log4j-config-3.xsd">
   <Appenders>
     <NoSql name="MONGO">
-      <!-- collectionSize="2147483657" is max int + 10 -->
       <MongoDb
         connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}"
-        databaseName="testDb"
-        collectionName="MongoDbCappedLongIT"
         capped="true"
-        collectionSize="2147483657"/>
+        collectionSize="1073741824"
+        databaseName="testDb"
+        collectionName="MongoDbDatabaseAndCollectionNameIT"/>
     </NoSql>
   </Appenders>
   <Loggers>
     <Root level="ALL">
-      <AppenderRef ref="MONGO" />
+      <AppenderRef ref="MONGO"/>
     </Root>
   </Loggers>
 </Configuration>

--- a/log4j-mongodb/src/test/resources/MongoDbIT.xml
+++ b/log4j-mongodb/src/test/resources/MongoDbIT.xml
@@ -22,7 +22,7 @@
                    https://logging.apache.org/xml/ns/log4j-config-3.xsd">
   <Appenders>
     <NoSql name="MONGO">
-      <MongoDb connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}/testDb.MongoDbIT" />
+      <MongoDb connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}" collectionName="MongoDbIT" databaseName="testDb" />
     </NoSql>
   </Appenders>
   <Loggers>

--- a/log4j-mongodb/src/test/resources/MongoDbMapMessageIT.xml
+++ b/log4j-mongodb/src/test/resources/MongoDbMapMessageIT.xml
@@ -22,13 +22,16 @@
                    https://logging.apache.org/xml/ns/log4j-config-3.xsd">
   <Appenders>
     <NoSql name="MONGO">
-      <MongoDb connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}/testDb.MongoDbMapMessageIT" />
+      <MongoDb
+        connection="mongodb://localhost:${sys:log4j.mongo.port:-27017}"
+        databaseName="testDb"
+        collectionName="MongoDbMapMessageIT"/>
       <MessageLayout />
     </NoSql>
   </Appenders>
   <Loggers>
     <Root level="ALL">
-      <AppenderRef ref="MONGO" />
+      <AppenderRef ref="MONGO"/>
     </Root>
   </Loggers>
 </Configuration>

--- a/src/changelog/.3.x.x/update_org_log4j_mongodb.xml
+++ b/src/changelog/.3.x.x/update_org_log4j_mongodb.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+  <issue id="3322" link="https://github.com/apache/logging-log4j2/pull/3322"/>
+  <description format="asciidoc">Add `collectionName` and `databaseName` arguments to the MongoDB appender</description>
+</entry>

--- a/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo-keys.json
+++ b/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo-keys.json
@@ -5,7 +5,9 @@
       "NoSql": {
         "name": "MONGO",
         "MongoDb": {
-          "connection": "mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017/logging.logs"
+          "connection": "mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017",
+          "databaseName": "logging",
+          "collectionName": "logs"
         },
         "KeyValuePair": [
           {

--- a/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo-keys.properties
+++ b/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo-keys.properties
@@ -19,7 +19,9 @@
 Appenders.0.type = NoSql
 Appenders.0.name = MONGO
 Appenders.0.provider.type = MongoDB
-Appenders.0.provider.connection = mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017/logging.logs
+Appenders.0.provider.connection = mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017
+Appenders.0.provider.databaseName = logging
+Appenders.0.provider.collectionName = logs
 
 Appenders.0.kv[0].type = KeyValuePair
 Appenders.0.kv[0].key = startTime

--- a/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo-keys.xml
+++ b/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo-keys.xml
@@ -23,7 +23,7 @@
   <Appenders>
     <!-- tag::appender[] -->
     <NoSql name="MONGO">
-      <MongoDb connection="mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017/logging.logs"/>
+      <MongoDb connection="mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017" databaseName="logging" collectionName="logs"/>
       <KeyValuePair key="startTime" value="${date:yyyy-MM-dd hh:mm:ss.SSS}"/> <!--1-->
       <KeyValuePair key="currentTime" value="$${date:yyyy-MM-dd hh:mm:ss.SSS}"/> <!--2-->
     </NoSql>

--- a/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo-keys.yaml
+++ b/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo-keys.yaml
@@ -20,7 +20,9 @@ Configuration:
     NoSql:
       name: "MONGO"
       MongoDb:
-        connection: "mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017/logging.logs"
+        connection: "mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017"
+        databaseName: "logging"
+        collectionName: "logs"
       KeyValuePair:
         - key: "startTime"
           value: "${date:yyyy-MM-dd hh:mm:ss.SSS}" # <1>

--- a/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo.json
+++ b/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo.json
@@ -10,7 +10,9 @@
       "NoSql": {
         "name": "MONGO",
         "MongoDb": {
-          "connection": "mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017/logging.logs"
+          "connection": "mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017",
+          "databaseName" : "logging",
+          "collectionName": "logs"
         }
       }
       // end::appender[]

--- a/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo.properties
+++ b/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo.properties
@@ -22,7 +22,9 @@ Appenders.0.layout.type = JsonTemplateLayout
 Appenders.1.type = NoSql
 Appenders.1.name = MONGO
 Appenders.1.provider.type = MongoDB
-Appenders.1.provider.connection = mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017/logging.logs
+Appenders.1.provider.connection = mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017
+Appenders.1.provider.databaseName = logging
+Appenders.1.provider.collectionName = logs
 # end::appender[]
 # tag::loggers[]
 

--- a/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo.xml
+++ b/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo.xml
@@ -27,7 +27,7 @@
     </File>
     <!-- tag::appender[] -->
     <NoSql name="MONGO">
-      <MongoDb connection="mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017/logging.logs"/>
+      <MongoDb connection="mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017" databaseName="logging" collectionName="logs"/>
     </NoSql>
     <!-- end::appender[] -->
   </Appenders>

--- a/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo.yaml
+++ b/src/site/antora/modules/ROOT/examples/manual/appenders/database/nosql-mongo.yaml
@@ -24,7 +24,9 @@ Configuration:
     NoSql:
       name: "MONGO"
       MongoDb:
-        connection: "mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017/logging.logs"
+        connection: "mongodb://${env:DB_USER}:${env:DB_PASS}@localhost:27017"
+        databaseName: "logging"
+        collectionName: "logs"
     # end::appender[]
   Loggers:
     # tag::loggers[]

--- a/src/site/antora/modules/ROOT/pages/manual/appenders/database.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/appenders/database.adoc
@@ -817,6 +817,23 @@ for its format.
 
 **Required**
 
+| [[MongoDbProvider-attr-databaseName]]databaseName
+| `string`
+|
+|
+It specifies the name of the database for the appender to use.
+
+Overrides the value provided in the connection string if present.
+
+| [[MongoDbProvider-attr-collectionName]]collectionName
+| `string`
+|
+|
+It specifies the name of the collection for the appender to use.
+For backward compatibility, the collection name can also be specified in the
+https://mongodb.github.io/mongo-java-driver/5.0/apidocs/mongodb-driver-core/com/mongodb/ConnectionString.html[Java-specific connection string].
+If collection name is specified in both places, the value provided here will be used.
+
 | [[MongoDbProvider-attr-capped]]capped
 | `boolean`
 | `false`


### PR DESCRIPTION
This work is a clone of #3322 authored by @jesmith17. Commit signatures were missing, Spotless was failing, and author could not address these issues. I created a separate PR to avoid truncating the git & GitHub conversation history in the old PR.