### PR TITLE
Replace fixed delay with polling in `SyslogAppenderCustomLayoutTest`

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTestBase.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SyslogAppenderTestBase.java
@@ -16,6 +16,8 @@
  */
 package org.apache.logging.log4j.core.appender;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,7 +51,7 @@ abstract class SyslogAppenderTestBase {
             "TestApp - Audit [Transfer@18060 Amount=\"200.00\" FromAccount=\"123457\" ToAccount=\"123456\"]"
                     + "[RequestContext@18060 ipAddress=\"192.168.0.120\" loginId=\"JohnDoe\"] Transfer Complete";
     protected LoggerContext ctx = LoggerContext.getContext();
-    protected static final int DEFAULT_TIMEOUT_IN_MS = 100;
+    protected static final int DEFAULT_TIMEOUT_IN_MS = 3000;
     protected MockSyslogServer syslogServer;
     protected SyslogAppender appender;
     protected Logger root = ctx.getLogger("SyslogAppenderTest");
@@ -61,7 +63,7 @@ abstract class SyslogAppenderTestBase {
         LoggerContext.getContext().reconfigure();
     }
 
-    protected void sendAndCheckLegacyBsdMessages(final List<String> messagesToSend) throws InterruptedException {
+    protected void sendAndCheckLegacyBsdMessages(final List<String> messagesToSend) {
         for (final String message : messagesToSend) {
             sendDebugLegacyBsdMessage(message);
         }
@@ -69,7 +71,7 @@ abstract class SyslogAppenderTestBase {
         checkTheEqualityOfSentAndReceivedMessages(Level.DEBUG);
     }
 
-    protected void sendAndCheckLegacyBsdMessage(final String message) throws InterruptedException {
+    protected void sendAndCheckLegacyBsdMessage(final String message) {
         sendDebugLegacyBsdMessage(message);
         checkTheNumberOfSentAndReceivedMessages();
         checkTheEqualityOfSentAndReceivedMessages(Level.DEBUG);
@@ -80,7 +82,7 @@ abstract class SyslogAppenderTestBase {
         root.debug(message);
     }
 
-    protected void sendAndCheckStructuredMessages(final int numberOfMessages) throws InterruptedException {
+    protected void sendAndCheckStructuredMessages(final int numberOfMessages) {
         for (int i = 0; i < numberOfMessages; i++) {
             sendInfoStructuredMessage();
         }
@@ -88,7 +90,7 @@ abstract class SyslogAppenderTestBase {
         checkTheEqualityOfSentAndReceivedMessages(Level.INFO);
     }
 
-    protected void sendAndCheckStructuredMessage() throws InterruptedException {
+    protected void sendAndCheckStructuredMessage() {
         sendInfoStructuredMessage();
         checkTheNumberOfSentAndReceivedMessages();
         checkTheEqualityOfSentAndReceivedMessages(Level.INFO);
@@ -108,15 +110,13 @@ abstract class SyslogAppenderTestBase {
         root.info(MarkerManager.getMarker("EVENT"), msg);
     }
 
-    protected void checkTheNumberOfSentAndReceivedMessages() throws InterruptedException {
-        assertEquals(
-                sentMessages.size(),
-                getReceivedMessages(DEFAULT_TIMEOUT_IN_MS).size(),
-                "The number of received messages should be equal with the number of sent messages");
+    protected void checkTheNumberOfSentAndReceivedMessages() {
+        await().atMost(DEFAULT_TIMEOUT_IN_MS, MILLISECONDS)
+                .until(() -> syslogServer.getMessageList().size() == sentMessages.size());
     }
 
-    protected void checkTheEqualityOfSentAndReceivedMessages(final Level expectedLevel) throws InterruptedException {
-        final List<String> receivedMessages = getReceivedMessages(DEFAULT_TIMEOUT_IN_MS);
+    protected void checkTheEqualityOfSentAndReceivedMessages(final Level expectedLevel) {
+        final List<String> receivedMessages = getReceivedMessages();
 
         assertNotNull(receivedMessages, "No messages received");
         for (int i = 0; i < receivedMessages.size(); i++) {
@@ -148,10 +148,7 @@ abstract class SyslogAppenderTestBase {
         root.setLevel(Level.DEBUG);
     }
 
-    protected List<String> getReceivedMessages(final int timeOutInMs) throws InterruptedException {
-        synchronized (syslogServer) {
-            syslogServer.wait(timeOutInMs);
-        }
+    protected List<String> getReceivedMessages() {
         return syslogServer.getMessageList();
     }
 


### PR DESCRIPTION
This PR fixes a flaky test that was failing because of a race condition.

This pull request addresses intermittent test failures caused by relying on a fixed delay `Thread.sleep()` to wait for asynchronous operations. Fixed delays are unreliable because the operation may occasionally take longer than the predefined wait time.

This commit replaces the fixed delay with a polling mechanism using the Awaitility library. Awaitility continuously checks for the expected condition within a specified timeout, ensuring the test only proceeds once the desired state is reached. This makes the test more robust and reliable by synchronizing with actual operation completion rather than arbitrary timing.

Fixes #3006


> [!IMPORTANT]  
> Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise.

## Checklist

Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.

### ✅ Required checks

- [x] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [x] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [x] **Code formatting**: The code is formatted according to the project’s style guide.
  <details>
    <summary>How to check and fix formatting</summary>

    - To **check** formatting: `./mvnw spotless:check`
    - To **fix** formatting: `./mvnw spotless:apply`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>
- [x] **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

### 🧪 Tests (select one)

- [ ] I have added or updated tests to cover my changes.
- [x] No additional tests are needed for this change.

### 📝 Changelog (select one)

- [ ] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [x] This is a trivial change and does not require a changelog entry.
