### PR TITLE
Fix `ArrayIndexOutOfBoundsException` in `ThrowableStackTraceRenderer` when the stack trace is mutated concurrently

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/RootThrowablePatternConverterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/RootThrowablePatternConverterTest.java
@@ -17,6 +17,7 @@
 package org.apache.logging.log4j.core.pattern;
 
 import static java.util.Arrays.asList;
+import static org.apache.logging.log4j.core.pattern.ThrowablePatternConverterTest.EXCEPTION;
 import static org.apache.logging.log4j.core.pattern.ThrowablePatternConverterTest.LEVEL;
 import static org.apache.logging.log4j.core.pattern.ThrowablePatternConverterTest.convert;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,8 +37,6 @@ import org.junit.jupiter.params.provider.MethodSource;
  * {@link RootThrowablePatternConverter} tests.
  */
 class RootThrowablePatternConverterTest {
-
-    static final Throwable EXCEPTION = TestFriendlyException.INSTANCE;
 
     private static final StackTraceElement THROWING_METHOD =
             Throwables.getRootCause(EXCEPTION).getStackTrace()[0];

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/RootThrowablePatternConverterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/RootThrowablePatternConverterTest.java
@@ -17,7 +17,6 @@
 package org.apache.logging.log4j.core.pattern;
 
 import static java.util.Arrays.asList;
-import static org.apache.logging.log4j.core.pattern.ThrowablePatternConverterTest.EXCEPTION;
 import static org.apache.logging.log4j.core.pattern.ThrowablePatternConverterTest.LEVEL;
 import static org.apache.logging.log4j.core.pattern.ThrowablePatternConverterTest.convert;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,6 +36,8 @@ import org.junit.jupiter.params.provider.MethodSource;
  * {@link RootThrowablePatternConverter} tests.
  */
 class RootThrowablePatternConverterTest {
+
+    static final Throwable EXCEPTION = TestFriendlyException.INSTANCE;
 
     private static final StackTraceElement THROWING_METHOD =
             Throwables.getRootCause(EXCEPTION).getStackTrace()[0];

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverterTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Collectors;
@@ -443,10 +444,51 @@ public class ThrowablePatternConverterTest {
                     .replaceAll(" ~\\[\\?:[^]]+](\\Q" + conversionEnding + "\\E|$)", " ~[?:0]$1");
         }
 
+        @Test
+        @Issue("https://github.com/apache/logging-log4j2/issues/3940")
+        void concurrent_stacktrace_mutation_should_not_cause_failure() throws Exception {
+            final ExecutorService executor = Executors.newFixedThreadPool(2);
+
+            // Create the formatter
+            final List<PatternFormatter> patternFormatters = PATTERN_PARSER.parse(patternPrefix, false, true, true);
+            assertThat(patternFormatters).hasSize(1);
+            final PatternFormatter patternFormatter = patternFormatters.get(0);
+            final StringBuilder buffer = new StringBuilder();
+
+            try {
+                for (int i = 0; i < 10; i++) {
+                    final CountDownLatch latch = new CountDownLatch(2);
+                    final Throwable exception = new RuntimeException();
+                    final LogEvent logEvent = Log4jLogEvent.newBuilder()
+                            .setThrown(exception)
+                            .setLevel(LEVEL)
+                            .build();
+
+                    executor.submit(() -> {
+                        try {
+                            patternFormatter.format(logEvent, buffer);
+                            buffer.setLength(0);
+                            latch.countDown();
+                        } catch (Throwable e) {
+                            e.printStackTrace();
+                        }
+                    });
+                    executor.submit(() -> {
+                        exception.setStackTrace(new StackTraceElement[0]);
+                        latch.countDown();
+                    });
+                    if (latch.await(1, TimeUnit.SECONDS) == false) {
+                        throw new IllegalStateException("timed out waiting for tasks to complete");
+                    }
+                }
+            } finally {
+                executor.shutdownNow();
+            }
+        }
+
         @RepeatedTest(10)
         @Issue("https://github.com/apache/logging-log4j2/issues/3929")
         void concurrent_suppressed_mutation_should_not_cause_failure() throws Exception {
-
             // Test constants
             final int threadCount = Math.max(8, Runtime.getRuntime().availableProcessors());
             final ExecutorService executor = Executors.newFixedThreadPool(threadCount);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/ThrowablePatternConverterTest.java
@@ -25,13 +25,15 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -444,105 +446,101 @@ public class ThrowablePatternConverterTest {
                     .replaceAll(" ~\\[\\?:[^]]+](\\Q" + conversionEnding + "\\E|$)", " ~[?:0]$1");
         }
 
-        @Test
+        @RepeatedTest(10)
         @Issue("https://github.com/apache/logging-log4j2/issues/3940")
-        void concurrent_stacktrace_mutation_should_not_cause_failure() throws Exception {
-            final ExecutorService executor = Executors.newFixedThreadPool(2);
+        void concurrent_stack_trace_mutation_should_not_cause_failure() throws Exception {
+            final int stackTracePerThreadCount = 100;
+            formatThrowableWhileMutatingConcurrently(threadIndex -> {
+                final List<StackTraceElement[]> stackTraces = createExceptionsOfDifferentDepths().stream()
+                        .map(Throwable::getStackTrace)
+                        .collect(Collectors.toList());
+                return exception -> {
+                    for (int stackTraceIndex = 0; stackTraceIndex < stackTracePerThreadCount; stackTraceIndex++) {
+                        exception.setStackTrace(stackTraces.get(stackTraceIndex));
+                        // Give some time slack to increase randomness
+                        LockSupport.parkNanos(1);
+                    }
+                };
+            });
+        }
 
-            // Create the formatter
-            final List<PatternFormatter> patternFormatters = PATTERN_PARSER.parse(patternPrefix, false, true, true);
-            assertThat(patternFormatters).hasSize(1);
-            final PatternFormatter patternFormatter = patternFormatters.get(0);
-            final StringBuilder buffer = new StringBuilder();
+        @RepeatedTest(10)
+        @Issue("https://github.com/apache/logging-log4j2/issues/3929")
+        void concurrent_suppressed_mutation_should_not_cause_failure() throws Exception {
+            formatThrowableWhileMutatingConcurrently(threadIndex -> {
+                final List<Exception> exceptions = createExceptionsOfDifferentDepths();
+                return exception -> exceptions.forEach(suppressed -> {
+                    exception.addSuppressed(suppressed);
+                    // Give some time slack to increase randomness
+                    LockSupport.parkNanos(1);
+                });
+            });
+        }
 
+        private void formatThrowableWhileMutatingConcurrently(
+                Function<Integer, Consumer<Throwable>> throwableMutatorFactory) throws Exception {
+
+            // Test constants
+            final int threadCount = Math.max(8, Runtime.getRuntime().availableProcessors());
+            final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
             try {
-                for (int i = 0; i < 10; i++) {
-                    final CountDownLatch latch = new CountDownLatch(2);
-                    final Throwable exception = new RuntimeException();
-                    final LogEvent logEvent = Log4jLogEvent.newBuilder()
-                            .setThrown(exception)
-                            .setLevel(LEVEL)
-                            .build();
+                final Exception exception = new Exception();
+                final CountDownLatch startLatch =
+                        new CountDownLatch(threadCount + /* the main thread invoking the rendering: */ 1);
+                final AtomicInteger runningThreadCountRef = new AtomicInteger(threadCount);
 
+                // Schedule threads that will start mutating the exception with the start signal
+                for (int threadIndex = 0; threadIndex < threadCount; threadIndex++) {
+                    final Consumer<Throwable> exceptionMutator = throwableMutatorFactory.apply(threadIndex);
                     executor.submit(() -> {
                         try {
-                            patternFormatter.format(logEvent, buffer);
-                            buffer.setLength(0);
-                            latch.countDown();
-                        } catch (Throwable e) {
-                            e.printStackTrace();
+                            startLatch.countDown();
+                            startLatch.await();
+                            exceptionMutator.accept(exception);
+                        } catch (InterruptedException ignored) {
+                            // Restore the interrupt
+                            Thread.currentThread().interrupt();
+                        } finally {
+                            runningThreadCountRef.decrementAndGet();
                         }
                     });
-                    executor.submit(() -> {
-                        exception.setStackTrace(new StackTraceElement[0]);
-                        latch.countDown();
-                    });
-                    if (latch.await(1, TimeUnit.SECONDS) == false) {
-                        throw new IllegalStateException("timed out waiting for tasks to complete");
-                    }
+                }
+
+                // Create the formatter
+                final List<PatternFormatter> patternFormatters = PATTERN_PARSER.parse(patternPrefix, false, true, true);
+                assertThat(patternFormatters).hasSize(1);
+                final PatternFormatter patternFormatter = patternFormatters.get(0);
+
+                // Create the log event and the layout buffer
+                final LogEvent logEvent = Log4jLogEvent.newBuilder()
+                        .setThrown(exception)
+                        .setLevel(LEVEL)
+                        .build();
+                final StringBuilder buffer = new StringBuilder(16384);
+
+                // Trigger the start latch and format the exception
+                startLatch.countDown();
+                startLatch.await();
+                while (runningThreadCountRef.get() > 0) {
+                    // Give some time slack to increase randomness
+                    LockSupport.parkNanos(1);
+                    patternFormatter.format(logEvent, buffer);
+                    buffer.setLength(0);
                 }
             } finally {
                 executor.shutdownNow();
             }
         }
 
-        @RepeatedTest(10)
-        @Issue("https://github.com/apache/logging-log4j2/issues/3929")
-        void concurrent_suppressed_mutation_should_not_cause_failure() throws Exception {
-            // Test constants
-            final int threadCount = Math.max(8, Runtime.getRuntime().availableProcessors());
-            final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-            final Exception exception = new Exception();
-            final CountDownLatch startLatch =
-                    new CountDownLatch(threadCount + /* the main thread invoking the rendering: */ 1);
-            final int exceptionPerThreadCount = 100;
-            final AtomicInteger runningThreadCountRef = new AtomicInteger(threadCount);
-
-            // Schedule threads that will start adding suppressed exceptions with the start signal
-            for (int threadIndex = 0; threadIndex < threadCount; threadIndex++) {
-                final int threadIndex_ = threadIndex;
-                executor.submit(() -> {
-                    try {
-                        List<Exception> exceptions = IntStream.range(0, exceptionPerThreadCount)
-                                .mapToObj(exceptionIndex -> new Exception(threadIndex_ + "-" + exceptionIndex))
-                                .collect(Collectors.toList());
-                        startLatch.countDown();
-                        startLatch.await();
-                        for (int exceptionIndex = 0; exceptionIndex < exceptionPerThreadCount; exceptionIndex++) {
-                            exception.addSuppressed(exceptions.get(exceptionIndex));
-                            // Give some time slack to increase randomness
-                            LockSupport.parkNanos(1);
-                        }
-                    } catch (InterruptedException ignored) {
-                        // Restore the interrupt
-                        Thread.currentThread().interrupt();
-                    } finally {
-                        runningThreadCountRef.decrementAndGet();
-                    }
-                });
-            }
-
-            // Create the formatter
-            final List<PatternFormatter> patternFormatters = PATTERN_PARSER.parse(patternPrefix, false, true, true);
-            assertThat(patternFormatters).hasSize(1);
-            final PatternFormatter patternFormatter = patternFormatters.get(0);
-
-            // Create the log event and the layout buffer
-            final LogEvent logEvent = Log4jLogEvent.newBuilder()
-                    .setThrown(exception)
-                    .setLevel(LEVEL)
-                    .build();
-            final StringBuilder buffer = new StringBuilder(16384);
-
-            // Trigger the start latch and format the exception
-            startLatch.countDown();
-            startLatch.await();
-            while (runningThreadCountRef.get() > 0) {
-                // Give some time slack to increase randomness
-                LockSupport.parkNanos(1);
-                patternFormatter.format(logEvent, buffer);
-                buffer.setLength(0);
-            }
+        private static List<Exception> createExceptionsOfDifferentDepths() {
+            final StackTraceElement[] stackTrace = new Exception().getStackTrace();
+            return IntStream.range(0, stackTrace.length)
+                    .mapToObj(depth -> {
+                        final Exception exception = new Exception();
+                        exception.setStackTrace(Arrays.copyOfRange(stackTrace, 0, depth));
+                        return exception;
+                    })
+                    .collect(Collectors.toList());
         }
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowableExtendedStackTraceRenderer.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowableExtendedStackTraceRenderer.java
@@ -132,7 +132,7 @@ final class ThrowableExtendedStackTraceRenderer
                 Class<?> executionStackTraceElementClass =
                         executionStackTrace.isEmpty() ? null : executionStackTrace.peekLast();
                 ClassLoader lastLoader = null;
-                final StackTraceElement[] stackTraceElements = throwable.getStackTrace();
+                final StackTraceElement[] stackTraceElements = metadata.stackTrace;
                 for (int throwableStackIndex = metadata.stackLength - 1;
                         throwableStackIndex >= 0;
                         --throwableStackIndex) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowableInvertedStackTraceRenderer.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowableInvertedStackTraceRenderer.java
@@ -74,7 +74,7 @@ final class ThrowableInvertedStackTraceRenderer
             }
             renderThrowableMessage(buffer, throwable);
             buffer.append(lineSeparator);
-            renderStackTraceElements(buffer, throwable, context, metadata, prefix, lineSeparator);
+            renderStackTraceElements(buffer, context, metadata, prefix, lineSeparator);
             renderSuppressed(buffer, metadata.suppressed, context, visitedThrowables, prefix + '\t', lineSeparator);
         }
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowableStackTraceRenderer.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowableStackTraceRenderer.java
@@ -98,7 +98,7 @@ class ThrowableStackTraceRenderer<C extends ThrowableStackTraceRenderer.Context>
             final Context.Metadata metadata = context.metadataByThrowable.get(throwable);
             renderThrowableMessage(buffer, throwable);
             buffer.append(lineSeparator);
-            renderStackTraceElements(buffer, throwable, context, metadata, prefix, lineSeparator);
+            renderStackTraceElements(buffer, context, metadata, prefix, lineSeparator);
             renderSuppressed(buffer, metadata.suppressed, context, visitedThrowables, prefix + '\t', lineSeparator);
             renderCause(buffer, throwable.getCause(), context, visitedThrowables, prefix, lineSeparator);
         }
@@ -148,13 +148,12 @@ class ThrowableStackTraceRenderer<C extends ThrowableStackTraceRenderer.Context>
 
     final void renderStackTraceElements(
             final StringBuilder buffer,
-            final Throwable throwable,
             final C context,
             final Context.Metadata metadata,
             final String prefix,
             final String lineSeparator) {
         context.ignoredStackTraceElementCount = 0;
-        final StackTraceElement[] stackTraceElements = throwable.getStackTrace();
+        final StackTraceElement[] stackTraceElements = metadata.stackTrace;
         for (int i = 0; i < metadata.stackLength; i++) {
             renderStackTraceElement(buffer, stackTraceElements[i], context, prefix, lineSeparator);
         }
@@ -269,6 +268,11 @@ class ThrowableStackTraceRenderer<C extends ThrowableStackTraceRenderer.Context>
             final int stackLength;
 
             /**
+             * The stack trace of this {@link Throwable}
+             */
+            final StackTraceElement[] stackTrace;
+
+            /**
              * The suppressed exceptions attached to this {@link Throwable}.
              * This needs to be captured separately since {@link Throwable#getSuppressed()} can change.
              *
@@ -277,9 +281,14 @@ class ThrowableStackTraceRenderer<C extends ThrowableStackTraceRenderer.Context>
              */
             final Throwable[] suppressed;
 
-            private Metadata(final int commonElementCount, final int stackLength, final Throwable[] suppressed) {
+            private Metadata(
+                    final int commonElementCount,
+                    final int stackLength,
+                    final StackTraceElement[] stackTrace,
+                    final Throwable[] suppressed) {
                 this.commonElementCount = commonElementCount;
                 this.stackLength = stackLength;
+                this.stackTrace = stackTrace;
                 this.suppressed = suppressed;
             }
 
@@ -339,7 +348,7 @@ class ThrowableStackTraceRenderer<C extends ThrowableStackTraceRenderer.Context>
                     commonElementCount = 0;
                     stackLength = currentTrace.length;
                 }
-                return new Metadata(commonElementCount, stackLength, suppressed);
+                return new Metadata(commonElementCount, stackLength, currentTrace, suppressed);
             }
         }
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowableStackTraceRenderer.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/ThrowableStackTraceRenderer.java
@@ -268,7 +268,11 @@ class ThrowableStackTraceRenderer<C extends ThrowableStackTraceRenderer.Context>
             final int stackLength;
 
             /**
-             * The stack trace of this {@link Throwable}
+             * The stack trace of this {@link Throwable}.
+             * This needs to be captured separately since {@link Throwable#getStackTrace()} can change.
+             *
+             * @see <a href="https://github.com/apache/logging-log4j2/issues/3940">#3940</a>
+             * @see <a href="https://github.com/apache/logging-log4j2/pull/3955">#3955</a>
              */
             final StackTraceElement[] stackTrace;
 

--- a/src/changelog/2.25.2/3940_ThrowableStackTraceRenderer_ArrayIndexOutOfBoundsException.xml
+++ b/src/changelog/2.25.2/3940_ThrowableStackTraceRenderer_ArrayIndexOutOfBoundsException.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3940" link="https://github.com/apache/logging-log4j2/pull/3940"/>
+  <description format="asciidoc">
+    Fixes `ArrayIndexOutOfBoundsException` thrown by `ThrowableStackTraceRenderer` when a `Throwable`'s stacktrace is mutated concurrently.
+  </description>
+</entry>

--- a/src/changelog/2.25.2/3940_ThrowableStackTraceRenderer_ArrayIndexOutOfBoundsException.xml
+++ b/src/changelog/2.25.2/3940_ThrowableStackTraceRenderer_ArrayIndexOutOfBoundsException.xml
@@ -5,8 +5,9 @@
            https://logging.apache.org/xml/ns
            https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
-  <issue id="3940" link="https://github.com/apache/logging-log4j2/pull/3940"/>
+  <issue id="3940" link="https://github.com/apache/logging-log4j2/issues/3940"/>
+  <issue id="3955" link="https://github.com/apache/logging-log4j2/pull/3955"/>
   <description format="asciidoc">
-    Fixes `ArrayIndexOutOfBoundsException` thrown by `ThrowableStackTraceRenderer` when a `Throwable`'s stacktrace is mutated concurrently.
+    Fixes `ArrayIndexOutOfBoundsException` thrown by `ThrowableStackTraceRenderer` when the stack trace is mutated concurrently.
   </description>
 </entry>


### PR DESCRIPTION
Fix `ArrayIndexOutOfBoundsException` in `ThrowableStackTraceRenderer` if concurrently modifying the stack trace of a `Throwable` while rendering it

Closes #3940