### PR TITLE
Switch reusable builds to `gha/v0`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ permissions: read-all
 jobs:
 
   build:
-    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@rel/12.1.1
+    uses: apache/logging-parent/.github/workflows/build-reusable.yaml@gha/v0
     secrets:
       DV_ACCESS_TOKEN: ${{ startsWith(github.ref_name, 'release/') && '' || secrets.DEVELOCITY_ACCESS_KEY }}
     with:
@@ -44,7 +44,7 @@ jobs:
   deploy-snapshot:
     needs: build
     if: github.repository == 'apache/logging-log4j2' && github.ref_name == '2.x'
-    uses: apache/logging-parent/.github/workflows/deploy-snapshot-reusable.yaml@rel/12.1.1
+    uses: apache/logging-parent/.github/workflows/deploy-snapshot-reusable.yaml@gha/v0
     # Secrets for deployments
     secrets:
       NEXUS_USERNAME: ${{ secrets.NEXUS_USER }}
@@ -57,7 +57,7 @@ jobs:
   deploy-release:
     needs: build
     if: github.repository == 'apache/logging-log4j2' && startsWith(github.ref_name, 'release/')
-    uses: apache/logging-parent/.github/workflows/deploy-release-reusable.yaml@rel/12.1.1
+    uses: apache/logging-parent/.github/workflows/deploy-release-reusable.yaml@gha/v0
     # Secrets for deployments
     secrets:
       GPG_SECRET_KEY: ${{ secrets.LOGGING_GPG_SECRET_KEY }}
@@ -78,7 +78,7 @@ jobs:
     needs: [ deploy-snapshot, deploy-release ]
     if: ${{ always() && (needs.deploy-snapshot.result == 'success' || needs.deploy-release.result == 'success') }}
     name: "verify-reproducibility (${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.project-version || needs.deploy-snapshot.outputs.project-version }})"
-    uses: apache/logging-parent/.github/workflows/verify-reproducibility-reusable.yaml@rel/12.1.1
+    uses: apache/logging-parent/.github/workflows/verify-reproducibility-reusable.yaml@gha/v0
     with:
       nexus-url: ${{ needs.deploy-release.result == 'success' && needs.deploy-release.outputs.nexus-url || 'https://repository.apache.org/content/groups/snapshots' }}
       # Encode the `runs-on` input as JSON array

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -30,7 +30,7 @@ permissions: read-all
 jobs:
 
   analyze:
-    uses: apache/logging-parent/.github/workflows/codeql-analysis-reusable.yaml@rel/12.1.1
+    uses: apache/logging-parent/.github/workflows/codeql-analysis-reusable.yaml@gha/v0
     with:
       java-version: |
         8

--- a/.github/workflows/deploy-site.yaml
+++ b/.github/workflows/deploy-site.yaml
@@ -33,7 +33,7 @@ jobs:
 
   deploy-site-stg:
     if: github.repository == 'apache/logging-log4j2' && github.ref_name == '2.x'
-    uses: apache/logging-parent/.github/workflows/deploy-site-reusable.yaml@rel/12.1.1
+    uses: apache/logging-parent/.github/workflows/deploy-site-reusable.yaml@gha/v0
     # Secrets for committing the generated site
     secrets:
       GPG_SECRET_KEY: ${{ secrets.LOGGING_GPG_SECRET_KEY }}
@@ -51,7 +51,7 @@ jobs:
 
   deploy-site-pro:
     if: github.repository == 'apache/logging-log4j2' && github.ref_name == '2.x-site-pro'
-    uses: apache/logging-parent/.github/workflows/deploy-site-reusable.yaml@rel/12.1.1
+    uses: apache/logging-parent/.github/workflows/deploy-site-reusable.yaml@gha/v0
     # Secrets for committing the generated site
     secrets:
       GPG_SECRET_KEY: ${{ secrets.LOGGING_GPG_SECRET_KEY }}
@@ -80,7 +80,7 @@ jobs:
 
   deploy-site-rel:
     needs: export-version
-    uses: apache/logging-parent/.github/workflows/deploy-site-reusable.yaml@rel/12.1.1
+    uses: apache/logging-parent/.github/workflows/deploy-site-reusable.yaml@gha/v0
     # Secrets for committing the generated site
     secrets:
       GPG_SECRET_KEY: ${{ secrets.LOGGING_GPG_SECRET_KEY }}


### PR DESCRIPTION
By switching to the `gha/v0` branch of the reusable builds we make sure that the GitHub Action dependency versions are always authorized.
