### PR TITLE
Respect `log4j1.compatibility` for programmatic configuration

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/Category.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/Category.java
@@ -35,6 +35,7 @@ import org.apache.log4j.spi.AppenderAttachable;
 import org.apache.log4j.spi.HierarchyEventListener;
 import org.apache.log4j.spi.LoggerRepository;
 import org.apache.log4j.spi.LoggingEvent;
+import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.message.LocalizedMessage;
 import org.apache.logging.log4j.message.MapMessage;
 import org.apache.logging.log4j.message.Message;
@@ -42,6 +43,7 @@ import org.apache.logging.log4j.message.ObjectMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.spi.ExtendedLogger;
 import org.apache.logging.log4j.spi.LoggerContext;
+import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.StackLocatorUtil;
 import org.apache.logging.log4j.util.Strings;
 
@@ -51,6 +53,10 @@ import org.apache.logging.log4j.util.Strings;
 public class Category implements AppenderAttachable {
 
     private static final String FQCN = Category.class.getName();
+
+    private static boolean isFullCompatibilityEnabled() {
+        return PropertiesUtil.getProperties().getBooleanProperty(ConfigurationFactory.LOG4J1_EXPERIMENTAL);
+    }
 
     /**
      * Tests if the named category exists (in the default hierarchy).
@@ -192,6 +198,9 @@ public class Category implements AppenderAttachable {
      */
     @Override
     public void addAppender(final Appender appender) {
+        if (!isFullCompatibilityEnabled()) {
+            return;
+        }
         if (appender != null) {
             if (LogManager.isLog4jCorePresent()) {
                 CategoryUtil.addAppender(logger, AppenderAdapter.adapt(appender));
@@ -572,6 +581,9 @@ public class Category implements AppenderAttachable {
      */
     @Override
     public void removeAllAppenders() {
+        if (!isFullCompatibilityEnabled()) {
+            return;
+        }
         if (aai != null) {
             final Vector appenders = new Vector();
             for (final Enumeration iter = aai.getAllAppenders(); iter != null && iter.hasMoreElements(); ) {
@@ -593,6 +605,9 @@ public class Category implements AppenderAttachable {
      */
     @Override
     public void removeAppender(final Appender appender) {
+        if (!isFullCompatibilityEnabled()) {
+            return;
+        }
         if (appender == null || aai == null) {
             return;
         }
@@ -611,6 +626,9 @@ public class Category implements AppenderAttachable {
      */
     @Override
     public void removeAppender(final String name) {
+        if (!isFullCompatibilityEnabled()) {
+            return;
+        }
         if (name == null || aai == null) {
             return;
         }
@@ -622,6 +640,9 @@ public class Category implements AppenderAttachable {
     }
 
     public void setAdditivity(final boolean additivity) {
+        if (!isFullCompatibilityEnabled()) {
+            return;
+        }
         if (LogManager.isLog4jCorePresent()) {
             CategoryUtil.setAdditivity(logger, additivity);
         }
@@ -635,6 +656,9 @@ public class Category implements AppenderAttachable {
     }
 
     public void setLevel(final Level level) {
+        if (!isFullCompatibilityEnabled()) {
+            return;
+        }
         setLevel(level != null ? level.getVersion2Level() : null);
     }
 
@@ -645,10 +669,16 @@ public class Category implements AppenderAttachable {
     }
 
     public void setPriority(final Priority priority) {
+        if (!isFullCompatibilityEnabled()) {
+            return;
+        }
         setLevel(priority != null ? priority.getVersion2Level() : null);
     }
 
     public void setResourceBundle(final ResourceBundle bundle) {
+        if (!isFullCompatibilityEnabled()) {
+            return;
+        }
         this.bundle = bundle;
     }
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/LogManager.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/LogManager.java
@@ -26,7 +26,9 @@ import org.apache.log4j.spi.LoggerRepository;
 import org.apache.log4j.spi.NOPLoggerRepository;
 import org.apache.log4j.spi.RepositorySelector;
 import org.apache.log4j.spi.RootLogger;
+import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.spi.LoggerContext;
+import org.apache.logging.log4j.util.PropertiesUtil;
 import org.apache.logging.log4j.util.StackLocatorUtil;
 
 /**
@@ -63,6 +65,10 @@ public final class LogManager {
     private static RepositorySelector repositorySelector;
 
     private static final boolean LOG4J_CORE_PRESENT;
+
+    private static boolean isFullCompatibilityEnabled() {
+        return PropertiesUtil.getProperties().getBooleanProperty(ConfigurationFactory.LOG4J1_EXPERIMENTAL);
+    }
 
     static {
         LOG4J_CORE_PRESENT = checkLog4jCore();
@@ -201,6 +207,9 @@ public final class LogManager {
     }
 
     public static void resetConfiguration() {
+        if (!isFullCompatibilityEnabled()) {
+            return;
+        }
         resetConfiguration(StackLocatorUtil.getCallerClassLoader(2));
     }
 
@@ -225,6 +234,9 @@ public final class LogManager {
      * Shuts down the current configuration.
      */
     public static void shutdown() {
+        if (!isFullCompatibilityEnabled()) {
+            return;
+        }
         shutdown(StackLocatorUtil.getCallerClassLoader(2));
     }
 

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/CategoryTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/CategoryTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.log4j;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -27,11 +28,14 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.ResourceBundle;
 import java.util.function.Consumer;
 import org.apache.log4j.bridge.AppenderAdapter;
 import org.apache.log4j.bridge.AppenderWrapper;
 import org.apache.log4j.spi.LoggingEvent;
+import org.apache.log4j.varia.NullAppender;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -42,6 +46,7 @@ import org.apache.logging.log4j.message.MapMessage;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ObjectMessage;
 import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
 import org.apache.logging.log4j.util.Constants;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.AfterAll;
@@ -52,6 +57,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests of Category.
  */
+@SetTestProperty(key = "log4j1.compatibility", value = "true")
 class CategoryTest {
 
     static ConfigurationFactory cf = new BasicConfigurationFactory();
@@ -407,6 +413,72 @@ class CategoryTest {
         } finally {
             LogManager.resetConfiguration();
         }
+    }
+
+    @Test
+    @SetTestProperty(key = "log4j1.compatibility", value = "false")
+    void testSetLevelCompatibilityDisabled() {
+        final Category category = Category.getInstance("TestCategory");
+        final Level initialLevel = category.getEffectiveLevel();
+        category.setLevel(Level.FATAL);
+        assertEquals(initialLevel, category.getEffectiveLevel(), "level should be unchanged when compatibility is off");
+    }
+
+    @Test
+    @SetTestProperty(key = "log4j1.compatibility", value = "false")
+    void testSetAdditivityCompatibilityDisabled() {
+        final Category category = Category.getInstance("TestCategory");
+        final boolean initialAdditivity = category.getAdditivity();
+        category.setAdditivity(!initialAdditivity);
+        assertEquals(
+                initialAdditivity,
+                category.getAdditivity(),
+                "additivity should be unchanged when compatibility is off");
+    }
+
+    @Test
+    @SetTestProperty(key = "log4j1.compatibility", value = "false")
+    void testAddAppenderCompatibilityDisabled() {
+        final Category category = Category.getInstance("TestCategory");
+        category.addAppender(new NullAppender());
+        assertFalse(
+                category.getAllAppenders().hasMoreElements(), "no appenders should be added when compatibility is off");
+    }
+
+    @Test
+    @SetTestProperty(key = "log4j1.compatibility", value = "false")
+    void testSetPriorityCompatibilityDisabled() {
+        final Category category = Category.getInstance("TestCategory");
+        final Priority initialPriority = category.getPriority();
+        category.setPriority(Level.FATAL);
+        assertEquals(initialPriority, category.getPriority(), "priority should be unchanged when compatibility is off");
+    }
+
+    @Test
+    @SetTestProperty(key = "log4j1.compatibility", value = "false")
+    void testSetResourceBundleCompatibilityDisabled() {
+        final Category category = Category.getInstance("TestCategory");
+        final ResourceBundle bundle = ResourceBundle.getBundle("L7D", new Locale("en", "US"));
+        category.setResourceBundle(bundle);
+        assertNull(category.getResourceBundle(), "resource bundle should not be set when compatibility is off");
+    }
+
+    @Test
+    @SetTestProperty(key = "log4j1.compatibility", value = "false")
+    void testRemoveAppenderCompatibilityDisabled() {
+        final Category category = Category.getInstance("TestCategory");
+        assertDoesNotThrow(
+                () -> category.removeAppender("TestAppender"),
+                "removeAppender should be a no-op and not throw exceptions when compatibility is off");
+    }
+
+    @Test
+    @SetTestProperty(key = "log4j1.compatibility", value = "false")
+    void testRemoveAllAppendersCompatibilityDisabled() {
+        final Category category = Category.getInstance("TestCategory");
+        assertDoesNotThrow(
+                category::removeAllAppenders,
+                "removeAllAppenders should be a no-op and not throw exceptions when compatibility is off");
     }
 
     /**

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LogManagerTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LogManagerTest.java
@@ -16,17 +16,20 @@
  */
 package org.apache.log4j;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link LogManager}.
  */
+@SetTestProperty(key = "log4j1.compatibility", value = "true")
 class LogManagerTest {
 
     private static final String SIMPLE_NAME = LogManagerTest.class.getSimpleName();
@@ -46,5 +49,21 @@ class LogManagerTest {
         assertTrue(names.contains(SIMPLE_NAME));
         assertTrue(names.contains(SIMPLE_NAME + ".foo"));
         assertTrue(names.contains(SIMPLE_NAME + ".foo.bar"));
+    }
+
+    @Test
+    @SetTestProperty(key = "log4j1.compatibility", value = "false")
+    void testResetConfigurationCompatibilityDisabled() {
+        assertDoesNotThrow(
+                () -> LogManager.resetConfiguration(),
+                "resetConfiguration should be a no-op and not throw exceptions when compatibility is off");
+    }
+
+    @Test
+    @SetTestProperty(key = "log4j1.compatibility", value = "false")
+    void testShutdownCompatibilityDisabled() {
+        assertDoesNotThrow(
+                () -> LogManager.shutdown(),
+                "shutdown should be a no-op and not throw exceptions when compatibility is off");
     }
 }

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/LoggerTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/LoggerTest.java
@@ -38,6 +38,7 @@ import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,6 +47,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Used for internal unit testing the Logger class.
  */
+@SetTestProperty(key = "log4j1.compatibility", value = "true")
 class LoggerTest {
 
     Appender a1;

--- a/src/changelog/.2.x.x/3667_respect_log4j1_compatibility_flag.xml
+++ b/src/changelog/.2.x.x/3667_respect_log4j1_compatibility_flag.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <issue id="3667" link="https://github.com/apache/logging-log4j2/issues/3667"/>
+    <description format="asciidoc">
+        Programmatic configuration changes using the Log4j 1.x API now respect the `log4j1.compatibility` flag.
+    </description>
+</entry>


### PR DESCRIPTION
This PR addresses issue #3667 by adding guard logic to methods in `Category` and `LogManager` that can modify the configuration. These changes ensure that programmatic configuration using the Log4j 1.x API is ignored unless the `log4j1.compatibility` flag is explicitly set to `true`.

I have confirmed the fix by running the [reproducer](https://github.com/rschmitt/logging-log4j2/tree/log4j-1.2-init-bug-repro) provided in the issue, which now yields the following corrected output for the latest snapshot:

```
Testing 2.22.0
00:11:30.417 [main] INFO  org.example.App - Initializing Log4j 1.2 API...
00:11:30.423 [main] INFO  org.example.App - Log4j 1.2 API initialized.
Recorded 2 events (expected 2)

Testing 2.23.0
00:11:32.276 [main] INFO  org.example.App - Initializing Log4j 1.2 API...
Recorded 1 events (expected 2)

Testing 2.25.0
2025-07-09T15:11:36.970645Z main INFO Initializing Log4j 1.2 API...Recorded 1 events (expected 2)

Testing 2.26.0-SNAPSHOT
2025-07-09T15:11:39.258845Z main INFO Initializing Log4j 1.2 API...2025-07-09T15:11:39.262583Z main INFO Log4j 1.2 API initialized.Recorded 2 events (expected 2)
```

Additionally, I have updated the existing unit tests and added new tests to verify that the guard logic works as expected when the compatibility mode is disabled. I am not entirely confident that the new unit tests are perfect. Please let me know if there are any areas for improvement.

## Checklist

Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.

### ✅ Required checks

- [X] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [X] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [X] **Code formatting**: The code is formatted according to the project’s style guide.
  <details>
    <summary>How to check and fix formatting</summary>

    - To **check** formatting: `./mvnw spotless:check`
    - To **fix** formatting: `./mvnw spotless:apply`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>
- [X] **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

### 🧪 Tests (select one)

- [X] I have added or updated tests to cover my changes.
- [ ] No additional tests are needed for this change.

### 📝 Changelog (select one)

- [X] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [ ] This is a trivial change and does not require a changelog entry.
