### PR TITLE
fix: Restore Backward Compatibility with Spring Boot Reconfiguration

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/ShutdownDisabledTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/ShutdownDisabledTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 @SetTestProperty(key = "log4j2.isWebapp", value = "false")
-@LoggerContextSource("log4j-test3.xml")
 class ShutdownDisabledTest {
 
     private static final Field shutdownCallbackField;
@@ -47,7 +46,8 @@ class ShutdownDisabledTest {
     }
 
     @Test
-    void testShutdownFlag(final Configuration config, final LoggerContext ctx) throws NoSuchFieldException {
+    @LoggerContextSource("log4j-test3.xml")
+    void testShutdownFlag(final Configuration config, final LoggerContext ctx) {
         assertThat(config.isShutdownHookEnabled())
                 .as("Shutdown hook is enabled")
                 .isFalse();

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/ShutdownDisabledTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/ShutdownDisabledTest.java
@@ -16,25 +16,84 @@
  */
 package org.apache.logging.log4j.core;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.apache.logging.log4j.core.util.ReflectionUtil.getFieldValue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import java.lang.reflect.Field;
+import org.apache.logging.log4j.core.config.AbstractConfiguration;
 import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
-import org.apache.logging.log4j.core.util.ReflectionUtil;
 import org.apache.logging.log4j.test.junit.SetTestProperty;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 @SetTestProperty(key = "log4j2.isWebapp", value = "false")
 @LoggerContextSource("log4j-test3.xml")
 class ShutdownDisabledTest {
 
+    private static final Field shutdownCallbackField;
+
+    static {
+        try {
+            shutdownCallbackField = LoggerContext.class.getDeclaredField("shutdownCallback");
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Test
     void testShutdownFlag(final Configuration config, final LoggerContext ctx) throws NoSuchFieldException {
-        Field shutdownCallback = LoggerContext.class.getDeclaredField("shutdownCallback");
-        Object fieldValue = ReflectionUtil.getFieldValue(shutdownCallback, ctx);
-        assertFalse(config.isShutdownHookEnabled(), "Shutdown hook is enabled");
-        assertNull(fieldValue, "Shutdown callback");
+        assertThat(config.isShutdownHookEnabled())
+                .as("Shutdown hook is enabled")
+                .isFalse();
+        assertThat(getFieldValue(shutdownCallbackField, ctx))
+                .as("Shutdown callback")
+                .isNull();
+    }
+
+    @Test
+    void whenLoggerContextInitialized_respectsShutdownDisabled(TestInfo testInfo) {
+        Configuration configuration = mockConfiguration();
+        when(configuration.isShutdownHookEnabled()).thenReturn(false);
+        try (final LoggerContext ctx = new LoggerContext(testInfo.getDisplayName())) {
+            ctx.start(configuration);
+            assertThat(ctx.isStarted()).isTrue();
+            assertThat(ctx.getConfiguration()).isSameAs(configuration);
+            assertThat(getFieldValue(shutdownCallbackField, ctx))
+                    .as("Shutdown callback")
+                    .isNull();
+        }
+    }
+
+    @Test
+    void whenLoggerContextStarted_ignoresShutdownDisabled(TestInfo testInfo) {
+        // Traditional behavior: during reconfiguration, the shutdown hook is not removed.
+        Configuration initialConfiguration = mockConfiguration();
+        when(initialConfiguration.isShutdownHookEnabled()).thenReturn(true);
+        Configuration configuration = mockConfiguration();
+        when(configuration.isShutdownHookEnabled()).thenReturn(false);
+        try (final LoggerContext ctx = new LoggerContext(testInfo.getDisplayName())) {
+            ctx.start(initialConfiguration);
+            assertThat(ctx.isStarted()).isTrue();
+            Object shutdownCallback = getFieldValue(shutdownCallbackField, ctx);
+            assertThat(shutdownCallback).as("Shutdown callback").isNotNull();
+            ctx.start(configuration);
+            assertThat(getFieldValue(shutdownCallbackField, ctx))
+                    .as("Shutdown callback")
+                    .isSameAs(shutdownCallback);
+        }
+    }
+
+    private static Configuration mockConfiguration() {
+        return mock(
+                AbstractConfiguration.class,
+                withSettings()
+                        .useConstructor(null, ConfigurationSource.NULL_SOURCE)
+                        .defaultAnswer(CALLS_REAL_METHODS));
     }
 }

--- a/src/changelog/.2.x.x/3770_LoggerContext_start.xml
+++ b/src/changelog/.2.x.x/3770_LoggerContext_start.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3770" link="https://github.com/apache/logging-log4j2/issues/3770"/>
+  <description format="asciidoc">
+    Restore backward compatibility with the Spring Boot reconfiguration process.
+  </description>
+</entry>


### PR DESCRIPTION
Although Spring Boot never directly starts a `LoggerContext`, its logging system — including our `Log4j2SpringBootLoggingSystem` and equivalents in Spring Boot 2.x and 3.x — has consistently used `LoggerContext.start(Configuration)` for reconfiguration.

This use case was not taken into consideration in #2614, causing a regression for Spring Boot users.

To maintain backward compatibility with these usages, `start(Configuration)` now falls back to `reconfigure(Configuration)` if the context is already started.

Closes #3770