### PR TITLE
Add new date pattern for DatePatternConverterTestBase and add new test class for LegacyInstantFormatter - tests for #3930

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/DatePatternConverterTestBase.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/DatePatternConverterTestBase.java
@@ -32,6 +32,7 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.time.Instant;
 import org.apache.logging.log4j.core.time.MutableInstant;
 import org.apache.logging.log4j.core.util.Constants;
+import org.apache.logging.log4j.core.util.internal.instant.InstantPatternFormatter;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.Test;
 
@@ -67,9 +68,15 @@ abstract class DatePatternConverterTestBase {
     private static final String[] ISO8601_FORMAT_OPTIONS = {ISO8601};
 
     private final boolean threadLocalsEnabled;
+    private final boolean legacyFormatterEnabled;
 
     DatePatternConverterTestBase(final boolean threadLocalsEnabled) {
+        this(threadLocalsEnabled, false);
+    }
+
+    DatePatternConverterTestBase(final boolean threadLocalsEnabled, final boolean legacyFormatterEnabled) {
         this.threadLocalsEnabled = threadLocalsEnabled;
+        this.legacyFormatterEnabled = legacyFormatterEnabled;
     }
 
     private static Date date(final int year, final int month, final int date) {
@@ -82,6 +89,11 @@ abstract class DatePatternConverterTestBase {
     @Test
     void testThreadLocalsConstant() {
         assertEquals(Constants.ENABLE_THREADLOCALS, threadLocalsEnabled);
+    }
+
+    @Test
+    void testInstantFormatterConstant() {
+        assertEquals(InstantPatternFormatter.LEGACY_FORMATTERS_ENABLED, legacyFormatterEnabled);
     }
 
     @Test
@@ -163,6 +175,7 @@ abstract class DatePatternConverterTestBase {
         assertDatePattern("dd/MM/yyyy HH:mm:ss.SSSSSS", date, "11/03/2011 14:15:16.123000");
         assertDatePattern("dd/MM/yy HH:mm:ss.SSS", date, "11/03/11 14:15:16.123");
         assertDatePattern("dd/MM/yy HH:mm:ss.SSSSSS", date, "11/03/11 14:15:16.123000");
+        assertDatePattern("EEE, dd MMM yyyy HH:mm:ss zzz", date, "Fri, 11 Mar 2011 14:15:16 PST");
     }
 
     @SuppressWarnings("deprecation")

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/DatePatternConverterWithLegacyInstantFormatterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/DatePatternConverterWithLegacyInstantFormatterTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.pattern;
+
+import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.apache.logging.log4j.test.junit.UsingTestProperties;
+
+@SetTestProperty.SetTestProperties(value = {
+        @SetTestProperty(key = "log4j2.enable.threadlocals", value = "false"),
+        @SetTestProperty(key = "log4j2.instantFormatter", value = "legacy")
+})
+@UsingTestProperties
+class DatePatternConverterWithLegacyInstantFormatterTest extends DatePatternConverterTestBase {
+
+    DatePatternConverterWithLegacyInstantFormatterTest() {
+        super(false, true);
+    }
+}


### PR DESCRIPTION
This change adds tests for bug reported in #3930 

Following tests are failing as expected due to #3930:

```
[ERROR]   DatePatternConverterWithLegacyInstantFormatterTest>DatePatternConverterTestBase.testFormatAmericanPatterns:175->DatePatternConverterTestBase.assertDatePattern:187 expected: <11/03/2011 14:15:16.123000> but was: <11/03/2011 14:15:16.000123>
[ERROR]   DatePatternConverterWithThreadLocalsTest>DatePatternConverterTestBase.testFormatAmericanPatterns:178->DatePatternConverterTestBase.assertDatePattern:187 expected: <Fri, 11 Mar 2011 14:15:16 PST> but was: <Fri,' 11 Mar 2011 14:15:16 PST>
[ERROR]   DatePatternConverterWithoutThreadLocalsTest>DatePatternConverterTestBase.testFormatAmericanPatterns:178->DatePatternConverterTestBase.assertDatePattern:187 expected: <Fri, 11 Mar 2011 14:15:16 PST> but was: <Fri,' 11 Mar 2011 14:15:16 PST>
```

## Checklist

Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.

### ✅ Required checks

- [x] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [x] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [x] **Code formatting**: The code is formatted according to the project’s style guide.
  <details>
    <summary>How to check and fix formatting</summary>

    - To **check** formatting: `./mvnw spotless:check`
    - To **fix** formatting: `./mvnw spotless:apply`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>
- [x] **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

### 🧪 Tests (select one)

- [x] I have added or updated tests to cover my changes.

### 📝 Changelog (select one)

- [x] This is a trivial change and does not require a changelog entry.
