### PR TITLE
feat(rolling): enhance compression delay with minCompressionDelaySeconds/maxCompressionDelaySeconds

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/FileExtensionCompressDelayTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/FileExtensionCompressDelayTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -167,6 +168,178 @@ class FileExtensionCompressDelayTest {
         assertTrue(elapsed < 500, "ZIP with delay=0 should be instant, took " + elapsed + "ms");
         assertTrue(dest.exists(), "Compressed .zip file must exist");
         assertFalse(source.exists(), "Source must be deleted");
+    }
+
+    // ── GZ min/max ────────────────────────────────────────────────────────
+
+    /**
+     * FileExtension.GZ.createCompressAction(6-args) with min==max must sleep for exactly that duration.
+     */
+    @Test
+    void testGzCreateCompressActionWithMinMaxFixedDelay(@TempDir File tempDir) throws Exception {
+        File source = new File(tempDir, "app-fixed.log");
+        File dest = new File(tempDir, "app-fixed.log.gz");
+        writeContent(source, "gz fixed delay content");
+
+        int fixedDelay = 1;
+        Action action =
+                FileExtension.GZ.createCompressAction(source.getPath(), dest.getPath(), true, -1, fixedDelay, fixedDelay);
+
+        assertInstanceOf(GzCompressAction.class, action, "Expected GzCompressAction");
+
+        long start = System.currentTimeMillis();
+        action.execute();
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(
+                elapsed >= fixedDelay * 1000L - 100,
+                "GZ fixed delay should sleep at least " + fixedDelay + "s, took " + elapsed + "ms");
+        assertTrue(
+                elapsed <= fixedDelay * 1000L + 500,
+                "GZ fixed delay exceeded expected duration, took " + elapsed + "ms");
+        assertTrue(dest.exists(), "Compressed .gz file must exist");
+        assertFalse(source.exists(), "Source must be deleted after compression");
+    }
+
+    /**
+     * FileExtension.GZ.createCompressAction(6-args) with min=0, max=0 must be instant.
+     */
+    @Test
+    void testGzCreateCompressActionWithMinMaxBothZero(@TempDir File tempDir) throws Exception {
+        File source = new File(tempDir, "app-zero.log");
+        File dest = new File(tempDir, "app-zero.log.gz");
+        writeContent(source, "gz zero delay content");
+
+        Action action = FileExtension.GZ.createCompressAction(source.getPath(), dest.getPath(), true, -1, 0, 0);
+
+        assertInstanceOf(GzCompressAction.class, action);
+
+        long start = System.currentTimeMillis();
+        action.execute();
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(elapsed < 500, "GZ with min=0,max=0 should be instant, took " + elapsed + "ms");
+        assertTrue(dest.exists(), "Compressed .gz file must exist");
+        assertFalse(source.exists(), "Source must be deleted");
+    }
+
+    /**
+     * FileExtension.GZ.createCompressAction(6-args) with a range [min, max] must sleep within bounds.
+     */
+    @Test
+    void testGzCreateCompressActionWithMinMaxRange(@TempDir File tempDir) throws Exception {
+        File source = new File(tempDir, "app-range.log");
+        File dest = new File(tempDir, "app-range.log.gz");
+        writeContent(source, "gz range delay content");
+
+        int min = 1;
+        int max = 2;
+        Action action = FileExtension.GZ.createCompressAction(source.getPath(), dest.getPath(), true, -1, min, max);
+
+        assertInstanceOf(GzCompressAction.class, action);
+
+        long start = System.currentTimeMillis();
+        action.execute();
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(
+                elapsed >= min * 1000L - 100,
+                "GZ range delay should sleep at least " + min + "s, took " + elapsed + "ms");
+        assertTrue(
+                elapsed <= max * 1000L + 500,
+                "GZ range delay should sleep at most " + max + "s, took " + elapsed + "ms");
+        assertTrue(dest.exists(), "Compressed .gz file must exist");
+        assertFalse(source.exists(), "Source must be deleted");
+    }
+
+    // ── ZIP min/max ───────────────────────────────────────────────────────
+
+    /**
+     * FileExtension.ZIP.createCompressAction(6-args) with min==max must sleep for exactly that duration.
+     */
+    @Test
+    void testZipCreateCompressActionWithMinMaxFixedDelay(@TempDir File tempDir) throws Exception {
+        File source = new File(tempDir, "app-fixed.log");
+        File dest = new File(tempDir, "app-fixed.log.zip");
+        writeContent(source, "zip fixed delay content");
+
+        int fixedDelay = 1;
+        Action action =
+                FileExtension.ZIP.createCompressAction(source.getPath(), dest.getPath(), true, 0, fixedDelay, fixedDelay);
+
+        assertInstanceOf(ZipCompressAction.class, action, "Expected ZipCompressAction");
+
+        long start = System.currentTimeMillis();
+        action.execute();
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(
+                elapsed >= fixedDelay * 1000L - 100,
+                "ZIP fixed delay should sleep at least " + fixedDelay + "s, took " + elapsed + "ms");
+        assertTrue(
+                elapsed <= fixedDelay * 1000L + 500,
+                "ZIP fixed delay exceeded expected duration, took " + elapsed + "ms");
+        assertTrue(dest.exists(), "Compressed .zip file must exist");
+        assertFalse(source.exists(), "Source must be deleted after compression");
+    }
+
+    /**
+     * FileExtension.ZIP.createCompressAction(6-args) with min=0, max=0 must be instant.
+     */
+    @Test
+    void testZipCreateCompressActionWithMinMaxBothZero(@TempDir File tempDir) throws Exception {
+        File source = new File(tempDir, "app-zero.log");
+        File dest = new File(tempDir, "app-zero.log.zip");
+        writeContent(source, "zip zero delay content");
+
+        Action action = FileExtension.ZIP.createCompressAction(source.getPath(), dest.getPath(), true, 0, 0, 0);
+
+        assertInstanceOf(ZipCompressAction.class, action);
+
+        long start = System.currentTimeMillis();
+        action.execute();
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(elapsed < 500, "ZIP with min=0,max=0 should be instant, took " + elapsed + "ms");
+        assertTrue(dest.exists(), "Compressed .zip file must exist");
+        assertFalse(source.exists(), "Source must be deleted");
+    }
+
+    // ── DefaultRolloverStrategy builder ───────────────────────────────────
+
+    /**
+     * DefaultRolloverStrategy.Builder must accept minCompressionDelaySeconds and expose it via getter.
+     */
+    @Test
+    void testDefaultRolloverStrategyBuilderMinCompressionDelay() {
+        DefaultRolloverStrategy strategy = DefaultRolloverStrategy.newBuilder()
+                .setMin("1")
+                .setMax("7")
+                .setMinCompressionDelaySeconds(2)
+                .setMaxCompressionDelaySeconds(5)
+                .build();
+
+        assertEquals(2, strategy.getMinCompressionDelaySeconds(),
+                "minCompressionDelaySeconds should be 2");
+        assertEquals(5, strategy.getMaxCompressionDelaySeconds(),
+                "maxCompressionDelaySeconds should be 5");
+    }
+
+    /**
+     * DefaultRolloverStrategy.Builder with only maxCompressionDelaySeconds (backward compat) must default min to 0.
+     */
+    @Test
+    void testDefaultRolloverStrategyBuilderMaxOnlyDefaultsMinToZero() {
+        DefaultRolloverStrategy strategy = DefaultRolloverStrategy.newBuilder()
+                .setMin("1")
+                .setMax("7")
+                .setMaxCompressionDelaySeconds(3)
+                .build();
+
+        assertEquals(0, strategy.getMinCompressionDelaySeconds(),
+                "minCompressionDelaySeconds should default to 0");
+        assertEquals(3, strategy.getMaxCompressionDelaySeconds(),
+                "maxCompressionDelaySeconds should be 3");
     }
 
     // ── helpers ───────────────────────────────────────────────────────────

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/AbstractActionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/AbstractActionTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -88,6 +89,78 @@ class AbstractActionTest {
         assertEquals(Level.WARN, statusData.getLevel());
         final String formattedMessage = statusData.getFormattedStatus();
         assertThat(formattedMessage, containsString("Exception reported by action"));
+    }
+
+    // ── blockThread(min, max) ─────────────────────────────────────────────
+
+    /**
+     * blockThread(0, 0) must return immediately without sleeping.
+     */
+    @Test
+    void testBlockThreadBothZeroIsInstant() {
+        long start = System.currentTimeMillis();
+        AbstractAction.blockThread(0, 0);
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue(elapsed < 500, "blockThread(0,0) should be instant, took " + elapsed + "ms");
+    }
+
+    /**
+     * blockThread(min, max) with min == max must sleep for exactly that many seconds.
+     */
+    @Test
+    void testBlockThreadFixedDelay() {
+        int fixedDelay = 1;
+        long start = System.currentTimeMillis();
+        AbstractAction.blockThread(fixedDelay, fixedDelay);
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue(
+                elapsed >= fixedDelay * 1000L - 100,
+                "blockThread(" + fixedDelay + "," + fixedDelay + ") should sleep ~" + fixedDelay + "s, took "
+                        + elapsed + "ms");
+        assertTrue(
+                elapsed <= fixedDelay * 1000L + 500,
+                "blockThread(" + fixedDelay + "," + fixedDelay + ") exceeded expected duration, took " + elapsed
+                        + "ms");
+    }
+
+    /**
+     * blockThread(min, max) with a range must sleep within [min, max] seconds.
+     */
+    @Test
+    void testBlockThreadRangeDelay() {
+        int min = 1;
+        int max = 2;
+        long start = System.currentTimeMillis();
+        AbstractAction.blockThread(min, max);
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue(
+                elapsed >= min * 1000L - 100,
+                "blockThread(" + min + "," + max + ") should sleep at least " + min + "s, took " + elapsed + "ms");
+        assertTrue(
+                elapsed <= max * 1000L + 500,
+                "blockThread(" + min + "," + max + ") should sleep at most " + max + "s, took " + elapsed + "ms");
+    }
+
+    /**
+     * blockThread with invalid arguments (min > max) must return immediately without sleeping.
+     */
+    @Test
+    void testBlockThreadInvalidArgsAreIgnored() {
+        long start = System.currentTimeMillis();
+        AbstractAction.blockThread(5, 2); // min > max — invalid
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue(elapsed < 500, "blockThread with invalid args should be instant, took " + elapsed + "ms");
+    }
+
+    /**
+     * blockThread with negative min must return immediately without sleeping.
+     */
+    @Test
+    void testBlockThreadNegativeMinIsIgnored() {
+        long start = System.currentTimeMillis();
+        AbstractAction.blockThread(-1, 2);
+        long elapsed = System.currentTimeMillis() - start;
+        assertTrue(elapsed < 500, "blockThread with negative min should be instant, took " + elapsed + "ms");
     }
 
     private static final class TestAction extends AbstractAction {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DefaultRolloverStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DefaultRolloverStrategy.java
@@ -109,6 +109,9 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
         @PluginBuilderAttribute(value = "tempCompressedFilePattern")
         private String tempCompressedFilePattern;
 
+        @PluginBuilderAttribute("minCompressionDelaySeconds")
+        private int minCompressionDelaySeconds = 0;
+
         @PluginBuilderAttribute("maxCompressionDelaySeconds")
         private int maxCompressionDelaySeconds = 0;
 
@@ -160,11 +163,24 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
                     customActions,
                     stopCustomActionsOnError,
                     tempCompressedFilePattern,
+                    minCompressionDelaySeconds,
                     maxCompressionDelaySeconds);
         }
 
         public String getMax() {
             return max;
+        }
+
+        /**
+         * Sets the minimum delay in seconds before compression.
+         *
+         * @param minCompressionDelaySeconds minimum delay in seconds before compression.
+         * @return This builder for chaining convenience
+         * @since 2.27.0
+         */
+        public Builder setMinCompressionDelaySeconds(final int minCompressionDelaySeconds) {
+            this.minCompressionDelaySeconds = minCompressionDelaySeconds;
+            return this;
         }
 
         /**
@@ -438,6 +454,7 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
     private final List<Action> customActions;
     private final boolean stopCustomActionsOnError;
     private final PatternProcessor tempCompressedFilePattern;
+    private final int minCompressionDelaySeconds;
     private final int maxCompressionDelaySeconds;
 
     /**
@@ -467,6 +484,7 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
                 customActions,
                 stopCustomActionsOnError,
                 null,
+                0,
                 0);
     }
 
@@ -498,19 +516,59 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
                 customActions,
                 stopCustomActionsOnError,
                 tempCompressedFilePatternString,
+                0,
                 0);
     }
 
     /**
      * Constructs a new instance.
      *
-     * @param minIndex The minimum index.
-     * @param maxIndex The maximum index.
-     * @param customActions custom actions to perform asynchronously after rollover
-     * @param stopCustomActionsOnError whether to stop executing asynchronous actions if an error occurs
-     * @param tempCompressedFilePatternString File pattern of the working file
-     *                                     used during compression, if null no temporary file are used
-     * @param maxCompressionDelaySeconds maximum delay in seconds before compression.
+     * @param minIndex                       The minimum index.
+     * @param maxIndex                       The maximum index.
+     * @param customActions                  custom actions to perform asynchronously after rollover
+     * @param stopCustomActionsOnError       whether to stop executing asynchronous actions if an error occurs
+     * @param tempCompressedFilePatternString File pattern of the working file used during compression,
+     *                                       if null no temporary file are used
+     * @param maxCompressionDelaySeconds     maximum delay in seconds before compression.
+     * @since 2.27.0
+     * @deprecated Use {@link #DefaultRolloverStrategy(int, int, boolean, int, StrSubstitutor, Action[], boolean,
+     *             String, int, int)} with an explicit minimum delay.
+     */
+    @Deprecated
+    protected DefaultRolloverStrategy(
+            final int minIndex,
+            final int maxIndex,
+            final boolean useMax,
+            final int compressionLevel,
+            final StrSubstitutor strSubstitutor,
+            final Action[] customActions,
+            final boolean stopCustomActionsOnError,
+            final String tempCompressedFilePatternString,
+            final int maxCompressionDelaySeconds) {
+        this(
+                minIndex,
+                maxIndex,
+                useMax,
+                compressionLevel,
+                strSubstitutor,
+                customActions,
+                stopCustomActionsOnError,
+                tempCompressedFilePatternString,
+                0,
+                maxCompressionDelaySeconds);
+    }
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param minIndex                       The minimum index.
+     * @param maxIndex                       The maximum index.
+     * @param customActions                  custom actions to perform asynchronously after rollover
+     * @param stopCustomActionsOnError       whether to stop executing asynchronous actions if an error occurs
+     * @param tempCompressedFilePatternString File pattern of the working file used during compression,
+     *                                       if null no temporary file are used
+     * @param minCompressionDelaySeconds     minimum delay in seconds before compression (inclusive).
+     * @param maxCompressionDelaySeconds     maximum delay in seconds before compression (inclusive).
      * @since 2.27.0
      */
     protected DefaultRolloverStrategy(
@@ -522,6 +580,7 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
             final Action[] customActions,
             final boolean stopCustomActionsOnError,
             final String tempCompressedFilePatternString,
+            final int minCompressionDelaySeconds,
             final int maxCompressionDelaySeconds) {
         super(strSubstitutor);
         this.minIndex = minIndex;
@@ -532,6 +591,7 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
         this.customActions = customActions == null ? Collections.<Action>emptyList() : Arrays.asList(customActions);
         this.tempCompressedFilePattern =
                 tempCompressedFilePatternString != null ? new PatternProcessor(tempCompressedFilePatternString) : null;
+        this.minCompressionDelaySeconds = minCompressionDelaySeconds;
         this.maxCompressionDelaySeconds = maxCompressionDelaySeconds;
     }
 
