### PR TITLE
Remove Log4j Jakarta EE link from navigation file

### DIFF
--- a/src/site/antora/modules/ROOT/nav.adoc
+++ b/src/site/antora/modules/ROOT/nav.adoc
@@ -85,7 +85,6 @@
 * xref:log4j-to-jul.adoc[]
 
 .Related projects
-* {logging-services-url}/log4j/jakarta/index.html[Log4j Jakarta EE]
 * {logging-services-url}/log4j/jmx-gui/index.html[Log4j JMX GUI]
 * {logging-services-url}/log4j/kotlin/index.html[Log4j Kotlin]
 * {logging-services-url}/log4j/scala/index.html[Log4j Scala]


### PR DESCRIPTION
- related issue #4023
- Remove broken link in related project because Log4j 3 is not released yet