### PR TITLE
Remove `publish.profile` from production site

### DIFF
--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -61,7 +61,6 @@ jobs:
     with:
       asf-yaml-content: |
         publish:
-          profile: ~
           whoami: ${{ github.ref_name }}-out
           subdir: content/log4j/2.x
       install-required: true


### PR DESCRIPTION
There is no `publish.profile` property in the `.asf.yaml` schema.

Fixes #3598
