### PR TITLE
Fix resource leaks in `ConfigurationSource` when loading via URL

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationSourceTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationSourceTest.java
@@ -178,23 +178,17 @@ public class ConfigurationSourceTest {
             openConnectionCalls.set(0);
             getInputStreamCalls.set(0);
 
-            final Method method =
-                    ConfigurationSource.class.getDeclaredMethod("getConfigurationSource", URL.class);
+            final Method method = ConfigurationSource.class.getDeclaredMethod("getConfigurationSource", URL.class);
             method.setAccessible(true);
             final Object result = method.invoke(null, url);
 
-            assertTrue(
-                    openConnectionCalls.get() > 0,
-                    "Custom URLStreamHandler was not used by UrlConnectionFactory");
+            assertTrue(openConnectionCalls.get() > 0, "Custom URLStreamHandler was not used by UrlConnectionFactory");
 
             assertNull(result, "Expected null return for a 404 response");
 
             assertTrue(disconnected.get(), "disconnect() must be called on the error path");
 
-            assertEquals(
-                    1,
-                    getInputStreamCalls.get(),
-                    "getInputStream() should be called exactly once");
+            assertEquals(1, getInputStreamCalls.get(), "getInputStream() should be called exactly once");
         } finally {
             if (previous != null) {
                 System.setProperty(propKey, previous);

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationSourceTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationSourceTest.java
@@ -134,11 +134,6 @@ public class ConfigurationSourceTest {
      * Verifies that the error-path cleanup in {@code getConfigurationSource}
      * properly disconnects an {@link HttpURLConnection} on failure without
      * calling {@link URLConnection#getInputStream()} a second time.
-     *
-     * <p>This test fails against the original code (no cleanup) because
-     * {@code disconnect()} is never called, and fails against an intermediate
-     * fix that added a {@code finally} block calling {@code getInputStream()}
-     * again to obtain a stream for closing.
      */
     @Test
     void getConfigurationSource_disconnectsHttpConnection_onError() throws Exception {
@@ -194,13 +189,8 @@ public class ConfigurationSourceTest {
 
             assertNull(result, "Expected null return for a 404 response");
 
-            // Negative‐test #1: the original code has no finally block, so
-            // disconnect() is never called on the HttpURLConnection.
             assertTrue(disconnected.get(), "disconnect() must be called on the error path");
 
-            // Negative‐test #2: an intermediate fix called getInputStream()
-            // a second time in the finally block instead of closing the
-            // already-tracked stream reference.
             assertEquals(
                     1,
                     getInputStreamCalls.get(),

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationSourceTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationSourceTest.java
@@ -25,15 +25,22 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.sun.management.UnixOperatingSystemMXBean;
 import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.Method;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -121,6 +128,90 @@ public class ConfigurationSourceTest {
 
         assertEquals(expectedFdCount, getOpenFileDescriptorCount());
         Files.delete(jarFile);
+    }
+
+    /**
+     * Verifies that the error-path cleanup in {@code getConfigurationSource}
+     * properly disconnects an {@link HttpURLConnection} on failure without
+     * calling {@link URLConnection#getInputStream()} a second time.
+     *
+     * <p>This test fails against the original code (no cleanup) because
+     * {@code disconnect()} is never called, and fails against an intermediate
+     * fix that added a {@code finally} block calling {@code getInputStream()}
+     * again to obtain a stream for closing.
+     */
+    @Test
+    void getConfigurationSource_disconnectsHttpConnection_onError() throws Exception {
+        final AtomicInteger getInputStreamCalls = new AtomicInteger();
+        final AtomicBoolean disconnected = new AtomicBoolean();
+        final AtomicInteger openConnectionCalls = new AtomicInteger();
+
+        final URLStreamHandler handler = new URLStreamHandler() {
+            @Override
+            protected URLConnection openConnection(final URL u) {
+                openConnectionCalls.incrementAndGet();
+                return new HttpURLConnection(u) {
+                    @Override
+                    public InputStream getInputStream() throws IOException {
+                        getInputStreamCalls.incrementAndGet();
+                        throw new FileNotFoundException("Mocked 404");
+                    }
+
+                    @Override
+                    public void disconnect() {
+                        disconnected.set(true);
+                    }
+
+                    @Override
+                    public boolean usingProxy() {
+                        return false;
+                    }
+
+                    @Override
+                    public void connect() {}
+                };
+            }
+        };
+
+        final URL url = new URL("http", "example.com", 80, "/missing.xml", handler);
+
+        // Allow the "http" protocol for this test.
+        final String propKey = "log4j2.Configuration.allowedProtocols";
+        final String previous = System.getProperty(propKey);
+        System.setProperty(propKey, "file, https, jar, http");
+        try {
+            openConnectionCalls.set(0);
+            getInputStreamCalls.set(0);
+
+            final Method method =
+                    ConfigurationSource.class.getDeclaredMethod("getConfigurationSource", URL.class);
+            method.setAccessible(true);
+            final Object result = method.invoke(null, url);
+
+            assertTrue(
+                    openConnectionCalls.get() > 0,
+                    "Custom URLStreamHandler was not used by UrlConnectionFactory");
+
+            assertNull(result, "Expected null return for a 404 response");
+
+            // Negative‐test #1: the original code has no finally block, so
+            // disconnect() is never called on the HttpURLConnection.
+            assertTrue(disconnected.get(), "disconnect() must be called on the error path");
+
+            // Negative‐test #2: an intermediate fix called getInputStream()
+            // a second time in the finally block instead of closing the
+            // already-tracked stream reference.
+            assertEquals(
+                    1,
+                    getInputStreamCalls.get(),
+                    "getInputStream() should be called exactly once");
+        } finally {
+            if (previous != null) {
+                System.setProperty(propKey, previous);
+            } else {
+                System.clearProperty(propKey);
+            }
+        }
     }
 
     private long getOpenFileDescriptorCount() {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationSourceTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationSourceTest.java
@@ -104,6 +104,28 @@ public class ConfigurationSourceTest {
         }
     }
 
+    /**
+     * Verifies that a failed JAR configuration load (missing entry) does not leak file descriptors
+     * or hold a lock on the JAR file.
+     */
+    @Test
+    void testNoJarFileLeakOnFailure() throws Exception {
+        final Path jarFile = prepareJarConfigURL(tempDir);
+        // Path inside JAR that does NOT exist
+        final URL brokenJarConfigURL = new URL("jar:" + jarFile.toUri().toURL() + "!/missing/file.xml");
+        final long expectedFdCount = getOpenFileDescriptorCount();
+        final ConfigurationSource configSource = ConfigurationSource.fromUri(brokenJarConfigURL.toURI());
+        assertNull(configSource, "Source should be null for a missing JAR entry");
+        // This can only fail on UNIX
+        assertEquals(expectedFdCount, getOpenFileDescriptorCount(), "File descriptors leaked after failed JAR load");
+        // This can only fail on Windows
+        try {
+            Files.delete(jarFile);
+        } catch (IOException e) {
+            fail("JAR file locked after failed load: " + e.getMessage());
+        }
+    }
+
     private long getOpenFileDescriptorCount() {
         final OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
         if (os instanceof UnixOperatingSystemMXBean) {

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationSourceTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/ConfigurationSourceTest.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -109,21 +110,17 @@ public class ConfigurationSourceTest {
      * or hold a lock on the JAR file.
      */
     @Test
-    void testNoJarFileLeakOnFailure() throws Exception {
+    void testJarFileLeakOnFailure() throws Exception {
         final Path jarFile = prepareJarConfigURL(tempDir);
-        // Path inside JAR that does NOT exist
-        final URL brokenJarConfigURL = new URL("jar:" + jarFile.toUri().toURL() + "!/missing/file.xml");
+        final String jarUriStr = "jar:" + jarFile.toUri().toASCIIString() + "!/" + java.util.UUID.randomUUID();
+        final URI jarUri = URI.create(jarUriStr);
+
         final long expectedFdCount = getOpenFileDescriptorCount();
-        final ConfigurationSource configSource = ConfigurationSource.fromUri(brokenJarConfigURL.toURI());
-        assertNull(configSource, "Source should be null for a missing JAR entry");
-        // This can only fail on UNIX
-        assertEquals(expectedFdCount, getOpenFileDescriptorCount(), "File descriptors leaked after failed JAR load");
-        // This can only fail on Windows
-        try {
-            Files.delete(jarFile);
-        } catch (IOException e) {
-            fail("JAR file locked after failed load: " + e.getMessage());
-        }
+
+        assertNull(ConfigurationSource.fromUri(jarUri));
+
+        assertEquals(expectedFdCount, getOpenFileDescriptorCount());
+        Files.delete(jarFile);
     }
 
     private long getOpenFileDescriptorCount() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
@@ -361,19 +361,22 @@ public class ConfigurationSource {
             final File file = FileUtils.fileFromUri(url.toURI());
             final URLConnection urlConnection = UrlConnectionFactory.createConnection(url);
             boolean success = false;
+            InputStream openedStream = null;
             try {
                 final ConfigurationSource source;
                 if (file != null) {
-                    source = new ConfigurationSource(urlConnection.getInputStream(), file);
+                    openedStream = urlConnection.getInputStream();
+                    source = new ConfigurationSource(openedStream, file);
                 } else if (urlConnection instanceof JarURLConnection) {
                     // Work around https://bugs.openjdk.java.net/browse/JDK-6956385.
                     URL jarFileUrl = ((JarURLConnection) urlConnection).getJarFileURL();
                     File jarFile = new File(jarFileUrl.getFile());
                     long lastModified = jarFile.lastModified();
-                    source = new ConfigurationSource(urlConnection.getInputStream(), url, lastModified);
+                    openedStream = urlConnection.getInputStream();
+                    source = new ConfigurationSource(openedStream, url, lastModified);
                 } else {
-                    source = new ConfigurationSource(
-                            urlConnection.getInputStream(), url, urlConnection.getLastModified());
+                    openedStream = urlConnection.getInputStream();
+                    source = new ConfigurationSource(openedStream, url, urlConnection.getLastModified());
                 }
                 success = true;
                 return source;
@@ -382,10 +385,12 @@ public class ConfigurationSource {
                 return null;
             } finally {
                 if (!success) {
-                    try {
-                        urlConnection.getInputStream().close();
-                    } catch (final IOException ignored) {
-                        // Best-effort cleanup; the stream may not have been opened
+                    if (openedStream != null) {
+                        try {
+                            openedStream.close();
+                        } catch (final IOException ignored) {
+                            // Best-effort cleanup
+                        }
                     }
                     if (urlConnection instanceof HttpURLConnection) {
                         ((HttpURLConnection) urlConnection).disconnect();

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.JarURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -359,24 +360,39 @@ public class ConfigurationSource {
         try {
             final File file = FileUtils.fileFromUri(url.toURI());
             final URLConnection urlConnection = UrlConnectionFactory.createConnection(url);
+            boolean success = false;
             try {
+                final ConfigurationSource source;
                 if (file != null) {
-                    return new ConfigurationSource(urlConnection.getInputStream(), FileUtils.fileFromUri(url.toURI()));
+                    source = new ConfigurationSource(urlConnection.getInputStream(), file);
                 } else if (urlConnection instanceof JarURLConnection) {
                     // Work around https://bugs.openjdk.java.net/browse/JDK-6956385.
                     URL jarFileUrl = ((JarURLConnection) urlConnection).getJarFileURL();
                     File jarFile = new File(jarFileUrl.getFile());
                     long lastModified = jarFile.lastModified();
-                    return new ConfigurationSource(urlConnection.getInputStream(), url, lastModified);
+                    source = new ConfigurationSource(urlConnection.getInputStream(), url, lastModified);
                 } else {
-                    return new ConfigurationSource(
+                    source = new ConfigurationSource(
                             urlConnection.getInputStream(), url, urlConnection.getLastModified());
                 }
-            } catch (FileNotFoundException ex) {
+                success = true;
+                return source;
+            } catch (final FileNotFoundException ex) {
                 ConfigurationFactory.LOGGER.info("Unable to locate file {}, ignoring.", url.toString());
                 return null;
+            } finally {
+                if (!success) {
+                    try {
+                        urlConnection.getInputStream().close();
+                    } catch (final IOException ignored) {
+                        // Best-effort cleanup; the stream may not have been opened
+                    }
+                    if (urlConnection instanceof HttpURLConnection) {
+                        ((HttpURLConnection) urlConnection).disconnect();
+                    }
+                }
             }
-        } catch (IOException | URISyntaxException ex) {
+        } catch (final IOException | URISyntaxException ex) {
             ConfigurationFactory.LOGGER.warn(
                     "Error accessing {} due to {}, ignoring.", url.toString(), ex.getMessage());
             return null;

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/ConfigurationSource.java
@@ -357,49 +357,39 @@ public class ConfigurationSource {
             value = "PATH_TRAVERSAL_IN",
             justification = "The name of the accessed files is based on a configuration value.")
     private static /*@Nullable*/ ConfigurationSource getConfigurationSource(final URL url) {
+        final File file;
+        final URLConnection urlConnection;
         try {
-            final File file = FileUtils.fileFromUri(url.toURI());
-            final URLConnection urlConnection = UrlConnectionFactory.createConnection(url);
-            boolean success = false;
-            InputStream openedStream = null;
-            try {
-                final ConfigurationSource source;
-                if (file != null) {
-                    openedStream = urlConnection.getInputStream();
-                    source = new ConfigurationSource(openedStream, file);
-                } else if (urlConnection instanceof JarURLConnection) {
-                    // Work around https://bugs.openjdk.java.net/browse/JDK-6956385.
-                    URL jarFileUrl = ((JarURLConnection) urlConnection).getJarFileURL();
-                    File jarFile = new File(jarFileUrl.getFile());
-                    long lastModified = jarFile.lastModified();
-                    openedStream = urlConnection.getInputStream();
-                    source = new ConfigurationSource(openedStream, url, lastModified);
-                } else {
-                    openedStream = urlConnection.getInputStream();
-                    source = new ConfigurationSource(openedStream, url, urlConnection.getLastModified());
-                }
-                success = true;
-                return source;
-            } catch (final FileNotFoundException ex) {
-                ConfigurationFactory.LOGGER.info("Unable to locate file {}, ignoring.", url.toString());
-                return null;
-            } finally {
-                if (!success) {
-                    if (openedStream != null) {
-                        try {
-                            openedStream.close();
-                        } catch (final IOException ignored) {
-                            // Best-effort cleanup
-                        }
-                    }
-                    if (urlConnection instanceof HttpURLConnection) {
-                        ((HttpURLConnection) urlConnection).disconnect();
-                    }
-                }
-            }
+            file = FileUtils.fileFromUri(url.toURI());
+            urlConnection = UrlConnectionFactory.createConnection(url);
         } catch (final IOException | URISyntaxException ex) {
             ConfigurationFactory.LOGGER.warn(
                     "Error accessing {} due to {}, ignoring.", url.toString(), ex.getMessage());
+            return null;
+        }
+        try {
+            if (file != null) {
+                return new ConfigurationSource(urlConnection.getInputStream(), file);
+            } else if (urlConnection instanceof JarURLConnection) {
+                // Work around https://bugs.openjdk.java.net/browse/JDK-6956385.
+                final URL jarFileUrl = ((JarURLConnection) urlConnection).getJarFileURL();
+                final File jarFile = new File(jarFileUrl.getFile());
+                final long lastModified = jarFile.lastModified();
+                return new ConfigurationSource(urlConnection.getInputStream(), url, lastModified);
+            } else {
+                final long lastModified = urlConnection.getLastModified();
+                return new ConfigurationSource(urlConnection.getInputStream(), url, lastModified);
+            }
+        } catch (final IOException ex) {
+            if (ex instanceof FileNotFoundException) {
+                ConfigurationFactory.LOGGER.info("Unable to locate file {}, ignoring.", url.toString());
+            } else {
+                ConfigurationFactory.LOGGER.warn(
+                        "Error accessing {} due to {}, ignoring.", url.toString(), ex.getMessage());
+            }
+            if (urlConnection instanceof HttpURLConnection) {
+                ((HttpURLConnection) urlConnection).disconnect();
+            }
             return null;
         }
     }

--- a/src/changelog/.2.x.x/fix_configuration_source_url_leak.xml
+++ b/src/changelog/.2.x.x/fix_configuration_source_url_leak.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="4127" link="https://github.com/apache/logging-log4j2/pull/4127"/>
+  <description format="asciidoc">Fix resource leaks in `ConfigurationSource` when loading configuration via URL fails</description>
+</entry>


### PR DESCRIPTION
## What this PR does

In `log4j-core/.../config/ConfigurationSource.java`, method `getConfigurationSource(URL)`: `url.openConnection()` creates a URLConnection, but on both error paths (FileNotFoundException, IOException/URISyntaxException) the connection is never closed or disconnected.

For `HttpURLConnection` this leaks a socket. For `JarURLConnection` this leaks a file handle (relevant to locked JARs on Tomcat redeploy scenarios).

**Fix:**
- Added a `boolean success` flag with try-finally pattern to disconnect/close on error paths
- Reused the existing `file` variable instead of calling `FileUtils.fileFromUri(url.toURI())` a second time
