### PR TITLE
fix: Disable sharing of formatted timestamps between threads

### DIFF
--- a/src/changelog/.2.x.x/3792_formatted-datetime-sharing.xml
+++ b/src/changelog/.2.x.x/3792_formatted-datetime-sharing.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3792" link="https://github.com/apache/logging-log4j2/issues/3792"/>
+  <description format="asciidoc">
+    Fix timestamp formatting concurrency issue, when `log4j2.enabledThreadlocals` is `true`.
+  </description>
+</entry>


### PR DESCRIPTION
This change disables the sharing of formatted timestamps between threads in `InstantPatternThreadLocalCachedFormatter`.

Previously, a mutable `StringBuilder` was shared across threads via a cached object. This could lead to situations where one thread ("owner") was modifying the builder while another thread was reading from it, resulting in inaccurate or truncated timestamps.

This fix ensures that only thread-local instances are used, preventing concurrency issues and improving timestamp correctness under load.

This change is similar in nature to #1485 and fixes #3792.
