### PR TITLE
Fix writeHeader computation in RollingRandomAccessFileManager

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManagerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManagerTest.java
@@ -339,10 +339,10 @@ class RollingRandomAccessFileManagerTest {
 
     @ParameterizedTest
     @CsvSource({
-            "true,true",
-            "true,false",
-            "false,true",
-            "false,false",
+        "true,true",
+        "true,false",
+        "false,true",
+        "false,false",
     })
     void testWriteHeaderWhetherAppendOrExists(final boolean append, final boolean fileExists) throws Exception {
         final File file = File.createTempFile("log4j2", "test");
@@ -357,9 +357,8 @@ class RollingRandomAccessFileManagerTest {
         file.deleteOnExit();
 
         final String header = "HEADER";
-        final PatternLayout layout = PatternLayout.newBuilder()
-                .setHeader(header)
-                .build();
+        final PatternLayout layout =
+                PatternLayout.newBuilder().setHeader(header).build();
 
         final RollingRandomAccessFileManager manager = RollingRandomAccessFileManager.getRollingRandomAccessFileManager(
                 file.getAbsolutePath(),
@@ -385,11 +384,14 @@ class RollingRandomAccessFileManagerTest {
         final String content = new String(fileContent);
         final boolean expectedHeaderWritten = !append || !fileExists;
         if (expectedHeaderWritten) {
-            assertTrue(content.startsWith(header), "File should start with header when append=" + append
-                    + ", fileExists=" + fileExists + ", content: " + content);
+            assertTrue(
+                    content.startsWith(header),
+                    "File should start with header when append=" + append + ", fileExists=" + fileExists + ", content: "
+                            + content);
         } else {
             // When append=true and fileExists=true, file has existing content, so header should not be written
-            assertTrue(!content.startsWith(header),
+            assertTrue(
+                    !content.startsWith(header),
                     "File should not start with header when append=" + append + ", fileExists=" + fileExists
                             + ", content: " + content);
         }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManagerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManagerTest.java
@@ -47,6 +47,8 @@ import org.apache.logging.log4j.core.util.FileUtils;
 import org.apache.logging.log4j.core.util.NullOutputStream;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 /**
  * Tests the RollingRandomAccessFileManager class.
@@ -335,10 +337,23 @@ class RollingRandomAccessFileManagerTest {
         assertEquals(filePermissions, actualFilePermissions);
     }
 
-    @Test
-    void testWriteHeaderWhenFileDoesNotExistBefore() throws IOException {
+    @ParameterizedTest
+    @CsvSource({
+            "true,true",
+            "true,false",
+            "false,true",
+            "false,false",
+    })
+    void testWriteHeaderWhetherAppendOrExists(final boolean append, final boolean fileExists) throws Exception {
         final File file = File.createTempFile("log4j2", "test");
-        file.delete(); // Ensure file doesn't exist
+        if (!fileExists) {
+            file.delete(); // Ensure file doesn't exist
+        } else {
+            // If file exists, write some content to it so it's not empty
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                fos.write("EXISTING_CONTENT".getBytes());
+            }
+        }
         file.deleteOnExit();
 
         final String header = "HEADER";
@@ -346,11 +361,10 @@ class RollingRandomAccessFileManagerTest {
                 .setHeader(header)
                 .build();
 
-        final boolean isAppend = true;
         final RollingRandomAccessFileManager manager = RollingRandomAccessFileManager.getRollingRandomAccessFileManager(
                 file.getAbsolutePath(),
                 Strings.EMPTY,
-                isAppend,
+                append,
                 true,
                 RollingRandomAccessFileManager.DEFAULT_BUFFER_SIZE,
                 new SizeBasedTriggeringPolicy(Long.MAX_VALUE),
@@ -364,10 +378,20 @@ class RollingRandomAccessFileManagerTest {
         assertNotNull(manager);
         manager.close();
 
-        // Verify header was written
+        // Verify header was written based on logic: writeHeader = !append || !fileExistedBefore
+        // Note: writeHeader() also checks file.length() == 0, so header is only written if file is empty
         assertTrue(file.exists(), "File should exist");
         final byte[] fileContent = Files.readAllBytes(file.toPath());
         final String content = new String(fileContent);
-        assertTrue(content.startsWith(header), "File should start with header: " + content);
+        final boolean expectedHeaderWritten = !append || !fileExists;
+        if (expectedHeaderWritten) {
+            assertTrue(content.startsWith(header), "File should start with header when append=" + append
+                    + ", fileExists=" + fileExists + ", content: " + content);
+        } else {
+            // When append=true and fileExists=true, file has existing content, so header should not be written
+            assertTrue(!content.startsWith(header),
+                    "File should not start with header when append=" + append + ", fileExists=" + fileExists
+                            + ", content: " + content);
+        }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManagerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManagerTest.java
@@ -41,6 +41,7 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
 import java.util.concurrent.locks.LockSupport;
 import org.apache.logging.log4j.core.config.DefaultConfiguration;
+import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.core.util.Closer;
 import org.apache.logging.log4j.core.util.FileUtils;
 import org.apache.logging.log4j.core.util.NullOutputStream;
@@ -332,5 +333,41 @@ class RollingRandomAccessFileManagerTest {
                 .readAttributes()
                 .permissions();
         assertEquals(filePermissions, actualFilePermissions);
+    }
+
+    @Test
+    void testWriteHeaderWhenFileDoesNotExistBefore() throws IOException {
+        final File file = File.createTempFile("log4j2", "test");
+        file.delete(); // Ensure file doesn't exist
+        file.deleteOnExit();
+
+        final String header = "HEADER";
+        final PatternLayout layout = PatternLayout.newBuilder()
+                .setHeader(header)
+                .build();
+
+        final boolean isAppend = true;
+        final RollingRandomAccessFileManager manager = RollingRandomAccessFileManager.getRollingRandomAccessFileManager(
+                file.getAbsolutePath(),
+                Strings.EMPTY,
+                isAppend,
+                true,
+                RollingRandomAccessFileManager.DEFAULT_BUFFER_SIZE,
+                new SizeBasedTriggeringPolicy(Long.MAX_VALUE),
+                null,
+                null,
+                layout,
+                null,
+                null,
+                null,
+                null);
+        assertNotNull(manager);
+        manager.close();
+
+        // Verify header was written
+        assertTrue(file.exists(), "File should exist");
+        final byte[] fileContent = Files.readAllBytes(file.toPath());
+        final String content = new String(fileContent);
+        assertTrue(content.startsWith(header), "File should start with header: " + content);
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
@@ -177,7 +177,7 @@ public class RollingRandomAccessFileManager extends RollingFileManager {
                             boolean fileExistedBefore = false;
                             if (fileName != null) {
                                 file = new File(name);
-                                fileExistedBefore = new File(name).exists();
+                                fileExistedBefore = file.exists();
 
                                 if (!append) {
                                     file.delete();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/RollingRandomAccessFileManager.java
@@ -174,8 +174,10 @@ public class RollingRandomAccessFileManager extends RollingFileManager {
                             long size = 0;
                             long time = System.currentTimeMillis();
                             RandomAccessFile raf = null;
+                            boolean fileExistedBefore = false;
                             if (fileName != null) {
                                 file = new File(name);
+                                fileExistedBefore = new File(name).exists();
 
                                 if (!append) {
                                     file.delete();
@@ -207,7 +209,7 @@ public class RollingRandomAccessFileManager extends RollingFileManager {
                                     return null;
                                 }
                             }
-                            final boolean writeHeader = !append || file == null || !file.exists();
+                            final boolean writeHeader = !append || file == null || !fileExistedBefore;
 
                             final RollingRandomAccessFileManager rrm = new RollingRandomAccessFileManager(
                                     data.getLoggerContext(),

--- a/src/changelog/.2.x.x/fix_RollingRandomAccessFileManager_writeHeader.xml
+++ b/src/changelog/.2.x.x/fix_RollingRandomAccessFileManager_writeHeader.xml
@@ -6,7 +6,7 @@
            https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <description format="asciidoc">
-    Fix writeHeader computation in RollingRandomAccessFileManager. The writeHeader boolean was computed after creating the RandomAccessFile, which creates the file if it doesn't exist. This made file.exists() always return true, causing incorrect header write decisions when append=true and the file didn't exist before.
+    Fix header write in `RollingRandomAccessFileManager` that was being incorrectly skipped if `append=true` and the file didn't exist before.
   </description>
 </entry>
 

--- a/src/changelog/.2.x.x/fix_RollingRandomAccessFileManager_writeHeader.xml
+++ b/src/changelog/.2.x.x/fix_RollingRandomAccessFileManager_writeHeader.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <description format="asciidoc">
+    Fix writeHeader computation in RollingRandomAccessFileManager. The writeHeader boolean was computed after creating the RandomAccessFile, which creates the file if it doesn't exist. This made file.exists() always return true, causing incorrect header write decisions when append=true and the file didn't exist before.
+  </description>
+</entry>
+


### PR DESCRIPTION
Fix writeHeader computation in RollingRandomAccessFileManager

The writeHeader boolean was computed after creating the RandomAccessFile, which creates the file if it doesn't exist. This made file.exists() always return true, causing incorrect header write decisions.

This change captures the file's pre-existing state before opening the RandomAccessFile by:
- Declaring a fileExistedBefore boolean initialized to false
- Setting it by checking fileName != null && new File(fileName).exists() before calling new RandomAccessFile(...)
- Using !fileExistedBefore instead of !file.exists() in the writeHeader calculation

When fileName is null, fileExistedBefore remains false as expected.