### PR TITLE
[main] Fix RegexFilter NPE when `useRawMsg` is null (#3265 port)

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/filter/RegexFilterTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/filter/RegexFilterTest.java
@@ -18,6 +18,7 @@ package org.apache.logging.log4j.core.filter;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -109,5 +110,12 @@ public class RegexFilterTest {
                 Result.DENY);
         final Result fmtResult = fmtFilter.filter(null, null, null, msg, params);
         assertThat(fmtResult, equalTo(Result.ACCEPT));
+    }
+
+    @Test
+    void testRegexFilterDoesNotThrowWithAllTheParametersExceptRegexEqualNull() {
+        assertDoesNotThrow(() -> {
+            RegexFilter.createFilter(".* test .*", null, null, null, null);
+        });
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/RegexFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/RegexFilter.java
@@ -139,7 +139,11 @@ public final class RegexFilter extends AbstractFilter {
             LOGGER.error("A regular expression must be provided for RegexFilter");
             return null;
         }
-        return new RegexFilter(Boolean.TRUE.equals(useRawMsg), Pattern.compile(regex, toPatternFlags(patternFlags)), onMatch, onMismatch);
+        return new RegexFilter(
+                Boolean.TRUE.equals(useRawMsg),
+                Pattern.compile(regex, toPatternFlags(patternFlags)),
+                onMatch,
+                onMismatch);
     }
 
     private static int toPatternFlags(final String[] patternFlags)

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/RegexFilter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/filter/RegexFilter.java
@@ -139,7 +139,7 @@ public final class RegexFilter extends AbstractFilter {
             LOGGER.error("A regular expression must be provided for RegexFilter");
             return null;
         }
-        return new RegexFilter(useRawMsg, Pattern.compile(regex, toPatternFlags(patternFlags)), onMatch, onMismatch);
+        return new RegexFilter(Boolean.TRUE.equals(useRawMsg), Pattern.compile(regex, toPatternFlags(patternFlags)), onMatch, onMismatch);
     }
 
     private static int toPatternFlags(final String[] patternFlags)


### PR DESCRIPTION
Ports the fix from **#3265** from the `2.x` branch to `main`.

In the `RegexFilter.createFilter()` factory method, the `useRawMsg` parameter is declared as `Boolean` (boxed). When passed directly to the `RegexFilter(boolean raw, ...)` constructor, a `null` value causes an NPE during unboxing.

This change uses `Boolean.TRUE.equals(useRawMsg)` instead, which safely handles `null` by defaulting to `false`.

## Changes

- **`log4j-core/.../filter/RegexFilter.java`**: Changed `useRawMsg` → `Boolean.TRUE.equals(useRawMsg)` in constructor call
- **`log4j-core-test/.../filter/RegexFilterTest.java`**: Added test ensuring no exception when `useRawMsg` is `null`
