### PR TITLE
Fix Dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -48,8 +48,8 @@ updates:
     exclude-paths:
       # These use versions of MongoDB and SLF4J different
       # from the remaining artifacts
-      - "/log4j-mongodb4"
-      - "/log4j-slf4j-impl"
+      - "log4j-mongodb4/**"
+      - "log4j-slf4j-impl/**"
     schedule:
       interval: "monthly"
     groups:


### PR DESCRIPTION
This change restores a valid Dependabot configuration that was broken in #3990 (see the failing GHA run: [57824321555](https://github.com/apache/logging-log4j2/runs/57824321555)).

Because GitHub does not validate Dependabot configuration files before merge, the fix is based **entirely** on the documented format and examples in the [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#exclude-paths-).

**Note:** Dependabot appears to interpret the `exclude-paths` key differently from `directories`; unlike `directories`, `exclude-paths` does **not** require a leading slash.
