### PR TITLE
Fix sizing of Maps

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/ThreadContextTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/ThreadContextTest.java
@@ -22,10 +22,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.logging.log4j.test.ThreadContextUtilityClass;
 import org.apache.logging.log4j.test.junit.UsingAnyThreadContext;
+import org.apache.logging.log4j.util.Maps;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -115,7 +115,7 @@ class ThreadContextTest {
         assertTrue(ThreadContext.isEmpty());
         assertFalse(ThreadContext.containsKey("key"));
         final int mapSize = 10;
-        final Map<String, String> newMap = new HashMap<>(mapSize);
+        final Map<String, String> newMap = Maps.newHashMap(mapSize);
         for (int i = 1; i <= mapSize; i++) {
             newMap.put("key" + i, "value" + i);
         }

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/spi/DefaultThreadContextMapTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/spi/DefaultThreadContextMapTest.java
@@ -20,11 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.logging.log4j.test.junit.UsingThreadContextMap;
 import org.apache.logging.log4j.test.spi.ThreadContextMapSuite;
+import org.apache.logging.log4j.util.Maps;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.junit.jupiter.api.Test;
 
@@ -56,7 +56,7 @@ class DefaultThreadContextMapTest extends ThreadContextMapSuite {
         assertTrue(map.isEmpty());
         assertFalse(map.containsKey("key"));
         final int mapSize = 10;
-        final Map<String, String> newMap = new HashMap<>(mapSize);
+        final Map<String, String> newMap = Maps.newHashMap(mapSize);
         for (int i = 1; i <= mapSize; i++) {
             newMap.put("key" + i, "value" + i);
         }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/CloseableThreadContext.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/CloseableThreadContext.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.logging.log4j.util.Maps;
 
 /**
  * Adds entries to the {@link ThreadContext stack or map} and them removes them when the object is closed, e.g. as part
@@ -206,7 +207,7 @@ public class CloseableThreadContext {
         }
 
         private void closeMap() {
-            final Map<String, String> valuesToReplace = new HashMap<>(originalValues.size());
+            final Map<String, String> valuesToReplace = Maps.newHashMap(originalValues.size());
             final List<String> keysToRemove = new ArrayList<>(originalValues.size());
             for (final Map.Entry<String, String> entry : originalValues.entrySet()) {
                 final String key = entry.getKey();

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadDumpMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ThreadDumpMessage.java
@@ -24,12 +24,12 @@ import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 import org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Lazy;
+import org.apache.logging.log4j.util.Maps;
 import org.apache.logging.log4j.util.ServiceLoaderUtil;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 import org.apache.logging.log4j.util.Strings;
@@ -176,7 +176,7 @@ public class ThreadDumpMessage implements Message, StringBuilderFormattable {
         @Override
         public Map<ThreadInformation, StackTraceElement[]> createThreadInfo() {
             final Map<Thread, StackTraceElement[]> map = Thread.getAllStackTraces();
-            final Map<ThreadInformation, StackTraceElement[]> threads = new HashMap<>(map.size());
+            final Map<ThreadInformation, StackTraceElement[]> threads = Maps.newHashMap(map.size());
             for (final Map.Entry<Thread, StackTraceElement[]> entry : map.entrySet()) {
                 threads.put(new BasicThreadInformation(entry.getKey()), entry.getValue());
             }

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/Maps.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/Maps.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.util;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+public final class Maps {
+    private Maps() {}
+
+    /**
+     * Calculate initial capacity from expected size and default load factor (0.75).
+     */
+    private static int calculateCapacity(int numMappings) {
+        return (int) Math.ceil(numMappings / 0.75d);
+    }
+
+    /**
+     * Creates a new, empty HashMap suitable for the expected number of mappings.
+     * The returned map is large enough so that the expected number of mappings can be
+     * added without resizing the map.
+     *
+     * This is essentially a backport of HashMap.newHashMap which was added in JDK19.
+     */
+    public static <K, V> HashMap<K, V> newHashMap(int numMappings) {
+        return new HashMap<>(calculateCapacity(numMappings));
+    }
+
+    /**
+     * Creates a new, empty LinkedHashMap suitable for the expected number of mappings.
+     * The returned map is large enough so that the expected number of mappings can be
+     * added without resizing the map.
+     *
+     * This is essentially a backport of LinkedHashMap.newLinkedHashMap which was added in JDK19.
+     */
+    public static <K, V> LinkedHashMap<K, V> newLinkedHashMap(int numMappings) {
+        return new LinkedHashMap<>(calculateCapacity(numMappings));
+    }
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
@@ -21,7 +21,6 @@ import java.io.InvalidObjectException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.ConcurrentModificationException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.logging.log4j.util.internal.SerializationUtil;
@@ -152,7 +151,7 @@ public class SortedArrayStringMap implements IndexedStringMap {
 
     @Override
     public Map<String, String> toMap() {
-        final Map<String, String> result = new HashMap<>(size());
+        final Map<String, String> result = Maps.newHashMap(size());
         for (int i = 0; i < size(); i++) {
             final Object value = getValueAt(i);
             result.put(getKeyAt(i), value == null ? null : String.valueOf(value));

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/context/internal/GarbageFreeSortedArrayThreadContextMapTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/context/internal/GarbageFreeSortedArrayThreadContextMapTest.java
@@ -20,11 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.logging.log4j.spi.ThreadContextMap;
 import org.apache.logging.log4j.test.spi.ThreadContextMapSuite;
+import org.apache.logging.log4j.util.Maps;
 import org.apache.logging.log4j.util.PropertiesUtil;
 import org.junit.jupiter.api.Test;
 
@@ -52,7 +52,7 @@ class GarbageFreeSortedArrayThreadContextMapTest extends ThreadContextMapSuite {
         assertTrue(map.isEmpty());
         assertFalse(map.containsKey("key"));
         final int mapSize = 10;
-        final Map<String, String> newMap = new HashMap<>(mapSize);
+        final Map<String, String> newMap = Maps.newHashMap(mapSize);
         for (int i = 1; i <= mapSize; i++) {
             newMap.put("key" + i, "value" + i);
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AppenderSet.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AppenderSet.java
@@ -16,7 +16,6 @@
  */
 package org.apache.logging.log4j.core.appender;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.core.Appender;
@@ -29,6 +28,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
 import org.apache.logging.log4j.core.config.plugins.PluginNode;
 import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Maps;
 
 /**
  * A deferred plugin for appenders.
@@ -60,7 +60,7 @@ public class AppenderSet {
                 LOGGER.error("No children node in AppenderSet {}", this);
                 return null;
             }
-            final Map<String, Node> map = new HashMap<>(children.size());
+            final Map<String, Node> map = Maps.newHashMap(children.size());
             for (final Node childNode : children) {
                 final String key = childNode.getAttributes().get("name");
                 if (key == null) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/LoggerNameLevelRewritePolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/LoggerNameLevelRewritePolicy.java
@@ -18,7 +18,6 @@ package org.apache.logging.log4j.core.appender.rewrite;
 
 import static org.apache.logging.log4j.util.Strings.toRootUpperCase;
 
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.Core;
@@ -29,6 +28,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginElement;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.util.KeyValuePair;
+import org.apache.logging.log4j.util.Maps;
 
 /**
  * Rewrites log event levels for a given logger name.
@@ -45,11 +45,9 @@ public class LoggerNameLevelRewritePolicy implements RewritePolicy {
     /**
      * Creates a policy to rewrite levels for a given logger name.
      *
-     * @param loggerNamePrefix
-     *        The logger name prefix for events to rewrite; all event logger names that start with this string will be
-     *        rewritten.
-     * @param levelPairs
-     *        The levels to rewrite, the key is the source level, the value the target level.
+     * @param loggerNamePrefix The logger name prefix for events to rewrite; all event logger names that start with this string will be
+     *                         rewritten.
+     * @param levelPairs       The levels to rewrite, the key is the source level, the value the target level.
      * @return a new LoggerNameLevelRewritePolicy
      */
     @PluginFactory
@@ -58,7 +56,7 @@ public class LoggerNameLevelRewritePolicy implements RewritePolicy {
             @PluginAttribute("logger") final String loggerNamePrefix,
             @PluginElement("KeyValuePair") final KeyValuePair[] levelPairs) {
         // @formatter:on
-        final Map<Level, Level> newMap = new HashMap<>(levelPairs.length);
+        final Map<Level, Level> newMap = Maps.newHashMap(levelPairs.length);
         for (final KeyValuePair keyValuePair : levelPairs) {
             newMap.put(getLevel(keyValuePair.getKey()), getLevel(keyValuePair.getValue()));
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/PropertiesRewritePolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rewrite/PropertiesRewritePolicy.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.core.appender.rewrite;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.Logger;
@@ -32,6 +31,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.core.impl.ContextDataFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Maps;
 import org.apache.logging.log4j.util.StringMap;
 
 /**
@@ -55,7 +55,7 @@ public final class PropertiesRewritePolicy implements RewritePolicy {
 
     private PropertiesRewritePolicy(final Configuration config, final List<Property> props) {
         this.config = config;
-        this.properties = new HashMap<>(props.size());
+        this.properties = Maps.newHashMap(props.size());
         for (final Property property : props) {
             final Boolean interpolate = Boolean.valueOf(property.getValue().contains("${"));
             properties.put(property, interpolate);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/MapFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/MapFilter.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.message.MapMessage;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.IndexedReadOnlyStringMap;
 import org.apache.logging.log4j.util.IndexedStringMap;
+import org.apache.logging.log4j.util.Maps;
 import org.apache.logging.log4j.util.PerformanceSensitive;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
@@ -286,7 +287,7 @@ public class MapFilter extends AbstractFilter {
     /** @deprecated  use {@link #getStringMap()} instead */
     @Deprecated
     protected Map<String, List<String>> getMap() {
-        final Map<String, List<String>> result = new HashMap<>(map.size());
+        final Map<String, List<String>> result = Maps.newHashMap(map.size());
         map.forEach((key, value) -> result.put(key, (List<String>) value));
         return result;
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/ListOfMapEntryDeserializer.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/jackson/ListOfMapEntryDeserializer.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.logging.log4j.util.Maps;
 
 /**
  * <p>
@@ -46,7 +47,7 @@ public class ListOfMapEntryDeserializer extends StdDeserializer<Map<String, Stri
                 new TypeReference<List<MapEntry>>() {
                     // empty
                 });
-        final HashMap<String, String> map = new HashMap<>(list.size());
+        final HashMap<String, String> map = Maps.newHashMap(list.size());
         for (final MapEntry mapEntry : list) {
             map.put(mapEntry.getKey(), mapEntry.getValue());
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/AbstractJacksonLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/AbstractJacksonLayout.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.Charset;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Marker;
@@ -43,6 +42,7 @@ import org.apache.logging.log4j.core.time.Instant;
 import org.apache.logging.log4j.core.util.KeyValuePair;
 import org.apache.logging.log4j.core.util.StringBuilderWriter;
 import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.util.Maps;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.Strings;
 
@@ -356,7 +356,7 @@ abstract class AbstractJacksonLayout extends AbstractStringLayout {
 
     private Map<String, String> resolveAdditionalFields(final LogEvent logEvent) {
         // Note: LinkedHashMap retains order
-        final Map<String, String> additionalFieldsMap = new LinkedHashMap<>(additionalFields.length);
+        final Map<String, String> additionalFieldsMap = Maps.newLinkedHashMap(additionalFields.length);
         final StrSubstitutor strSubstitutor = configuration.getStrSubstitutor();
 
         // Go over each field

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/Rfc5424Layout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/Rfc5424Layout.java
@@ -56,6 +56,7 @@ import org.apache.logging.log4j.message.MessageCollectionMessage;
 import org.apache.logging.log4j.message.StructuredDataCollectionMessage;
 import org.apache.logging.log4j.message.StructuredDataId;
 import org.apache.logging.log4j.message.StructuredDataMessage;
+import org.apache.logging.log4j.util.Maps;
 import org.apache.logging.log4j.util.ProcessIdUtil;
 import org.apache.logging.log4j.util.StringBuilders;
 import org.apache.logging.log4j.util.Strings;
@@ -219,7 +220,7 @@ public final class Rfc5424Layout extends AbstractStringLayout {
 
     private Map<String, FieldFormatter> createFieldFormatters(
             final LoggerFields[] loggerFields, final Configuration config) {
-        final Map<String, FieldFormatter> sdIdMap = new HashMap<>(loggerFields == null ? 0 : loggerFields.length);
+        final Map<String, FieldFormatter> sdIdMap = Maps.newHashMap(loggerFields == null ? 0 : loggerFields.length);
         if (loggerFields != null) {
             for (final LoggerFields loggerField : loggerFields) {
                 final StructuredDataId key = loggerField.getSdId() == null ? mdcSdId : loggerField.getSdId();
@@ -908,7 +909,7 @@ public final class Rfc5424Layout extends AbstractStringLayout {
         }
 
         public StructuredDataElement format(final LogEvent event) {
-            final Map<String, String> map = new HashMap<>(delegateMap.size());
+            final Map<String, String> map = Maps.newHashMap(delegateMap.size());
 
             for (final Map.Entry<String, List<PatternFormatter>> entry : delegateMap.entrySet()) {
                 final StringBuilder buffer = new StringBuilder();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/MapLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/MapLookup.java
@@ -16,12 +16,12 @@
  */
 package org.apache.logging.log4j.core.lookup;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.message.MapMessage;
+import org.apache.logging.log4j.util.Maps;
 import org.apache.logging.log4j.util.Strings;
 
 /**
@@ -62,10 +62,6 @@ public class MapLookup implements StrLookup {
         return destMap;
     }
 
-    static HashMap<String, String> newMap(final int initialCapacity) {
-        return new HashMap<>(initialCapacity);
-    }
-
     /**
      * An application's {@code public static main(String[])} method calls this method to make its main arguments
      * available for lookup with the prefix {@code main}.
@@ -102,14 +98,14 @@ public class MapLookup implements StrLookup {
             return null;
         }
         final int size = args.size();
-        return initMap(args.toArray(Strings.EMPTY_ARRAY), newMap(size));
+        return initMap(args.toArray(Strings.EMPTY_ARRAY), Maps.newHashMap(size));
     }
 
     static Map<String, String> toMap(final String[] args) {
         if (args == null) {
             return null;
         }
-        return initMap(args, newMap(args.length));
+        return initMap(args, Maps.newHashMap(args.length));
     }
 
     protected Map<String, String> getMap() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/PropertiesLookup.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/PropertiesLookup.java
@@ -17,11 +17,11 @@
 package org.apache.logging.log4j.core.lookup;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.util.Maps;
 
 /**
  * A lookup designed for {@code Properties} defined in the configuration. This is similar
@@ -102,7 +102,7 @@ public final class PropertiesLookup implements StrLookup {
         // The raw property values must be used without the substitution handled by the plugin framework
         // which calls this method, otherwise we risk re-interpolating through unexpected data.
         // The PropertiesLookup is unique in that results from this lookup support recursive evaluation.
-        final Map<String, ConfigurationPropertyResult> result = new HashMap<>(props.length);
+        final Map<String, ConfigurationPropertyResult> result = Maps.newHashMap(props.length);
         for (Property property : props) {
             result.put(property.getName(), new ConfigurationPropertyResult(property.getRawValue()));
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/StrSubstitutor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/StrSubstitutor.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.ConfigurationAware;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Maps;
 import org.apache.logging.log4j.util.Strings;
 
 /**
@@ -472,7 +473,7 @@ public class StrSubstitutor implements ConfigurationAware {
     }
 
     private static Map<String, String> toTypeSafeMap(final Properties properties) {
-        final Map<String, String> map = new HashMap<>(properties.size());
+        final Map<String, String> map = Maps.newHashMap(properties.size());
         for (final String name : properties.stringPropertyNames()) {
             map.put(name, properties.getProperty(name));
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/message/ExtendedThreadInfoFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/message/ExtendedThreadInfoFactory.java
@@ -22,10 +22,10 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.lang.reflect.Method;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.logging.log4j.message.ThreadDumpMessage.ThreadInfoFactory;
 import org.apache.logging.log4j.message.ThreadInformation;
+import org.apache.logging.log4j.util.Maps;
 
 /**
  * Factory to create extended thread information.
@@ -51,7 +51,7 @@ public class ExtendedThreadInfoFactory implements ThreadInfoFactory {
         final ThreadMXBean bean = ManagementFactory.getThreadMXBean();
         final ThreadInfo[] array = bean.dumpAllThreads(true, true);
 
-        final Map<ThreadInformation, StackTraceElement[]> threads = new HashMap<>(array.length);
+        final Map<ThreadInformation, StackTraceElement[]> threads = Maps.newHashMap(array.length);
         for (final ThreadInfo info : array) {
             threads.put(new ExtendedThreadInformation(info), info.getStackTrace());
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/JAnsiTextRenderer.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/JAnsiTextRenderer.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Maps;
 
 /**
  * Renders an input as ANSI escaped output.
@@ -104,7 +105,7 @@ public final class JAnsiTextRenderer implements TextRenderer {
 
     @SafeVarargs
     private static <V> Map<String, V> ofEntries(final Map.Entry<String, V>... entries) {
-        final Map<String, V> map = new HashMap<>(entries.length);
+        final Map<String, V> map = Maps.newHashMap(entries.length);
         for (final Map.Entry<String, V> entry : entries) {
             map.put(entry.getKey(), entry.getValue());
         }
@@ -209,7 +210,7 @@ public final class JAnsiTextRenderer implements TextRenderer {
             final String predefinedStyle = map.remove("Style");
 
             // Create style map
-            final Map<String, String> styleMap = new HashMap<>(map.size() + defaultStyleMap.size());
+            final Map<String, String> styleMap = Maps.newHashMap(map.size() + defaultStyleMap.size());
             defaultStyleMap.forEach((k, v) -> styleMap.put(toRootUpperCase(k), v));
             if (predefinedStyle != null) {
                 final Map<String, String> predefinedMap = PREFEDINED_STYLE_MAPS.get(predefinedStyle);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/WatchManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/WatchManager.java
@@ -22,7 +22,6 @@ import aQute.bnd.annotation.spi.ServiceConsumer;
 import java.io.File;
 import java.time.Instant;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -39,6 +38,7 @@ import org.apache.logging.log4j.core.AbstractLifeCycle;
 import org.apache.logging.log4j.core.config.ConfigurationFileWatcher;
 import org.apache.logging.log4j.core.config.ConfigurationScheduler;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Maps;
 import org.apache.logging.log4j.util.ServiceLoaderUtil;
 
 /**
@@ -154,7 +154,7 @@ public class WatchManager extends AbstractLifeCycle {
      * @since 2.11.2
      */
     public Map<Source, Watcher> getConfigurationWatchers() {
-        final Map<Source, Watcher> map = new HashMap<>(watchers.size());
+        final Map<Source, Watcher> map = Maps.newHashMap(watchers.size());
         for (final Map.Entry<Source, ConfigurationMonitor> entry : watchers.entrySet()) {
             map.put(entry.getKey(), entry.getValue().getWatcher());
         }
@@ -182,7 +182,7 @@ public class WatchManager extends AbstractLifeCycle {
      */
     @Deprecated
     public Map<File, FileWatcher> getWatchers() {
-        final Map<File, FileWatcher> map = new HashMap<>(watchers.size());
+        final Map<File, FileWatcher> map = Maps.newHashMap(watchers.size());
         for (Map.Entry<Source, ConfigurationMonitor> entry : watchers.entrySet()) {
             if (entry.getValue().getWatcher() instanceof ConfigurationFileWatcher) {
                 map.put(entry.getKey().getFile(), (FileWatcher) entry.getValue().getWatcher());

--- a/log4j-perf-test/src/main/java/org/apache/logging/log4j/perf/nogc/OpenHashStringMap.java
+++ b/log4j-perf-test/src/main/java/org/apache/logging/log4j/perf/nogc/OpenHashStringMap.java
@@ -22,10 +22,10 @@ import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.logging.log4j.spi.ThreadContextMap;
 import org.apache.logging.log4j.util.BiConsumer;
+import org.apache.logging.log4j.util.Maps;
 import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.StringMap;
 import org.apache.logging.log4j.util.TriConsumer;
@@ -233,7 +233,7 @@ public class OpenHashStringMap<K, V> implements StringMap, ThreadContextMap {
 
     @Override
     public Map<String, String> toMap() {
-        final Map<String, String> result = new HashMap<>(size);
+        final Map<String, String> result = Maps.newHashMap(size);
         forEach(COPY_INTO_MAP, result);
         return result;
     }


### PR DESCRIPTION
Fix several instances where Maps were sized incorrectly when the number of elements to insert is known; specifying the capacity without taking into account the load factor meant it would always result in a rehash / resize operation.

To this end, add a simple Maps utility class that handles the capacity calculation, much like the static HashMap.newHashMap helper that was added in JDK19.

## Checklist

Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.

### ✅ Required checks

- [ X ] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [ X ] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [ X ] **Code formatting**: The code is formatted according to the project’s style guide.
- [ X ] **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

### 🧪 Tests (select one)

- [ ] I have added or updated tests to cover my changes.
- [ X ] No additional tests are needed for this change.

### 📝 Changelog (select one)

- [ ] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [ X ] This is a trivial change and does not require a changelog entry.
