### PR TITLE
Correct script resolution order dependency

### DIFF
--- a/log4j-core-test/src/test/resources/log4j2-script-order-test.xml
+++ b/log4j-core-test/src/test/resources/log4j2-script-order-test.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="WARN">
+    <Filters>
+        <ScriptFilter onMatch="ACCEPT" onMisMatch="DENY">
+            <ScriptRef ref="GLOBAL_FILTER"/>
+        </ScriptFilter>
+    </Filters>
+
+    <Scripts>
+        <Script name="GLOBAL_FILTER" language="groovy"><![CDATA[
+        // simple script
+        return true
+    ]]></Script>
+    </Scripts>
+</Configuration>

--- a/src/changelog/.2.x.x/3336_script_resolution_order_fix.xml
+++ b/src/changelog/.2.x.x/3336_script_resolution_order_fix.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <issue id="3336" link="https://github.com/apache/logging-log4j2/issues/3336"/>
+    <description format="asciidoc">
+        Fix script resolution failure when the Scripts element is placed after a ScriptRef in the configuration.
+    </description>
+</entry>

--- a/src/changelog/.2.x.x/3336_script_resolution_order_fix.xml
+++ b/src/changelog/.2.x.x/3336_script_resolution_order_fix.xml
@@ -7,6 +7,6 @@
        type="fixed">
     <issue id="3336" link="https://github.com/apache/logging-log4j2/issues/3336"/>
     <description format="asciidoc">
-        Fix script resolution failure when the Scripts element is placed after a ScriptRef in the configuration.
+        Fix script resolution failure when the `Scripts` element is placed after a `ScriptRef` in the configuration.
     </description>
 </entry>


### PR DESCRIPTION
This pull request resolves issue #3336 by fixing the script resolution failure that occurred when a `<ScriptRef>` element was placed before the `<Scripts>` block in a configuration file.

> [!IMPORTANT]  
> Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise.

## Checklist

Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.

### ✅ Required checks

- [X] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [X] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [X] **Code formatting**: The code is formatted according to the project’s style guide.
  <details>
    <summary>How to check and fix formatting</summary>

    - To **check** formatting: `./mvnw spotless:check`
    - To **fix** formatting: `./mvnw spotless:apply`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>
- [X] **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

### 🧪 Tests (select one)

- [X] I have added or updated tests to cover my changes.
- [ ] No additional tests are needed for this change.

### 📝 Changelog (select one)

- [X] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [ ] This is a trivial change and does not require a changelog entry.
