### PR TITLE
Restrict JUnit dependencies to below version 6.x to maintain compatib…

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -131,6 +131,15 @@ updates:
       # Kafka 4.x is not compatible with our appender
       - dependency-name: "org.apache.kafka:*"
         versions: [ "[4,)" ]
+      # Keep JUnit below 6.x: JUnit 6+ requires Java 17 and breaks Java 8 test runs
+      - dependency-name: "org.junit:junit-bom"
+        versions: [ "[6,)" ]
+      - dependency-name: "org.junit.jupiter:*"
+        versions: [ "[6,)" ]
+      - dependency-name: "org.junit.platform:*"
+        versions: [ "[6,)" ]
+      - dependency-name: "org.junit.vintage:*"
+        versions: [ "[6,)" ]
 
   - package-ecosystem: maven
     directories:
@@ -188,6 +197,15 @@ updates:
       # see https://github.com/apache/logging-log4j2/issues/1736
       - dependency-name: "org.fusesource.jansi:jansi"
         update-types: [ "version-update:semver-major" ]
+      # Keep JUnit below 6.x: JUnit 6+ requires Java 17 and breaks Java 8 test runs
+      - dependency-name: "org.junit:junit-bom"
+        versions: [ "[6,)" ]
+      - dependency-name: "org.junit.jupiter:*"
+        versions: [ "[6,)" ]
+      - dependency-name: "org.junit.platform:*"
+        versions: [ "[6,)" ]
+      - dependency-name: "org.junit.vintage:*"
+        versions: [ "[6,)" ]
 
   - package-ecosystem: maven
     directories:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -131,7 +131,7 @@ updates:
       # Kafka 4.x is not compatible with our appender
       - dependency-name: "org.apache.kafka:*"
         versions: [ "[4,)" ]
-      # Keep JUnit below 6.x: JUnit 6+ requires Java 17 and breaks Java 8 test runs
+      # Keep JUnit below 6.x on 2.x: JUnit 6+ requires Java 17 and breaks Java 8 test runs
       - dependency-name: "org.junit:junit-bom"
         versions: [ "[6,)" ]
       - dependency-name: "org.junit.jupiter:*"
@@ -197,15 +197,6 @@ updates:
       # see https://github.com/apache/logging-log4j2/issues/1736
       - dependency-name: "org.fusesource.jansi:jansi"
         update-types: [ "version-update:semver-major" ]
-      # Keep JUnit below 6.x: JUnit 6+ requires Java 17 and breaks Java 8 test runs
-      - dependency-name: "org.junit:junit-bom"
-        versions: [ "[6,)" ]
-      - dependency-name: "org.junit.jupiter:*"
-        versions: [ "[6,)" ]
-      - dependency-name: "org.junit.platform:*"
-        versions: [ "[6,)" ]
-      - dependency-name: "org.junit.vintage:*"
-        versions: [ "[6,)" ]
 
   - package-ecosystem: maven
     directories:


### PR DESCRIPTION
Related update for Fixes #4109 

Add Dependabot ignore rules for JUnit 6+ updates

This PR updates `.github/dependabot.yaml` to prevent Dependabot from proposing JUnit 6 and above upgrades.

### What changed

Added ignore rules for:
- `org.junit:junit-bom` with `versions: [ "[6,)" ]`
- `org.junit.jupiter:*` with `versions: [ "[6,)" ]`
- `org.junit.platform:*` with `versions: [ "[6,)" ]`
- `org.junit.vintage:*` with `versions: [ "[6,)" ]`

Applied for existing Maven update entries (`2.x` and `main` target branches).

### How I tested

1. Triggered/ran Dependabot update after config change.
2. Reviewed the generated Dependabot PR(s), especially `Files changed`.
3. Checked dependency changes in `pom.xml` and related files.

### Test result

- No JUnit dependency was upgraded to 6.x.
- Dependabot PR did not include JUnit 6+ bumps.
- This confirms the ignore rules are working as expected.