### PR TITLE
Add Dependabot config for the 2.26.x maintenance branch

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -166,6 +166,27 @@ updates:
         patterns: [ "*" ]
     target-branch: "2.x"
 
+  # The `2.26.x` maintenance branch only receives patch-level Maven updates.
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      # "Bump the Maven patch updates group across N directories with M updates"
+      Maven patch updates:
+        patterns: [ "*" ]
+    target-branch: "2.26.x"
+    registries:
+      - maven-central
+    ignore:
+      # Only allow patch-level upgrades on this maintenance branch
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+
   - package-ecosystem: maven
     directory: "/"
     schedule:


### PR DESCRIPTION
Configure a Maven update entry targeting the `2.26.x` branch that only proposes patch-level upgrades. All dependencies are bundled into a single `Maven patch updates` group with a 7-day cooldown.

