### PR TITLE
Use binary names in `GraalVmProcessor`

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessorTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessorTest.java
@@ -79,7 +79,9 @@ class GraalVmProcessorTest {
                                     "org.apache.logging.log4j.core.config.Configuration",
                                     "org.apache.logging.log4j.core.config.Node",
                                     "org.apache.logging.log4j.core.LoggerContext",
-                                    "java.lang.String"))),
+                                    "java.lang.String",
+                                    "org.apache.logging.log4j.core.Filter$Result",
+                                    "org.apache.logging.log4j.core.Filter[]"))),
             "fields",
             emptyList());
     private static final String FAKE_PLUGIN_BUILDER_NAME = FAKE_PLUGIN_NAME + "$Builder";
@@ -93,9 +95,11 @@ class GraalVmProcessorTest {
                     asMap("name", "attribute"),
                     asMap("name", "attributeWithoutPublicSetterButWithSuppressAnnotation"),
                     asMap("name", "config"),
+                    asMap("name", "filters"),
                     asMap("name", "layout"),
                     asMap("name", "loggerContext"),
                     asMap("name", "node"),
+                    asMap("name", "onMatch"),
                     asMap("name", "value")));
     private static final String FAKE_PLUGIN_NESTED_NAME = FAKE_PLUGIN_NAME + "$Nested";
     private static final Object FAKE_PLUGIN_NESTED = onlyNoArgsConstructor(FAKE_PLUGIN_NESTED_NAME);
@@ -229,7 +233,7 @@ class GraalVmProcessorTest {
         }
         // The generated folder name should be deterministic and based solely on the descriptor content.
         // If the descriptor changes, this test and the expected folder name must be updated accordingly.
-        assertThat(reachabilityMetadataFolders).hasSize(1).containsExactly(path.resolve("72c240aa"));
+        assertThat(reachabilityMetadataFolders).hasSize(1).containsExactly(path.resolve("791e18c8"));
         assertThat(reachabilityMetadataFolders.get(0).resolve("reflect-config.json"))
                 .as("Reachability metadata file")
                 .exists();

--- a/log4j-core-test/src/test/resources/GraalVmProcessorTest/java/FakePlugin.java
+++ b/log4j-core-test/src/test/resources/GraalVmProcessorTest/java/FakePlugin.java
@@ -17,6 +17,7 @@
 package example;
 
 import java.io.Serializable;
+import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
@@ -49,7 +50,9 @@ public class FakePlugin {
             @PluginConfiguration Configuration config,
             @PluginNode Node node,
             @PluginLoggerContext LoggerContext loggerContext,
-            @PluginValue("value") String value) {
+            @PluginValue("value") String value,
+            @PluginValue("onMatch") Filter.Result onMatch,
+            @PluginElement("filters") Filter[] filters) {
         return null;
     }
 
@@ -81,6 +84,12 @@ public class FakePlugin {
 
         @PluginValue("value")
         private String value;
+
+        @PluginValue("onMatch")
+        private Filter.Result onMatch;
+
+        @PluginElement("filters")
+        private Filter[] filters;
 
         @Override
         public FakePlugin build() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/GraalVmProcessor.java
@@ -36,16 +36,13 @@ import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedOptions;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
-import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.SimpleElementVisitor8;
 import javax.lang.model.util.SimpleTypeVisitor8;
 import javax.tools.Diagnostic;
 import javax.tools.StandardLocation;
@@ -300,9 +297,7 @@ public class GraalVmProcessor extends AbstractProcessor {
 
                     @Override
                     public @Nullable String visitDeclared(final DeclaredType t, final Void unused) {
-                        return safeCast(t.asElement(), TypeElement.class)
-                                .getQualifiedName()
-                                .toString();
+                        return GraalVmProcessor.this.toString(safeCast(t.asElement(), TypeElement.class));
                     }
                 },
                 null);
@@ -313,28 +308,7 @@ public class GraalVmProcessor extends AbstractProcessor {
      *
      * @param element A Java language element.
      */
-    private String toString(Element element) {
-        return element.accept(
-                new SimpleElementVisitor8<String, @Nullable Void>() {
-                    @Override
-                    public String visitPackage(PackageElement e, @Nullable Void unused) {
-                        return e.getQualifiedName().toString();
-                    }
-
-                    @Override
-                    public String visitType(TypeElement e, @Nullable Void unused) {
-                        Element parent = e.getEnclosingElement();
-                        String separator = parent.getKind() == ElementKind.PACKAGE ? "." : "$";
-                        return visit(parent, unused)
-                                + separator
-                                + e.getSimpleName().toString();
-                    }
-
-                    @Override
-                    protected String defaultAction(Element e, @Nullable Void unused) {
-                        return "";
-                    }
-                },
-                null);
+    private String toString(TypeElement element) {
+        return processingEnv.getElementUtils().getBinaryName(element).toString();
     }
 }

--- a/src/changelog/.2.x.x/3871_graalvm_binary_name.xml
+++ b/src/changelog/.2.x.x/3871_graalvm_binary_name.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="removed">
+    <issue id="3871" link="https://github.com/apache/logging-log4j2/issues/3871"/>
+    <issue id="3996" link="https://github.com/apache/logging-log4j2/pull/3996"/>
+    <description format="asciidoc">
+        Fix GraalVM metadata for nested classes to use binary names instead of canonical names.
+    </description>
+</entry>

--- a/src/changelog/.2.x.x/3871_graalvm_binary_name.xml
+++ b/src/changelog/.2.x.x/3871_graalvm_binary_name.xml
@@ -4,7 +4,7 @@
        xsi:schemaLocation="
            https://logging.apache.org/xml/ns
            https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
-       type="removed">
+       type="fixed">
     <issue id="3871" link="https://github.com/apache/logging-log4j2/issues/3871"/>
     <issue id="3996" link="https://github.com/apache/logging-log4j2/pull/3996"/>
     <description format="asciidoc">


### PR DESCRIPTION
`GraalVmProcessor` currently emits canonical type names (JLS §6.7) for parameter types in the GraalVM reachability metadata. However, testing shows that GraalVM expects **binary names** (JLS §13.1) for reference types. For example:

* Canonical: `org.apache.logging.log4j.core.Filter.Result`
* Required (binary): `org.apache.logging.log4j.core.Filter$Result`

For array types, GraalVM accepts two forms:

* The JVM descriptor form: `[L<component_type>;`
* The Java-like form: `<component_type>[]`

This PR updates the processor to use binary names and emits the simpler Java-like syntax for arrays.

Fixes #3871
