### PR TITLE
Fixes OSGi descriptor to accept Disruptor 4

### DIFF
--- a/log4j-core/pom.xml
+++ b/log4j-core/pom.xml
@@ -51,6 +51,7 @@
     <!--
       ~ OSGi and JPMS options
       -->
+    <disruptor.support.range>[3.4,5)</disruptor.support.range>
     <bnd-multi-release>true</bnd-multi-release>
     <bnd-extra-package-options>
       <!-- Annotations only -->
@@ -58,7 +59,7 @@
       <!-- External optional dependencies -->
       com.conversantmedia.util.concurrent;resolution:=optional;
       com.fasterxml.jackson.*;resolution:=optional,
-      com.lmax.disruptor.*;resolution:=optional,
+      com.lmax.disruptor.*;version="${disruptor.support.range}";resolution:=optional,
       javax.activation;resolution:=optional,
       javax.jms;version="[1.1,3)";resolution:=optional,
       javax.mail.*;version="[1.6,2)";resolution:=optional,

--- a/log4j-osgi-test/pom.xml
+++ b/log4j-osgi-test/pom.xml
@@ -257,8 +257,7 @@
                 <include>org.apache.logging.log4j.osgi.tests.DisruptorTest</include>
               </includes>
               <systemPropertyVariables>
-                <log4j2.contextSelector>org.apache.logging.log4j.core.async.BasicAsyncLoggerContextSelector
-                </log4j2.contextSelector>
+                <log4j2.contextSelector>org.apache.logging.log4j.core.async.BasicAsyncLoggerContextSelector</log4j2.contextSelector>
               </systemPropertyVariables>
             </configuration>
           </execution>
@@ -292,8 +291,7 @@
                 <include>org.apache.logging.log4j.osgi.tests.DisruptorTest</include>
               </includes>
               <systemPropertyVariables>
-                <log4j2.contextSelector>org.apache.logging.log4j.core.async.BasicAsyncLoggerContextSelector
-                </log4j2.contextSelector>
+                <log4j2.contextSelector>org.apache.logging.log4j.core.async.BasicAsyncLoggerContextSelector</log4j2.contextSelector>
               </systemPropertyVariables>
             </configuration>
           </execution>

--- a/log4j-osgi-test/pom.xml
+++ b/log4j-osgi-test/pom.xml
@@ -87,6 +87,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
@@ -233,7 +238,28 @@
               </classpathDependencyExcludes>
               <excludes>
                 <exclude>org.apache.logging.log4j.osgi.tests.FelixLoadApiBundleTest</exclude>
+                <exclude>org.apache.logging.log4j.osgi.tests.DisruptorTest</exclude>
               </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-equinox-disruptor</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <classpathDependencyExcludes combine.children="append">
+                <!-- Ensure that Disruptor is not accidentally loaded from the parent classpath -->
+                <exclude>com.lmax.disruptor:disruptor</exclude>
+                <exclude>org.apache.felix:org.apache.felix.framework</exclude>
+              </classpathDependencyExcludes>
+              <includes>
+                <include>org.apache.logging.log4j.osgi.tests.DisruptorTest</include>
+              </includes>
+              <systemPropertyVariables>
+                <log4j2.contextSelector>org.apache.logging.log4j.core.async.BasicAsyncLoggerContextSelector
+                </log4j2.contextSelector>
+              </systemPropertyVariables>
             </configuration>
           </execution>
           <execution>
@@ -247,7 +273,28 @@
               </classpathDependencyExcludes>
               <excludes>
                 <exclude>org.apache.logging.log4j.osgi.tests.EquinoxLoadApiBundleTest</exclude>
+                <exclude>org.apache.logging.log4j.osgi.tests.DisruptorTest</exclude>
               </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-felix-disruptor</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <classpathDependencyExcludes combine.children="append">
