### PR TITLE
Adjust GcpLayout JSON to latest format (#3586)

### DIFF
--- a/log4j-layout-template-json/src/main/resources/GcpLayout.json
+++ b/log4j-layout-template-json/src/main/resources/GcpLayout.json
@@ -1,10 +1,15 @@
 {
-  "timestamp": {
+  "timestampSeconds": {
     "$resolver": "timestamp",
-    "pattern": {
-      "format": "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-      "timeZone": "UTC",
-      "locale": "en_US"
+    "epoch": {
+      "unit": "secs",
+      "rounded": true
+    }
+  },
+  "timestampNanos": {
+    "$resolver": "timestamp",
+    "epoch": {
+      "unit": "secs.nanos"
     }
   },
   "severity": {
@@ -36,10 +41,6 @@
       "stackTraceEnabled": false
     }
   },
-  "logging.googleapis.com/insertId": {
-    "$resolver": "counter",
-    "stringified": true
-  },
   "logging.googleapis.com/trace": {
     "$resolver": "mdc",
     "key": "trace_id"
@@ -49,25 +50,18 @@
     "key": "span_id"
   },
   "logging.googleapis.com/trace_sampled": true,
-  "_exception": {
-    "class": {
-      "$resolver": "exception",
-      "field": "className"
-    },
-    "message": {
-      "$resolver": "exception",
-      "field": "message"
-    },
+  "exception": {
+    "$resolver": "exception",
+    "field": "stackTrace",
     "stackTrace": {
-      "$resolver": "pattern",
-      "pattern": "%xEx"
+      "stringified": true
     }
   },
-  "_thread": {
+  "thread": {
     "$resolver": "thread",
     "field": "name"
   },
-  "_logger": {
+  "logger": {
     "$resolver": "logger",
     "field": "name"
   }


### PR DESCRIPTION
* Adjust GcpLayout JSON to latest format

First, it formats the log timestamp field to the correct format recognized by Fluent-Bit (component of Google Cloud Logging) and Google Ops Agent.

Secondly, severity field now must be prefixed with logging.googleapis.com.

Third, counter cannot be used for insertId as it is duplicated on different threads.

And the last but not the least, exception, thread and logger fields are pretty standard when logging via Logback's JSON layout and Google's Spring GCP libraries. Field name changes now match these other loggers.

* revert severity changes, remove insertId

* Remove insertid from tests

* fix spotless error

* Switch exception field to use exception resolver

* try to fix timestamp tests

* Fix tests with empty exceptions

* Add changelog

* Improve changelog.

---------

Cherry pick of https://github.com/apache/logging-log4j2/pull/3586 to 3.x.
