### PR TITLE
Fix warning when last argument is null (#3975)

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterFormatterTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/ParameterFormatterTest.java
@@ -98,6 +98,19 @@ class ParameterFormatterTest {
                         placeholderCount, argCount, pattern);
     }
 
+    @Test
+    void format_should_not_warn_on_insufficient_args() {
+        final String expectedMessage = "pan a";
+        final String pattern = "pan {}";
+        final String[] args = new String[] {"a", null};
+        final int argCount = args.length;
+
+        String actualMessage = ParameterFormatter.format(pattern, args, argCount);
+        assertThat(actualMessage).isEqualTo(expectedMessage);
+        final List<StatusData> statusDataList = statusListener.getStatusData().collect(Collectors.toList());
+        assertThat(statusDataList).isEmpty();
+    }
+
     @ParameterizedTest
     @MethodSource("messageFormattingTestCases")
     void format_should_work(

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/ParameterFormatter.java
@@ -247,7 +247,7 @@ final class ParameterFormatter {
         // #2380: check if the count of placeholder is not equal to the count of arguments
         if (analysis.placeholderCount != argCount) {
             final int noThrowableArgCount =
-                    argCount < 1 ? 0 : argCount - ((args[argCount - 1] instanceof Throwable) ? 1 : 0);
+                    argCount < 1 ? 0 : argCount - (isLastArgumentThrowable(args, argCount) ? 1 : 0);
             if (analysis.placeholderCount != noThrowableArgCount) {
                 STATUS_LOGGER.warn(
                         "found {} argument placeholders, but provided {} for pattern `{}`",
@@ -266,6 +266,12 @@ final class ParameterFormatter {
         else {
             formatMessageContainingNoEscapes(buffer, pattern, args, argCount, analysis);
         }
+    }
+
+    private static boolean isLastArgumentThrowable(final Object[] args, final int argCount) {
+        final Object lastArgument = args[argCount - 1];
+        // #3975: tolerate null in the last argument since it could have been Throwable parameter
+        return (lastArgument == null) || (lastArgument instanceof Throwable);
     }
 
     private static void formatMessageContainingNoEscapes(

--- a/src/changelog/.2.x.x/3975_prevent_warning_for_last_null_argument.xml
+++ b/src/changelog/.2.x.x/3975_prevent_warning_for_last_null_argument.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+    <issue id="3975" link="https://github.com/apache/logging-log4j2/issues/3975"/>
+    <issue id="4014" link="https://github.com/apache/logging-log4j2/pull/4014"/>
+    <description format="asciidoc">
+      Prevent ParameterFormatter issuing a warning in case there is an extra null argument.
+      Needed to support cases with Throwable parameter that may be null.
+    </description>
+</entry>


### PR DESCRIPTION
Allow extra null argument to ParameterFormatter without issuing a warning.

Fixes #3975
