### PR TITLE
docs: Update Javadoc output path to match plugin changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -830,7 +830,7 @@
               <outputDirectory>${maven.multiModuleProjectDirectory}/target/site/javadoc/${project.artifactId}</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${project.build.directory}/site/apidocs</directory>
+                  <directory>${project.build.directory}/reports/apidocs</directory>
                 </resource>
               </resources>
             </configuration>


### PR DESCRIPTION
The Javadoc site generation broke after upgrading to Maven Javadoc Plugin 3.10.0 due to a change in the output directory structure (see apache/maven-javadoc-plugin#1163). This update adjusts our build script to look in the new output location, restoring proper Javadoc generation.

Closes #3753

> [!NOTE]
> This change has already been applied to `2.x-site-pro`
