### PR TITLE
Add API to list supported configuration file extensions

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationFactory.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/Log4j1ConfigurationFactory.java
@@ -18,6 +18,8 @@ package org.apache.log4j.config;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationException;
@@ -52,5 +54,10 @@ public class Log4j1ConfigurationFactory extends ConfigurationFactory {
     @Override
     protected String[] getSupportedTypes() {
         return SUFFIXES;
+    }
+
+    @Override
+    public List<String> getSupportedExtensions() {
+        return Collections.emptyList();
     }
 }

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/PropertiesConfigurationFactory.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/PropertiesConfigurationFactory.java
@@ -16,6 +16,8 @@
  */
 package org.apache.log4j.config;
 
+import java.util.Collections;
+import java.util.List;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
@@ -50,6 +52,11 @@ public class PropertiesConfigurationFactory extends ConfigurationFactory {
             return null;
         }
         return new String[] {FILE_EXTENSION};
+    }
+
+    @Override
+    public List<String> getSupportedExtensions() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/config/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/config/package-info.java
@@ -18,7 +18,7 @@
  * Log4j 1.x compatibility layer.
  */
 @Export
-@Version("2.20.1")
+@Version("2.21.0")
 @Open("org.apache.logging.log4j.core")
 package org.apache.log4j.config;
 

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfigurationFactory.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfigurationFactory.java
@@ -16,6 +16,8 @@
  */
 package org.apache.log4j.xml;
 
+import java.util.Collections;
+import java.util.List;
 import org.apache.log4j.config.Log4j1Configuration;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
@@ -54,6 +56,11 @@ public class XmlConfigurationFactory extends ConfigurationFactory {
             return null;
         }
         return new String[] {FILE_EXTENSION};
+    }
+
+    @Override
+    public List<String> getSupportedExtensions() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/xml/package-info.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/xml/package-info.java
@@ -18,7 +18,7 @@
  * Log4j 1.x compatibility layer.
  */
 @Export
-@Version("2.20.2")
+@Version("2.21.0")
 package org.apache.log4j.xml;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/BasicConfigurationFactory.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/BasicConfigurationFactory.java
@@ -17,6 +17,8 @@
 package org.apache.log4j;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.AbstractConfiguration;
