### PR TITLE
Support `AsyncAppender::requiresLocation`

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/AsyncAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/AsyncAppenderTest.java
@@ -151,4 +151,11 @@ public class AsyncAppenderTest {
         context.getLogger("Logger").info("This is a test");
         context.stop();
     }
+
+    @Test
+    @LoggerContextSource("log4j-asynch-location.xml")
+    public void testRequiresLocation(final LoggerContext context) {
+        final AsyncAppender appender = context.getConfiguration().getAppender("Async");
+        assertTrue(appender.requiresLocation());
+    }
 }

--- a/log4j-core-test/src/test/resources/log4j-asynch-location.xml
+++ b/log4j-core-test/src/test/resources/log4j-asynch-location.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<Configuration status="OFF">
+
+  <Appenders>
+    <Console name="STDOUT">
+      <PatternLayout pattern="%m%L%n"/>
+    </Console>
+    <Async name="Async" includeLocation="true">
+      <AppenderRef ref="STDOUT"/>
+    </Async>
+  </Appenders>
+
+  <Loggers>
+    <Root level="debug" includeLocation="true">
+      <AppenderRef ref="Async"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppender.java
@@ -427,4 +427,9 @@ public final class AsyncAppender extends AbstractAppender {
     public int getQueueSize() {
         return queue.size();
     }
+
+    @Override
+    public boolean requiresLocation() {
+        return includeLocation && dispatcher.requiresLocation();
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppenderEventDispatcher.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppenderEventDispatcher.java
@@ -167,4 +167,13 @@ class AsyncAppenderEventDispatcher extends Log4jThread {
         // Wait for the completion.
         join(timeoutMillis);
     }
+
+    boolean requiresLocation() {
+        for (var appender : appenders) {
+            if (appender.getAppender().requiresLocation()) {
+                return true;
+            }
+        }
+        return errorAppender != null && errorAppender.getAppender().requiresLocation();
+    }
 }

--- a/src/changelog/.3.x.x/3257_fix_AsyncAppender_requiresLocation.xml
+++ b/src/changelog/.3.x.x/3257_fix_AsyncAppender_requiresLocation.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <issue id="3257" link="https://github.com/apache/logging-log4j2/issues/3257"/>
+    <description format="asciidoc">Fix detection of location requirements in `AsyncAppender`.</description>
+</entry>

--- a/src/changelog/.3.x.x/3257_fix_AsyncAppender_requiresLocation.xml
+++ b/src/changelog/.3.x.x/3257_fix_AsyncAppender_requiresLocation.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns="https://logging.apache.org/xml/ns"
-       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
-       type="fixed">
-    <issue id="3257" link="https://github.com/apache/logging-log4j2/issues/3257"/>
-    <description format="asciidoc">Fix detection of location requirements in `AsyncAppender`.</description>
-</entry>


### PR DESCRIPTION
This is a port of https://github.com/apache/logging-log4j2/pull/3260 to 3.x. This addresses #3257.