### PR TITLE
doc: clarify `%ex` whitespace behavior across versions

### DIFF
--- a/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
@@ -603,7 +603,13 @@ In this mode, the exception stack trace will be rendered according to the config
 
 [IMPORTANT]
 ====
-All rendered exception stack traces are ensured to be prefixed with a new line obtained using `System.lineSeparator()`.
+Earlier versions of Log4j Core always inserted a space between the *output* of the previous conversion specifier and the stack trace.
+
+Starting with version `2.25.0`, this was changed to a line separator instead of a space.
+
+Since version `2.25.2`, automatic separation occurs *only* for converters implicitly added via the <<plugin-attr-alwaysWriteExceptions>> option.
+
+When you add a throwable converter explicitly in your pattern, Log4j Core no longer inserts any separator on its own: you have full control over whether and how to separate the stack trace from the preceding message.
 ====
 
 link:../javadoc/log4j-core/org/apache/logging/log4j/core/pattern/ThrowablePatternConverter.html[`ThrowablePatternConverter`] specifier grammar **for rendering stack traces**:


### PR DESCRIPTION
This update documents the historical whitespace handling of the `%ex` pattern converter and how it has evolved in the `2.25.x` releases.

Key point: since `2.25.2`, when users add `%ex` explicitly in their pattern, Log4j no longer inserts any automatic separator. It is now entirely up to the user to decide how (or whether) to separate the stack trace from the preceding output.

Related to #3837
