### PR TITLE
Remove mentions of Log4j Scala

### DIFF
--- a/src/site/antora/modules/ROOT/nav.adoc
+++ b/src/site/antora/modules/ROOT/nav.adoc
@@ -87,6 +87,5 @@
 .Related projects
 * {logging-services-url}/log4j/jmx-gui/index.html[Log4j JMX GUI]
 * {logging-services-url}/log4j/kotlin/index.html[Log4j Kotlin]
-* {logging-services-url}/log4j/scala/index.html[Log4j Scala]
 * {logging-services-url}/log4j/tools/index.html[Log4j Tools]
 * {logging-services-url}/log4j/transform/index.html[Log4j Transformation Tools]

--- a/src/site/antora/modules/ROOT/pages/manual/api.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/api.adoc
@@ -42,12 +42,8 @@ This page tries to cover the most prominent Log4j API features.
 
 [TIP]
 ====
-Did you know that Log4j provides specialized APIs for Kotlin and Scala?
-Check out
-{logging-services-url}/log4j/kotlin/index.html[Log4j Kotlin]
-and
-{logging-services-url}/log4j/scala/index.html[Log4j Scala]
-projects for details.
+Did you know that Log4j provides a specialized API for Kotlin?
+Check out the {logging-services-url}/log4j/kotlin/index.html[Log4j Kotlin] project for details.
 ====
 
 [#intro]

--- a/src/site/antora/modules/ROOT/partials/log4j-features.adoc
+++ b/src/site/antora/modules/ROOT/partials/log4j-features.adoc
@@ -39,11 +39,7 @@ Powerful API::
 Log4j is a logging system where the API (called Log4j API) and its implementation (called Log4j Core) is distinctly separate from each other.
 xref:manual/api.adoc[Log4j API] provides the most feature-rich logging facade in the market; support for various `Message` types (such as `Object` or `Map`) besides plain `String`, lambda expressions, parameterized logging, markers, levels, diagnostic contexts (aka. MDC/NDC), etc.
 Log4j team takes backward compatibility very seriously and makes sure people relying on Log4j API gets a logging facade that is straightforward to use in a correct and future-proof way.
-Check out the xref:manual/api.adoc[Java API],
-{logging-services-url}/log4j/kotlin/index.html[Kotlin API]
-and
-{logging-services-url}/log4j/scala/index.html[Scala API]
-pages for further information.
+Check out the xref:manual/api.adoc[Java API] and {logging-services-url}/log4j/kotlin/index.html[Kotlin API] pages for further information.
 
 No vendor lock-in::
 Log4j API is a generic logging facade for various logging frameworks.


### PR DESCRIPTION
Log4j Scala is retired, remove its mentions.