### PR TITLE
Remove `/log4j-slf4j-impl` Dependabot execution

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -219,22 +219,6 @@ updates:
       - dependency-name: "org.fusesource.jansi:jansi"
         update-types: [ "version-update:semver-major" ]
 
-  - package-ecosystem: maven
-    directories:
-      - "/log4j-slf4j-impl"
-    schedule:
-      interval: "monthly"
-    groups:
-      dependencies:
-        patterns: [ "*" ]
-    target-branch: "main"
-    registries:
-      - maven-central
-    ignore:
-      # SLF4J 1.7.x should only upgrade to 1.7.x and
-      - dependency-name: "org.slf4j:slf4j-api"
-        versions: [ "[1,)" ]
-
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
The `/log4j-slf4j-impl` execution is configured on the wrong branch (`main`, which doesn't have such an artifact, instead of `2.x`).

Instead of correcting the target branch, we can safely remove it: the only dependency version defined in `log4j-slf4j-impl` is SLF4J 1.x, which is highly unlikely to see any new releases.
