### PR TITLE
fix: parsing and merging of literals in `InstantPatternDynamicFormatter`

### DIFF
--- a/src/changelog/.2.x.x/3930_date-converter.xml
+++ b/src/changelog/.2.x.x/3930_date-converter.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3930" link="https://github.com/apache/logging-log4j2/issues/3930"/>
+  <description format="asciidoc">
+    Fix parsing and merging of literals in `InstantPatternDynamicFormatter`.
+  </description>
+</entry>


### PR DESCRIPTION
This PR fixes edge cases involving the apostrophe (`'`) in pattern literals. Previously, certain inputs produced unintended escaped apostrophes (`''`) at fragment boundaries or misinterpreted doubled quotes inside quoted blocks.

## What’s changed

* **Parsing:** Correctly interprets `''` as a literal apostrophe **inside** quoted sections.
* **Merging:** When concatenating pattern fragments, if the left ends with `'` and the right starts with `'`, we now drop the left closing quote and the right opening quote to keep a single continuous quoted block, avoiding an unintended literal `''`.
* **Tests:** Added comprehensive cases covering parsing and boundary merges.

## Rationale

`DateTimeFormatter` uses `'...'` to denote literals and `''` to escape a literal apostrophe. When two quoted literal blocks are concatenated naïvely, a `...''...` boundary can be produced, which `DateTimeFormatter` reads as a **literal apostrophe**, not close+open delimiters.

Closes #3930.

## Checklist

Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.

### ✅ Required checks

- [x] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [x] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [x] **Code formatting**: The code is formatted according to the project’s style guide.
  <details>
    <summary>How to check and fix formatting</summary>

    - To **check** formatting: `./mvnw spotless:check`
    - To **fix** formatting: `./mvnw spotless:apply`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>
- [x] **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

### 🧪 Tests (select one)

- [x] I have added or updated tests to cover my changes.
- [ ] No additional tests are needed for this change.

### 📝 Changelog (select one)

- [x] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [ ] This is a trivial change and does not require a changelog entry.
