### PR TITLE
Fix log message in `ApiLogger::setUseParentHandlers`

### DIFF
--- a/log4j-jul/src/main/java/org/apache/logging/log4j/jul/ApiLogger.java
+++ b/log4j-jul/src/main/java/org/apache/logging/log4j/jul/ApiLogger.java
@@ -125,7 +125,7 @@ public class ApiLogger extends Logger {
 
     @Override
     public void setUseParentHandlers(boolean useParentHandlers) {
-        LOGGER.warn(MUTATOR_DISABLED, "setLevel", useParentHandlers);
+        LOGGER.warn(MUTATOR_DISABLED, "setUseParentHandlers", useParentHandlers);
         super.setUseParentHandlers(useParentHandlers);
     }
 


### PR DESCRIPTION
replace `setLevel ` with `setUseParentHandlers`

Fixes #3942