### PR TITLE
Improve logging for `LinkageError` scenarios involving the LMAX Disruptor library

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DisruptorUtilTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DisruptorUtilTest.java
@@ -31,16 +31,33 @@ import org.junit.jupiter.api.Test;
 class DisruptorUtilTest {
 
     @Test
-    void detectDisruptorMajorVersion_logsVersionDetection(final ListStatusListener statusListener) throws Exception {
+    void detectDisruptorMajorVersion_returnsValidVersion() throws Exception {
         final Method method = DisruptorUtil.class.getDeclaredMethod("detectDisruptorMajorVersion");
         method.setAccessible(true);
         final int detectedVersion = (int) method.invoke(null);
 
         assertThat(detectedVersion).isIn(3, 4);
+    }
+
+    @Test
+    void detectDisruptorMajorVersion_logsVersionDetection(final ListStatusListener statusListener) throws Exception {
+        final Method method = DisruptorUtil.class.getDeclaredMethod("detectDisruptorMajorVersion");
+        method.setAccessible(true);
+        final int detectedVersion = (int) method.invoke(null);
 
         final List<StatusData> debugData =
                 statusListener.findStatusData(Level.DEBUG).collect(Collectors.toList());
-        assertThat(debugData).anySatisfy(data -> assertThat(data.getMessage().getFormattedMessage())
-                .contains("LMAX Disruptor version detected: " + detectedVersion));
+
+        if (detectedVersion == 4) {
+            // v4 path: ClassNotFoundException caught, falls through to LOGGER.debug()
+            assertThat(debugData)
+                    .anySatisfy(data -> assertThat(data.getMessage().getFormattedMessage())
+                            .contains("LMAX Disruptor version detected: 4"));
+        } else {
+            // v3 path: early `return 3` inside try — LOGGER.debug() is never reached
+            assertThat(debugData)
+                    .noneSatisfy(data -> assertThat(data.getMessage().getFormattedMessage())
+                            .contains("LMAX Disruptor version detected:"));
+        }
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DisruptorUtilTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DisruptorUtilTest.java
@@ -18,94 +18,29 @@ package org.apache.logging.log4j.core.async;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.lmax.disruptor.ExceptionHandler;
+import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.status.StatusData;
 import org.apache.logging.log4j.test.ListStatusListener;
-import org.apache.logging.log4j.test.junit.SetTestProperty;
 import org.apache.logging.log4j.test.junit.UsingStatusListener;
 import org.junit.jupiter.api.Test;
 
 @UsingStatusListener
 class DisruptorUtilTest {
 
-    private static final String LINKAGE_ERROR_MESSAGE =
-            "Log4j2 detected a linkage error while initializing LMAX Disruptor";
-
     @Test
-    @SetTestProperty(
-            key = DisruptorUtil.LOGGER_EXCEPTION_HANDLER_PROPERTY,
-            value = "org.apache.logging.log4j.core.async.DisruptorUtilTest$BrokenAsyncLoggerExceptionHandler")
-    void getAsyncLoggerExceptionHandler_logsLinkageErrors(final ListStatusListener statusListener) {
-        final ExceptionHandler<RingBufferLogEvent> exceptionHandler = DisruptorUtil.getAsyncLoggerExceptionHandler();
+    void detectDisruptorMajorVersion_logsVersionDetection(final ListStatusListener statusListener) throws Exception {
+        final Method method = DisruptorUtil.class.getDeclaredMethod("detectDisruptorMajorVersion");
+        method.setAccessible(true);
+        final int detectedVersion = (int) method.invoke(null);
 
-        assertThat(exceptionHandler).isInstanceOf(AsyncLoggerDefaultExceptionHandler.class);
+        assertThat(detectedVersion).isIn(3, 4);
 
-        final List<StatusData> statusData =
-                statusListener.findStatusData(Level.ERROR).collect(Collectors.toList());
-        assertThat(statusData).anySatisfy(data -> {
-            assertThat(data.getMessage().getFormattedMessage()).contains(LINKAGE_ERROR_MESSAGE);
-            assertThat(data.getThrowable()).isInstanceOf(NoClassDefFoundError.class);
-            assertThat(data.getThrowable().getMessage()).contains("broken AsyncLogger handler");
-        });
-    }
-
-    @Test
-    @SetTestProperty(
-            key = DisruptorUtil.LOGGER_CONFIG_EXCEPTION_HANDLER_PROPERTY,
-            value = "org.apache.logging.log4j.core.async.DisruptorUtilTest$BrokenAsyncLoggerConfigExceptionHandler")
-    void getAsyncLoggerConfigExceptionHandler_logsLinkageErrors(final ListStatusListener statusListener) {
-        final ExceptionHandler<AsyncLoggerConfigDisruptor.Log4jEventWrapper> exceptionHandler =
-                DisruptorUtil.getAsyncLoggerConfigExceptionHandler();
-
-        assertThat(exceptionHandler).isInstanceOf(AsyncLoggerConfigDefaultExceptionHandler.class);
-
-        final List<StatusData> statusData =
-                statusListener.findStatusData(Level.ERROR).collect(Collectors.toList());
-        assertThat(statusData).anySatisfy(data -> {
-            assertThat(data.getMessage().getFormattedMessage()).contains(LINKAGE_ERROR_MESSAGE);
-            assertThat(data.getThrowable()).isInstanceOf(NoClassDefFoundError.class);
-            assertThat(data.getThrowable().getMessage()).contains("broken AsyncLoggerConfig handler");
-        });
-    }
-
-    public static class BrokenAsyncLoggerExceptionHandler implements ExceptionHandler<RingBufferLogEvent> {
-
-        static {
-            if (System.nanoTime() >= 0) {
-                throw new NoClassDefFoundError("broken AsyncLogger handler");
-            }
-        }
-
-        @Override
-        public void handleEventException(final Throwable ex, final long sequence, final RingBufferLogEvent event) {}
-
-        @Override
-        public void handleOnStartException(final Throwable ex) {}
-
-        @Override
-        public void handleOnShutdownException(final Throwable ex) {}
-    }
-
-    public static class BrokenAsyncLoggerConfigExceptionHandler
-            implements ExceptionHandler<AsyncLoggerConfigDisruptor.Log4jEventWrapper> {
-
-        static {
-            if (System.nanoTime() >= 0) {
-                throw new NoClassDefFoundError("broken AsyncLoggerConfig handler");
-            }
-        }
-
-        @Override
-        public void handleEventException(
-                final Throwable ex, final long sequence, final AsyncLoggerConfigDisruptor.Log4jEventWrapper event) {}
-
-        @Override
-        public void handleOnStartException(final Throwable ex) {}
-
-        @Override
-        public void handleOnShutdownException(final Throwable ex) {}
+        final List<StatusData> debugData =
+                statusListener.findStatusData(Level.DEBUG).collect(Collectors.toList());
+        assertThat(debugData).anySatisfy(data -> assertThat(data.getMessage().getFormattedMessage())
+                .contains("LMAX Disruptor version " + detectedVersion + " detected."));
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DisruptorUtilTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DisruptorUtilTest.java
@@ -41,6 +41,6 @@ class DisruptorUtilTest {
         final List<StatusData> debugData =
                 statusListener.findStatusData(Level.DEBUG).collect(Collectors.toList());
         assertThat(debugData).anySatisfy(data -> assertThat(data.getMessage().getFormattedMessage())
-                .contains("LMAX Disruptor version " + detectedVersion + " detected."));
+                .contains("LMAX Disruptor version detected: " + detectedVersion));
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DisruptorUtilTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/async/DisruptorUtilTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.async;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.lmax.disruptor.ExceptionHandler;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.status.StatusData;
+import org.apache.logging.log4j.test.ListStatusListener;
+import org.apache.logging.log4j.test.junit.SetTestProperty;
+import org.apache.logging.log4j.test.junit.UsingStatusListener;
+import org.junit.jupiter.api.Test;
+
+@UsingStatusListener
+class DisruptorUtilTest {
+
+    private static final String LINKAGE_ERROR_MESSAGE =
+            "Log4j2 detected a linkage error while initializing LMAX Disruptor";
+
+    @Test
+    @SetTestProperty(
+            key = DisruptorUtil.LOGGER_EXCEPTION_HANDLER_PROPERTY,
+            value = "org.apache.logging.log4j.core.async.DisruptorUtilTest$BrokenAsyncLoggerExceptionHandler")
+    void getAsyncLoggerExceptionHandler_logsLinkageErrors(final ListStatusListener statusListener) {
+        final ExceptionHandler<RingBufferLogEvent> exceptionHandler = DisruptorUtil.getAsyncLoggerExceptionHandler();
+
+        assertThat(exceptionHandler).isInstanceOf(AsyncLoggerDefaultExceptionHandler.class);
+
+        final List<StatusData> statusData =
+                statusListener.findStatusData(Level.ERROR).collect(Collectors.toList());
+        assertThat(statusData).anySatisfy(data -> {
+            assertThat(data.getMessage().getFormattedMessage()).contains(LINKAGE_ERROR_MESSAGE);
+            assertThat(data.getThrowable()).isInstanceOf(NoClassDefFoundError.class);
+            assertThat(data.getThrowable().getMessage()).contains("broken AsyncLogger handler");
+        });
+    }
+
+    @Test
+    @SetTestProperty(
+            key = DisruptorUtil.LOGGER_CONFIG_EXCEPTION_HANDLER_PROPERTY,
+            value = "org.apache.logging.log4j.core.async.DisruptorUtilTest$BrokenAsyncLoggerConfigExceptionHandler")
+    void getAsyncLoggerConfigExceptionHandler_logsLinkageErrors(final ListStatusListener statusListener) {
+        final ExceptionHandler<AsyncLoggerConfigDisruptor.Log4jEventWrapper> exceptionHandler =
+                DisruptorUtil.getAsyncLoggerConfigExceptionHandler();
+
+        assertThat(exceptionHandler).isInstanceOf(AsyncLoggerConfigDefaultExceptionHandler.class);
+
+        final List<StatusData> statusData =
+                statusListener.findStatusData(Level.ERROR).collect(Collectors.toList());
+        assertThat(statusData).anySatisfy(data -> {
+            assertThat(data.getMessage().getFormattedMessage()).contains(LINKAGE_ERROR_MESSAGE);
+            assertThat(data.getThrowable()).isInstanceOf(NoClassDefFoundError.class);
+            assertThat(data.getThrowable().getMessage()).contains("broken AsyncLoggerConfig handler");
+        });
+    }
+
+    public static class BrokenAsyncLoggerExceptionHandler implements ExceptionHandler<RingBufferLogEvent> {
+
+        static {
+            if (System.nanoTime() >= 0) {
+                throw new NoClassDefFoundError("broken AsyncLogger handler");
+            }
+        }
+
+        @Override
+        public void handleEventException(final Throwable ex, final long sequence, final RingBufferLogEvent event) {}
+
+        @Override
+        public void handleOnStartException(final Throwable ex) {}
+
+        @Override
+        public void handleOnShutdownException(final Throwable ex) {}
+    }
+
+    public static class BrokenAsyncLoggerConfigExceptionHandler
+            implements ExceptionHandler<AsyncLoggerConfigDisruptor.Log4jEventWrapper> {
+
+        static {
+            if (System.nanoTime() >= 0) {
+                throw new NoClassDefFoundError("broken AsyncLoggerConfig handler");
+            }
+        }
+
+        @Override
+        public void handleEventException(
+                final Throwable ex, final long sequence, final AsyncLoggerConfigDisruptor.Log4jEventWrapper event) {}
+
+        @Override
+        public void handleOnStartException(final Throwable ex) {}
+
+        @Override
+        public void handleOnShutdownException(final Throwable ex) {}
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
@@ -32,6 +32,9 @@ import org.apache.logging.log4j.util.PropertiesUtil;
  */
 final class DisruptorUtil {
     private static final Logger LOGGER = StatusLogger.getLogger();
+    private static final String LINKAGE_ERROR_MESSAGE =
+            "Log4j2 detected a linkage error while initializing LMAX Disruptor. "
+                    + "Please check your classpath and ensure Disruptor version is compatible.";
     private static final int RINGBUFFER_MIN_SIZE = 128;
     private static final int RINGBUFFER_DEFAULT_SIZE = 256 * 1024;
     private static final int RINGBUFFER_NO_GC_DEFAULT_SIZE = 4 * 1024;
@@ -52,14 +55,13 @@ final class DisruptorUtil {
 
     static final int DISRUPTOR_MAJOR_VERSION = detectDisruptorMajorVersion();
 
-    // TODO: replace with LoaderUtil.isClassAvailable() when TCCL is removed
-    // See: https://github.com/apache/logging-log4j2/issues/3706
     private static int detectDisruptorMajorVersion() {
+        // Avoid using `LoaderUtil`, which might choose an incorrect class loader (e.g. TCCL in OSGi) – see #2768.
         try {
             Class.forName(
-                    "com.lmax.disruptor.SequenceReportingEventHandler", true, DisruptorUtil.class.getClassLoader());
+                    "com.lmax.disruptor.SequenceReportingEventHandler", false, DisruptorUtil.class.getClassLoader());
             return 3;
-        } catch (final ClassNotFoundException e) {
+        } catch (final ClassNotFoundException | LinkageError ignored) {
             return 4;
         }
     }
@@ -77,7 +79,12 @@ final class DisruptorUtil {
         LOGGER.debug(
                 "Using configured AsyncWaitStrategyFactory {}",
                 asyncWaitStrategyFactory.getClass().getName());
-        return asyncWaitStrategyFactory.createWaitStrategy();
+        try {
+            return asyncWaitStrategyFactory.createWaitStrategy();
+        } catch (final LinkageError e) {
+            logDisruptorLinkageError("while creating the async wait strategy", e);
+            return new DefaultAsyncWaitStrategyFactory(propertyName).createWaitStrategy();
+        }
     }
 
     static int calculateRingBufferSize(final String propertyName) {
@@ -105,6 +112,9 @@ final class DisruptorUtil {
         } catch (final ReflectiveOperationException e) {
             LOGGER.debug("Invalid AsyncLogger.ExceptionHandler value: {}", e.getMessage(), e);
             return new AsyncLoggerDefaultExceptionHandler();
+        } catch (final LinkageError e) {
+            logDisruptorLinkageError("while creating AsyncLogger exception handler", e);
+            return new AsyncLoggerDefaultExceptionHandler();
         }
     }
 
@@ -117,7 +127,14 @@ final class DisruptorUtil {
         } catch (final ReflectiveOperationException e) {
             LOGGER.debug("Invalid AsyncLogger.ExceptionHandler value: {}", e.getMessage(), e);
             return new AsyncLoggerConfigDefaultExceptionHandler();
+        } catch (final LinkageError e) {
+            logDisruptorLinkageError("while creating AsyncLoggerConfig exception handler", e);
+            return new AsyncLoggerConfigDefaultExceptionHandler();
         }
+    }
+
+    private static void logDisruptorLinkageError(final String phase, final LinkageError error) {
+        LOGGER.error("{} ({})", LINKAGE_ERROR_MESSAGE, phase, error);
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
@@ -32,9 +32,6 @@ import org.apache.logging.log4j.util.PropertiesUtil;
  */
 final class DisruptorUtil {
     private static final Logger LOGGER = StatusLogger.getLogger();
-    private static final String LINKAGE_ERROR_MESSAGE =
-            "Log4j2 detected a linkage error while initializing LMAX Disruptor. "
-                    + "Please check your classpath and ensure Disruptor version is compatible.";
     private static final int RINGBUFFER_MIN_SIZE = 128;
     private static final int RINGBUFFER_DEFAULT_SIZE = 256 * 1024;
     private static final int RINGBUFFER_NO_GC_DEFAULT_SIZE = 4 * 1024;
@@ -55,13 +52,17 @@ final class DisruptorUtil {
 
     static final int DISRUPTOR_MAJOR_VERSION = detectDisruptorMajorVersion();
 
+    // TODO: replace with LoaderUtil.isClassAvailable() when TCCL is removed
+    // See: https://github.com/apache/logging-log4j2/issues/3706
     private static int detectDisruptorMajorVersion() {
-        // Avoid using `LoaderUtil`, which might choose an incorrect class loader (e.g. TCCL in OSGi) – see #2768.
+        LOGGER.trace("Detecting LMAX Disruptor version from classpath.");
         try {
             Class.forName(
                     "com.lmax.disruptor.SequenceReportingEventHandler", false, DisruptorUtil.class.getClassLoader());
+            LOGGER.debug("LMAX Disruptor version {} detected.", 3);
             return 3;
-        } catch (final ClassNotFoundException | LinkageError ignored) {
+        } catch (final ClassNotFoundException e) {
+            LOGGER.debug("LMAX Disruptor version {} detected.", 4);
             return 4;
         }
     }
@@ -79,12 +80,7 @@ final class DisruptorUtil {
         LOGGER.debug(
                 "Using configured AsyncWaitStrategyFactory {}",
                 asyncWaitStrategyFactory.getClass().getName());
-        try {
-            return asyncWaitStrategyFactory.createWaitStrategy();
-        } catch (final LinkageError e) {
-            logDisruptorLinkageError("while creating the async wait strategy", e);
-            return new DefaultAsyncWaitStrategyFactory(propertyName).createWaitStrategy();
-        }
+        return asyncWaitStrategyFactory.createWaitStrategy();
     }
 
     static int calculateRingBufferSize(final String propertyName) {
@@ -112,9 +108,6 @@ final class DisruptorUtil {
         } catch (final ReflectiveOperationException e) {
             LOGGER.debug("Invalid AsyncLogger.ExceptionHandler value: {}", e.getMessage(), e);
             return new AsyncLoggerDefaultExceptionHandler();
-        } catch (final LinkageError e) {
-            logDisruptorLinkageError("while creating AsyncLogger exception handler", e);
-            return new AsyncLoggerDefaultExceptionHandler();
         }
     }
 
@@ -127,14 +120,7 @@ final class DisruptorUtil {
         } catch (final ReflectiveOperationException e) {
             LOGGER.debug("Invalid AsyncLogger.ExceptionHandler value: {}", e.getMessage(), e);
             return new AsyncLoggerConfigDefaultExceptionHandler();
-        } catch (final LinkageError e) {
-            logDisruptorLinkageError("while creating AsyncLoggerConfig exception handler", e);
-            return new AsyncLoggerConfigDefaultExceptionHandler();
         }
-    }
-
-    private static void logDisruptorLinkageError(final String phase, final LinkageError error) {
-        LOGGER.error("{} ({})", LINKAGE_ERROR_MESSAGE, phase, error);
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
@@ -55,14 +55,14 @@ final class DisruptorUtil {
     // TODO: replace with LoaderUtil.isClassAvailable() when TCCL is removed
     // See: https://github.com/apache/logging-log4j2/issues/3706
     private static int detectDisruptorMajorVersion() {
-        final int version;
+        int version = 4;
         try {
             Class.forName(
                     "com.lmax.disruptor.SequenceReportingEventHandler", false, DisruptorUtil.class.getClassLoader());
             version = 3;
             return 3;
         } catch (final ClassNotFoundException ignored) {
-            version = 4;
+            // Do nothing
         }
         LOGGER.debug("LMAX Disruptor version detected: {}", version);
         return version;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/DisruptorUtil.java
@@ -55,16 +55,17 @@ final class DisruptorUtil {
     // TODO: replace with LoaderUtil.isClassAvailable() when TCCL is removed
     // See: https://github.com/apache/logging-log4j2/issues/3706
     private static int detectDisruptorMajorVersion() {
-        LOGGER.trace("Detecting LMAX Disruptor version from classpath.");
+        final int version;
         try {
             Class.forName(
                     "com.lmax.disruptor.SequenceReportingEventHandler", false, DisruptorUtil.class.getClassLoader());
-            LOGGER.debug("LMAX Disruptor version {} detected.", 3);
+            version = 3;
             return 3;
-        } catch (final ClassNotFoundException e) {
-            LOGGER.debug("LMAX Disruptor version {} detected.", 4);
-            return 4;
+        } catch (final ClassNotFoundException ignored) {
+            version = 4;
         }
+        LOGGER.debug("LMAX Disruptor version detected: {}", version);
+        return version;
     }
 
     private DisruptorUtil() {}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler4.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler4.java
@@ -64,9 +64,7 @@ class RingBufferLogEventHandler4 implements EventHandler<RingBufferLogEvent> {
 
     private void notifyCallback(final long sequence) {
         if (++counter > NOTIFY_PROGRESS_THRESHOLD) {
-            if (sequenceCallback != null) {
-                sequenceCallback.set(sequence);
-            }
+            sequenceCallback.set(sequence);
             counter = 0;
         }
     }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler4.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/async/RingBufferLogEventHandler4.java
@@ -64,7 +64,9 @@ class RingBufferLogEventHandler4 implements EventHandler<RingBufferLogEvent> {
 
     private void notifyCallback(final long sequence) {
         if (++counter > NOTIFY_PROGRESS_THRESHOLD) {
-            sequenceCallback.set(sequence);
+            if (sequenceCallback != null) {
+                sequenceCallback.set(sequence);
+            }
             counter = 0;
         }
     }

--- a/src/changelog/.2.x.x/fix-log-disruptor-initialization-errors.xml
+++ b/src/changelog/.2.x.x/fix-log-disruptor-initialization-errors.xml
@@ -8,6 +8,6 @@
     <issue id="3176" link="https://github.com/apache/logging-log4j2/issues/2250"/>
     <issue id="3176" link="https://github.com/apache/logging-log4j2/pull/4124"/>
     <description format="asciidoc">
-        Improved status logging for LinkageError scenarios involving the LMAX Disruptor library to provide better diagnostics and user visibility during initialization failures. This change helps users more easily identify dependency compatibility issues that were previously not surfaced in the status log.
+        Improve logging for `LinkageError` scenarios involving the LMAX Disruptor library
     </description>
 </entry>

--- a/src/changelog/.2.x.x/fix-log-disruptor-initialization-errors.xml
+++ b/src/changelog/.2.x.x/fix-log-disruptor-initialization-errors.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+    <issue id="3176" link="https://github.com/apache/logging-log4j2/issues/2250"/>
+    <issue id="3176" link="https://github.com/apache/logging-log4j2/pull/4124"/>
+    <description format="asciidoc">
+        Improved status logging for LinkageError scenarios involving the LMAX Disruptor library to provide better diagnostics and user visibility during initialization failures. This change helps users more easily identify dependency compatibility issues that were previously not surfaced in the status log.
+    </description>
+</entry>


### PR DESCRIPTION
FIxes #2250

## Reference URLs
- https://logging.apache.org/log4j/2.x/manual/async.html
- https://github.com/LMAX-Exchange/disruptor
- https://lists.apache.org/thread/ynxrn9vsmdqs31jrml71xb582o7m74qf

## What was done
-Improves user visibility by updating the logging message while keeping the existing initialization error handling behavior unchanged.