### PR TITLE
Generate changelog for Dependabot PRs

### DIFF
--- a/.github/workflows/analyze-dependabot.yaml
+++ b/.github/workflows/analyze-dependabot.yaml
@@ -15,33 +15,23 @@
 # limitations under the License.
 #
 
-name: codeql-analysis
+name: "Dependabot Analyze PR"
 
 on:
-  push:
-    branches: [ "2.x", "main" ]
   pull_request:
-    branches: [ "2.x", "main" ]
-  schedule:
-    - cron: '32 12 * * 5'
 
-# Cancel in-progress runs when a newer commit lands on the same PR; pushes to 2.x run to completion.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
-permissions: read-all
+# Default permissions for each job.
+# Additional permissions should be assigned on a per-job basis.
+permissions: { }
 
 jobs:
 
-  analyze:
-    uses: apache/logging-parent/.github/workflows/codeql-analysis-reusable.yaml@gha/v0
-    with:
-      java-version: |
-        8
-        17
-    # Permissions required to publish Security Alerts
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
+  analyze-dependabot:
+    # `github.actor` prevents recursive calls when `github-actions[bot]` pushes to the PR;
+    # `github.event.pull_request.user.login` skips PRs not opened by Dependabot.
+    if: ${{
+      github.repository == 'apache/logging-log4j2'
+      && github.actor == 'dependabot[bot]'
+      && github.event.pull_request.user.login == 'dependabot[bot]'
+      }}
+    uses: apache/logging-parent/.github/workflows/analyze-dependabot-reusable.yaml@gha/v0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,11 @@ on:
       - "release/2*"
   pull_request:
 
+# Cancel in-progress runs when a newer commit lands on the same PR; pushes to 2.x run to completion.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions: read-all
 
 jobs:

--- a/.github/workflows/process-dependabot.yaml
+++ b/.github/workflows/process-dependabot.yaml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "Dependabot Process PR"
+
+on:
+  workflow_run:
+    workflows:
+      - "Dependabot Analyze PR"
+    types:
+      - completed
+
+# Default permissions for each job.
+# Additional permissions should be assigned on a per-job basis.
+permissions: { }
+
+jobs:
+
+  process-dependabot:
+    # Skip this workflow on commits not pushed by Dependabot
+    if: ${{
+      github.repository == 'apache/logging-log4j2'
+      && github.actor == 'dependabot[bot]'
+      && github.event.workflow_run.conclusion == 'success'
+      }}
+    uses: apache/logging-parent/.github/workflows/process-dependabot-reusable.yaml@gha/v0
+    permissions:
+      # The default GITHUB_TOKEN will be used to enable the "auto-merge" on the PR
+      # This requires the following two permissions:
+      contents: write
+      pull-requests: write
+    secrets:
+      # This token will be used to push new content to the repo and trigger workflows again
+      RECURSIVE_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
+    with:
+      # The path to the changelog directory for the current development branch.
+      changelog-path: src/changelog/.2.x.x


### PR DESCRIPTION
Wire up the reusable workflows from apache/logging-parent#419 to:

- Generate changelog entries for Dependabot PRs.
- Re-run build checks on the newly created commit.
- Enable auto-merge, which only merges once required checks pass and a maintainer approves.

Together, these allow merging Dependabot PRs in a single click.

Also add a concurrency setting to `build.yaml` and `codeql-analysis.yaml` so superseded PR commits stop consuming runners.
