### PR TITLE
Fix UuidPatternConverter javadoc/adoc

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/UuidPatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/UuidPatternConverter.java
@@ -41,13 +41,12 @@ public final class UuidPatternConverter extends LogEventPatternConverter {
     /**
      * Creates an instance of {@link UuidPatternConverter}.
      * <p>
-     * The {@code "RANDOM"} option generates a type 4 (pseudo randomly generated) UUID. The UUID is generated using
-     * a cryptographically strong pseudo random number generator.
+     * The {@code RANDOM} option generates a Type 4 (pseudo-randomly generated) UUID.
+     * The UUID is generated using a cryptographically strong pseudo-random number generator.
      * <p>
-     * The {@code "TIME"} option generates a type 1 (date and time based) UUID using the MAC address of each host.
-     * To ensure uniqueness across multiple JVMs and/or class loaders on the same host, a random number between
-     * 0 and 16,384 will be associated with each instance of the UUID generator class, and included in each time-based
-     * UUID generated. See {@link UuidUtil#UUID_SEQUENCE} how to seed the UUID generation with an integer value.
+     * The {@code TIME} option generates a Type 1 (date and time based) UUID using the local network interface's MAC address.
+     * To ensure uniqueness across multiple JVMs and/or class loaders on the same host, a random number between 0 and 16384 will be associated with each instance of the UUID generator class, and included in each time-based UUID generated.
+     * See {@link UuidUtil#UUID_SEQUENCE} how to seed the UUID generation with an integer value.
      * Because time-based UUIDs contain the MAC address and timestamp, they should be used with care.
      *
      * @param options a single option with the value {@code "RANDOM"} or {@code "TIME"}, or an empty array for {@code "TIME"}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/UuidPatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/UuidPatternConverter.java
@@ -50,7 +50,7 @@ public final class UuidPatternConverter extends LogEventPatternConverter {
      * Because time-based UUIDs contain the MAC address and timestamp, they should be used with care.
      *
      * @param options An array containing either {@code RANDOM} or {@code TIME}.
-                      If empty, {@code TIME} will be used.
+     * If empty, {@code TIME} will be used.
      * @return a new {@link UuidPatternConverter} instance
      */
     public static UuidPatternConverter newInstance(final String[] options) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/UuidPatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/UuidPatternConverter.java
@@ -51,7 +51,7 @@ public final class UuidPatternConverter extends LogEventPatternConverter {
      *
      * @param options An array containing either {@code RANDOM} or {@code TIME}.
                       If empty, {@code TIME} will be used.
-     * @return instance of SequencePatternConverter.
+     * @return a new {@link UuidPatternConverter} instance
      */
     public static UuidPatternConverter newInstance(final String[] options) {
         if (options.length == 0) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/UuidPatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/UuidPatternConverter.java
@@ -22,7 +22,7 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.util.UuidUtil;
 
 /**
- * Formats the event sequence number.
+ * Formats a UUID.
  */
 @Plugin(name = "UuidPatternConverter", category = PatternConverter.CATEGORY)
 @ConverterKeys({"u", "uuid"})
@@ -39,9 +39,18 @@ public final class UuidPatternConverter extends LogEventPatternConverter {
     }
 
     /**
-     * Obtains an instance of SequencePatternConverter.
+     * Obtains an instance of UuidPatternConverter.
+     * <p>
+     * The {@code "RANDOM"} option generates a type 4 (pseudo randomly generated) UUID. The UUID is generated using
+     * a cryptographically strong pseudo random number generator.
+     * <p>
+     * The {@code "TIME"} option generates a type 1 (date and time based) UUID using the MAC address of each host.
+     * To ensure uniqueness across multiple JVMs and/or class loaders on the same host, a random number between
+     * 0 and 16,384 will be associated with each instance of the UUID generator class, and included in each time-based
+     * UUID generated. See {@link UuidUtil#UUID_SEQUENCE} how to seed the UUID generation with an integer value.
+     * Because time-based UUIDs contain the MAC address and timestamp, they should be used with care.
      *
-     * @param options options, currently ignored, may be null.
+     * @param options a single option with the value {@code "RANDOM"} or {@code "TIME"}, or an empty array for {@code "TIME"}
      * @return instance of SequencePatternConverter.
      */
     public static UuidPatternConverter newInstance(final String[] options) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/UuidPatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/UuidPatternConverter.java
@@ -39,7 +39,7 @@ public final class UuidPatternConverter extends LogEventPatternConverter {
     }
 
     /**
-     * Obtains an instance of UuidPatternConverter.
+     * Creates an instance of {@link UuidPatternConverter}.
      * <p>
      * The {@code "RANDOM"} option generates a type 4 (pseudo randomly generated) UUID. The UUID is generated using
      * a cryptographically strong pseudo random number generator.

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/UuidPatternConverter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/UuidPatternConverter.java
@@ -49,7 +49,8 @@ public final class UuidPatternConverter extends LogEventPatternConverter {
      * See {@link UuidUtil#UUID_SEQUENCE} how to seed the UUID generation with an integer value.
      * Because time-based UUIDs contain the MAC address and timestamp, they should be used with care.
      *
-     * @param options a single option with the value {@code "RANDOM"} or {@code "TIME"}, or an empty array for {@code "TIME"}
+     * @param options An array containing either {@code RANDOM} or {@code TIME}.
+                      If empty, {@code TIME} will be used.
      * @return instance of SequencePatternConverter.
      */
     public static UuidPatternConverter newInstance(final String[] options) {

--- a/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
@@ -1339,14 +1339,18 @@ Includes either a random or a time-based UUID
 .link:../javadoc/log4j-core/org/apache/logging/log4j/core/pattern/UuidPatternConverter.html[`UuidPatternConverter`] specifier grammar
 [source,text]
 ----
-u{RANDOM|TIME}
-uuid{RANDOM|TIME}
+u[{RANDOM|TIME}]
+uuid[{RANDOM|TIME}]
 ----
 
-The time-based UUID is a Type 1 UUID generated using the MAC address of each host
+The random UUID is a type 4 UUID. The UUID is generated using a cryptographically strong pseudo-random number generator.
+
+The time-based UUID is a Type 1 (date and time based) UUID generated using the MAC address of each host.
 To ensure uniqueness across multiple JVMs and/or class loaders on the same host, a random number between 0 and 16,384 will be associated with each instance of the UUID generator class, and included in each time-based UUID generated.
 See also xref:manual/systemproperties.adoc#log4j2.uuidSequence[`log4j2.uuidSequence`].
 Because time-based UUIDs contain the MAC address and timestamp, they should be used with care.
+
+TIME is the default.
 
 [#format-modifiers]
 === Format modifiers


### PR DESCRIPTION
Remove javadoc incorrectly copied from SequencePatternConverter.

Add javadoc for UuidPatternConverter based on the pattern-layout.adoc manual page.

Add details to the UuidPatternConverter section in pattern-layout.adoc.

## Checklist

Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.

### ✅ Required checks

- [x] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [x] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [x] **Code formatting**: The code is formatted according to the project’s style guide.
  <details>
    <summary>How to check and fix formatting</summary>

    - To **check** formatting: `./mvnw spotless:check`
    - To **fix** formatting: `./mvnw spotless:apply`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>
- [x] **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

### 🧪 Tests (select one)

- n/a: I have added or updated tests to cover my changes.
- [x] No additional tests are needed for this change.

### 📝 Changelog (select one)

- n/a: I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [x] This is a trivial change and does not require a changelog entry.
