### PR TITLE
Fix SLF4JLogger.atFatal() returning Level.TRACE instead of Level.FATAL

### DIFF
--- a/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogger.java
+++ b/log4j-to-slf4j/src/main/java/org/apache/logging/slf4j/SLF4JLogger.java
@@ -363,7 +363,7 @@ public class SLF4JLogger extends AbstractLogger {
 
     @Override
     public LogBuilder atFatal() {
-        return atLevel(Level.TRACE);
+        return atLevel(Level.FATAL);
     }
 
     @Override

--- a/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/LogBuilderTest.java
+++ b/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/LogBuilderTest.java
@@ -114,7 +114,9 @@ class LogBuilderTest {
     @MethodSource("logBuilderMethods")
     void atFatal_should_log_at_error_level(final Consumer<LogBuilder> consumer) {
         consumer.accept(logger.atFatal());
-        assertThat(list.strList).as("atFatal() must produce a log event (SLF4J ERROR equivalent)").hasSize(1);
+        assertThat(list.strList)
+                .as("atFatal() must produce a log event (SLF4J ERROR equivalent)")
+                .hasSize(1);
         list.strList.clear();
     }
 }

--- a/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/LogBuilderTest.java
+++ b/log4j-to-slf4j/src/test/java/org/apache/logging/slf4j/LogBuilderTest.java
@@ -103,4 +103,18 @@ class LogBuilderTest {
         assertThat(list.strList).hasSize(1);
         list.strList.clear();
     }
+
+    /**
+     * Verifies that {@code atFatal()} delegates to {@code atLevel(Level.FATAL)}
+     * and not {@code atLevel(Level.TRACE)}.
+     *
+     * @see <a href="https://github.com/apache/logging-log4j2/issues/4068">#4068</a>
+     */
+    @ParameterizedTest
+    @MethodSource("logBuilderMethods")
+    void atFatal_should_log_at_error_level(final Consumer<LogBuilder> consumer) {
+        consumer.accept(logger.atFatal());
+        assertThat(list.strList).as("atFatal() must produce a log event (SLF4J ERROR equivalent)").hasSize(1);
+        list.strList.clear();
+    }
 }

--- a/src/changelog/.2.x.x/4068_fix_SLF4JLogger_atFatal_wrong_level.xml
+++ b/src/changelog/.2.x.x/4068_fix_SLF4JLogger_atFatal_wrong_level.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <issue id="4068" link="https://github.com/apache/logging-log4j2/issues/4068"/>
+    <description format="asciidoc">
+        Fixed `SLF4JLogger.atFatal()` returning `atLevel(Level.TRACE)` instead of `atLevel(Level.FATAL)`, which caused FATAL log events to be silently discarded when using the fluent API through the `log4j-to-slf4j` bridge.
+    </description>
+</entry>

--- a/src/changelog/.2.x.x/4068_fix_SLF4JLogger_atFatal_wrong_level.xml
+++ b/src/changelog/.2.x.x/4068_fix_SLF4JLogger_atFatal_wrong_level.xml
@@ -6,6 +6,7 @@
            https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
     <issue id="4068" link="https://github.com/apache/logging-log4j2/issues/4068"/>
+    <issue id="4089" link="https://github.com/apache/logging-log4j2/pull/4089"/>
     <description format="asciidoc">
         Fixed `SLF4JLogger.atFatal()` returning `atLevel(Level.TRACE)` instead of `atLevel(Level.FATAL)`, which caused FATAL log events to be silently discarded when using the fluent API through the `log4j-to-slf4j` bridge.
     </description>


### PR DESCRIPTION
Fixes #4068.

## Summary

`SLF4JLogger.atFatal()` returns `atLevel(Level.TRACE)` instead of `atLevel(Level.FATAL)`. This was a copy-paste error introduced in commit `113a8e85f4` (LOG4J2-3647, 2023-01-13). Every `logger.atFatal().log(...)` call through the `log4j-to-slf4j` bridge emits at TRACE level, causing the message to be silently discarded in any environment where TRACE is disabled.

## Changes

- **`SLF4JLogger.java`**: Changed `Level.TRACE` to `Level.FATAL` in `atFatal()`
- **Changelog**: Added entry `4068_fix_SLF4JLogger_atFatal_wrong_level.xml`

## Affected versions

2.20.0 through 2.24.3 (every release since the fluent API was added to the SLF4J bridge).