### PR TITLE
fix: null-check parseAppender result in log4j-1.2-api XmlConfiguration

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfiguration.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfiguration.java
@@ -774,6 +774,9 @@ public class XmlConfiguration extends Log4j1Configuration {
                     break;
                 case APPENDER_TAG:
                     final Appender appender = parseAppender(currentElement);
+                    if (appender == null) {
+                        break;
+                    }
                     appenderMap.put(appender.getName(), appender);
                     addAppender(AppenderAdapter.adapt(appender));
                     break;

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfiguration.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfiguration.java
@@ -775,8 +775,6 @@ public class XmlConfiguration extends Log4j1Configuration {
                 case APPENDER_TAG:
                     final Appender appender = parseAppender(currentElement);
                     if (appender == null) {
-                        // parseAppender already logs the creation failure; warn at this
-                        // site so the configuration skip is visible to users.
                         LOGGER.warn(
                                 "Could not create appender named [{}] of class [{}]; ignoring.",
                                 subst(currentElement.getAttribute(NAME_ATTR)),

--- a/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfiguration.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/xml/XmlConfiguration.java
@@ -775,9 +775,22 @@ public class XmlConfiguration extends Log4j1Configuration {
                 case APPENDER_TAG:
                     final Appender appender = parseAppender(currentElement);
                     if (appender == null) {
+                        // parseAppender already logs the creation failure; warn at this
+                        // site so the configuration skip is visible to users.
+                        LOGGER.warn(
+                                "Could not create appender named [{}] of class [{}]; ignoring.",
+                                subst(currentElement.getAttribute(NAME_ATTR)),
+                                subst(currentElement.getAttribute(CLASS_ATTR)));
                         break;
                     }
-                    appenderMap.put(appender.getName(), appender);
+                    final String appenderName = appender.getName();
+                    if (appenderName == null) {
+                        LOGGER.warn(
+                                "Appender of class [{}] has a null name; ignoring.",
+                                subst(currentElement.getAttribute(CLASS_ATTR)));
+                        break;
+                    }
+                    appenderMap.put(appenderName, appender);
                     addAppender(AppenderAdapter.adapt(appender));
                     break;
                 default:

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -16,9 +16,11 @@
  */
 package org.apache.log4j.config;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -97,6 +99,23 @@ class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
         file = new File("target/temp.A2");
         assertTrue(file.exists(), "File A2 was not created");
         assertTrue(file.length() > 0, "File A2 is empty");
+    }
+
+    /**
+     * Invalid appender class names make {@code parseAppender} return null.
+     * Configuration must skip those elements without throwing NPE on getName().
+     */
+    @Test
+    void testInvalidAppenderDoesNotNpe() throws Exception {
+        final LoggerContext loggerContext =
+                assertDoesNotThrow(() -> TestConfigurator.configure("target/test-classes/log4j1-invalid-appender.xml"));
+        final Configuration configuration = loggerContext.getConfiguration();
+        assertNotNull(configuration, "Configuration should still be created");
+        // The invalid appender must not be registered.
+        assertNull(configuration.getAppender("bad"), "Invalid appender should not be registered");
+        // The valid ListAppender must still load.
+        final Appender list = configuration.getAppender("list");
+        assertNotNull(list, "Valid list appender should be registered");
     }
 
     @Override

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/XmlConfigurationTest.java
@@ -101,19 +101,13 @@ class XmlConfigurationTest extends AbstractLog4j1ConfigurationTest {
         assertTrue(file.length() > 0, "File A2 is empty");
     }
 
-    /**
-     * Invalid appender class names make {@code parseAppender} return null.
-     * Configuration must skip those elements without throwing NPE on getName().
-     */
     @Test
     void testInvalidAppenderDoesNotNpe() throws Exception {
         final LoggerContext loggerContext =
                 assertDoesNotThrow(() -> TestConfigurator.configure("target/test-classes/log4j1-invalid-appender.xml"));
         final Configuration configuration = loggerContext.getConfiguration();
         assertNotNull(configuration, "Configuration should still be created");
-        // The invalid appender must not be registered.
         assertNull(configuration.getAppender("bad"), "Invalid appender should not be registered");
-        // The valid ListAppender must still load.
         final Appender list = configuration.getAppender("list");
         assertNotNull(list, "Valid list appender should be registered");
     }

--- a/log4j-1.2-api/src/test/resources/log4j1-invalid-appender.xml
+++ b/log4j-1.2-api/src/test/resources/log4j1-invalid-appender.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<!-- Invalid appender class must not NPE during parse(); valid ListAppender still loads. -->
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="bad" class="org.apache.log4j.DoesNotExistAppender"/>
+
+  <appender name="list" class="org.apache.log4j.ListAppender">
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern" value="%m%n" />
+    </layout>
+  </appender>
+
+  <root>
+    <priority value="debug" />
+    <appender-ref ref="list" />
+  </root>
+
+</log4j:configuration>

--- a/src/changelog/.2.x.x/fix_xml_parse_appender_npe.xml
+++ b/src/changelog/.2.x.x/fix_xml_parse_appender_npe.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="4172" link="https://github.com/apache/logging-log4j2/pull/4172"/>
+  <description format="asciidoc">Fix NPE in log4j-1.2-api `XmlConfiguration` when `parseAppender` returns null for an invalid appender element</description>
+</entry>


### PR DESCRIPTION
## Summary

In log4j-1.2-api `XmlConfiguration`, `parseAppender()` can return null. The code called `appender.getName()` unconditionally, causing an NPE on bad appender configuration.

## Fix

Skip null appenders after `parseAppender`.

## Testing

Logic-only guard; existing suite in CI.
