### PR TITLE
ConsoleAppender: Fix missing default Target value

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/ConsoleAppender.java
@@ -162,7 +162,7 @@ public final class ConsoleAppender extends AbstractOutputStreamAppender<OutputSt
         return newBuilder()
                 .setLayout(layout)
                 .setFilter(filter)
-                .setTarget(target)
+                .setTarget(target == null ? DEFAULT_TARGET : target)
                 .setName(name)
                 .setFollow(follow)
                 .setDirect(direct)


### PR DESCRIPTION
This adds a trivial missing code path to implement the documented default value for `Target`.