### PR TITLE
fix: Define version of `error_prone_annotations` in parent POM

### DIFF
--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -80,6 +80,7 @@
     <conversant.disruptor.version>1.2.15</conversant.disruptor.version>
     <disruptor.version>3.4.4</disruptor.version>
     <embedded-ldap.version>0.9.0</embedded-ldap.version>
+    <error-prone-annotations.version>2.38.0</error-prone-annotations.version>
     <felix.version>7.0.5</felix.version>
     <groovy.version>4.0.27</groovy.version>
     <guava.version>33.4.8-jre</guava.version>
@@ -1109,7 +1110,7 @@
             <dependency>
               <groupId>com.google.errorprone</groupId>
               <artifactId>error_prone_annotations</artifactId>
-              <version>${error-prone.version}</version>
+              <version>${error-prone-annotations.version}</version>
             </dependency>
             <dependency>
               <groupId>org.osgi</groupId>

--- a/src/changelog/.2.x.x/3758_fix_jspecify_dep.xml
+++ b/src/changelog/.2.x.x/3758_fix_jspecify_dep.xml
@@ -6,7 +6,8 @@
            https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
     <issue id="3758" link="https://github.com/apache/logging-log4j2/issues/3758"/>
+    <issue id="3779" link="https://github.com/apache/logging-log4j2/issues/3779"/>
     <description format="asciidoc">
-        Move `jspecify.version` Maven property and `java8-tests` profile from `log4j-bom` to `log4j-parent`, since the former gets trimmed before deployment.
+        Fix version resolution of `jspecify` and `error_prone_annotations` dependencies in published POM files.
     </description>
 </entry>


### PR DESCRIPTION
This change explicitly defines the version of the `error_prone_annotations` dependency in the `log4j` parent POM.

Previously, the version was inherited via the `error-prone.version` property from `logging-parent`. However, because the `log4j-bom` POM is flattened during publication, this property no longer resolves in consumer projects.

Fixes #3779
