### PR TITLE
Disable commit signatures

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -75,8 +75,6 @@ github:
   # Enforce Review-then-Commit
   protected_branches:
     2.x:
-      # All commits must be signed
-      required_signatures: true
       # All reviews must be addressed before merging
       required_conversation_resolution: true
       # Require checks to pass before merging
@@ -92,8 +90,6 @@ github:
       required_pull_request_reviews:
         required_approving_review_count: 1
     main:
-      # All commits must be signed
-      required_signatures: true
       # All reviews must be addressed before merging
       required_conversation_resolution: true
       # Require checks to pass before merging

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,40 +1,8 @@
 **INSERT HERE** a clear and concise description of what the pull request is for along with a reference to the associated issue IDs, if they exist.
 
-> [!IMPORTANT]  
-> Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise.
-
 ## Checklist
 
-Before we can review and merge your changes, please go through the checklist below. If you're still working on some items, feel free to submit your pull request as a draft—our CI will help guide you through the remaining steps.
-
-### ✅ Required checks
-
-- [ ] **License**: I confirm that my changes are submitted under the [Apache License, Version 2.0](https://apache.org/licenses/LICENSE-2.0).
-- [ ] **Commit signatures**: All commits are signed and verifiable. (See [GitHub Docs on Commit Signature Verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)).
-- [ ] **Code formatting**: The code is formatted according to the project’s style guide.
-  <details>
-    <summary>How to check and fix formatting</summary>
-
-    - To **check** formatting: `./mvnw spotless:check`
-    - To **fix** formatting: `./mvnw spotless:apply`
-
-    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
-  </details>
-- [ ] **Build & Test**: I verified that the project builds and all unit tests pass.
-  <details>
-    <summary>How to build the project</summary>
-
-    Run: `./mvnw verify`
-
-    See [the build instructions](https://logging.apache.org/log4j/2.x/development.html#building) for details.
-  </details>
-
-### 🧪 Tests (select one)
-
-- [ ] I have added or updated tests to cover my changes.
-- [ ] No additional tests are needed for this change.
-
-### 📝 Changelog (select one)
-
-- [ ] I added a changelog entry in `src/changelog/.2.x.x`. (See [Changelog Entry File Guide](https://logging.apache.org/log4j/tools/log4j-changelog.html#changelog-entry-file)).
-- [ ] This is a trivial change and does not require a changelog entry.
+* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
+* `./mvnw verify` succeeds ([the build instructions](https://logging.apache.org/log4j/2.x/development.html#building))
+* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
+* Tests are provided


### PR DESCRIPTION
Per this `dev@logging` [lazy consensus](https://lists.apache.org/thread/k6cb4yw2dc9p186l64osy71sm7j8sjn4), disable commit signatures. While at it, simplify the PR checklist, since nobody reads it.