### PR TITLE
Fix state leakage in `AbstractAsyncThreadContextTestBase`

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AbstractAsyncThreadContextTestBase.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/AbstractAsyncThreadContextTestBase.java
@@ -48,6 +48,7 @@ import org.apache.logging.log4j.test.junit.UsingTestProperties;
 import org.apache.logging.log4j.util.ProviderUtil;
 import org.apache.logging.log4j.util.Unbox;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 @UsingStatusListener
@@ -58,6 +59,11 @@ public abstract class AbstractAsyncThreadContextTestBase {
     private static final int LINE_COUNT = 130;
 
     private static TestProperties props;
+
+    @BeforeEach
+    public void beforeEach() {
+        ThreadContext.clearAll();
+    }
 
     @BeforeAll
     public static void beforeClass() {


### PR DESCRIPTION
`AsyncThreadContextDefaultTest` was a state leak. Since the test is parameterized, the `ThreadContext` wasn't being reset between runs. This meant data from a previous test execution could sometimes carry over and cause assertions in the next run to fail.

The fix is to ensure the `ThreadContext` is cleared before every test execution.

I added a `@BeforeEach` method to the shared base class, `AbstractAsyncThreadContextTestBase.java`. This new method simply calls `ThreadContext.clearAll()`, guaranteeing that each test starts with a clean slate.

This change prevents the state leak and makes the test reliable. Placing the fix in the base class also protects other tests that inherit from it against similar issues.

Fixes: [#3049](https://github.com/apache/logging-log4j2/issues/3049)

> [!IMPORTANT]  
> Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise.

## Checklist

Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.

### ✅ Required checks

- [x] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- [x] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- [x] **Code formatting**: The code is formatted according to the project’s style guide.
  <details>
    <summary>How to check and fix formatting</summary>

    - To **check** formatting: `./mvnw spotless:check`
    - To **fix** formatting: `./mvnw spotless:apply`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>
- [x] **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

### 🧪 Tests (select one)

- [x] I have added or updated tests to cover my changes.
- [ ] No additional tests are needed for this change.

### 📝 Changelog (select one)

- [ ] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [x] This is a trivial change and does not require a changelog entry.
