### PR TITLE
Avoid referring to `PluginBuilderAttribute.class` in `PluginProcessor`

### DIFF
--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessor.java
@@ -53,7 +53,6 @@ import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAliases;
-import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.util.Strings;
 
 /**
@@ -84,9 +83,13 @@ public class PluginProcessor extends AbstractProcessor {
         return SourceVersion.latest();
     }
 
+    private static final String PLUGIN_BUILDER_ATTRIBUTE_ANNOTATION =
+            "org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute";
+
     @Override
     public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
         final Messager messager = processingEnv.getMessager();
+        final Elements elementUtils = processingEnv.getElementUtils();
         // Process the elements for this round
         if (!annotations.isEmpty()) {
             final Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(Plugin.class);
@@ -95,7 +98,8 @@ public class PluginProcessor extends AbstractProcessor {
 
             // process plugin builder Attributes
             final Set<? extends Element> pluginAttributeBuilderElements =
-                    roundEnv.getElementsAnnotatedWith(PluginBuilderAttribute.class);
+                    roundEnv.getElementsAnnotatedWith(
+                            elementUtils.getTypeElement(PLUGIN_BUILDER_ATTRIBUTE_ANNOTATION));
             processBuilderAttribute(pluginAttributeBuilderElements);
             processedElements.addAll(pluginAttributeBuilderElements);
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/processor/PluginProcessor.java
@@ -98,8 +98,7 @@ public class PluginProcessor extends AbstractProcessor {
 
             // process plugin builder Attributes
             final Set<? extends Element> pluginAttributeBuilderElements =
-                    roundEnv.getElementsAnnotatedWith(
-                            elementUtils.getTypeElement(PLUGIN_BUILDER_ATTRIBUTE_ANNOTATION));
+                    roundEnv.getElementsAnnotatedWith(elementUtils.getTypeElement(PLUGIN_BUILDER_ATTRIBUTE_ANNOTATION));
             processBuilderAttribute(pluginAttributeBuilderElements);
             processedElements.addAll(pluginAttributeBuilderElements);
         }


### PR DESCRIPTION
This makes it easier to build PluginProcessor by itself separately from the rest of log4j-core, and then include that processor when building the rest of core, instead of having to compile all of core twice.