### PR TITLE
Add org.apache.logging.log4j.core.appender.FileManager.getPath()

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/FileManager.java
@@ -246,19 +246,20 @@ public class FileManager extends OutputStreamManager {
     protected OutputStream createOutputStream() throws IOException {
         final String filename = getFileName();
         LOGGER.debug("Now writing to {} at {}", filename, new Date());
-        final File file = new File(filename);
+        final Path path = getPath();
+        final File file = path.toFile();
         createParentDir(file);
         final FileOutputStream fos = new FileOutputStream(file, isAppend);
         if (file.exists() && file.length() == 0) {
             try {
                 final FileTime now = FileTime.fromMillis(System.currentTimeMillis());
-                Files.setAttribute(file.toPath(), "creationTime", now);
+                Files.setAttribute(path, "creationTime", now);
             } catch (Exception ex) {
                 LOGGER.warn("Unable to set current file time for {}", filename);
             }
             writeHeader(fos);
         }
-        defineAttributeView(Paths.get(filename));
+        defineAttributeView(path);
         return fos;
     }
 
@@ -343,6 +344,16 @@ public class FileManager extends OutputStreamManager {
     public String getFileName() {
         return getName();
     }
+
+    /**
+     * Returns the Path of the file being managed.
+     * @return The name of the file being managed.
+     * @since 2.26.0
+     */
+    public Path getPath() {
+        return Paths.get(getFileName());
+    }
+
     /**
      * Returns the append status.
      * @return true if the file will be appended to, false if it is overwritten.

--- a/src/changelog/.2.x.x/add_FileManager_getPath_.xml
+++ b/src/changelog/.2.x.x/add_FileManager_getPath_.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+  <description format="asciidoc">Add org.apache.logging.log4j.core.appender.FileManager.getPath().</description>
+</entry>


### PR DESCRIPTION
Add `org.apache.logging.log4j.core.appender.FileManager.getPath()`

> [!IMPORTANT]  
> Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise.

## Checklist

Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.

### ✅ Required checks

- [x] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [ ] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [x] **Code formatting**: The code is formatted according to the project’s style guide.
  <details>
    <summary>How to check and fix formatting</summary>

    - To **check** formatting: `./mvnw spotless:check`
    - To **fix** formatting: `./mvnw spotless:apply`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>
- [x] **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

Note that there are still problems on Windows:
```
[ERROR] Failures:
[ERROR]   SyslogAppenderCustomLayoutTest>SyslogAppenderTest.testTCPAppender:56->SyslogAppenderTestBase.sendAndCheckLegacyBsdMessage:74->SyslogAppenderTestBase.checkTheNumberOfSentAndReceivedMessages:112 The number of received messages should be equal with the number of sent messages ==> expected: <1> but was: <0>
[ERROR]   RollingAppenderDeleteScriptTest.testAppender:74 target\rolling-with-delete-script\test\test-2.log should have odd index expected:<1> but was:<0>
[ERROR]   AsyncLoggersWithAsyncLoggerConfigTest.testLoggingWorks:46 Incorrect number of events. Expected 2, got 0 expected:<2> but was:<0>
[INFO]
[ERROR] Tests run: 8447, Failures: 3, Errors: 0, Skipped: 36
```

### 🧪 Tests (select one)

- [ ] I have added or updated tests to cover my changes.
- [x] No additional tests are needed for this change.

### 📝 Changelog (select one)

- [x] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [ ] This is a trivial change and does not require a changelog entry.
