### PR TITLE
Reopen log file when rollover is unsuccessful (#3226)

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
@@ -516,43 +516,43 @@ public class RollingFileManager extends FileManager {
 
     private boolean rollover(final RolloverStrategy strategy) {
 
-        boolean releaseRequired = false;
+        boolean outputStreamClosed = false;
         try {
             // Block until the asynchronous operation is completed.
             semaphore.acquire();
-            releaseRequired = true;
         } catch (final InterruptedException e) {
             logError("Thread interrupted while attempting to check rollover", e);
-            return false;
+            return outputStreamClosed;
         }
 
-        boolean success = true;
+        boolean asyncActionStarted = true;
 
         try {
             final RolloverDescription descriptor = strategy.rollover(this);
             if (descriptor != null) {
                 writeFooter();
                 closeOutputStream();
+                outputStreamClosed = true;
+                boolean syncActionSuccess = true;
                 if (descriptor.getSynchronous() != null) {
                     LOGGER.debug("RollingFileManager executing synchronous {}", descriptor.getSynchronous());
                     try {
-                        success = descriptor.getSynchronous().execute();
+                        syncActionSuccess = descriptor.getSynchronous().execute();
                     } catch (final Exception ex) {
-                        success = false;
+                        syncActionSuccess = false;
                         logError("Caught error in synchronous task", ex);
                     }
                 }
 
-                if (success && descriptor.getAsynchronous() != null) {
+                if (syncActionSuccess && descriptor.getAsynchronous() != null) {
                     LOGGER.debug("RollingFileManager executing async {}", descriptor.getAsynchronous());
                     asyncExecutor.execute(new AsyncAction(descriptor.getAsynchronous(), this));
-                    releaseRequired = false;
+                    asyncActionStarted = false;
                 }
-                return success;
             }
-            return false;
+            return outputStreamClosed;
         } finally {
-            if (releaseRequired) {
+            if (asyncActionStarted) {
                 semaphore.release();
             }
         }

--- a/src/changelog/.3.x.x/2592_fix_RollingFileManager_unsuccessful_rollover.xml
+++ b/src/changelog/.3.x.x/2592_fix_RollingFileManager_unsuccessful_rollover.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="2592" link="https://github.com/apache/logging-log4j2/issues/2592"/>
+  <description format="asciidoc">Fix `RollingFileManager` to reopen the log file when the rollover was unsuccessful</description>
+</entry>


### PR DESCRIPTION
Fixes `RollingFileManager` to reopen the log file when the rollover was unsuccessful

---

Port of #3226.