### PR TITLE
Consolidate string-to-URI conversion in NetUtils.toURI

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/NetUtilsTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/NetUtilsTest.java
@@ -18,67 +18,101 @@ package org.apache.logging.log4j.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import java.io.File;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class NetUtilsTest {
 
-    @Test
-    void testToUriWithoutBackslashes() {
-        final String config = "file:///path/to/something/on/unix";
-        URI uri = NetUtils.toURI(config);
+    /**
+     * {@link NetUtils#toURI(String)} over a mix of URIs and file system paths.
+     *
+     * <p>Every input is exercised on every OS. Only the expected result differs.</p>
+     */
+    @ParameterizedTest
+    @MethodSource
+    void toUriConvertsLocationsToUris(final String input, final String expected) {
+        assertThat(NetUtils.toURI(input)).hasToString(expected);
+    }
 
-        assertNotNull(uri, "The URI should not be null.");
-        assertEquals("file:///path/to/something/on/unix", uri.toString(), "The URI is not correct.");
+    static Stream<Arguments> toUriConvertsLocationsToUris() {
+        return Stream.of(
+                // Genuine absolute URIs are returned verbatim on every platform.
+                arguments("file:///path/to/something/on/unix", "file:///path/to/something/on/unix"),
+                arguments("classpath:log4j2.xml", "classpath:log4j2.xml"),
+                arguments("classloader:log4j2.xml", "classloader:log4j2.xml"),
+                arguments("vfsfile:/some/path/log4j2.xml", "vfsfile:/some/path/log4j2.xml"),
+                // Well-formed layered Apache Commons VFS URLs are valid (opaque) URIs, returned verbatim.
+                arguments("zip:file:///path/a.zip!/dir/log4j2.xml", "zip:file:///path/a.zip!/dir/log4j2.xml"),
+                arguments(
+                        "tar:gz:http://example.com/a.tar.gz!/a.tar!/log4j2.xml",
+                        "tar:gz:http://example.com/a.tar.gz!/a.tar!/log4j2.xml"),
+                // Blanks are illegal in a URI: a hierarchical URL is rebuilt with them encoded, preserving user info,
+                // host, port and query.
+                arguments(
+                        "http://example.com/a b/log4j2.xml?env=prod x",
+                        "http://example.com/a%20b/log4j2.xml?env=prod%20x"),
+                arguments(
+                        "https://user@example.com:8443/a b/log4j2.xml",
+                        "https://user@example.com:8443/a%20b/log4j2.xml"),
+                // A relative path stays a scheme-less relative URI on every platform.
+                arguments("relative/path/log4j2.xml", "relative/path/log4j2.xml"),
+                // The remaining inputs are file system paths: absolute on one OS (resolved to a `file:` URI) and
+                // relative on the other (a scheme-less URI, any drive-letter colon escaped to `%3A`).
+                perOs("/path/without/spaces", "/path/without/spaces", "file:/path/without/spaces"),
+                perOs(
+                        "/ path / with / spaces",
+                        "/%20path%20/%20with%20/%20spaces",
+                        "file:/%20path%20/%20with%20/%20spaces"),
+                perOs("C:/dir/log4j2.xml", "file:/C:/dir/log4j2.xml", "C%3A/dir/log4j2.xml"),
+                perOs("C:\\dir\\log4j2.xml", "file:/C:/dir/log4j2.xml", "C%3A%5Cdir%5Clog4j2.xml"),
+                perOs(
+                        "D:\\path\\to\\something\\on\\windows",
+                        "file:/D:/path/to/something/on/windows",
+                        "D%3A%5Cpath%5Cto%5Csomething%5Con%5Cwindows"),
+                perOs(
+                        "file:///D:\\path\\to\\something/on/windows",
+                        "file:///D:/path/to/something/on/windows",
+                        "file:///D:%5Cpath%5Cto%5Csomething/on/windows"));
+    }
 
-        final String properUriPath = "/path/without/spaces";
-        uri = NetUtils.toURI(properUriPath);
+    /**
+     * Builds a case whose expected {@code toString()} differs between Windows and the other platforms.
+     */
+    private static Arguments perOs(final String input, final String onWindows, final String onUnix) {
+        return arguments(input, SystemUtils.IS_OS_WINDOWS ? onWindows : onUnix);
+    }
 
-        assertNotNull(uri, "The URI should not be null.");
-        assertEquals(properUriPath, uri.toString(), "The URI is not correct.");
+    @ParameterizedTest
+    @MethodSource
+    void toUrisSplitsOnComma(final String input, final String[] expected) {
+        assertThat(NetUtils.toURIs(input)).extracting(URI::toString).containsExactly(expected);
+    }
+
+    static Stream<Arguments> toUrisSplitsOnComma() {
+        return Stream.of(
+                // A single location yields a single URI.
+                arguments("classpath:log4j2.xml", new String[] {"classpath:log4j2.xml"}),
+                // The scheme of the first location is propagated to the following ones, and blanks around the comma are
+                // trimmed.
+                arguments("classpath:first.xml, second.xml", new String[] {"classpath:first.xml", "classpath:second.xml"
+                }),
+                // Without a scheme each (relative) location is kept as-is.
+                arguments("a/first.xml,b/second.xml", new String[] {"a/first.xml", "b/second.xml"}));
     }
 
     @Test
-    void testToUriUnixWithSpaces() {
-        final String pathWithSpaces = "/ path / with / spaces";
-        final URI uri = NetUtils.toURI(pathWithSpaces);
-
-        assertNotNull(uri, "The URI should not be null.");
-        assertEquals(new File(pathWithSpaces).toURI().toString(), uri.toString(), "The URI is not correct.");
-    }
-
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
-    void testToUriWindowsWithBackslashes() {
-        final String config = "file:///D:\\path\\to\\something/on/windows";
-        final URI uri = NetUtils.toURI(config);
-
-        assertNotNull(uri, "The URI should not be null.");
-        assertEquals("file:///D:/path/to/something/on/windows", uri.toString(), "The URI is not correct.");
-    }
-
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
-    void testToUriWindowsAbsolutePath() {
-        final String config = "D:\\path\\to\\something\\on\\windows";
-        final URI uri = NetUtils.toURI(config);
-
-        assertNotNull(uri, "The URI should not be null.");
-        assertEquals("file:/D:/path/to/something/on/windows", uri.toString(), "The URI is not correct.");
-    }
-
-    @Test
-    void testCanonicalHostName() throws UnknownHostException {
+    void canonicalHostNameContainsDot() throws UnknownHostException {
         assumeThat(InetAddress.getLocalHost().getCanonicalHostName()).contains(".");
-        // If this fails the host might be misconfigured
+        // If this fails the host might be misconfigured.
         assertThat(NetUtils.getCanonicalLocalHostname()).contains(".");
     }
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/NetUtils.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/NetUtils.java
@@ -156,28 +156,100 @@ public final class NetUtils {
     }
 
     /**
-     * Converts a URI string or file path to a URI object.
+     * Converts a configuration location, expressed as either a {@link URI} or a file system path, into a {@link URI}.
      *
-     * @param path the URI string or path
-     * @return the URI object
+     * <p>The argument is classified by syntax:</p>
+     *
+     * <ul>
+     * <li>An <strong>absolute URI</strong> (one bearing a scheme) is returned unchanged.
+     * A single-letter scheme is the exception: it is read as a Windows drive letter, not a URI scheme.</li>
+     * <li>An <strong>absolute file system path</strong> for the current OS is converted to a {@code file:} URI.</li>
+     * <li>A <strong>relative</strong> path or URI ({@code log4j2.xml}, {@code config/log4j2.xml}) is returned as a
+     * relative URI and will require disambiguation later.</li>
+     * </ul>
+     *
+     * <p><em>Note:</em> URI parsing is performed leniently and might fix minor syntax errors.</p>
+     *
+     * @param path a URI string or a file system path
+     * @return the matching URI, never {@code null}
      */
     @SuppressFBWarnings(
             value = "PATH_TRAVERSAL_IN",
             justification = "Currently `path` comes from a configuration file.")
     public static URI toURI(final String path) {
-        try {
-            // Resolves absolute URI
-            return new URI(path);
-        } catch (final URISyntaxException e) {
-            // A file path or a Apache Commons VFS URL might contain blanks.
-            // A file path may start with a driver letter
-            try {
-                final URL url = new URL(path);
-                return new URI(url.getProtocol(), url.getHost(), url.getPath(), null);
-            } catch (MalformedURLException | URISyntaxException nestedEx) {
-                return new File(path).toURI();
-            }
+        final URI uri = parseURI(path);
+        // 1. A genuine absolute URI (a real scheme, not a Windows drive letter) is used as commanded.
+        if (uri != null && uri.isAbsolute() && !isWindowsDriveLetter(uri.getScheme())) {
+            return uri;
         }
+        // 2. Otherwise, the value is a file system path:
+        //
+        // - an absolute path becomes a `file:` URI holding the full path,
+        // - a relative one becomes a scheme-less URI, to be resolved later as a file or a class path resource.
+        final File file = new File(path);
+        return file.isAbsolute() ? file.toURI() : toRelativeUri(file);
+    }
+
+    /**
+     * Converts a relative file system path into a scheme-less {@link URI}.
+     *
+     * <p>Characters illegal in a URI (such as {@code \} or blanks) are percent-encoded.
+     * A leading Windows drive letter is escaped too ({@code C:} becomes {@code C%3A}),
+     * so the result is a relative reference rather than a URI whose scheme is the drive letter.</p>
+     */
+    private static URI toRelativeUri(final File file) {
+        try {
+            final URI uri = new URI(null, null, file.toString(), null);
+            return uri.isAbsolute() ? URI.create(uri.toASCIIString().replaceFirst(":", "%3A")) : uri;
+        } catch (final URISyntaxException e) {
+            // Unreachable: the multi-argument constructor escapes every character illegal in a URI.
+            throw new IllegalArgumentException("Cannot convert to a relative URI: " + file, e);
+        }
+    }
+
+    /**
+     * Leniently parses a string into a {@link URI}.
+     *
+     * <p>The string is first parsed with {@link URI#URI(String)}. If it is not valid URI syntax,
+     * it is parsed with {@link URL#URL(String)} and rebuilt into a properly encoded URI.</p>
+     *
+     * <p>The {@link URL} step consults the installed {@link java.net.URLStreamHandler URL stream handlers},
+     * so a scheme contributed by Apache Commons VFS (or any other {@link java.net.URLStreamHandlerFactory}) is
+     * recognized and its illegal characters are encoded.</p>
+     *
+     * @param value the value to parse
+     * @return the parsed {@link URI}, or {@code null} if neither {@link URI} nor {@link URL} can parse it
+     */
+    private static /*@Nullable*/ URI parseURI(final String value) {
+        try {
+            return new URI(value);
+        } catch (URISyntaxException e) {
+            LOGGER.trace("Could not parse value '{}' as URI. Falling back to URL parsing.", value, e);
+        }
+        try {
+            final URL url = new URL(value);
+            return new URI(
+                    url.getProtocol(),
+                    url.getUserInfo(),
+                    url.getHost(),
+                    url.getPort(),
+                    url.getPath(),
+                    url.getQuery(),
+                    null);
+        } catch (MalformedURLException | URISyntaxException e) {
+            LOGGER.trace("Could not parse value '{}' as URL.", value, e);
+        }
+        return null;
+    }
+
+    /**
+     * Returns {@code true} if the given URI scheme is in fact a Windows drive letter, that is, a single letter.
+     *
+     * <p>No registered URI scheme is a single letter, so a single-letter scheme always denotes the drive letter of a
+     * path such as {@code C:/dir/file} that happens to be valid URI syntax.</p>
+     */
+    private static boolean isWindowsDriveLetter(final /* @Nullable */ String scheme) {
+        return scheme != null && scheme.length() == 1 && Character.isLetter(scheme.charAt(0));
     }
 
     public static List<URI> toURIs(final String path) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/NetUtils.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/NetUtils.java
@@ -187,7 +187,7 @@ public final class NetUtils {
         // - an absolute path becomes a `file:` URI holding the full path,
         // - a relative one becomes a scheme-less URI, to be resolved later as a file or a class path resource.
         final File file = new File(path);
-        return file.isAbsolute() ? file.toURI() : toRelativeUri(file);
+        return file.isAbsolute() ? file.toURI() : toRelativeUri(path);
     }
 
     /**
@@ -197,13 +197,13 @@ public final class NetUtils {
      * A leading Windows drive letter is escaped too ({@code C:} becomes {@code C%3A}),
      * so the result is a relative reference rather than a URI whose scheme is the drive letter.</p>
      */
-    private static URI toRelativeUri(final File file) {
+    private static URI toRelativeUri(final String path) {
         try {
-            final URI uri = new URI(null, null, file.toString(), null);
+            final URI uri = new URI(null, null, path, null);
             return uri.isAbsolute() ? URI.create(uri.toASCIIString().replaceFirst(":", "%3A")) : uri;
         } catch (final URISyntaxException e) {
             // Unreachable: the multi-argument constructor escapes every character illegal in a URI.
-            throw new IllegalArgumentException("Cannot convert to a relative URI: " + file, e);
+            throw new IllegalArgumentException("Cannot convert to a relative URI: " + path, e);
         }
     }
 

--- a/src/changelog/.2.x.x/uniform_path_uri_resolution.xml
+++ b/src/changelog/.2.x.x/uniform_path_uri_resolution.xml
@@ -5,6 +5,7 @@
            https://logging.apache.org/xml/ns
            https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="changed">
+    <issue id="4160" link="https://github.com/apache/logging-log4j2/pull/4160"/>
     <description format="asciidoc">
         Configuration locations provided as a file path or `URI` are now handled consistently across operating systems.
     </description>

--- a/src/changelog/.2.x.x/uniform_path_uri_resolution.xml
+++ b/src/changelog/.2.x.x/uniform_path_uri_resolution.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+    <description format="asciidoc">
+        Configuration locations provided as a file path or `URI` are now handled consistently across operating systems.
+    </description>
+</entry>

--- a/src/site/antora/modules/ROOT/pages/manual/configuration.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/configuration.adoc
@@ -28,12 +28,14 @@ If you are looking for a quick start on using Log4j in your application or libra
 [id=automatic-configuration]
 == [[AutomaticConfiguration]] Configuration file location
 
-Upon initialization of a new xref:manual/architecture.adoc#LoggerContext[logger context, the anchor of the logging implementation], Log4j Core assigns it a context name and scans the following **classpath** locations for a configuration file in following order:
+Upon initialization of a new xref:manual/architecture.adoc#LoggerContext[logger context, the anchor of the logging implementation], Log4j Core assigns it a context name and scans the **classpath** for a configuration file at the following locations, in order:
 
-. Files named `log4j2-test<contextName>.<extension>`
-. Files named `log4j2-test.<extension>`
-. Files named `log4j2<contextName>.<extension>`
-. Files named `log4j2.<extension>`
+. `classpath:log4j2-test<contextName>.<extension>`
+. `classpath:log4j2-test.<extension>`
+. `classpath:log4j2<contextName>.<extension>`
+. `classpath:log4j2.<extension>`
+
+These locations are class path resources: a configuration file of the same name placed in the working directory is **not** loaded automatically.
 
 The `<contextName>` and `<extension>` placeholders above have the following meaning
 

--- a/src/site/antora/modules/ROOT/partials/manual/path-or-uri.adoc
+++ b/src/site/antora/modules/ROOT/partials/manual/path-or-uri.adoc
@@ -1,0 +1,31 @@
+////
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+////
+
+Such a location is given as either a file system
+https://docs.oracle.com/javase/{java-target-version}/docs/api/java/nio/file/Path.html[path]
+or a
+https://docs.oracle.com/javase/{java-target-version}/docs/api/java/net/URI.html[`URI`],
+and is resolved as follows:
+
+* An **absolute URI**, that is one carrying a scheme such as `file:`, `https:` or `classpath:`, is used as provided.
+Absolute URIs whose scheme is not `classpath:` are subject to the
+xref:manual/systemproperties.adoc#properties-transport-security[transport security] restrictions.
+
+* An **absolute file path** for the current operating system (for example `/var/log4j2.xml` on UNIX, or
+`C:\log4j2.xml` and `C:/log4j2.xml` on Windows) is resolved to a local file.
+
+* A **relative path** is resolved to a local file if that file exists, or to a class path resource otherwise.

--- a/src/site/antora/modules/ROOT/partials/manual/systemproperties/properties-configuration-factory.adoc
+++ b/src/site/antora/modules/ROOT/partials/manual/systemproperties/properties-configuration-factory.adoc
@@ -42,12 +42,7 @@ Log4j will attempt to use the provided configuration factory before any other fa
 
 Specifies a comma-separated list of URIs or file paths to Log4j 2 configuration files.
 
-If a relative URL is provided, it is interpreted as:
-
-* path to a file, if the file exists,
-* a classpath resource otherwise.
-
-Usage of absolute URLs is restricted by the xref:manual/configuration.adoc#properties-transport-security[Transport Security] configuration options.
+include::partial$manual/path-or-uri.adoc[]
 
 See also xref:manual/configuration.adoc#AutomaticConfiguration[Automatic Configuration].
 


### PR DESCRIPTION
## Motivation

`NetUtils.toURI(String)` is the single entry point that turns a configuration location (given as a URI or a file system
path) into a `URI`.
Its previous implementation mixed several special cases and behaved inconsistently across platforms:

- an absolute UNIX path stayed a scheme-less URI while an absolute Windows path became a `file:` URI,
- a Windows drive letter (`C:`) could be mistaken for a URI scheme,
- and a URL repaired for blanks silently lost its user-info, port and query.

This PR rewrites the method around two rules and isolates the awkward cases in
one helper.

## Conversion logic

1. **Absolute URI** (a real scheme, not a single-letter Windows drive letter) is returned **as commanded**, unchanged.
   This covers `classpath:`, `file:`, `http(s):`, and Apache Commons VFS URLs such as `zip:file:///a.zip!/log4j2.xml`.

2. Otherwise, the value is a **file system path**:
    - an **absolute** path (as `File.isAbsolute()` judges it on the running OS: a UNIX `/...` path, a Windows drive
      `C:\...`/`C:/...`) becomes a `file:` URI holding the full path;
    - a **relative** path becomes a **scheme-less** URI, to be resolved later as a file or a class path resource.

> [!IMPORTANT]
>
> Log4j Core handles **relative** URIs specially: first it tries to resolve the URI as a local file and falls back to a classpath lookup.

## Behavioral changes

The conversion outcome changes in the following cases. The before/after values below were captured by running the new test suite against the previous implementation (`<cwd>` is the process working directory).

| Input                         | Before                              | After                               | Note                            |
|-------------------------------|-------------------------------------|-------------------------------------|---------------------------------|
| `http://h/a b/x?env=prod x`   | `http://h/a%20b/x`                  | `http://h/a%20b/x?env=prod%20x`     | query preserved                 |
| `https://user@h:8443/a b/x`   | `https://h/a%20b/x`                 | `https://user@h:8443/a%20b/x`       | user-info and port preserved    |
| `/path/without/spaces` (UNIX) | `/path/without/spaces`              | `file:/path/without/spaces`         | absolute path now a `file:` URI |
| `C:/dir/log4j2.xml`   | `C:/dir/log4j2.xml` (scheme `C`)    | `C%3A/dir/log4j2.xml` (scheme-less) | drive letter is not a scheme    |
| `C:\dir\log4j2.xml` (UNIX)    | `file:/<cwd>/C:%5Cdir%5Clog4j2.xml` | `C%3A%5Cdir%5Clog4j2.xml`           | relative path stays scheme-less |

Summarized:

1. **URL repair no longer drops components.** Blanks in an `http(s)`/`ftp`/VFS URL are encoded while user-info, port and query are kept.
2. **An absolute UNIX path resolves to a `file:` URI**, matching the existing Windows behavior, so absolute paths are symmetric across platforms.
3. **A Windows drive letter is never a URI scheme.** `C:/...` (and `C:\...`) resolve to a `file:` URI on Windows (the drive) and to a scheme-less relative URI on UNIX (the colon escaped), instead of a `scheme=C` URI or a working-directory-resolved `file:` URI.

These are corner cases (remote URLs with blanks, drive-letter paths used on the wrong OS, absolute UNIX config paths).
Common locations (`log4j2.xml`, `config/log4j2.xml`, `classpath:...`, `file:...`, a plain absolute Windows path) are unaffected.

## Tests

`NetUtilsTest` is reworked into parameterized cases.
Every input runs on every OS; only the expected `toString()` differs, selected through `SystemUtils.IS_OS_WINDOWS`.
The commits are ordered tests-first:

- the first commit adds the tests (failing against the old behavior, which is how the table above was produced),
- the second commit applies the fix.

## Follow-up

A `src/changelog/.2.x.x/*.xml` entry still needs to be added for these
behavioral changes before merge.
