### PR TITLE
Stabilize `RollingAppenderDirectCronTest` and `XmlCompleteFileAppenderTest`

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/XmlCompleteFileAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/XmlCompleteFileAppenderTest.java
@@ -82,8 +82,13 @@ public class XmlCompleteFileAppenderTest {
         try (final BufferedReader reader = new BufferedReader(new FileReader(logFile))) {
             line1 = reader.readLine();
             line2 = reader.readLine();
-            reader.readLine(); // ignore the empty line after the <Events> root
-            line3 = reader.readLine();
+            
+            String tmp;
+            do {
+                tmp = reader.readLine(); // ignore the empty lines after the <Events> root
+            } while (tmp != null && tmp.trim().isEmpty());
+
+            line3 = tmp;
             line4 = reader.readLine();
             line5 = reader.readLine();
         } finally {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/XmlCompleteFileAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/XmlCompleteFileAppenderTest.java
@@ -82,13 +82,10 @@ public class XmlCompleteFileAppenderTest {
         try (final BufferedReader reader = new BufferedReader(new FileReader(logFile))) {
             line1 = reader.readLine();
             line2 = reader.readLine();
-            
-            String tmp;
-            do {
-                tmp = reader.readLine(); // ignore the empty lines after the <Events> root
-            } while (tmp != null && tmp.trim().isEmpty());
 
-            line3 = tmp;
+            // Locate the first non-empty line after the `<Events>` root
+            while ((line3 = reader.readLine()) != null && line3.trim().isEmpty()) {}
+
             line4 = reader.readLine();
             line5 = reader.readLine();
         } finally {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectCronTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectCronTest.java
@@ -18,9 +18,7 @@ package org.apache.logging.log4j.core.appender.rolling;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.waitAtMost;
-import static org.junit.jupiter.api.Assertions.fail;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -70,7 +68,7 @@ class RollingAppenderDirectCronTest {
     private static class RolloverDelay implements RolloverListener {
         private final Logger logger = StatusLogger.getLogger();
         private volatile CountDownLatch latch;
-        private volatile AssertionError assertion;
+        private volatile Exception verificationFailure;
 
         public RolloverDelay(final RollingFileManager manager) {
             latch = new CountDownLatch(1);
@@ -78,11 +76,11 @@ class RollingAppenderDirectCronTest {
         }
 
         public void waitForRollover() {
-            waitAtMost(7, TimeUnit.SECONDS)
+            waitAtMost(5, TimeUnit.SECONDS)
                     .alias("Rollover timeout")
-                    .until(() -> latch.getCount() == 0 || assertion != null);
-            if (assertion != null) {
-                throw assertion;
+                    .until(() -> latch.getCount() == 0 || verificationFailure != null);
+            if (verificationFailure != null) {
+                throw new RuntimeException(verificationFailure);
             }
         }
 
@@ -102,18 +100,15 @@ class RollingAppenderDirectCronTest {
                 final Path path = Paths.get(fileName);
                 final Matcher matcher = FILE_PATTERN.matcher(path.getFileName().toString());
                 assertThat(matcher).as("Rolled file").matches();
-
-                // Wait until the file is non-empty (or timeout)
-                waitAtMost(2, TimeUnit.SECONDS).until(() -> Files.exists(path) && Files.size(path) > 0);
-
-                final List<String> lines = Files.readAllLines(path);
-                assertThat(lines).isNotEmpty();
-                assertThat(lines.get(0)).startsWith(matcher.group(1));
+                waitAtMost(2, TimeUnit.SECONDS).untilAsserted(() -> {
+                    final List<String> lines = Files.readAllLines(path);
+                    assertThat(lines).isNotEmpty();
+                    assertThat(lines.get(0)).startsWith(matcher.group(1));
+                });
                 latch.countDown();
-            } catch (final AssertionError ex) {
-                assertion = ex;
-            } catch (final IOException ex) {
-                fail("Unable to read file " + fileName + ": " + ex.getMessage());
+            } catch (final Exception ex) {
+                verificationFailure =
+                        new RuntimeException("Rollover completion verification failure for file: " + fileName, ex);
             }
         }
     }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectCronTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingAppenderDirectCronTest.java
@@ -78,7 +78,7 @@ class RollingAppenderDirectCronTest {
         }
 
         public void waitForRollover() {
-            waitAtMost(5, TimeUnit.SECONDS)
+            waitAtMost(7, TimeUnit.SECONDS)
                     .alias("Rollover timeout")
                     .until(() -> latch.getCount() == 0 || assertion != null);
             if (assertion != null) {
@@ -102,16 +102,18 @@ class RollingAppenderDirectCronTest {
                 final Path path = Paths.get(fileName);
                 final Matcher matcher = FILE_PATTERN.matcher(path.getFileName().toString());
                 assertThat(matcher).as("Rolled file").matches();
-                try {
-                    final List<String> lines = Files.readAllLines(path);
-                    assertThat(lines).isNotEmpty();
-                    assertThat(lines.get(0)).startsWith(matcher.group(1));
-                } catch (final IOException ex) {
-                    fail("Unable to read file " + fileName + ": " + ex.getMessage());
-                }
+
+                // Wait until the file is non-empty (or timeout)
+                waitAtMost(2, TimeUnit.SECONDS).until(() -> Files.exists(path) && Files.size(path) > 0);
+
+                final List<String> lines = Files.readAllLines(path);
+                assertThat(lines).isNotEmpty();
+                assertThat(lines.get(0)).startsWith(matcher.group(1));
                 latch.countDown();
             } catch (final AssertionError ex) {
                 assertion = ex;
+            } catch (final IOException ex) {
+                fail("Unable to read file " + fileName + ": " + ex.getMessage());
             }
         }
     }


### PR DESCRIPTION
Stabilize `RollingAppenderDirectCronTest`.

Fixes #3046.