### PR TITLE
Fix BurstFilter documentation regarding the level parameter

### DIFF
--- a/src/site/antora/modules/ROOT/pages/manual/filters.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/filters.adoc
@@ -385,7 +385,7 @@ Timestamp filters use the timestamp of log events to decide whether to accept th
 [#BurstFilter]
 ==== `BurstFilter`
 
-The BurstFilter limits the rate of log events at or below a configured severity level.
+The `BurstFilter` limits the rate of log events at or below a configured severity level.
 
 Besides the <<common-configuration-attributes,common configuration attributes>>,
 the `BurstFilter` supports the following parameters:
@@ -398,8 +398,8 @@ the `BurstFilter` supports the following parameters:
 | level
 | link:../javadoc/log4j-api/org/apache/logging/log4j/Level.html[`Level`]
 | link:../javadoc/log4j-api/org/apache/logging/log4j/Level.html#WARN[`WARN`]
-| The rate limit is only applied up until and including this level. Events more severe than this level
-will always match.
+| The rate limit is only applied up until and including this level.
+Events more severe than this level will always match.
 
 | rate
 | `float`

--- a/src/site/antora/modules/ROOT/pages/manual/filters.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/filters.adoc
@@ -385,8 +385,7 @@ Timestamp filters use the timestamp of log events to decide whether to accept th
 [#BurstFilter]
 ==== `BurstFilter`
 
-The `BurstFilter` limits the rate of log events.
-The rate limit is only applied to log events less severe than a configured log level.
+The BurstFilter limits the rate of log events at or below a configured severity level.
 
 Besides the <<common-configuration-attributes,common configuration attributes>>,
 the `BurstFilter` supports the following parameters:
@@ -399,8 +398,8 @@ the `BurstFilter` supports the following parameters:
 | level
 | link:../javadoc/log4j-api/org/apache/logging/log4j/Level.html[`Level`]
 | link:../javadoc/log4j-api/org/apache/logging/log4j/Level.html#WARN[`WARN`]
-| The rate limit only applies to log events less severe than this level.
-Events at least as severe as this level will always match.
+| The rate limit is only applied up until and including this level. Events more severe than this level
+will always match.
 
 | rate
 | `float`


### PR DESCRIPTION
I've discovered that the `BurstFilter` implementation and documentation differ in regards to the treatment of the level parameter. This PR addresses that by adapting the documentation, since my feeling is that this is saver than adapting the behavior of implementation.

> [!IMPORTANT]  
> Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise.

## Checklist

Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.

### ✅ Required checks

- ✅  **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
- ✅  **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
- ✅  **Code formatting**: The code is formatted according to the project’s style guide.
  <details>
    <summary>How to check and fix formatting</summary>

    - To **check** formatting: `./mvnw spotless:check`
    - To **fix** formatting: `./mvnw spotless:apply`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>
- ✅  **Build & Test**: I verified that the project builds and all unit tests pass.
  <details>
    <summary>How to build the project</summary>

    Run: `./mvnw verify`

    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
  </details>

### 🧪 Tests (select one)

- [ ] I have added or updated tests to cover my changes.
- [x] No additional tests are needed for this change.

### 📝 Changelog (select one)

- [ ] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
- [x] This is a trivial change and does not require a changelog entry.