+                <!-- Ensure that Disruptor is not accidentally loaded from the parent classpath -->
+                <exclude>com.lmax.disruptor:disruptor</exclude>
+                <exclude>org.eclipse.platform:org.eclipse.osgi</exclude>
+              </classpathDependencyExcludes>
+              <includes>
+                <include>org.apache.logging.log4j.osgi.tests.DisruptorTest</include>
+              </includes>
+              <systemPropertyVariables>
+                <log4j2.contextSelector>org.apache.logging.log4j.core.async.BasicAsyncLoggerContextSelector
+                </log4j2.contextSelector>
+              </systemPropertyVariables>
             </configuration>
           </execution>
         </executions>

--- a/log4j-osgi-test/src/test/java/org/apache/logging/log4j/osgi/tests/DisruptorTest.java
+++ b/log4j-osgi-test/src/test/java/org/apache/logging/log4j/osgi/tests/DisruptorTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.osgi.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.CoreOptions.junitBundles;
+import static org.ops4j.pax.exam.CoreOptions.linkBundle;
+import static org.ops4j.pax.exam.CoreOptions.options;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.async.AsyncLoggerContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
+public class DisruptorTest {
+
+    @org.ops4j.pax.exam.Configuration
+    public Option[] config() {
+        return options(
+                linkBundle("org.apache.logging.log4j.api"),
+                linkBundle("org.apache.logging.log4j.core"),
+                linkBundle("com.lmax.disruptor"),
+                // required by Pax Exam's logging
+                linkBundle("org.objectweb.asm"),
+                linkBundle("org.objectweb.asm.commons"),
+                linkBundle("org.objectweb.asm.tree"),
+                linkBundle("org.objectweb.asm.tree.analysis"),
+                linkBundle("org.objectweb.asm.util"),
+                linkBundle("org.apache.aries.spifly.dynamic.bundle").startLevel(2),
+                linkBundle("slf4j.api"),
+                linkBundle("ch.qos.logback.classic"),
+                linkBundle("ch.qos.logback.core"),
+                junitBundles());
+    }
+
+    @Test
+    public void testDisruptorLog() {
+        // Logger context
+        LoggerContext context = getLoggerContext();
+        assertTrue("LoggerContext is an instance of AsyncLoggerContext", context instanceof AsyncLoggerContext);
+        final CustomConfiguration custom = (CustomConfiguration) context.getConfiguration();
+        // Logging
+        final Logger logger = LogManager.getLogger(getClass());
+        logger.info("Hello OSGI from Log4j2!");
+
+        context.stop();
+        assertEquals(1, custom.getEvents().size());
+        final LogEvent event = custom.getEvents().get(0);
+        assertEquals("Hello OSGI from Log4j2!", event.getMessage().getFormattedMessage());
+        assertEquals(Level.INFO, event.getLevel());
+        custom.clearEvents();
+    }
+
+    private static LoggerContext getLoggerContext() {
+        final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        assertEquals("AsyncDefault", ctx.getName());
+        return ctx;
+    }
+}

--- a/src/changelog/.2.x.x/3706_osgi-disruptor.xml
+++ b/src/changelog/.2.x.x/3706_osgi-disruptor.xml
@@ -2,7 +2,7 @@
 <entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns="https://logging.apache.org/xml/ns"
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
-       type="added">
-  <issue id="1829" link="https://github.com/apache/logging-log4j2/issues/1829"/>
-  <description format="asciidoc">Added support for LMAX Disruptor 4.x</description>
+       type="fixed">
+  <issue id="3706" link="https://github.com/apache/logging-log4j2/issues/3706"/>
+  <description format="asciidoc">Fixes OSGi descriptor to accept Disruptor 4.</description>
 </entry>


### PR DESCRIPTION
Log4j Core added support for Disruptor 4 in `2.23.0` (see #1829), but we forgot to update the OSGi metadata to allow Disruptor 4 in that environment.

This PR expands the accepted Disruptor version range in the OSGi descriptor to ``[3.4,5)``, which partially addresses #3706.

I've also added a small test to try and reproduce the issue from #3706 (where Disruptor version 3 is misidentified as Disruptor 4), and to confirm that async logging works in an OSGi setup. Unfortunately, we couldn't reproduce the bug in our test environment—so that part still needs investigation. However, the version range issue is separate and should now be resolved by this change.

