### PR TITLE
Fix the missing Error Prone version

### DIFF
--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -859,7 +859,7 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
-      <version>${error-prone.version}</version>
+      <version>${error-prone-annotations.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/src/changelog/.2.x.x/3758_fix_error_prone_dep.xml
+++ b/src/changelog/.2.x.x/3758_fix_error_prone_dep.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3758" link="https://github.com/apache/logging-log4j2/issues/3758"/>
+  <issue id="3779" link="https://github.com/apache/logging-log4j2/issues/3779"/>
+  <description format="asciidoc">
+    Fix the `com.google.errorprone:error_prone_annotations` dependency whose version property gets orphan due to flattening.
+  </description>
+</entry>

--- a/src/changelog/.2.x.x/3905_fix_error_prone_dep.xml
+++ b/src/changelog/.2.x.x/3905_fix_error_prone_dep.xml
@@ -5,9 +5,10 @@
            https://logging.apache.org/xml/ns
            https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
-  <issue id="3758" link="https://github.com/apache/logging-log4j2/issues/3758"/>
   <issue id="3779" link="https://github.com/apache/logging-log4j2/issues/3779"/>
+  <issue id="3785" link="https://github.com/apache/logging-log4j2/pull/3785"/>
+  <issue id="3905" link="https://github.com/apache/logging-log4j2/pull/3905"/>
   <description format="asciidoc">
-    Fix the `com.google.errorprone:error_prone_annotations` dependency whose version property gets orphan due to flattening.
+    Fix the `com.google.errorprone:error_prone_annotations` dependency whose version property gets erased due to flattening
   </description>
 </entry>


### PR DESCRIPTION
#3785 introduced a new `error-prone-annotations.version` property to substitute the `error-prone.version` provided by `logging-parent`, though the latter got erased at BOM-flattening. #3785 left behind a `error-prone.version` usage and it is causing problems reported in #3779. This PR replaces all `error-prone.version` usages with `error-prone-annotations.version` and fixes #3779.