### PR TITLE
Discard defined but unused loggers, appenders and filters

### DIFF
--- a/log4j-core-test/src/test/resources/log4j-rolling.properties
+++ b/log4j-core-test/src/test/resources/log4j-rolling.properties
@@ -51,6 +51,11 @@ appender.my.list.filters = threshold
 appender.my.list.filter.threshold.type = ThresholdFilter
 appender.my.list.filter.threshold.level = error
 
+appender.unused.type = RollingFile
+appender.unused.name = UnusedRollingFile
+appender.unused.fileName = ${filename}.unused
+appender.unused.filePattern = target/rolling2/test1-%d{MM-dd-yy-HH-mm-ss}-unused-%i.log.gz
+
 loggers = rolling.file
 
 logger.rolling.file.name = org.apache.logging.log4j.core.appender.rolling

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
@@ -131,6 +131,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
                 final String name = filterName.trim();
                 builder.add(createFilter(name, PropertiesUtil.extractSubset(rootProperties, "filter." + name)));
             }
+            removeDefinedButUnusedProperties("filter");
         } else {
 
             final Map<String, Properties> filters =
@@ -148,6 +149,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
                 builder.add(createAppender(
                         appenderName.trim(), PropertiesUtil.extractSubset(rootProperties, "appender." + name)));
             }
+            removeDefinedButUnusedProperties(Appender.ELEMENT_TYPE);
         } else {
             final Map<String, Properties> appenders = PropertiesUtil.partitionOnCommonPrefixes(
                     PropertiesUtil.extractSubset(rootProperties, Appender.ELEMENT_TYPE));
@@ -165,6 +167,7 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
                     builder.add(createLogger(name, PropertiesUtil.extractSubset(rootProperties, "logger." + name)));
                 }
             }
+            removeDefinedButUnusedProperties("logger");
         } else {
 
             final Map<String, Properties> loggers = PropertiesUtil.partitionOnCommonPrefixes(
@@ -192,6 +195,10 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
         builder.setLoggerContext(loggerContext);
 
         return builder.build(false);
+    }
+
+    private void removeDefinedButUnusedProperties(final String prefix) {
+        PropertiesUtil.extractSubset(rootProperties, prefix);
     }
 
     private void processRemainingProperties(

--- a/src/changelog/.2.x.x/prevent_configexception_non_used_config.xml
+++ b/src/changelog/.2.x.x/prevent_configexception_non_used_config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+    <issue id="4036" link="https://github.com/apache/logging-log4j2/issues/4036"/>
+    <issue id="4069" link="https://github.com/apache/logging-log4j2/pull/4069"/>
+    <description format="asciidoc">
+        Disregarded defined logger, appender and filter properties not referenced in loggers, appenders and filters respectively
+    </description>
+</entry>


### PR DESCRIPTION
Closes #4036 

A ConfigurationException shall not be thrown where logger, appender or filter properties are defined in the configuration but not referenced in the "loggers", "appenders" or "filters" element respectively