### PR TITLE
Bump elasticsearch-java to version 9.x

### DIFF
--- a/log4j-layout-template-json-test/pom.xml
+++ b/log4j-layout-template-json-test/pom.xml
@@ -84,15 +84,15 @@
     </dependency>
 
     <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-client</artifactId>
-      <version>${elastic.version}</version>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+      <version>${elastic.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -360,9 +360,6 @@
                 <log4j.logstash.gelf.port>${logstash.gelf.port}</log4j.logstash.gelf.port>
                 <log4j.logstash.tcp.port>${logstash.tcp.port}</log4j.logstash.tcp.port>
               </systemPropertyVariables>
-              <jdkToolchain>
-                <version>17</version>
-              </jdkToolchain>
 
             </configuration>
             <executions>

--- a/log4j-layout-template-json-test/pom.xml
+++ b/log4j-layout-template-json-test/pom.xml
@@ -48,7 +48,7 @@
          2. The Docker image version of the ELK-stack
 
          As of 2024-09-16, these all (Maven artifacts and Elastic products) get released with the same version. -->
-    <elastic.version>8.17.3</elastic.version>
+    <elastic.version>9.1.3</elastic.version>
 
   </properties>
 
@@ -129,6 +129,13 @@
     <dependency>
       <groupId>co.elastic.logging</groupId>
       <artifactId>log4j2-ecs-layout</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+      <version>8.13.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/log4j-layout-template-json-test/pom.xml
+++ b/log4j-layout-template-json-test/pom.xml
@@ -48,7 +48,7 @@
          2. The Docker image version of the ELK-stack
 
          As of 2024-09-16, these all (Maven artifacts and Elastic products) get released with the same version. -->
-    <elastic.version>9.1.3</elastic.version>
+    <elastic.version>8.17.3</elastic.version>
 
   </properties>
 
@@ -195,6 +195,26 @@
 
       <build>
         <plugins>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-toolchains-plugin</artifactId>
+            <version>3.1.0</version>
+            <configuration>
+              <toolchains>
+                <jdk>
+                  <version>17</version>
+                </jdk>
+              </toolchains>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>toolchain</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
 
           <plugin>
             <groupId>io.fabric8</groupId>

--- a/log4j-layout-template-json-test/pom.xml
+++ b/log4j-layout-template-json-test/pom.xml
@@ -84,15 +84,15 @@
     </dependency>
 
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+      <version>${elastic.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
-      <groupId>co.elastic.clients</groupId>
-      <artifactId>elasticsearch-java</artifactId>
-      <version>${elastic.version}</version>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -129,13 +129,6 @@
     <dependency>
       <groupId>co.elastic.logging</groupId>
       <artifactId>log4j2-ecs-layout</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-client</artifactId>
-      <version>8.13.4</version>
       <scope>test</scope>
     </dependency>
 
@@ -195,26 +188,6 @@
 
       <build>
         <plugins>
-
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-toolchains-plugin</artifactId>
-            <version>3.1.0</version>
-            <configuration>
-              <toolchains>
-                <jdk>
-                  <version>17</version>
-                </jdk>
-              </toolchains>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>toolchain</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
 
           <plugin>
             <groupId>io.fabric8</groupId>
@@ -387,6 +360,10 @@
                 <log4j.logstash.gelf.port>${logstash.gelf.port}</log4j.logstash.gelf.port>
                 <log4j.logstash.tcp.port>${logstash.tcp.port}</log4j.logstash.tcp.port>
               </systemPropertyVariables>
+              <jdkToolchain>
+                <version>17</version>
+              </jdkToolchain>
+
             </configuration>
             <executions>
               <execution>

--- a/log4j-layout-template-json-test/pom.xml
+++ b/log4j-layout-template-json-test/pom.xml
@@ -48,7 +48,7 @@
          2. The Docker image version of the ELK-stack
 
          As of 2024-09-16, these all (Maven artifacts and Elastic products) get released with the same version. -->
-    <elastic.version>8.17.3</elastic.version>
+    <elastic.version>9.1.3</elastic.version>
 
   </properties>
 

--- a/log4j-layout-template-json-test/pom.xml
+++ b/log4j-layout-template-json-test/pom.xml
@@ -37,17 +37,17 @@
     <sign.skip>true</sign.skip>
 
     <!--
-          ~ OSGi and JPMS options
-          -->
+      ~ OSGi and JPMS options
+      -->
     <bnd-module-name>org.apache.logging.log4j.layout.template.json.test</bnd-module-name>
     <Fragment-Host>org.apache.logging.log4j.core</Fragment-Host>
 
     <!-- `elastic.version` is used for two purposes:
 
-             1. `co.elastic.clients:elasticsearch-java` version
-             2. The Docker image version of the ELK-stack
+         1. `co.elastic.clients:elasticsearch-java` version
+         2. The Docker image version of the ELK-stack
 
-             As of 2024-09-16, these all (Maven artifacts and Elastic products) get released with the same version. -->
+         As of 2024-09-16, these all (Maven artifacts and Elastic products) get released with the same version. -->
     <elastic.version>9.1.3</elastic.version>
 
   </properties>
@@ -104,18 +104,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
@@ -161,8 +149,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <!-- Enforcing a non-UTF-8 encoding to check that the layout
-                         indeed handles everything in UTF-8 without implicitly
-                         relying on the system defaults. -->
+               indeed handles everything in UTF-8 without implicitly
+               relying on the system defaults. -->
           <argLine>-Dfile.encoding=US-ASCII</argLine>
           <systemPropertyVariables>
             <!-- Enable JUnit 5 parallel execution. -->
@@ -181,8 +169,8 @@
       <id>docker</id>
 
       <!--
-              ~ Only the `ubuntu` CI runners have access to Docker
-              -->
+        ~ Only the `ubuntu` CI runners have access to Docker
+        -->
       <activation>
         <os>
           <family>linux</family>
@@ -200,7 +188,7 @@
         <docker.verbose>false</docker.verbose>
 
         <!-- `docker run elasticsearch:<TAG>` exists with code 137 due to insufficient memory.
-                     We limit the used JVM memory to avoid this OOM failure. -->
+             We limit the used JVM memory to avoid this OOM failure. -->
         <elastic.javaOpts>-Xms750m -Xmx750m</elastic.javaOpts>
 
       </properties>

--- a/log4j-layout-template-json-test/pom.xml
+++ b/log4j-layout-template-json-test/pom.xml
@@ -37,17 +37,17 @@
     <sign.skip>true</sign.skip>
 
     <!--
-      ~ OSGi and JPMS options
-      -->
+          ~ OSGi and JPMS options
+          -->
     <bnd-module-name>org.apache.logging.log4j.layout.template.json.test</bnd-module-name>
     <Fragment-Host>org.apache.logging.log4j.core</Fragment-Host>
 
     <!-- `elastic.version` is used for two purposes:
 
-         1. `co.elastic.clients:elasticsearch-java` version
-         2. The Docker image version of the ELK-stack
+             1. `co.elastic.clients:elasticsearch-java` version
+             2. The Docker image version of the ELK-stack
 
-         As of 2024-09-16, these all (Maven artifacts and Elastic products) get released with the same version. -->
+             As of 2024-09-16, these all (Maven artifacts and Elastic products) get released with the same version. -->
     <elastic.version>9.1.3</elastic.version>
 
   </properties>
@@ -90,9 +90,28 @@
     </dependency>
 
     <dependency>
+      <groupId>co.elastic.clients</groupId>
+      <artifactId>elasticsearch-java</artifactId>
+      <version>${elastic.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-client</artifactId>
       <version>${elastic.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -142,8 +161,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <!-- Enforcing a non-UTF-8 encoding to check that the layout
-               indeed handles everything in UTF-8 without implicitly
-               relying on the system defaults. -->
+                         indeed handles everything in UTF-8 without implicitly
+                         relying on the system defaults. -->
           <argLine>-Dfile.encoding=US-ASCII</argLine>
           <systemPropertyVariables>
             <!-- Enable JUnit 5 parallel execution. -->
@@ -162,8 +181,8 @@
       <id>docker</id>
 
       <!--
-        ~ Only the `ubuntu` CI runners have access to Docker
-        -->
+              ~ Only the `ubuntu` CI runners have access to Docker
+              -->
       <activation>
         <os>
           <family>linux</family>
@@ -181,7 +200,7 @@
         <docker.verbose>false</docker.verbose>
 
         <!-- `docker run elasticsearch:<TAG>` exists with code 137 due to insufficient memory.
-             We limit the used JVM memory to avoid this OOM failure. -->
+                     We limit the used JVM memory to avoid this OOM failure. -->
         <elastic.javaOpts>-Xms750m -Xmx750m</elastic.javaOpts>
 
       </properties>
@@ -360,7 +379,6 @@
                 <log4j.logstash.gelf.port>${logstash.gelf.port}</log4j.logstash.gelf.port>
                 <log4j.logstash.tcp.port>${logstash.tcp.port}</log4j.logstash.tcp.port>
               </systemPropertyVariables>
-
             </configuration>
             <executions>
               <execution>

--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/LogstashIT.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/LogstashIT.java
@@ -19,8 +19,19 @@ package org.apache.logging.log4j.layout.template.json;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.HealthStatus;
+import co.elastic.clients.elasticsearch.cluster.HealthResponse;
+import co.elastic.clients.elasticsearch.core.CountResponse;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.SourceConfig;
+import co.elastic.clients.elasticsearch.indices.DeleteIndexRequest;
+import co.elastic.clients.elasticsearch.indices.DeleteIndexResponse;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
 import co.elastic.logging.log4j2.EcsLayout;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -52,9 +63,6 @@ import org.apache.logging.log4j.layout.template.json.util.ThreadLocalRecyclerFac
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Strings;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -128,7 +136,10 @@ class LogstashIT {
     private static final String ES_INDEX_MESSAGE_FIELD_NAME = "message";
 
     private static RestClient REST_CLIENT;
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static ElasticsearchTransport ES_TRANSPORT;
+
+    private static ElasticsearchClient ES_CLIENT;
 
     /**
      * Constants hardcoded in `docker-maven-plugin` configuration, do not change!
@@ -171,16 +182,16 @@ class LogstashIT {
         final String hostUri =
                 String.format("http://%s:%d", MavenHardcodedConstants.HOST_NAME, MavenHardcodedConstants.ES_PORT);
         REST_CLIENT = RestClient.builder(HttpHost.create(hostUri)).build();
+        ES_TRANSPORT = new RestClientTransport(REST_CLIENT, new JacksonJsonpMapper());
+        ES_CLIENT = new ElasticsearchClient(ES_TRANSPORT);
+
         LOGGER.info(LOG_PREFIX + "verifying the ES connection to `{}`", hostUri);
         await("ES cluster health")
                 .pollDelay(100, TimeUnit.MILLISECONDS)
                 .atMost(1, TimeUnit.MINUTES)
                 .untilAsserted(() -> {
-                    Request request = new Request("GET", "/_cluster/health");
-                    Response response = REST_CLIENT.performRequest(request);
-                    Map<String, Object> health =
-                            OBJECT_MAPPER.readValue(response.getEntity().getContent(), Map.class);
-                    assertThat(health.get("status")).isNotEqualTo("red");
+                    final HealthResponse healthResponse = ES_CLIENT.cluster().health();
+                    assertThat(healthResponse.status()).isNotEqualTo(HealthStatus.Red);
                 });
     }
 
@@ -206,9 +217,11 @@ class LogstashIT {
     void deleteIndex() throws IOException {
         LOGGER.info(LOG_PREFIX + "deleting the ES index");
         try {
-            Request request = new Request("DELETE", "/" + MavenHardcodedConstants.ES_INDEX_NAME);
-            REST_CLIENT.performRequest(request);
-        } catch (ResponseException error) {
+            DeleteIndexResponse deleteIndexResponse = ES_CLIENT
+                    .indices()
+                    .delete(DeleteIndexRequest.of(builder -> builder.index(MavenHardcodedConstants.ES_INDEX_NAME)));
+            assertThat(deleteIndexResponse.acknowledged()).isTrue();
+        } catch (ElasticsearchException error) {
             if (!error.getMessage().contains("index_not_found_exception")) {
                 throw new RuntimeException(error);
             }
@@ -217,6 +230,7 @@ class LogstashIT {
 
     @AfterAll
     static void stopClient() throws Exception {
+        ES_TRANSPORT.close();
         REST_CLIENT.close();
     }
 
@@ -452,24 +466,42 @@ class LogstashIT {
     }
 
     private static void assertDocumentCount(final int expectedCount) throws IOException {
-        Request request = new Request("GET", "/" + MavenHardcodedConstants.ES_INDEX_NAME + "/_count");
-        Response response = REST_CLIENT.performRequest(request);
-        Map<String, Object> countResponse =
-                OBJECT_MAPPER.readValue(response.getEntity().getContent(), Map.class);
-        long actualCount = ((Number) countResponse.get("count")).longValue();
+        final CountResponse countResponse;
+        try {
+            countResponse = ES_CLIENT.count(builder -> builder.index(MavenHardcodedConstants.ES_INDEX_NAME));
+        }
+        // Try to enrich the failure with the available list of indices
+        catch (final ElasticsearchException error) {
+            try {
+                if (error.getMessage().contains("index_not_found_exception")) {
+                    final Set<String> indexNames =
+                            ES_CLIENT.cluster().health().indices().keySet();
+                    final String message = String.format("Could not find index! Available index names: %s", indexNames);
+                    throw new AssertionError(message, error);
+                }
+            } catch (final Exception suppressed) {
+                error.addSuppressed(suppressed);
+            }
+            throw error;
+        }
+        final long actualCount = countResponse.count();
         assertThat(actualCount).isEqualTo(expectedCount);
     }
 
     private static List<Map<String, Object>> queryDocuments() throws IOException {
-        Request request =
-                new Request("GET", "/" + MavenHardcodedConstants.ES_INDEX_NAME + "/_search?size=" + LOG_EVENT_COUNT);
-        Response response = REST_CLIENT.performRequest(request);
-        Map<String, Object> searchResponse =
-                OBJECT_MAPPER.readValue(response.getEntity().getContent(), Map.class);
-        List<Map<String, Object>> hits =
-                (List<Map<String, Object>>) ((Map<String, Object>) searchResponse.get("hits")).get("hits");
-        return hits.stream()
-                .map(hit -> (Map<String, Object>) hit.get("_source"))
+        @SuppressWarnings("rawtypes")
+        SearchResponse<Map> searchResponse = ES_CLIENT.search(
+                searchBuilder -> searchBuilder
+                        .index(MavenHardcodedConstants.ES_INDEX_NAME)
+                        .size(LOG_EVENT_COUNT)
+                        .source(SourceConfig.of(sourceConfigBuilder -> sourceConfigBuilder.fetch(true))),
+                Map.class);
+        return searchResponse.hits().hits().stream()
+                .map(hit -> {
+                    @SuppressWarnings("unchecked")
+                    final Map<String, Object> source = hit.source();
+                    return source;
+                })
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Fixes #3663.

This pull request updates the dependencies in the `log4j-layout-template-json-test/pom.xml` file to keep the project up to date with the latest Elastic Stack versions and adds a new test dependency. The most important changes are:

**Dependency updates:**

* Bumped the `elastic.version` property from `8.17.3` to `9.1.3` to align with the latest Elastic Stack release.

**New test dependency:**

* Added the `elasticsearch-rest-client` library (version `8.13.4`) as a test-scoped dependency to support testing with the Elasticsearch REST client.