### PR TITLE
Add ThreadContextStack injection capability

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/spi/ThreadContextStackFactoryTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/spi/ThreadContextStackFactoryTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.spi;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.junit.jupiter.api.Test;
+
+@UsingAnyThreadContext
+class ThreadContextStackFactoryTest {
+
+    @Test
+    void testDefaultThreadContextStack() {
+        final ThreadContextStack stack = ThreadContextStackFactory.createThreadContextStack();
+        assertNotNull(stack, "ThreadContextStack should not be null");
+        assertTrue(stack instanceof DefaultThreadContextStack, "Should return DefaultThreadContextStack by default");
+    }
+
+    @Test
+    @SetTestProperty(
+            key = "log4j2.threadContextStack",
+            value = "org.apache.logging.log4j.spi.ThreadContextStackFactoryTest$CustomThreadContextStack")
+    void testCustomThreadContextStack() {
+        final ThreadContextStack stack = ThreadContextStackFactory.createThreadContextStack();
+        assertNotNull(stack, "ThreadContextStack should not be null");
+        assertTrue(
+                stack instanceof CustomThreadContextStack,
+                "Expected CustomThreadContextStack but got " + stack.getClass().getName());
+
+        stack.push("test");
+        assertEquals("test", stack.peek(), "Custom stack should work normally");
+    }
+
+    @Test
+    @SetTestProperty(
+            key = "log4j2.threadContextStack",
+            value = "org.apache.logging.log4j.spi.ThreadContextStackFactoryTest$VerifiableThreadContextStack")
+    void testCustomStackRealBehavior() {
+        final ThreadContextStack stack = ThreadContextStackFactory.createThreadContextStack();
+        assertTrue(stack instanceof VerifiableThreadContextStack, "Should be VerifiableThreadContextStack");
+
+        VerifiableThreadContextStack verifiableStack = (VerifiableThreadContextStack) stack;
+
+        stack.push("operation1");
+        assertEquals("CUSTOM:operation1", stack.peek(), "Push should add custom prefix");
+        assertEquals(1, verifiableStack.getCallCount(), "Should track method calls");
+
+        stack.push("operation2");
+        assertEquals("CUSTOM:operation2", stack.peek(), "Second push should also have prefix");
+        assertEquals(2, verifiableStack.getCallCount(), "Call count should increment");
+
+        String popped = stack.pop();
+        assertEquals("CUSTOM:operation2", popped, "Pop should return prefixed value");
+        assertEquals(3, verifiableStack.getCallCount(), "Pop should increment call count");
+        assertEquals("CUSTOM:operation1", stack.peek(), "Remaining item should have prefix");
+
+        List<String> stackList = stack.asList();
+        assertEquals(1, stackList.size(), "Should have one remaining item");
+        assertEquals("CUSTOM:operation1", stackList.get(0), "List should contain prefixed item");
+        assertEquals(4, verifiableStack.getCallCount(), "asList should increment call count");
+
+        assertTrue(verifiableStack.wasMethodCalled("push"), "Should track push calls");
+        assertTrue(verifiableStack.wasMethodCalled("pop"), "Should track pop calls");
+        assertTrue(verifiableStack.wasMethodCalled("asList"), "Should track asList calls");
+        assertFalse(verifiableStack.wasMethodCalled("clear"), "Should not track uncalled methods");
+
+        stack.clear();
+        assertEquals(5, verifiableStack.getCallCount(), "Clear should also be tracked");
+        assertTrue(verifiableStack.wasMethodCalled("clear"), "Should track clear call");
+    }
+
+    @Test
+    @SetTestProperty(key = "log4j2.threadContextStack", value = "com.nonexistent.StackClass")
+    void testInvalidThreadContextStackClass() {
+        final ThreadContextStack stack = ThreadContextStackFactory.createThreadContextStack();
+        assertNotNull(stack, "ThreadContextStack should not be null");
+        assertTrue(
+                stack instanceof DefaultThreadContextStack,
+                "Should fallback to DefaultThreadContextStack when custom class fails to load");
+    }
+
+    @Test
+    @SetTestProperty(key = "log4j2.disableThreadContextStack", value = "true")
+    void testDisabledThreadContextStack() {
+        final ThreadContextStack stack = ThreadContextStackFactory.createThreadContextStack();
+        assertNotNull(stack, "ThreadContextStack should not be null");
+        assertSame(ThreadContext.NOOP_STACK, stack, "Should return NOOP_STACK when disabled");
+    }
+
+    @Test
+    @SetTestProperty(key = "log4j2.disableThreadContext", value = "true")
+    void testDisabledThreadContext() {
+        final ThreadContextStack stack = ThreadContextStackFactory.createThreadContextStack();
+        assertNotNull(stack, "ThreadContextStack should not be null");
+        assertSame(ThreadContext.NOOP_STACK, stack, "Should return NOOP_STACK when ThreadContext is disabled");
+    }
+
+    @Test
+    void testFactoryInitDoesNotThrow() {
+        assertDoesNotThrow(() -> ThreadContextStackFactory.init(), "ThreadContextStackFactory.init() should not throw");
+    }
+
+    @Test
+    void testFactoryCreateReturnsNonNull() {
+        final ThreadContextStack stack = ThreadContextStackFactory.createThreadContextStack();
+        assertNotNull(stack, "createThreadContextStack() should never return null");
+    }
+
+    public static class CustomThreadContextStack extends DefaultThreadContextStack {
+        public CustomThreadContextStack() {
+            super();
+        }
+
+        @Override
+        public String toString() {
+            return "CustomThreadContextStack";
+        }
+    }
+
+    public static class VerifiableThreadContextStack extends DefaultThreadContextStack {
+
+        private static final String PREFIX = "CUSTOM:";
+        private int callCount = 0;
+        private final Set<String> calledMethods = new HashSet<>();
+
+        @Override
+        public void push(String message) {
+            trackCall("push");
+            super.push(PREFIX + message);
+        }
+
+        @Override
+        public String pop() {
+            trackCall("pop");
+            return super.pop();
+        }
+
+        @Override
+        public String peek() {
+            calledMethods.add("peek");
+            return super.peek();
+        }
+
+        @Override
+        public List<String> asList() {
+            trackCall("asList");
+            return super.asList();
+        }
+
+        @Override
+        public void clear() {
+            trackCall("clear");
+            super.clear();
+        }
+
+        private void trackCall(String methodName) {
+            callCount++;
+            calledMethods.add(methodName);
+        }
+
+        public int getCallCount() {
+            return callCount;
+        }
+
+        public boolean wasMethodCalled(String methodName) {
+            return calledMethods.contains(methodName);
+        }
+
+        @Override
+        public String toString() {
+            return "VerifiableThreadContextStack[calls=" + callCount + ", methods=" + calledMethods + "]";
+        }
+    }
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/ThreadContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/ThreadContext.java
@@ -26,13 +26,13 @@ import java.util.Map;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.logging.log4j.spi.CleanableThreadContextMap;
 import org.apache.logging.log4j.spi.DefaultThreadContextMap;
-import org.apache.logging.log4j.spi.DefaultThreadContextStack;
 import org.apache.logging.log4j.spi.MutableThreadContextStack;
 import org.apache.logging.log4j.spi.ReadOnlyThreadContextMap;
 import org.apache.logging.log4j.spi.ThreadContextMap;
 import org.apache.logging.log4j.spi.ThreadContextMap2;
 import org.apache.logging.log4j.spi.ThreadContextMapFactory;
 import org.apache.logging.log4j.spi.ThreadContextStack;
+import org.apache.logging.log4j.spi.ThreadContextStackFactory;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.ProviderUtil;
 
@@ -196,6 +196,8 @@ public final class ThreadContext {
     @SuppressWarnings("PublicStaticCollectionField")
     public static final ThreadContextStack EMPTY_STACK = new EmptyThreadContextStack();
 
+    public static final ThreadContextStack NOOP_STACK = new NoOpThreadContextStack();
+
     private static final String DISABLE_STACK = "disableThreadContextStack";
     private static final String DISABLE_ALL = "disableThreadContext";
 
@@ -220,8 +222,8 @@ public final class ThreadContext {
     public static void init() {
         final PropertiesUtil properties = PropertiesUtil.getProperties();
         contextStack = properties.getBooleanProperty(DISABLE_STACK) || properties.getBooleanProperty(DISABLE_ALL)
-                ? new NoOpThreadContextStack()
-                : new DefaultThreadContextStack();
+                ? NOOP_STACK
+                : ThreadContextStackFactory.createThreadContextStack();
         // TODO: Fix the tests that need to reset the thread context map to use separate instance of the
         //       provider instead.
         ThreadContextMapFactory.init();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/package-info.java
@@ -32,7 +32,7 @@
  * @see <a href="https://logging.apache.org/log4j/2.x/manual/api.html">Log4j 2 API manual</a>
  */
 @Export
-@Version("2.20.2")
+@Version("2.21.0")
 package org.apache.logging.log4j;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextStackFactory.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/ThreadContextStackFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.spi;
+
+import org.apache.logging.log4j.util.ProviderUtil;
+
+/**
+ * Creates the ThreadContextStack instance used by the ThreadContext.
+ * <p>
+ * Any custom {@code ThreadContextStack} can be installed by setting system property
+ * {@code log4j2.threadContextStack} to the fully qualified class name of the class implementing the
+ * {@code ThreadContextStack} interface.
+ * </p><p>
+ * Instead of system properties, the above can also be specified in a properties file named
+ * {@code log4j2.component.properties} in the classpath.
+ * </p>
+ *
+ * @see ThreadContextStack
+ * @see org.apache.logging.log4j.ThreadContext
+ */
+public final class ThreadContextStackFactory {
+
+    /**
+     * Initializes static variables based on system properties. Normally called when this class is initialized by the VM
+     * and when Log4j is reconfigured.
+     */
+    public static void init() {
+        ProviderUtil.getProvider().getThreadContextStackInstance();
+    }
+
+    private ThreadContextStackFactory() {}
+
+    public static ThreadContextStack createThreadContextStack() {
+        return ProviderUtil.getProvider().getThreadContextStackInstance();
+    }
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/spi/package-info.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/spi/package-info.java
@@ -19,7 +19,7 @@
  * API classes.
  */
 @Export
-@Version("2.25.0")
+@Version("2.26.0")
 package org.apache.logging.log4j.spi;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/impl/package-info.java
@@ -18,7 +18,7 @@
  * Log4j 2 private implementation classes.
  */
 @Export
-@Version("2.24.1")
+@Version("2.25.0")
 package org.apache.logging.log4j.core.impl;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/package-info.java
@@ -18,7 +18,7 @@
  * Implementation of Log4j 2.
  */
 @Export
-@Version("2.24.2")
+@Version("2.25.0")
 package org.apache.logging.log4j.core;
 
 import org.osgi.annotation.bundle.Export;

--- a/src/changelog/.2.x.x/1507_add_threadContextStack_injection.xml
+++ b/src/changelog/.2.x.x/1507_add_threadContextStack_injection.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+  type="added">
+  <issue id="1507" link="https://github.com/apache/logging-log4j2/pull/1507"/>
+  <description format="asciidoc">
+    Add ThreadContextStackFactory following ThreadContextMapFactory pattern
+  </description>
+</entry>


### PR DESCRIPTION
Implements custom `ThreadContextStack` injection capability as requested in #1507.

Users can now inject custom `ThreadContextStack` implementations just like `ThreadContextMap`.

## Changes
- **ThreadContextStackFactory**: New factory class following existing ThreadContextMapFactory pattern
- **Provider class**: Extended with ThreadContextStack support while maintaining backward compatibility
- **ThreadContext**: Added `NOOP_STACK` constant and updated initialization logic
- **System property support**: `log4j2.threadContextStack=com.example.MyCustomStack`
- **Properties file support**: Can be configured in `log4j2.component.properties`

## Checklist

### ✅ Required checks

- [x] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [x] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [x] **Code formatting**: The code is formatted according to the project’s style guide.
  <details>
    <summary>How to check and fix formatting</summary>

    - To **check** formatting: `./mvnw spotless:check`
    - To **fix** formatting: `./mvnw spotless:apply`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>
- [x] **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

### 🧪 Tests (select one)

- [x] I have added or updated tests to cover my changes.
- [ ] No additional tests are needed for this change.

### 📝 Changelog (select one)

- [x] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [ ] This is a trivial change and does not require a changelog entry.


fixes #1507 