### PR TITLE
Don't override `apache-rat-plugin` version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,7 +566,6 @@
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
-        <version>0.16.1</version>
         <configuration>
           <consoleOutput>true</consoleOutput>
           <excludes combine.children="append">


### PR DESCRIPTION
Remove the version override for `apache-rat-plugin` so it falls back to the version provided by the ASF Parent POM.

Apache RAT `0.18`, for which Dependabot opened an update PR, contains a bug ([RAT-552](https://issues.apache.org/jira/browse/RAT-552)) that effectively disables the `excludeSubProjects` plugin option whenever `<excludes>` is present in the configuration.

Upgrading to `0.18` will require converting our `<excludes>` to `<inputExcludes>`, which depends on a new `logging-parent` release.
