### PR TITLE
LOG4J2-2073: Fix NPE in ConfigurationScheduler when scheduling cron tasks

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationScheduler.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationScheduler.java
@@ -147,12 +147,20 @@ public class ConfigurationScheduler extends AbstractLifeCycle {
     public CronScheduledFuture<?> scheduleWithCron(
             final CronExpression cronExpression, final Date startDate, final Runnable command) {
         final Date fireDate = cronExpression.getNextValidTimeAfter(startDate == null ? new Date() : startDate);
+
+        // --- FIX (part 1): prevent race by assigning a placeholder future BEFORE scheduling ---
         final CronRunnable runnable = new CronRunnable(command, cronExpression);
-        final ScheduledFuture<?> future = schedule(runnable, nextFireInterval(fireDate), TimeUnit.MILLISECONDS);
-        final CronScheduledFuture<?> cronScheduledFuture = new CronScheduledFuture<>(future, fireDate);
+        CronScheduledFuture<?> cronScheduledFuture = new CronScheduledFuture<>(null, fireDate);
         runnable.setScheduledFuture(cronScheduledFuture);
-        LOGGER.debug(
-                "{} scheduled cron expression {} to fire at {}", name, cronExpression.getCronExpression(), fireDate);
+
+        // schedule and then update the placeholder with the real ScheduledFuture
+        final ScheduledFuture<?> future =
+                schedule(runnable, nextFireInterval(fireDate), TimeUnit.MILLISECONDS);
+        cronScheduledFuture.reset(future, fireDate);
+        // --- end fix ---
+
+        LOGGER.debug("{} scheduled cron expression {} to fire at {}", name,
+                cronExpression.getCronExpression(), fireDate);
         return cronScheduledFuture;
     }
 
@@ -231,33 +239,47 @@ public class ConfigurationScheduler extends AbstractLifeCycle {
         @Override
         public void run() {
             try {
-                final long millis = scheduledFuture.getFireTime().getTime() - System.currentTimeMillis();
-                if (millis > 0) {
-                    LOGGER.debug("{} Cron thread woke up {} millis early. Sleeping", name, millis);
-                    try {
-                        Thread.sleep(millis);
-                    } catch (final InterruptedException ie) {
-                        // Ignore the interruption.
+                // --- FIX (part 2): guard against null scheduledFuture on first execution ---
+                final CronScheduledFuture<?> localFuture = this.scheduledFuture;
+                if (localFuture != null) {
+                    final long millis = localFuture.getFireTime().getTime() - System.currentTimeMillis();
+                    if (millis > 0) {
+                        LOGGER.debug("{} Cron thread woke up {} millis early. Sleeping", name, millis);
+                        try {
+                            Thread.sleep(millis);
+                        } catch (final InterruptedException ie) {
+                            // Ignore the interruption.
+                        }
                     }
                 }
+                // --- end fix ---
+
                 runnable.run();
             } catch (final Throwable ex) {
                 LOGGER.error("{} caught error running command", name, ex);
             } finally {
                 final Date fireDate = cronExpression.getNextValidTimeAfter(new Date());
-                final ScheduledFuture<?> future = schedule(this, nextFireInterval(fireDate), TimeUnit.MILLISECONDS);
-                LOGGER.debug(
-                        "{} Cron expression {} scheduled to fire again at {}",
-                        name,
-                        cronExpression.getCronExpression(),
-                        fireDate);
-                scheduledFuture.reset(future, fireDate);
+                final ScheduledFuture<?> future =
+                        schedule(this, nextFireInterval(fireDate), TimeUnit.MILLISECONDS);
+                LOGGER.debug("{} Cron expression {} scheduled to fire again at {}",
+                        name, cronExpression.getCronExpression(), fireDate);
+
+                // --- FIX (part 3): reset safely even if first execution had no future assigned ---
+                final CronScheduledFuture<?> currentFuture = this.scheduledFuture;
+                if (currentFuture != null) {
+                    currentFuture.reset(future, fireDate);
+                } else {
+                    setScheduledFuture(new CronScheduledFuture<>(future, fireDate));
+                }
+                // --- end fix ---
             }
         }
 
         @Override
         public String toString() {
-            return "CronRunnable{" + cronExpression.getCronExpression() + " - " + scheduledFuture.getFireTime();
+            final CronScheduledFuture<?> f = this.scheduledFuture;
+            return "CronRunnable{" + cronExpression.getCronExpression() + " - "
+                    + (f != null ? f.getFireTime() : "unassigned") + "}";
         }
     }
 

--- a/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CronSchedulerNpeTest.java
+++ b/log4j-core/src/test/java/org/apache/logging/log4j/core/config/CronSchedulerNpeTest.java
@@ -1,0 +1,32 @@
+package org.apache.logging.log4j.core.config;
+
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.logging.log4j.core.util.CronExpression;
+
+public class CronSchedulerNpeTest {
+
+    @Test
+    public void testCronSchedulerDoesNotThrowNpe() throws Exception {
+        ConfigurationScheduler scheduler = new ConfigurationScheduler();
+        scheduler.incrementScheduledItems(); // ensure a pool exists
+        scheduler.start();
+
+        // fire every second
+        CronExpression cron = new CronExpression("* * * * * ?");
+        AtomicBoolean ran = new AtomicBoolean(false);
+
+        scheduler.scheduleWithCron(cron, () -> ran.set(true));
+
+        // wait up to 2 seconds for the first fire; if an NPE happens, the test will fail
+        Thread.sleep(2000L);
+
+        scheduler.stop(0, TimeUnit.MILLISECONDS);
+
+        assertTrue("cron task should have executed at least once", ran.get());
+    }
+}


### PR DESCRIPTION
Problem
ConfigurationScheduler.scheduleWithCron created a CronRunnable, scheduled it, and only afterwards assigned its CronScheduledFuture.
Under fast-firing cron expressions the runnable could execute before its future was set, causing a NullPointerException when calling scheduledFuture.getFireTime().

Root cause
Race condition between scheduling the task and assigning the CronScheduledFuture to the runnable.

Fix

Assign a placeholder CronScheduledFuture to the runnable before scheduling.

Update that placeholder with the real ScheduledFuture immediately after scheduling.

Add null-guards in CronRunnable.run() and handle first execution safely.

Enhance toString() to tolerate an unassigned future.

Tests
Added CronSchedulerNpeTest which schedules a cron expression firing every second and asserts that it runs without throwing.
Before the fix it reproduced the NPE; after the fix all tests pass.

Risks
Minimal. Changes are contained to cron scheduling logic and do not alter normal scheduling semantics.

Fixes #2073.
