### PR TITLE
Fix the `AsyncLoggerConfig` ring buffer size property name in the manual

### DIFF
--- a/src/site/antora/modules/ROOT/partials/manual/systemproperties/properties-async-logger-config.adoc
+++ b/src/site/antora/modules/ROOT/partials/manual/systemproperties/properties-async-logger-config.adoc
@@ -35,7 +35,7 @@ The class needs to have a public zero-argument constructor.
 The default exception handler will print a message and stack trace to the standard error output stream.
 
 [id=log4j2.asyncLoggerConfigRingBufferSize]
-== `log4j2.asyncLoggerRingConfigBufferSize`
+== `log4j2.asyncLoggerConfigRingBufferSize`
 
 [cols="1h,5"]
 |===


### PR DESCRIPTION
The docs for the AsyncLoggerConfig properties, which are relevant for mixed sync and async loggers, specify the wrong property name for the config that controls the Disruptor ring buffer size. Interestingly the right property name is used in the anchor ID linking to the exact section in the docs, but if you copy the property name from the docs themselves (like me), you are gonna have a bad time.

I found this after noticing a too big ring buffer in a heap dump, and ended up chasing it with the `StatusLogger` debug logging and the log line in `AsyncLoggerConfigDisruptor.start` dumping the configured size. The small fix was also verified this way.

In hindsight, this should have been obvious, but it really wasn't (for me).

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds ([the build instructions](https://logging.apache.org/log4j/2.x/development.html#building))
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests are provided
