### PR TITLE
Adopt the Dependabot changelog 'draft trick'

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,13 @@ on:
       - "2.25.x"
       - "release/2*"
   pull_request:
+    types:
+      # Standard types
+      - opened
+      - synchronize
+      - reopened
+      # Used in Dependabot PRs to retrigger required workflows
+      - ready_for_review
 
 # Cancel in-progress runs when a newer commit lands on the same PR; pushes to 2.x run to completion.
 concurrency:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -22,6 +22,13 @@ on:
     branches: [ "2.x", "main" ]
   pull_request:
     branches: [ "2.x", "main" ]
+    types:
+      # Standard types
+      - opened
+      - synchronize
+      - reopened
+      # Used in Dependabot PRs to retrigger required workflows
+      - ready_for_review
   schedule:
     - cron: '32 12 * * 5'
 

--- a/.github/workflows/process-dependabot.yaml
+++ b/.github/workflows/process-dependabot.yaml
@@ -39,13 +39,10 @@ jobs:
       }}
     uses: apache/logging-parent/.github/workflows/process-dependabot-reusable.yaml@gha/v0
     permissions:
-      # The default GITHUB_TOKEN will be used to enable the "auto-merge" on the PR
-      # This requires the following two permissions:
+      # Append the changelog commit
       contents: write
+      # Convert the PR into draft
       pull-requests: write
-    secrets:
-      # This token will be used to push new content to the repo and trigger workflows again
-      RECURSIVE_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
     with:
       # The path to the changelog directory for the current development branch.
       changelog-path: src/changelog/.2.x.x


### PR DESCRIPTION
Applies the consumer-side changes from apache/logging-parent#476 so this repository works with the new Dependabot changelog "draft trick".

Pushes made with `GITHUB_TOKEN` do not retrigger workflows (GitHub anti-recursion rule), so the changelog commit cannot re-run the required checks on its own. Instead of relying on a privileged PAT, the reusable workflow now appends the changelog commit and parks the PR in draft mode; a maintainer clicks *Ready for review* and enables *Auto-merge* to complete the merge.

## Changes

* **`build.yaml`** and **`codeql-analysis.yaml`**: subscribe `pull_request` to explicit types including `ready_for_review`, so the required checks re-run when a Dependabot PR is taken out of draft.
* **`process-dependabot.yaml`**: drop the `RECURSIVE_TOKEN` (`DEPENDABOT_TOKEN`) PAT secret, which is no longer needed, and update the permission comments to reflect the draft-based flow.

The reusable-workflow references are left at the moving `@gha/v0` tag, which picks up the draft-trick behavior automatically.

> [!WARNING]
>
> Due to the breaking changes in `gha/v0`, Dependabot PR will not work, unless this is merged first.