### PR TITLE
feat: flatten non-BOM artifacts

### DIFF
--- a/log4j-mongodb/pom.xml
+++ b/log4j-mongodb/pom.xml
@@ -128,13 +128,6 @@
         <configuration>
           <skip>true</skip>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
-          </dependency>
-        </dependencies>
       </plugin>
 
     </plugins>

--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -1140,6 +1140,52 @@
         </executions>
       </plugin>
 
+      <!--
+       ~ Drop the <build> section from flattened POMs.
+       ~ Keeps the consumer POM minimal and prevents flattened build-only properties
+       ~ (e.g., `error-prone.version`) from causing resolution problems to users.
+       ~
+       ~ Ref: https://github.com/apache/logging-log4j2/issues/3779
+      -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <executions>
+          <!-- First use the special `resolveCiFriendliesOnly` mode to replace the special `${revision}` property with the actual version.
+               This is necessary because `flatten` mode does not support `ci-friendly` versions. -->
+          <execution>
+            <id>flatten-revision</id>
+          </execution>
+          <execution>
+            <id>flatten</id>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <!-- Use 'clean' as a base, then selectively retain key elements -->
+              <flattenMode>clean</flattenMode>
+              <pomElements>
+                <!-- Keep parent to maintain inheritance from log4j-bom and ancestors -->
+                <parent>keep</parent>
+
+                <!-- Retain meaningful module metadata -->
+                <name>expand</name>
+                <description>expand</description>
+
+                <!-- Expand URL to prevent default behavior of appending artifactId -->
+                <url>expand</url>
+
+                <!-- Keep dependencyManagement and dependencies, interpolating property-based versions -->
+                <dependencyManagement>interpolate</dependencyManagement>
+                <dependencies>interpolate</dependencies>
+              </pomElements>
+            </configuration>
+          </execution>
+
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -630,6 +630,37 @@
         </configuration>
       </plugin>
 
+      <!--
+        ~ Memento rules to remove overrides from child modules, whenever the changes are moved to `logging-parent`.
+        ~
+        ~ When empty, please comment this execution out, but do not delete it!
+        -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>remove-overrides</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <!-- Wait until we retrieve `parent.version` property in `build-helper-maven-plugin` below -->
+            <phase>initialize</phase>
+            <inherited>false</inherited>
+            <configuration>
+              <rules>
+                <requireProperty>
+                  <property>parent.version</property>
+                  <regex>12\.1\.1</regex>
+                  <regexMessage>Remember to remove overrides from child modules, whenever the changes are moved to `logging-parent`:
+                    * Remove the override `flatten-maven-plugin` configuration from `log4j-parent/pom.xml`.</regexMessage>
+                </requireProperty>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- ███████ ████████  █████  ██████  ████████        ███████ ██ ████████ ███████
            ██         ██    ██   ██ ██   ██    ██    ██     ██      ██    ██    ██
            ███████    ██    ███████ ██████     ██           ███████ ██    ██    █████
@@ -655,6 +686,21 @@
               <name>currentYear</name>
               <pattern>yyyy</pattern>
               <locale>en_US</locale>
+            </configuration>
+          </execution>
+          <!-- Used by `maven-enforcer-plugin` above -->
+          <execution>
+            <id>capture-parent-version</id>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <phase>validate</phase>
+            <inherited>false</inherited>
+            <configuration>
+              <name>parent.version</name>
+              <value>${project.parent.version}</value>
+              <regex>^(.+)$</regex>
+              <replacement>$1</replacement>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This change introduces a new execution of the Flatten Maven Plugin for non-BOM modules, aimed at simplifying their published POMs while preserving important metadata and build integrity.

### Key changes

* Applies `clean` mode, removing most optional POM elements.
* Retains key elements:

  * `<name>`, `<description>`, and `<url>` are expanded to preserve meaningful metadata and prevent undesirable URL inheritance (i.e., appending `artifactId` to the parent URL).
  * `<license>` is preserved in each module for clarity and utility.
* Keeps the `<parent>` element so modules continue to inherit metadata and `dependencyManagement` from `log4j-bom` and their direct ancestors.
* `<properties>` are removed, but `<dependencies>` and `<dependencyManagement>` are retained with interpolated values to avoid unresolved variables in the flattened POMs.

### Differences from the `clean` mode

* Keeps `name` and `description` per module to aid discoverability.
* Delegates all contact and project metadata (organization, developers, mailing lists, SCM, issue tracker, CI config, etc.) to the centralized `log4j-bom` POM.
* Preserves `dependencyManagement` sections by interpolating versions, rather than removing them.
* Retains non-transitive scopes (`provided`, `test`) to expose compile/test-time dependencies, even if consumers don't require them.

This flattening strategy reduces noise in published POMs while maintaining enough structure for clarity and downstream tool compatibility.

Another advantage of this approach is that the Flatten Maven Plugin computes the **effective** POM using the **already flattened** parent POMs, unlike Maven’s reactor, which uses the source POM files. This helps catch issues early and prevents unresolved properties from being accidentally propagated into the published POMs.

While this change will likely belong in `logging-parent` eventually, this PR is currently targeted here (and marked as a draft) for two main reasons:

* To allow for experimentation and validation before moving it upstream to `logging-parent`.
* To make it available in `2.25.2` without incurring the additional overhead of releasing a new version of `logging-parent`.


