### PR TITLE
Correct log message format in `AbstractDriverManagerConnectionSource`

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/jdbc/AbstractDriverManagerConnectionSource.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/jdbc/AbstractDriverManagerConnectionSource.java
@@ -160,7 +160,7 @@ public class AbstractDriverManagerConnectionSource extends AbstractConnectionSou
             connection = DriverManager.getConnection(actualConnectionString, toString(userName), toString(password));
         }
         LOGGER.debug(
-                "{} acquired connection for '{}': {} ({}{@})",
+                "{} acquired connection for '{}': {} ({}@{})",
                 getClass().getSimpleName(),
                 actualConnectionString,
                 connection,

--- a/src/changelog/.2.x.x/3828_fix_log_placeholder_mismatch.xml
+++ b/src/changelog/.2.x.x/3828_fix_log_placeholder_mismatch.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <issue id="3828" link="https://github.com/apache/logging-log4j2/issues/3828"/>
+    <description format="asciidoc">
+        Corrected an incorrect placeholder count in the AbstractDriverManagerConnectionSource debug log message to prevent unnecessary warnings.
+    </description>
+</entry>


### PR DESCRIPTION
The debug log message in `AbstractDriverManagerConnectionSource` had 4 placeholders but was supplied with 5 arguments. This corrects the format string to match the argument count, resolving the warning.

Fixes #3828

## Checklist

Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.

### ✅ Required checks

- [X] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [X] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [X] **Code formatting**: The code is formatted according to the project’s style guide.
  <details>
    <summary>How to check and fix formatting</summary>

    - To **check** formatting: `./mvnw spotless:check`
    - To **fix** formatting: `./mvnw spotless:apply`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>
- [X] **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

### 🧪 Tests (select one)

- [ ] I have added or updated tests to cover my changes.
- [X] No additional tests are needed for this change.

### 📝 Changelog (select one)

- [ ] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [X] This is a trivial change and does not require a changelog entry.
