### PR TITLE
CVE-2026-34481: JsonWriter: Write non-finite floating-point values as strings

### DIFF
--- a/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/util/JsonWriterTest.java
+++ b/log4j-layout-template-json-test/src/test/java/org/apache/logging/log4j/layout/template/json/util/JsonWriterTest.java
@@ -40,6 +40,8 @@ import org.apache.logging.log4j.util.Strings;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @SuppressWarnings({"DoubleBraceInitialization", "UnnecessaryStringBuilder"})
 class JsonWriterTest {
@@ -606,6 +608,14 @@ class JsonWriterTest {
         }
     }
 
+    @ParameterizedTest
+    @ValueSource(floats = {Float.NEGATIVE_INFINITY, Float.NaN, Float.POSITIVE_INFINITY})
+    void test_writeNumber_float_non_finite(final float number) {
+        final String expectedJson = "\"" + number + "\"";
+        final String actualJson = withLockedWriterReturning(writer -> writer.use(() -> writer.writeNumber(number)));
+        Assertions.assertThat(actualJson).isEqualTo(expectedJson);
+    }
+
     @Test
     void test_writeNumber_float() {
         for (final float number : new float[] {Float.MIN_VALUE, -1.0F, 0F, 1.0F, Float.MAX_VALUE}) {
@@ -613,6 +623,14 @@ class JsonWriterTest {
             final String actualJson = withLockedWriterReturning(writer -> writer.use(() -> writer.writeNumber(number)));
             Assertions.assertThat(actualJson).isEqualTo(expectedJson);
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {Double.NEGATIVE_INFINITY, Double.NaN, Double.POSITIVE_INFINITY})
+    void test_writeNumber_double_non_finite(final double number) {
+        final String expectedJson = "\"" + number + "\"";
+        final String actualJson = withLockedWriterReturning(writer -> writer.use(() -> writer.writeNumber(number)));
+        Assertions.assertThat(actualJson).isEqualTo(expectedJson);
     }
 
     @Test

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/JsonWriter.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/JsonWriter.java
@@ -722,7 +722,7 @@ public final class JsonWriter implements AutoCloseable, Cloneable {
     }
 
     public void writeNumber(final float number) {
-        // Follows the same logic as Jackson's JsonWriteFeatures#WRITE_NAN_AS_STRINGS feature.
+        // Follows the same logic as Jackson's JsonWriteFeature#WRITE_NAN_AS_STRINGS feature.
         if (!Float.isFinite(number)) {
             writeString(Float.toString(number));
         } else {
@@ -731,7 +731,7 @@ public final class JsonWriter implements AutoCloseable, Cloneable {
     }
 
     public void writeNumber(final double number) {
-        // Follows the same logic as Jackson's JsonWriteFeatures#WRITE_NAN_AS_STRINGS feature.
+        // Follows the same logic as Jackson's JsonWriteFeature#WRITE_NAN_AS_STRINGS feature.
         if (!Double.isFinite(number)) {
             writeString(Double.toString(number));
         } else {

--- a/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/JsonWriter.java
+++ b/log4j-layout-template-json/src/main/java/org/apache/logging/log4j/layout/template/json/util/JsonWriter.java
@@ -722,11 +722,21 @@ public final class JsonWriter implements AutoCloseable, Cloneable {
     }
 
     public void writeNumber(final float number) {
-        stringBuilder.append(number);
+        // Follows the same logic as Jackson's JsonWriteFeatures#WRITE_NAN_AS_STRINGS feature.
+        if (!Float.isFinite(number)) {
+            writeString(Float.toString(number));
+        } else {
+            stringBuilder.append(number);
+        }
     }
 
     public void writeNumber(final double number) {
-        stringBuilder.append(number);
+        // Follows the same logic as Jackson's JsonWriteFeatures#WRITE_NAN_AS_STRINGS feature.
+        if (!Double.isFinite(number)) {
+            writeString(Double.toString(number));
+        } else {
+            stringBuilder.append(number);
+        }
     }
 
     public void writeNumber(final short number) {

--- a/src/changelog/.2.x.x/4080_jtl-nan.xml
+++ b/src/changelog/.2.x.x/4080_jtl-nan.xml
@@ -5,6 +5,7 @@
            https://logging.apache.org/xml/ns
            https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
+    <issue id="4080" link="https://github.com/apache/logging-log4j2/pull/4080"/>
     <description format="asciidoc">
         Write non-finite floating-point numbers as strings in `JsonWriter`.
     </description>

--- a/src/changelog/.2.x.x/jtl-nan.xml
+++ b/src/changelog/.2.x.x/jtl-nan.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <description format="asciidoc">
+        Write non-finite floating-point numbers as strings in `JsonWriter`.
+    </description>
+</entry>


### PR DESCRIPTION
This change updates `JsonWriter` to serialize non-finite `float` and `double` values (`NaN`, `Infinity`, and `-Infinity`) as JSON strings.

This behavior aligns with Jackson's `JsonWriteFeature#WRITE_NAN_AS_STRINGS`.

Previously, these values were written without quotes, which produces **invalid JSON** according to the JSON specification.
