### PR TITLE
Round `initialTime` in `RollingFileManager`

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManagerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManagerTest.java
@@ -224,4 +224,20 @@ class RollingFileManagerTest {
         }
         assertEquals(testContent, new String(Files.readAllBytes(file.toPath()), StandardCharsets.US_ASCII));
     }
+
+    @Test
+    @Issue("https://github.com/apache/logging-log4j2/issues/3068")
+    void testInitialTimeRounded() throws IOException {
+        assertEquals(1755031147000L, RollingFileManager.alignMillisToSecond(1755031147000L));
+        assertEquals(1755031147000L, RollingFileManager.alignMillisToSecond(1755031147123L));
+        assertEquals(1755031147000L, RollingFileManager.alignMillisToSecond(1755031147499L));
+        assertEquals(1755031148000L, RollingFileManager.alignMillisToSecond(1755031147500L));
+        assertEquals(1755031148000L, RollingFileManager.alignMillisToSecond(1755031147999L));
+        assertEquals(1755031148000L, RollingFileManager.alignMillisToSecond(1755031148000L));
+
+        final File file = File.createTempFile("testFile", "log");
+        file.deleteOnExit();
+
+        assertEquals(0, RollingFileManager.initialFileTime(file) % 1000);
+    }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingFileManager.java
@@ -910,7 +910,7 @@ public class RollingFileManager extends FileManager {
         }
     }
 
-    private static long initialFileTime(final File file) {
+    static long initialFileTime(final File file) {
         final Path path = file.toPath();
         if (Files.exists(path)) {
             try {
@@ -918,15 +918,24 @@ public class RollingFileManager extends FileManager {
                 final FileTime fileTime = attrs.creationTime();
                 if (fileTime.compareTo(EPOCH) > 0) {
                     LOGGER.debug("Returning file creation time for {}", file.getAbsolutePath());
-                    return fileTime.toMillis();
+
+                    return alignMillisToSecond(fileTime.toMillis());
                 }
-                LOGGER.info("Unable to obtain file creation time for " + file.getAbsolutePath());
+                LOGGER.info("Unable to obtain file creation time for {}", file.getAbsolutePath());
             } catch (final Exception ex) {
-                LOGGER.info("Unable to calculate file creation time for " + file.getAbsolutePath() + ": "
-                        + ex.getMessage());
+                LOGGER.info(
+                        "Unable to calculate file creation time for {}: {}", file.getAbsolutePath(), ex.getMessage());
             }
         }
-        return file.lastModified();
+
+        return alignMillisToSecond(file.lastModified());
+    }
+
+    /**
+     * @see <a href="https://github.com/apache/logging-log4j2/issues/3068">Issue #3068</a>
+     */
+    static long alignMillisToSecond(long millis) {
+        return Math.round(millis / 1000d) * 1000;
     }
 
     private static class EmptyQueue extends ArrayBlockingQueue<Runnable> {

--- a/src/changelog/.2.x.x/3872_fix_RollingFileManager_initialTime.xml
+++ b/src/changelog/.2.x.x/3872_fix_RollingFileManager_initialTime.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <issue id="3068" link="https://github.com/apache/logging-log4j2/issues/3068"/>
+    <issue id="3872" link="https://github.com/apache/logging-log4j2/pull/3872"/>
+    <description format="asciidoc">
+        Discard the sub-second part while obtaining the initial time (i.e., creation time) of a file in `RollingFileManager`
+    </description>
+</entry>


### PR DESCRIPTION
Caching of filesystem timestamps (at least in ext4 on Linux) results in non-accurate creation timestamps.

Thus, let's round it to the second.

Rounding is also applied for the lastModified time, but I'm not sure whether it's needed there.

Fixes #3068.

### ✅ Required checks

- [x] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [x] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [x] **Code formatting**: The code is formatted according to the project’s style guide.
- [ ] **Build & Test**: I verified that the project builds and all unit tests pass.

### 🧪 Tests (select one)

- [x] I have added or updated tests to cover my changes.
- [ ] No additional tests are needed for this change.

### 📝 Changelog (select one)

- [ ] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [ ] This is a trivial change and does not require a changelog entry.
