### PR TITLE
Add new `ConfigurationFactory::getConfiguration` accepting multiple URIs

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationFactoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationFactoryTest.java
@@ -140,8 +140,7 @@ class ConfigurationFactoryTest {
     void testGetConfigurationWithNullUris() {
         final ConfigurationFactory factory = Mockito.spy(ConfigurationFactory.getInstance());
         try (final LoggerContext context = new LoggerContext("test")) {
-            factory.getConfiguration(context, "test", (List<URI>) null);
-            Mockito.verify(factory).getConfiguration(Mockito.same(context), Mockito.eq("test"), (URI) Mockito.isNull());
+            assertThrows(NullPointerException.class, () -> factory.getConfiguration(context, "test", (List<URI>) null));
         }
     }
 
@@ -158,9 +157,8 @@ class ConfigurationFactoryTest {
     void testGetConfigurationWithNullInList() {
         final ConfigurationFactory factory = Mockito.spy(ConfigurationFactory.getInstance());
         try (final LoggerContext context = new LoggerContext("test")) {
-            final List<URI> listWithNull = Collections.singletonList(null);
-            factory.getConfiguration(context, "test", listWithNull);
-            Mockito.verify(factory).getConfiguration(Mockito.same(context), Mockito.eq("test"), (URI) Mockito.isNull());
+            final List<URI> listWithNull = Arrays.asList(URI.create("path:://to/nowhere"), null);
+            assertThrows(NullPointerException.class, () -> factory.getConfiguration(context, "test", listWithNull));
         }
     }
 

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationFactoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationFactoryTest.java
@@ -19,7 +19,6 @@ package org.apache.logging.log4j.core.config;
 import static org.apache.logging.log4j.util.Unbox.box;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -48,6 +46,7 @@ import org.apache.logging.log4j.test.junit.TempLoggingDir;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class ConfigurationFactoryTest {
 
@@ -139,43 +138,41 @@ class ConfigurationFactoryTest {
 
     @Test
     void testGetConfigurationWithNullUris() {
-        final ConfigurationFactory factory = ConfigurationFactory.getInstance();
+        final ConfigurationFactory factory = Mockito.spy(ConfigurationFactory.getInstance());
         try (final LoggerContext context = new LoggerContext("test")) {
-            assertThrows(NullPointerException.class, () -> factory.getConfiguration(context, "test", (List<URI>) null));
+            factory.getConfiguration(context, "test", (List<URI>) null);
+            Mockito.verify(factory).getConfiguration(Mockito.same(context), Mockito.eq("test"), (URI) Mockito.isNull());
         }
     }
 
     @Test
     void testGetConfigurationWithEmptyUris() {
-        final ConfigurationFactory factory = ConfigurationFactory.getInstance();
+        final ConfigurationFactory factory = Mockito.spy(ConfigurationFactory.getInstance());
         try (final LoggerContext context = new LoggerContext("test")) {
-            assertThrows(
-                    IllegalArgumentException.class,
-                    () -> factory.getConfiguration(context, "test", Collections.emptyList()));
+            factory.getConfiguration(context, "test", Collections.emptyList());
+            Mockito.verify(factory).getConfiguration(Mockito.same(context), Mockito.eq("test"), (URI) Mockito.isNull());
         }
     }
 
     @Test
     void testGetConfigurationWithNullInList() {
-        final ConfigurationFactory factory = ConfigurationFactory.getInstance();
+        final ConfigurationFactory factory = Mockito.spy(ConfigurationFactory.getInstance());
         try (final LoggerContext context = new LoggerContext("test")) {
             final List<URI> listWithNull = Collections.singletonList(null);
-            assertThrows(ConfigurationException.class, () -> factory.getConfiguration(context, "test", listWithNull));
+            factory.getConfiguration(context, "test", listWithNull);
+            Mockito.verify(factory).getConfiguration(Mockito.same(context), Mockito.eq("test"), (URI) Mockito.isNull());
         }
     }
 
     @Test
     void testGetConfigurationWithSingleUri() throws Exception {
-        final ConfigurationFactory factory = ConfigurationFactory.getInstance();
+        final ConfigurationFactory factory = Mockito.spy(ConfigurationFactory.getInstance());
         try (final LoggerContext context = new LoggerContext("test")) {
-            final URL resource = getClass().getResource("/log4j-test1.xml");
-            assertNotNull(resource);
-
-            final List<URI> singleUri = Collections.singletonList(resource.toURI());
-            final Configuration config = factory.getConfiguration(context, "test", singleUri);
-
-            assertNotNull(config);
-            assertFalse(config instanceof CompositeConfiguration);
+            final URI configLocation =
+                    getClass().getResource("/log4j-test1.xml").toURI();
+            factory.getConfiguration(context, "test", Collections.singletonList(configLocation));
+            Mockito.verify(factory)
+                    .getConfiguration(Mockito.same(context), Mockito.eq("test"), Mockito.eq(configLocation));
         }
     }
 
@@ -183,16 +180,13 @@ class ConfigurationFactoryTest {
     void testGetConfigurationWithMultipleUris() throws Exception {
         final ConfigurationFactory factory = ConfigurationFactory.getInstance();
         try (final LoggerContext context = new LoggerContext("test")) {
-            final URL resource1 = getClass().getResource("/log4j-test1.xml");
-            final URL resource2 = getClass().getResource("/log4j-xinclude.xml");
-            assertNotNull(resource1);
-            assertNotNull(resource2);
-
-            final List<URI> multipleUris = Arrays.asList(resource1.toURI(), resource2.toURI());
-            final Configuration config = factory.getConfiguration(context, "test", multipleUris);
-
-            assertNotNull(config);
-            assertTrue(config instanceof CompositeConfiguration);
+            final URI configLocation1 =
+                    getClass().getResource("/log4j-test1.xml").toURI();
+            final URI configLocation2 =
+                    getClass().getResource("/log4j-xinclude.xml").toURI();
+            final List<URI> configLocations = Arrays.asList(configLocation1, configLocation2);
+            final Configuration config = factory.getConfiguration(context, "test", configLocations);
+            assertInstanceOf(CompositeConfiguration.class, config);
         }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationFactoryTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationFactoryTest.java
@@ -19,14 +19,19 @@ package org.apache.logging.log4j.core.config;
 import static org.apache.logging.log4j.util.Unbox.box;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +41,7 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.config.composite.CompositeConfiguration;
 import org.apache.logging.log4j.core.filter.ThreadContextMapFilter;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.test.junit.TempLoggingDir;
@@ -129,5 +135,64 @@ class ConfigurationFactoryTest {
         checkConfiguration(context);
         final Path logFile = loggingPath.resolve("test-properties.log");
         checkFileLogger(context, logFile);
+    }
+
+    @Test
+    void testGetConfigurationWithNullUris() {
+        final ConfigurationFactory factory = ConfigurationFactory.getInstance();
+        try (final LoggerContext context = new LoggerContext("test")) {
+            assertThrows(NullPointerException.class, () -> factory.getConfiguration(context, "test", (List<URI>) null));
+        }
+    }
+
+    @Test
+    void testGetConfigurationWithEmptyUris() {
+        final ConfigurationFactory factory = ConfigurationFactory.getInstance();
+        try (final LoggerContext context = new LoggerContext("test")) {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> factory.getConfiguration(context, "test", Collections.emptyList()));
+        }
+    }
+
+    @Test
+    void testGetConfigurationWithNullInList() {
+        final ConfigurationFactory factory = ConfigurationFactory.getInstance();
+        try (final LoggerContext context = new LoggerContext("test")) {
+            final List<URI> listWithNull = Collections.singletonList(null);
+            assertThrows(ConfigurationException.class, () -> factory.getConfiguration(context, "test", listWithNull));
+        }
+    }
+
+    @Test
+    void testGetConfigurationWithSingleUri() throws Exception {
+        final ConfigurationFactory factory = ConfigurationFactory.getInstance();
+        try (final LoggerContext context = new LoggerContext("test")) {
+            final URL resource = getClass().getResource("/log4j-test1.xml");
+            assertNotNull(resource);
+
+            final List<URI> singleUri = Collections.singletonList(resource.toURI());
+            final Configuration config = factory.getConfiguration(context, "test", singleUri);
+
+            assertNotNull(config);
+            assertFalse(config instanceof CompositeConfiguration);
+        }
+    }
+
+    @Test
+    void testGetConfigurationWithMultipleUris() throws Exception {
+        final ConfigurationFactory factory = ConfigurationFactory.getInstance();
+        try (final LoggerContext context = new LoggerContext("test")) {
+            final URL resource1 = getClass().getResource("/log4j-test1.xml");
+            final URL resource2 = getClass().getResource("/log4j-xinclude.xml");
+            assertNotNull(resource1);
+            assertNotNull(resource2);
+
+            final List<URI> multipleUris = Arrays.asList(resource1.toURI(), resource2.toURI());
+            final Configuration config = factory.getConfiguration(context, "test", multipleUris);
+
+            assertNotNull(config);
+            assertTrue(config instanceof CompositeConfiguration);
+        }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/CustomConfigurationFactory.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/builder/CustomConfigurationFactory.java
@@ -72,7 +72,7 @@ public class CustomConfigurationFactory extends ConfigurationFactory {
 
     @Override
     public Configuration getConfiguration(final LoggerContext loggerContext, final ConfigurationSource source) {
-        return getConfiguration(loggerContext, source.toString(), null);
+        return getConfiguration(loggerContext, source.toString(), (URI) null);
     }
 
     @Override

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.logging.log4j.Level;
@@ -331,6 +332,52 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
             }
         }
         return getConfiguration(loggerContext, name, configLocation);
+    }
+
+    /**
+     * Creates a Configuration from multiple configuration URIs.
+     * If multiple URIs are successfully loaded, they will be combined into a CompositeConfiguration.
+     *
+     * @param loggerContext the logger context (may be null)
+     * @param name the configuration name (may be null)
+     * @param uris the list of configuration URIs (must not be null or empty)
+     * @return a Configuration created from the provided URIs
+     * @throws NullPointerException if uris is null
+     * @throws IllegalArgumentException if uris is empty
+     * @throws ConfigurationException if no valid configuration could be created
+     * from any of the provided URIs
+     * @since 2.26.0
+     */
+    public Configuration getConfiguration(final LoggerContext loggerContext, final String name, final List<URI> uris) {
+
+        Objects.requireNonNull(uris, "uris parameter cannot be null");
+
+        if (uris.isEmpty()) {
+            throw new IllegalArgumentException("URI list cannot be empty");
+        }
+
+        final List<AbstractConfiguration> configurations = new ArrayList<>();
+
+        for (final URI uri : uris) {
+
+            if (uri == null) {
+                throw new ConfigurationException("URI list contains null element");
+            }
+
+            final Configuration config = getConfiguration(loggerContext, name, uri);
+
+            if (config == null) {
+                throw new ConfigurationException("Failed to create configuration from: " + uri);
+            }
+
+            if (!(config instanceof AbstractConfiguration)) {
+                throw new ConfigurationException("Configuration at " + uri + " is not an AbstractConfiguration");
+            }
+
+            configurations.add((AbstractConfiguration) config);
+        }
+
+        return configurations.size() == 1 ? configurations.get(0) : new CompositeConfiguration(configurations);
     }
 
     static boolean isClassLoaderUri(final URI uri) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -335,49 +336,68 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
     }
 
     /**
-     * Creates a Configuration from multiple configuration URIs.
-     * If multiple URIs are successfully loaded, they will be combined into a CompositeConfiguration.
+     * {@return a {@link Configuration} created using provided configuration location {@link URI}s}
+     * If the provided list of {@code URI}s is null or empty, {@code getConfiguration(loggerContext, name, (URI) null)} will be returned.
      *
-     * @param loggerContext the logger context (may be null)
-     * @param name the configuration name (may be null)
-     * @param uris the list of configuration URIs (must not be null or empty)
-     * @return a Configuration created from the provided URIs
-     * @throws NullPointerException if uris is null
-     * @throws IllegalArgumentException if uris is empty
-     * @throws ConfigurationException if no valid configuration could be created
-     * from any of the provided URIs
+     * @param loggerContext a logger context, may be null
+     * @param name a configuration name, may be null
+     * @param configLocations configuration location {@code URI}s, may be null or empty
+     * @throws ConfigurationException if configuration could not be created
+     *
      * @since 2.26.0
      */
-    public Configuration getConfiguration(final LoggerContext loggerContext, final String name, final List<URI> uris) {
+    public Configuration getConfiguration(
+            final LoggerContext loggerContext, final String name, final List<URI> configLocations) {
 
-        Objects.requireNonNull(uris, "uris parameter cannot be null");
+        // Sanitize URIs
+        final List<URI> distinctConfigLocations = configLocations == null
+                ? Collections.emptyList()
+                : configLocations.stream().filter(Objects::nonNull).distinct().collect(Collectors.toList());
 
-        if (uris.isEmpty()) {
-            throw new IllegalArgumentException("URI list cannot be empty");
-        }
-
-        final List<AbstractConfiguration> configurations = new ArrayList<>();
-
-        for (final URI uri : uris) {
-
-            if (uri == null) {
-                throw new ConfigurationException("URI list contains null element");
-            }
-
-            final Configuration config = getConfiguration(loggerContext, name, uri);
-
+        // Short-circuit if provided URIs are null or empty
+        if (distinctConfigLocations.isEmpty()) {
+            final Configuration config = getConfiguration(loggerContext, name, (URI) null);
             if (config == null) {
-                throw new ConfigurationException("Failed to create configuration from: " + uri);
+                throw new ConfigurationException("Configuration could not be created");
             }
-
-            if (!(config instanceof AbstractConfiguration)) {
-                throw new ConfigurationException("Configuration at " + uri + " is not an AbstractConfiguration");
-            }
-
-            configurations.add((AbstractConfiguration) config);
+            return config;
         }
 
-        return configurations.size() == 1 ? configurations.get(0) : new CompositeConfiguration(configurations);
+        // Short-circuit if there is only a single URI
+        if (distinctConfigLocations.size() == 1) {
+            final URI configLocation = distinctConfigLocations.get(0);
+            final Configuration config = getConfiguration(loggerContext, name, configLocation);
+            if (config == null) {
+                final String message =
+                        String.format("Configuration could not be created from location: `%s`", configLocation);
+                throw new ConfigurationException(message);
+            }
+            return config;
+        }
+
+        // Create individual configurations
+        final List<AbstractConfiguration> configs = distinctConfigLocations.stream()
+                .map(configLocation -> {
+                    final Configuration config = getConfiguration(loggerContext, name, configLocation);
+                    if (config == null) {
+                        final String message =
+                                String.format("Configuration could not be created from location: `%s`", configLocation);
+                        throw new ConfigurationException(message);
+                    }
+                    if (!(config instanceof AbstractConfiguration)) {
+                        final String message = String.format(
+                                "Configuration created from location `%s` was expected to be of type `%s`, found: `%s`",
+                                configLocation,
+                                AbstractConfiguration.class.getCanonicalName(),
+                                config.getClass().getCanonicalName());
+                        throw new ConfigurationException(message);
+                    }
+                    return (AbstractConfiguration) config;
+                })
+                .collect(Collectors.toList());
+
+        // Combine created configurations
+        return new CompositeConfiguration(configs);
     }
 
     static boolean isClassLoaderUri(final URI uri) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationFactory.java
@@ -337,12 +337,18 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
 
     /**
      * {@return a {@link Configuration} created using provided configuration location {@link URI}s}
-     * If the provided list of {@code URI}s is null or empty, {@code getConfiguration(loggerContext, name, (URI) null)} will be returned.
+     * <p>
+     * Configurations will be loaded and merged in the given order using the effective {@linkplain org.apache.logging.log4j.core.config.composite.MergeStrategy merge strategy}.
+     * The default can be changed using the {@value org.apache.logging.log4j.core.config.composite.CompositeConfiguration#MERGE_STRATEGY_PROPERTY} system property.
+     * <p>
+     * If the provided list of {@code URI}s is empty, the configuration factory attempts to load an implementation-dependent set of default locations.
+     * If no configuration can be found, a {@link ConfigurationException} is thrown.
      *
      * @param loggerContext a logger context, may be null
      * @param name a configuration name, may be null
-     * @param configLocations configuration location {@code URI}s, may be null or empty
+     * @param configLocations configuration location {@code URI}s, may not contain or be null
      * @throws ConfigurationException if configuration could not be created
+     * @throws NullPointerException if {@code configLocations} contains or is null
      *
      * @since 2.26.0
      */
@@ -350,9 +356,17 @@ public abstract class ConfigurationFactory extends ConfigurationBuilderFactory {
             final LoggerContext loggerContext, final String name, final List<URI> configLocations) {
 
         // Sanitize URIs
-        final List<URI> distinctConfigLocations = configLocations == null
-                ? Collections.emptyList()
-                : configLocations.stream().filter(Objects::nonNull).distinct().collect(Collectors.toList());
+        final int[] configLocationIndex = {0};
+        final List<URI> distinctConfigLocations = Objects.requireNonNull(configLocations, "configLocations").stream()
+                .peek(uri -> {
+                    if (uri == null) {
+                        final String message = String.format("configLocations[%d]", configLocationIndex[0]);
+                        throw new NullPointerException(message);
+                    }
+                    configLocationIndex[0]++;
+                })
+                .distinct()
+                .collect(Collectors.toList());
 
         // Short-circuit if provided URIs are null or empty
         if (distinctConfigLocations.isEmpty()) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/json/package-info.java
@@ -18,7 +18,7 @@
  * Classes and interfaces supporting configuration of Log4j 2 with JSON.
  */
 @Export
-@Version("2.20.1")
+@Version("2.26.0")
 package org.apache.logging.log4j.core.config.json;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/package-info.java
@@ -18,7 +18,7 @@
  * Configuration using Properties files.
  */
 @Export
-@Version("2.20.1")
+@Version("2.26.0")
 package org.apache.logging.log4j.core.config.properties;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/xml/package-info.java
@@ -18,7 +18,7 @@
  * Classes and interfaces supporting configuration of Log4j 2 with XML.
  */
 @Export
-@Version("2.20.2")
+@Version("2.26.0")
 package org.apache.logging.log4j.core.config.xml;
 
 import org.osgi.annotation.bundle.Export;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/yaml/package-info.java
@@ -18,7 +18,7 @@
  * Classes and interfaces supporting configuration of Log4j 2 with YAML.
  */
 @Export
-@Version("2.20.1")
+@Version("2.26.0")
 package org.apache.logging.log4j.core.config.yaml;
 
 import org.osgi.annotation.bundle.Export;

--- a/src/changelog/.2.x.x/add_getConfiguration_method_for_mulitiple_URIs.xml
+++ b/src/changelog/.2.x.x/add_getConfiguration_method_for_mulitiple_URIs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+  type="added">
+  <issue id="3775" link="https://github.com/apache/logging-log4j2/issues/3775"/>
+  <issue id="3921" link="https://github.com/apache/logging-log4j2/pull/3921"/>
+  <description format="asciidoc">
+    Add a new `ConfigurationFactory::getConfiguration` method accepting multiple `URI`s
+  </description>
+</entry>


### PR DESCRIPTION
Adds a new `ConfigurationFactory::getConfiguration` overload accepting multiple URIs.

This work is a spin-off from #3839 and fixes #3775.