@@ -33,6 +35,11 @@ public class BasicConfigurationFactory extends ConfigurationFactory {
     @Override
     public String[] getSupportedTypes() {
         return new String[] {"*"};
+    }
+
+    @Override
+    public List<String> getSupportedExtensions() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/BasicConfigurationFactory.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/BasicConfigurationFactory.java
@@ -17,6 +17,8 @@
 package org.apache.logging.log4j.core.test;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.AbstractConfiguration;
@@ -39,6 +41,11 @@ public class BasicConfigurationFactory extends ConfigurationFactory {
     @Override
     public String[] getSupportedTypes() {
         return null;
+    }
+
+    @Override
+    public List<String> getSupportedExtensions() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/package-info.java
+++ b/log4j-core-test/src/main/java/org/apache/logging/log4j/core/test/package-info.java
@@ -15,7 +15,7 @@
  * limitations under the license.
  */
 @Export
-@Version("2.25.0")
+@Version("2.26.0")
 @BaselineIgnore("2.25.0")
 package org.apache.logging.log4j.core.test;
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationFactoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationFactoryTest.java
@@ -19,6 +19,7 @@ package org.apache.logging.log4j.core.config;
 import static org.apache.logging.log4j.util.Unbox.box;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -36,6 +37,10 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.config.json.JsonConfigurationFactory;
+import org.apache.logging.log4j.core.config.properties.PropertiesConfigurationFactory;
+import org.apache.logging.log4j.core.config.xml.XmlConfigurationFactory;
+import org.apache.logging.log4j.core.config.yaml.YamlConfigurationFactory;
 import org.apache.logging.log4j.core.filter.ThreadContextMapFilter;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.test.junit.TempLoggingDir;
@@ -129,5 +134,56 @@ class ConfigurationFactoryTest {
         checkConfiguration(context);
         final Path logFile = loggingPath.resolve("test-properties.log");
         checkFileLogger(context, logFile);
+    }
+
+    @Test
+    void getSupportedExtensions() {
+        final List<String> extensions = ConfigurationFactory.getActiveFileExtensions();
+        assertNotNull(extensions);
+        assertFalse(extensions.isEmpty());
+        assertTrue(extensions.contains("xml"));
+        assertTrue(extensions.contains("properties"));
+        final long distinctCount = extensions.stream().distinct().count();
+        assertEquals(extensions.size(), distinctCount);
+    }
+
+    @Test
+    void xmlConfigurationFactoryExtensions() {
+        final XmlConfigurationFactory factory = new XmlConfigurationFactory();
+        final List<String> extensions = factory.getSupportedExtensions();
+        assertEquals(1, extensions.size());
+        assertEquals("xml", extensions.get(0));
+    }
+
+    @Test
+    void propertiesConfigurationFactoryExtensions() {
+        final PropertiesConfigurationFactory factory = new PropertiesConfigurationFactory();
+        final List<String> extensions = factory.getSupportedExtensions();
+        assertEquals(1, extensions.size());
+        assertEquals("properties", extensions.get(0));
+    }
+
+    @Test
+    @Tag("json")
+    void jsonConfigurationFactoryExtensions() {
+        final JsonConfigurationFactory factory = new JsonConfigurationFactory();
+        final List<String> extensions = factory.getSupportedExtensions();
+        assertTrue(extensions.size() == 0 || extensions.size() == 2);
+        if (!extensions.isEmpty()) {
+            assertTrue(extensions.contains("json"));
+            assertTrue(extensions.contains("jsn"));
+        }
+    }
+
+    @Test
+    @Tag("yaml")
+    void yamlConfigurationFactoryExtensions() {
+        final YamlConfigurationFactory factory = new YamlConfigurationFactory();
+        final List<String> extensions = factory.getSupportedExtensions();
+        assertTrue(extensions.size() == 0 || extensions.size() == 2);
+        if (!extensions.isEmpty()) {
+            assertTrue(extensions.contains("yml"));
+            assertTrue(extensions.contains("yaml"));
+        }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/CustomConfigurationFactory.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/CustomConfigurationFactory.java
@@ -17,6 +17,8 @@
 package org.apache.logging.log4j.core.config.builder;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -85,5 +87,10 @@ public class CustomConfigurationFactory extends ConfigurationFactory {
     @Override
     protected String[] getSupportedTypes() {
         return new String[] {"*"};
+    }
+
+    @Override
+    public List<String> getSupportedExtensions() {
+        return Collections.emptyList();
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -262,6 +263,14 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
     }
 
     protected abstract String[] getSupportedTypes();
+
+    /**
+     * Returns the file extensions supported by this configuration factory.
+     *
+     * @return list of supported file extensions (e.g., ["xml", "json"])
+     * @since 2.25.0
+     */
+    public abstract List<String> getSupportedExtensions();
 
     protected String getTestPrefix() {
         return TEST_PREFIX;
@@ -554,6 +563,16 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
         }
 
         @Override
+        public List<String> getSupportedExtensions() {
+            return getFactories().stream()
+                    .filter(factory -> factory != this)
+                    .filter(ConfigurationFactory::isActive)
+                    .flatMap(factory -> factory.getSupportedExtensions().stream())
+                    .distinct()
+                    .collect(Collectors.toList());
+        }
+
+        @Override
         public Configuration getConfiguration(final LoggerContext loggerContext, final ConfigurationSource source) {
             if (source != null) {
                 final String config = source.getLocation();
@@ -616,5 +635,20 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
 
     static List<ConfigurationFactory> getFactories() {
         return factories;
+    }
+
+    /**
+     * Returns all configuration file extensions currently supported at runtime.
+     * This aggregates extensions from all active configuration factories.
+     *
+     * @return list of supported file extensions
+     * @since 2.25.0
+     */
+    public static List<String> getActiveFileExtensions() {
+        return getFactories().stream()
+                .filter(ConfigurationFactory::isActive)
+                .flatMap(factory -> factory.getSupportedExtensions().stream())
+                .distinct()
+                .collect(Collectors.toList());
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/JsonConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/JsonConfigurationFactory.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.core.config.json;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
@@ -70,5 +73,23 @@ public class JsonConfigurationFactory extends ConfigurationFactory {
     @Override
     public String[] getSupportedTypes() {
         return SUFFIXES;
+    }
+
+    /**
+     * Returns the file extensions supported by this JSON configuration factory.
+     *
+     * <p>This method returns JSON file extensions that this factory can process.
+     * The factory requires Jackson dependencies to be available on the classpath.
+     * If Jackson libraries are missing, this method returns an empty list.</p>
+     *
+     * @return a list containing "json" and "jsn" extensions if Jackson dependencies
+     *         are available and the factory is active, empty list otherwise
+     */
+    @Override
+    public List<String> getSupportedExtensions() {
+        if (!isActive()) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList("json", "jsn");
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/package-info.java
@@ -18,7 +18,7 @@
  * Classes and interfaces supporting configuration of Log4j 2 with JSON.
  */
 @Export
-@Version("2.20.1")
+@Version("2.21.0")
 package org.apache.logging.log4j.core.config.json;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationFactory.java
@@ -18,6 +18,9 @@ package org.apache.logging.log4j.core.config.properties;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationException;
@@ -38,6 +41,24 @@ public class PropertiesConfigurationFactory extends ConfigurationFactory {
     @Override
     protected String[] getSupportedTypes() {
         return new String[] {".properties"};
+    }
+
+    /**
+     * Returns the file extensions supported by this Properties configuration factory.
+     *
+     * <p>This method returns Properties file extensions that this factory can process.
+     * The factory supports standard Java properties files used for Log4j 2 configuration.
+     * No external dependencies are required for properties file support.</p>
+     *
+     * @return a list containing "properties" extension if the factory is active,
+     *         empty list if inactive
+     */
+    @Override
+    public List<String> getSupportedExtensions() {
+        if (!isActive()) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList("properties");
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/package-info.java
@@ -18,7 +18,7 @@
  * Configuration using Properties files.
  */
 @Export
-@Version("2.20.1")
+@Version("2.21.0")
 package org.apache.logging.log4j.core.config.properties;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/XmlConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/XmlConfigurationFactory.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.core.config.xml;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
@@ -53,5 +56,22 @@ public class XmlConfigurationFactory extends ConfigurationFactory {
     @Override
     public String[] getSupportedTypes() {
         return SUFFIXES;
+    }
+
+    /**
+     * Returns the file extensions supported by this XML configuration factory.
+     *
+     * <p>This method returns XML file extensions that this factory can process.
+     * The factory supports standard XML configuration files used by Log4j 2.</p>
+     *
+     * @return a list containing "xml" extension if the factory is active,
+     *         empty list if inactive due to missing XML parsing dependencies
+     */
+    @Override
+    public List<String> getSupportedExtensions() {
+        if (!isActive()) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList("xml");
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/package-info.java
@@ -18,7 +18,7 @@
  * Classes and interfaces supporting configuration of Log4j 2 with XML.
  */
 @Export
-@Version("2.20.2")
+@Version("2.21.0")
 package org.apache.logging.log4j.core.config.xml;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/YamlConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/YamlConfigurationFactory.java
@@ -16,6 +16,9 @@
  */
 package org.apache.logging.log4j.core.config.yaml;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
@@ -71,5 +74,23 @@ public class YamlConfigurationFactory extends ConfigurationFactory {
     @Override
     public String[] getSupportedTypes() {
         return SUFFIXES;
+    }
+
+    /**
+     * Returns the file extensions supported by this YAML configuration factory.
+     *
+     * <p>This method returns YAML file extensions that this factory can process.
+     * The factory requires Jackson YAML dependencies to be available on the classpath.
+     * If Jackson YAML libraries are missing, this method returns an empty list.</p>
+     *
+     * @return a list containing "yml" and "yaml" extensions if Jackson YAML dependencies
+     *         are available and the factory is active, empty list otherwise
+     */
+    @Override
+    public List<String> getSupportedExtensions() {
+        if (!isActive()) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList("yml", "yaml");
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/package-info.java
@@ -18,7 +18,7 @@
  * Classes and interfaces supporting configuration of Log4j 2 with YAML.
  */
 @Export
-@Version("2.20.1")
+@Version("2.21.0")
 package org.apache.logging.log4j.core.config.yaml;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-osgi-test/src/test/java/org/apache/logging/log4j/osgi/tests/CustomConfigurationFactory.java
+++ b/log4j-osgi-test/src/test/java/org/apache/logging/log4j/osgi/tests/CustomConfigurationFactory.java
@@ -17,6 +17,8 @@
 package org.apache.logging.log4j.osgi.tests;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
@@ -59,5 +61,10 @@ public final class CustomConfigurationFactory extends ConfigurationFactory {
     @Override
     public String[] getSupportedTypes() {
         return SUFFIXES;
+    }
+
+    @Override
+    public List<String> getSupportedExtensions() {
+        return Collections.emptyList();
     }
 }

--- a/src/changelog/.2.x.x/3775_add_supported_configuration_file_locations_api.xml
+++ b/src/changelog/.2.x.x/3775_add_supported_configuration_file_locations_api.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+  <issue id="3775" link="https://github.com/apache/logging-log4j2/issues/3775"/>
+  <description format="asciidoc">
+    Add API to list supported configuration file extensions for external frameworks like Spring Boot to determine which configuration file formats are available at runtime
+  </description>
+</entry>


### PR DESCRIPTION
### Summary

Add ConfigurationFactory.getActiveFileExtensions() and getSupportedExtensions() methods to allow external frameworks like Spring Boot to determine which configuration file formats are currently supported at runtime.

- Add abstract getSupportedExtensions() method to ConfigurationFactory
- Add static getActiveFileExtensions() method to aggregate results
- Implement getSupportedExtensions() in all ConfigurationFactory subclasses
- Add test coverage for new functionality

### Example Usage

```java
List<String> supportedExtensions = ConfigurationFactory.getActiveFileExtensions();
// Returns: ["xml", "json", "jsn", "properties"] (if Jackson available)
// Returns: ["xml", "properties"] (if Jackson missing)
```

## Checklist

Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.

### ✅ Required checks

- [x] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [x] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [x] **Code formatting**: The code is formatted according to the project’s style guide.
  <details>
    <summary>How to check and fix formatting</summary>

    - To **check** formatting: `./mvnw spotless:check`
    - To **fix** formatting: `./mvnw spotless:apply`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>
- [x] **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

### 🧪 Tests (select one)

- [x] I have added or updated tests to cover my changes.
- [ ] No additional tests are needed for this change.

### 📝 Changelog (select one)

- [x] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [ ] This is a trivial change and does not require a changelog entry.
