### PR TITLE
Documentation Update for Logger Layout Pattern Precision Example

### DIFF
--- a/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
@@ -952,6 +952,10 @@ See the table below for abbreviation examples:
 |org.apache.commons.Foo
 |o.a.c.Foo
 
+|%c{2.}
+|org.apache.commons.Foo
+|or.ap.co.Foo
+
 |%c{1.1.\~.~}
 |org.apache.commons.test.Foo
 |o.a.~.~.Foo
@@ -964,17 +968,29 @@ See the table below for abbreviation examples:
 |org.apache.commons.test.Foo
 |o.a.c.test.Foo
 
+|%c{3.2.1.*}
+|org.apache.commons.test.Foo
+|org.ap.c.test.Foo
+
 |%c{1.2.*}
+|org.apache.commons.test.Foo
+|o.ap.commons.test.Foo
+
+|%c{1.2*}
 |org.apache.commons.test.Foo
 |o.a.c.test.Foo
 
 |%c{1.3.*}
 |org.apache.commons.test.Foo
+|o.apa.commons.test.Foo
+
+|%c{1.3*}
+|org.apache.commons.test.Foo
 |o.a.commons.test.Foo
 
 |%c{1.8.*}
 |org.apache.commons.test.Foo
-|org.apache.commons.test.Foo
+|o.apache.commons.test.Foo
 |===
 
 [#converter-marker]


### PR DESCRIPTION
Correct logger precision example.
The current example is incorrect.
`%c{1.2.*}` does not return `o.a.commons.test.Foo` due to the extra period before `*`, instead, it will use `1.2` as the pattern and shows `o.ap.commons.Foo`
To get the output `o.a.commons.test.Foo`, the formatter needs to be `%c{1.3*}` where the `3*` indicates number of right most token to be printed in full.  (bullet point 2 in the [doc](https://logging.apache.org/log4j/2.x/manual/pattern-layout.html#converter-logger))

|Pattern|Logger name|Output|Explanation
:-:|:-:|:-:|:-:
`%c{1.1*}`|`org.apache.commons.Foo`|`o.a.c.Foo`|abbreviate using 1 character, show last item in full
`%c{1.1.*}`|`org.apache.commons.Foo`|`o.a.commons.Foo`|first two items abbreviate with 1 character, rest in full
`%c{1.2*}`|`org.apache.commons.Foo`|`o.a.commons.Foo`|abbreviate using 1 character, show last two items in full
`%c{1.2.*}`|`org.apache.commons.Foo`|`o.ap.commons.Foo`|first item with 1 character, second with 2 character, rest is full

I do have a question/issue? where that logic only works if the number before the first period is 1, so
`%c{1.1*}` >> `o.a.c.Foo`
`%c{1.2*}` >> `o.a.commons.Foo`
`%c{1.3*}` >> `o.apache.commons.Foo`
works, but
`%c{2.1*}` >> `or.a*.c*.Foo`
`%c{2.2*}` >> `or.ap*.co*.Foo`
`%c{2.3*}` >> `or.apa*.com*.Foo`
does not work as expected.

> [!IMPORTANT]  
> Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise.

## Checklist

Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.

### ✅ Required checks

- [x] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [ ] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [x] **Code formatting**: The code is formatted according to the project’s style guide.
  <details>
    <summary>How to check and fix formatting</summary>

    - To **check** formatting: `./mvnw spotless:check`
    - To **fix** formatting: `./mvnw spotless:apply`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>
- [ ] **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

### 🧪 Tests (select one)

- [ ] I have added or updated tests to cover my changes.
- [x] No additional tests are needed for this change.

### 📝 Changelog (select one)

- [ ] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [x] This is a trivial change and does not require a changelog entry.