@@ -561,6 +621,16 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
 
     public PatternProcessor getTempCompressedFilePattern() {
         return tempCompressedFilePattern;
+    }
+
+    /**
+     * Returns the minimum delay in seconds before compression.
+     *
+     * @return minimum delay in seconds before compression.
+     * @since 2.27.0
+     */
+    public int getMinCompressionDelaySeconds() {
+        return minCompressionDelaySeconds;
     }
 
     /**
@@ -751,12 +821,14 @@ public class DefaultRolloverStrategy extends AbstractRolloverStrategy {
                                         tmpCompressedName,
                                         true,
                                         compressionLevel,
+                                        minCompressionDelaySeconds,
                                         maxCompressionDelaySeconds),
                                 new FileRenameAction(tmpCompressedNameFile, renameToFile, true)),
                         true);
             } else {
                 compressAction = fileExtension.createCompressAction(
-                        renameTo, compressedName, true, compressionLevel, maxCompressionDelaySeconds);
+                        renameTo, compressedName, true, compressionLevel,
+                        minCompressionDelaySeconds, maxCompressionDelaySeconds);
             }
         }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/FileExtension.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/FileExtension.java
@@ -35,7 +35,7 @@ public enum FileExtension {
                 final String compressedName,
                 final boolean deleteSource,
                 final int compressionLevel) {
-            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0);
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0, 0);
         }
 
         @Override
@@ -45,11 +45,24 @@ public enum FileExtension {
                 final boolean deleteSource,
                 final int compressionLevel,
                 final int maxCompressionDelaySeconds) {
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0,
+                    maxCompressionDelaySeconds);
+        }
+
+        @Override
+        public Action createCompressAction(
+                final String renameTo,
+                final String compressedName,
+                final boolean deleteSource,
+                final int compressionLevel,
+                final int minCompressionDelaySeconds,
+                final int maxCompressionDelaySeconds) {
             return new ZipCompressAction(
                     new File(renameTo),
                     new File(compressedName),
                     deleteSource,
                     compressionLevel,
+                    minCompressionDelaySeconds,
                     maxCompressionDelaySeconds);
         }
     },
@@ -60,7 +73,7 @@ public enum FileExtension {
                 final String compressedName,
                 final boolean deleteSource,
                 final int compressionLevel) {
-            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0);
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0, 0);
         }
 
         @Override
@@ -70,11 +83,24 @@ public enum FileExtension {
                 final boolean deleteSource,
                 final int compressionLevel,
                 final int maxCompressionDelaySeconds) {
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0,
+                    maxCompressionDelaySeconds);
+        }
+
+        @Override
+        public Action createCompressAction(
+                final String renameTo,
+                final String compressedName,
+                final boolean deleteSource,
+                final int compressionLevel,
+                final int minCompressionDelaySeconds,
+                final int maxCompressionDelaySeconds) {
             return new GzCompressAction(
                     new File(renameTo),
                     new File(compressedName),
                     deleteSource,
                     compressionLevel,
+                    minCompressionDelaySeconds,
                     maxCompressionDelaySeconds);
         }
     },
@@ -85,7 +111,7 @@ public enum FileExtension {
                 final String compressedName,
                 final boolean deleteSource,
                 final int compressionLevel) {
-            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0);
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0, 0);
         }
 
         @Override
@@ -95,9 +121,22 @@ public enum FileExtension {
                 final boolean deleteSource,
                 final int compressionLevel,
                 final int maxCompressionDelaySeconds) {
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0,
+                    maxCompressionDelaySeconds);
+        }
+
+        @Override
+        public Action createCompressAction(
+                final String renameTo,
+                final String compressedName,
+                final boolean deleteSource,
+                final int compressionLevel,
+                final int minCompressionDelaySeconds,
+                final int maxCompressionDelaySeconds) {
             // One of "gz", "bzip2", "xz", "zst", "pack200", or "deflate".
             return new CommonsCompressAction(
-                    "bzip2", source(renameTo), target(compressedName), deleteSource, maxCompressionDelaySeconds);
+                    "bzip2", source(renameTo), target(compressedName), deleteSource,
+                    minCompressionDelaySeconds, maxCompressionDelaySeconds);
         }
     },
     DEFLATE(".deflate") {
@@ -107,7 +146,7 @@ public enum FileExtension {
                 final String compressedName,
                 final boolean deleteSource,
                 final int compressionLevel) {
-            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0);
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0, 0);
         }
 
         @Override
@@ -117,9 +156,22 @@ public enum FileExtension {
                 final boolean deleteSource,
                 final int compressionLevel,
                 final int maxCompressionDelaySeconds) {
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0,
+                    maxCompressionDelaySeconds);
+        }
+
+        @Override
+        public Action createCompressAction(
+                final String renameTo,
+                final String compressedName,
+                final boolean deleteSource,
+                final int compressionLevel,
+                final int minCompressionDelaySeconds,
+                final int maxCompressionDelaySeconds) {
             // One of "gz", "bzip2", "xz", "zst", "pack200", or "deflate".
             return new CommonsCompressAction(
-                    "deflate", source(renameTo), target(compressedName), deleteSource, maxCompressionDelaySeconds);
+                    "deflate", source(renameTo), target(compressedName), deleteSource,
+                    minCompressionDelaySeconds, maxCompressionDelaySeconds);
         }
     },
     PACK200(".pack200") {
@@ -129,7 +181,7 @@ public enum FileExtension {
                 final String compressedName,
                 final boolean deleteSource,
                 final int compressionLevel) {
-            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0);
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0, 0);
         }
 
         @Override
@@ -139,9 +191,22 @@ public enum FileExtension {
                 final boolean deleteSource,
                 final int compressionLevel,
                 final int maxCompressionDelaySeconds) {
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0,
+                    maxCompressionDelaySeconds);
+        }
+
+        @Override
+        public Action createCompressAction(
+                final String renameTo,
+                final String compressedName,
+                final boolean deleteSource,
+                final int compressionLevel,
+                final int minCompressionDelaySeconds,
+                final int maxCompressionDelaySeconds) {
             // One of "gz", "bzip2", "xz", "zstd", "pack200", or "deflate".
             return new CommonsCompressAction(
-                    "pack200", source(renameTo), target(compressedName), deleteSource, maxCompressionDelaySeconds);
+                    "pack200", source(renameTo), target(compressedName), deleteSource,
+                    minCompressionDelaySeconds, maxCompressionDelaySeconds);
         }
     },
     XZ(".xz") {
@@ -151,7 +216,7 @@ public enum FileExtension {
                 final String compressedName,
                 final boolean deleteSource,
                 final int compressionLevel) {
-            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0);
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0, 0);
         }
 
         @Override
@@ -161,9 +226,22 @@ public enum FileExtension {
                 final boolean deleteSource,
                 final int compressionLevel,
                 final int maxCompressionDelaySeconds) {
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0,
+                    maxCompressionDelaySeconds);
+        }
+
+        @Override
+        public Action createCompressAction(
+                final String renameTo,
+                final String compressedName,
+                final boolean deleteSource,
+                final int compressionLevel,
+                final int minCompressionDelaySeconds,
+                final int maxCompressionDelaySeconds) {
             // One of "gz", "bzip2", "xz", "zstd", "pack200", or "deflate".
             return new CommonsCompressAction(
-                    "xz", source(renameTo), target(compressedName), deleteSource, maxCompressionDelaySeconds);
+                    "xz", source(renameTo), target(compressedName), deleteSource,
+                    minCompressionDelaySeconds, maxCompressionDelaySeconds);
         }
     },
     ZSTD(".zst") {
@@ -173,7 +251,7 @@ public enum FileExtension {
                 final String compressedName,
                 final boolean deleteSource,
                 final int compressionLevel) {
-            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0);
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0, 0);
         }
 
         @Override
@@ -183,9 +261,22 @@ public enum FileExtension {
                 final boolean deleteSource,
                 final int compressionLevel,
                 final int maxCompressionDelaySeconds) {
+            return createCompressAction(renameTo, compressedName, deleteSource, compressionLevel, 0,
+                    maxCompressionDelaySeconds);
+        }
+
+        @Override
+        public Action createCompressAction(
+                final String renameTo,
+                final String compressedName,
+                final boolean deleteSource,
+                final int compressionLevel,
+                final int minCompressionDelaySeconds,
+                final int maxCompressionDelaySeconds) {
             // One of "gz", "bzip2", "xz", "zstd", "pack200", or "deflate".
             return new CommonsCompressAction(
-                    "zstd", source(renameTo), target(compressedName), deleteSource, maxCompressionDelaySeconds);
+                    "zstd", source(renameTo), target(compressedName), deleteSource,
+                    minCompressionDelaySeconds, maxCompressionDelaySeconds);
         }
     };
 
@@ -222,6 +313,26 @@ public enum FileExtension {
             String compressedName,
             boolean deleteSource,
             int compressionLevel,
+            int maxCompressionDelaySeconds);
+
+    /**
+     * Creates a compress action for this file extension.
+     *
+     * @param renameTo                  the file to rename to.
+     * @param compressedName            the compressed file name.
+     * @param deleteSource              if true, attempt to delete file on completion.
+     * @param compressionLevel          the compression level.
+     * @param minCompressionDelaySeconds minimum delay in seconds before compression (inclusive).
+     * @param maxCompressionDelaySeconds maximum delay in seconds before compression (inclusive).
+     * @return the compress action.
+     * @since 2.27.0
+     */
+    public abstract Action createCompressAction(
+            String renameTo,
+            String compressedName,
+            boolean deleteSource,
+            int compressionLevel,
+            int minCompressionDelaySeconds,
             int maxCompressionDelaySeconds);
 
     public String getExtension() {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/AbstractAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/AbstractAction.java
@@ -83,22 +83,42 @@ public abstract class AbstractAction implements Action {
     }
 
     /**
+     * Blocks the current thread for a random delay in the range [{@code minDelaySeconds}, {@code maxDelaySeconds}].
+     *
+     * <p>If {@code minDelaySeconds} equals {@code maxDelaySeconds} the delay is fixed. If both are zero no delay
+     * is applied. The method validates that {@code maxDelaySeconds >= minDelaySeconds >= 0}; values that violate
+     * this constraint are silently ignored (no sleep is performed).</p>
+     *
+     * @param minDelaySeconds minimum delay in seconds (inclusive).
+     * @param maxDelaySeconds maximum delay in seconds (inclusive).
+     * @since 2.27.0
+     */
+    static void blockThread(final int minDelaySeconds, final int maxDelaySeconds) {
+        if (minDelaySeconds < 0 || maxDelaySeconds < minDelaySeconds) {
+            return;
+        }
+        final int range = maxDelaySeconds - minDelaySeconds;
+        final int delay = minDelaySeconds
+                + (range == 0 ? 0 : java.util.concurrent.ThreadLocalRandom.current().nextInt(range + 1));
+        if (delay > 0) {
+            try {
+                Thread.sleep(delay * 1000L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /**
      * Blocks the current thread for a random delay up to {@code maxDelaySeconds}.
      *
      * @param maxDelaySeconds maximum delay in seconds before returning.
      * @since 2.27.0
+     * @deprecated Use {@link #blockThread(int, int)} with an explicit minimum delay.
      */
+    @Deprecated
     static void blockThread(final int maxDelaySeconds) {
-        if (maxDelaySeconds > 0) {
-            int delay = java.util.concurrent.ThreadLocalRandom.current().nextInt(maxDelaySeconds + 1);
-            if (delay > 0) {
-                try {
-                    Thread.sleep(delay * 1000L);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            }
-        }
+        blockThread(0, maxDelaySeconds);
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/CommonsCompressAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/CommonsCompressAction.java
@@ -55,33 +55,39 @@ public final class CommonsCompressAction extends AbstractAction {
     private final boolean deleteSource;
 
     /**
+     * Minimum delay in seconds before compression.
+     */
+    private final int minDelaySeconds;
+
+    /**
      * Maximum delay in seconds before compression.
      */
     private final int maxDelaySeconds;
 
     /**
-     * Creates new instance of Bzip2CompressAction.
+     * Creates new instance of CommonsCompressAction.
      *
-     * @param name the compressor name. One of "gz", "bzip2", "xz", "zst", "pack200", or "deflate".
-     * @param source file to compress, may not be null.
-     * @param destination compressed file, may not be null.
+     * @param name         the compressor name. One of "gz", "bzip2", "xz", "zst", "pack200", or "deflate".
+     * @param source       file to compress, may not be null.
+     * @param destination  compressed file, may not be null.
      * @param deleteSource if true, attempt to delete file on completion. Failure to delete does not cause an exception
-     *            to be thrown or affect return value.
+     *                     to be thrown or affect return value.
      */
     public CommonsCompressAction(
             final String name, final File source, final File destination, final boolean deleteSource) {
-        this(name, source, destination, deleteSource, 0);
+        this(name, source, destination, deleteSource, 0, 0);
     }
 
     /**
-     * Creates new instance of Bzip2CompressAction.
+     * Creates new instance of CommonsCompressAction.
      *
-     * @param name the compressor name. One of "gz", "bzip2", "xz", "zst", "pack200", or "deflate".
-     * @param source file to compress, may not be null.
-     * @param destination compressed file, may not be null.
-     * @param deleteSource if true, attempt to delete file on completion. Failure to delete does not cause an exception
-     *            to be thrown or affect return value.
-     * @param maxDelaySeconds maximum delay in seconds before compression.
+     * @param name            the compressor name. One of "gz", "bzip2", "xz", "zst", "pack200", or "deflate".
+     * @param source          file to compress, may not be null.
+     * @param destination     compressed file, may not be null.
+     * @param deleteSource    if true, attempt to delete file on completion. Failure to delete does not cause an
+     *                        exception to be thrown or affect return value.
+     * @param minDelaySeconds minimum delay in seconds before compression (inclusive).
+     * @param maxDelaySeconds maximum delay in seconds before compression (inclusive).
      * @since 2.27.0
      */
     public CommonsCompressAction(
@@ -89,6 +95,7 @@ public final class CommonsCompressAction extends AbstractAction {
             final File source,
             final File destination,
             final boolean deleteSource,
+            final int minDelaySeconds,
             final int maxDelaySeconds) {
         Objects.requireNonNull(source, "source");
         Objects.requireNonNull(destination, "destination");
@@ -96,7 +103,31 @@ public final class CommonsCompressAction extends AbstractAction {
         this.source = source;
         this.destination = destination;
         this.deleteSource = deleteSource;
+        this.minDelaySeconds = minDelaySeconds;
         this.maxDelaySeconds = maxDelaySeconds;
+    }
+
+    /**
+     * Creates new instance of CommonsCompressAction.
+     *
+     * @param name            the compressor name. One of "gz", "bzip2", "xz", "zst", "pack200", or "deflate".
+     * @param source          file to compress, may not be null.
+     * @param destination     compressed file, may not be null.
+     * @param deleteSource    if true, attempt to delete file on completion. Failure to delete does not cause an
+     *                        exception to be thrown or affect return value.
+     * @param maxDelaySeconds maximum delay in seconds before compression.
+     * @since 2.27.0
+     * @deprecated Use {@link #CommonsCompressAction(String, File, File, boolean, int, int)} with an explicit minimum
+     *             delay.
+     */
+    @Deprecated
+    public CommonsCompressAction(
+            final String name,
+            final File source,
+            final File destination,
+            final boolean deleteSource,
+            final int maxDelaySeconds) {
+        this(name, source, destination, deleteSource, 0, maxDelaySeconds);
     }
 
     /**
@@ -107,7 +138,7 @@ public final class CommonsCompressAction extends AbstractAction {
      */
     @Override
     public boolean execute() throws IOException {
-        blockThread(maxDelaySeconds);
+        blockThread(minDelaySeconds, maxDelaySeconds);
         return execute(name, source, destination, deleteSource);
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/GzCompressAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/GzCompressAction.java
@@ -56,6 +56,11 @@ public final class GzCompressAction extends AbstractAction {
     private final int compressionLevel;
 
     /**
+     * Minimum delay in seconds before compression.
+     */
+    private final int minDelaySeconds;
+
+    /**
      * Maximum delay in seconds before compression.
      */
     private final int maxDelaySeconds;
@@ -78,21 +83,21 @@ public final class GzCompressAction extends AbstractAction {
     /**
      * Create new instance of GzCompressAction.
      *
-     * @param source       file to compress, may not be null.
-     * @param destination  compressed file, may not be null.
-     * @param deleteSource if true, attempt to delete file on completion.  Failure to delete
-     *                     does not cause an exception to be thrown or affect return value.
-     * @param compressionLevel
-     *                     Gzip deflater compression level.
+     * @param source           file to compress, may not be null.
+     * @param destination      compressed file, may not be null.
+     * @param deleteSource     if true, attempt to delete file on completion.  Failure to delete
+     *                         does not cause an exception to be thrown or affect return value.
+     * @param compressionLevel Gzip deflater compression level.
+     * @param minDelaySeconds  minimum delay in seconds before compression (inclusive).
+     * @param maxDelaySeconds  maximum delay in seconds before compression (inclusive).
      * @since 2.27.0
-     * @param maxDelaySeconds
-     *                     Maximum delay in seconds before compression.
      */
     public GzCompressAction(
             final File source,
             final File destination,
             final boolean deleteSource,
             final int compressionLevel,
+            final int minDelaySeconds,
             final int maxDelaySeconds) {
         Objects.requireNonNull(source, "source");
         Objects.requireNonNull(destination, "destination");
@@ -101,7 +106,30 @@ public final class GzCompressAction extends AbstractAction {
         this.destination = destination;
         this.deleteSource = deleteSource;
         this.compressionLevel = checkCompressionLevel(compressionLevel);
+        this.minDelaySeconds = minDelaySeconds;
         this.maxDelaySeconds = maxDelaySeconds;
+    }
+
+    /**
+     * Create new instance of GzCompressAction.
+     *
+     * @param source           file to compress, may not be null.
+     * @param destination      compressed file, may not be null.
+     * @param deleteSource     if true, attempt to delete file on completion.  Failure to delete
+     *                         does not cause an exception to be thrown or affect return value.
+     * @param compressionLevel Gzip deflater compression level.
+     * @param maxDelaySeconds  maximum delay in seconds before compression.
+     * @since 2.27.0
+     * @deprecated Use {@link #GzCompressAction(File, File, boolean, int, int, int)} with an explicit minimum delay.
+     */
+    @Deprecated
+    public GzCompressAction(
+            final File source,
+            final File destination,
+            final boolean deleteSource,
+            final int compressionLevel,
+            final int maxDelaySeconds) {
+        this(source, destination, deleteSource, compressionLevel, 0, maxDelaySeconds);
     }
 
     /**
@@ -113,7 +141,7 @@ public final class GzCompressAction extends AbstractAction {
      */
     public GzCompressAction(
             final File source, final File destination, final boolean deleteSource, final int compressionLevel) {
-        this(source, destination, deleteSource, compressionLevel, 0);
+        this(source, destination, deleteSource, compressionLevel, 0, 0);
     }
 
     /**
@@ -123,7 +151,7 @@ public final class GzCompressAction extends AbstractAction {
      */
     @Deprecated
     public GzCompressAction(final File source, final File destination, final boolean deleteSource) {
-        this(source, destination, deleteSource, Deflater.DEFAULT_COMPRESSION, 0);
+        this(source, destination, deleteSource, Deflater.DEFAULT_COMPRESSION, 0, 0);
     }
 
     /**
@@ -134,7 +162,7 @@ public final class GzCompressAction extends AbstractAction {
      */
     @Override
     public boolean execute() throws IOException {
-        blockThread(maxDelaySeconds);
+        blockThread(minDelaySeconds, maxDelaySeconds);
         return execute(source, destination, deleteSource, compressionLevel);
     }
 

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/ZipCompressAction.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/action/ZipCompressAction.java
@@ -52,6 +52,11 @@ public final class ZipCompressAction extends AbstractAction {
     private final int level;
 
     /**
+     * Minimum delay in seconds before compression.
+     */
+    private final int minDelaySeconds;
+
+    /**
      * Maximum delay in seconds before compression.
      */
     private final int maxDelaySeconds;
@@ -71,14 +76,15 @@ public final class ZipCompressAction extends AbstractAction {
     }
 
     /**
-     * Creates new instance of GzCompressAction.
+     * Creates new instance of ZipCompressAction.
      *
-     * @param source file to compress, may not be null.
-     * @param destination compressed file, may not be null.
-     * @param deleteSource if true, attempt to delete file on completion. Failure to delete does not cause an exception
-     *            to be thrown or affect return value.
-     * @param level the compression level
-     * @param maxDelaySeconds maximum delay in seconds before compression.
+     * @param source          file to compress, may not be null.
+     * @param destination     compressed file, may not be null.
+     * @param deleteSource    if true, attempt to delete file on completion. Failure to delete does not cause an
+     *                        exception to be thrown or affect return value.
+     * @param level           the compression level
+     * @param minDelaySeconds minimum delay in seconds before compression (inclusive).
+     * @param maxDelaySeconds maximum delay in seconds before compression (inclusive).
      * @since 2.27.0
      */
     public ZipCompressAction(
@@ -86,6 +92,7 @@ public final class ZipCompressAction extends AbstractAction {
             final File destination,
             final boolean deleteSource,
             final int level,
+            final int minDelaySeconds,
             final int maxDelaySeconds) {
         Objects.requireNonNull(source, "source");
         Objects.requireNonNull(destination, "destination");
@@ -94,20 +101,43 @@ public final class ZipCompressAction extends AbstractAction {
         this.destination = destination;
         this.deleteSource = deleteSource;
         this.level = checkLevel(level);
+        this.minDelaySeconds = minDelaySeconds;
         this.maxDelaySeconds = maxDelaySeconds;
+    }
+
+    /**
+     * Creates new instance of ZipCompressAction.
+     *
+     * @param source          file to compress, may not be null.
+     * @param destination     compressed file, may not be null.
+     * @param deleteSource    if true, attempt to delete file on completion. Failure to delete does not cause an
+     *                        exception to be thrown or affect return value.
+     * @param level           the compression level
+     * @param maxDelaySeconds maximum delay in seconds before compression.
+     * @since 2.27.0
+     * @deprecated Use {@link #ZipCompressAction(File, File, boolean, int, int, int)} with an explicit minimum delay.
+     */
+    @Deprecated
+    public ZipCompressAction(
+            final File source,
+            final File destination,
+            final boolean deleteSource,
+            final int level,
+            final int maxDelaySeconds) {
+        this(source, destination, deleteSource, level, 0, maxDelaySeconds);
     }
 
     /**
      * Creates new instance.
      *
-     * @param source file to compress, may not be null.
-     * @param destination compressed file, may not be null.
+     * @param source       file to compress, may not be null.
+     * @param destination  compressed file, may not be null.
      * @param deleteSource if true, attempt to delete file on completion. Failure to delete does not cause an exception
-     *            to be thrown or affect return value.
-     * @param level the compression level
+     *                     to be thrown or affect return value.
+     * @param level        the compression level
      */
     public ZipCompressAction(final File source, final File destination, final boolean deleteSource, final int level) {
-        this(source, destination, deleteSource, level, 0);
+        this(source, destination, deleteSource, level, 0, 0);
     }
 
     /**
@@ -118,7 +148,7 @@ public final class ZipCompressAction extends AbstractAction {
      */
     @Override
     public boolean execute() throws IOException {
-        blockThread(maxDelaySeconds);
+        blockThread(minDelaySeconds, maxDelaySeconds);
         return execute(source, destination, deleteSource, level);
     }
 

--- a/scripts/.pr_review_state.json
+++ b/scripts/.pr_review_state.json
@@ -1,0 +1,5 @@
+{
+  "seen_review_ids": [],
+  "seen_comment_ids": [],
+  "last_check": "2026-06-26T11:56:09.196518Z"
+}

--- a/src/changelog/.2.x.x/4012_enhance_compression_delay_min_max.xml
+++ b/src/changelog/.2.x.x/4012_enhance_compression_delay_min_max.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+    <issue id="4012" link="https://github.com/apache/logging-log4j2/issues/4012"/>
+    <description format="asciidoc">
+        Enhanced compression delay support in `DefaultRolloverStrategy` by replacing the single `maxCompressionDelaySeconds` attribute with a `minCompressionDelaySeconds` / `maxCompressionDelaySeconds` pair.
+        The actual delay is now chosen uniformly at random from the closed interval `[min, max]`, giving operators fine-grained control over the compression window.
+        The previous `maxCompressionDelaySeconds`-only configuration remains fully backward-compatible (min defaults to `0`).
+    </description>
+</entry>


### PR DESCRIPTION
## Summary

Enhances the compression delay feature introduced in #4071 by replacing the single `maxCompressionDelaySeconds` parameter with a `minCompressionDelaySeconds` + `maxCompressionDelaySeconds` pair.

The actual delay is now chosen uniformly at random from the closed interval `[min, max]`, giving operators fine-grained control over the compression window (e.g. `min=30, max=120` to always wait between 30 s and 2 min before compressing).

## Changes

- **`AbstractAction`**: add `blockThread(int min, int max)` that picks a uniform random delay in `[min, max]` seconds; keep the deprecated single-arg overload as a backward-compatible delegate to `blockThread(0, max)`.
- **`GzCompressAction` / `ZipCompressAction` / `CommonsCompressAction`**: add `minDelaySeconds` field; new 6-arg constructors; deprecated 5-arg constructors delegate to the 6-arg form with `min=0`.
- **`FileExtension`**: add abstract `createCompressAction(…, min, max)` method and implement it in every enum constant; existing 5-arg overloads delegate to the new 6-arg form with `min=0` for backward compatibility.
- **`DefaultRolloverStrategy`**: add `@PluginBuilderAttribute minCompressionDelaySeconds` to Builder; add `setMinCompressionDelaySeconds` setter; add `getMinCompressionDelaySeconds` getter; new 10-arg constructor; deprecated 9-arg constructor delegates to the 10-arg form with `min=0`; `rollover()` passes both min and max to `createCompressAction`.
- **Tests**: extend `AbstractActionTest` with `blockThread(min,max)` edge-case tests; extend `FileExtensionCompressDelayTest` with GZ/ZIP min/max range tests and `DefaultRolloverStrategy` builder tests (21 tests pass).
- **Changelog**: add `src/changelog/.2.x.x/4012_enhance_compression_delay_min_max.xml`.

## Backward Compatibility

All existing configurations using only `maxCompressionDelaySeconds` continue to work unchanged (`min` defaults to `0`, producing the same `[0, max]` range as before).

## Configuration Example

```xml
<DefaultRolloverStrategy max="10"
    minCompressionDelaySeconds="30"
    maxCompressionDelaySeconds="120"/>
```

Closes #4012
