### PR TITLE
Include free-form message when encoding StructuredDataMessage to XML

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/StructuredDataMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/StructuredDataMessageTest.java
@@ -111,8 +111,7 @@ class StructuredDataMessageTest {
         final String id = "i<&d>" + XmlFixture.TEXT;
         final String type = "t>yp<e&" + XmlFixture.TEXT;
         // null message: keep this test focused on id/type escaping (and covers omission of <message>)
-        final String actualXml =
-                new StructuredDataMessage(id, null, type).getFormattedMessage(new String[] {"XML"});
+        final String actualXml = new StructuredDataMessage(id, null, type).getFormattedMessage(new String[] {"XML"});
         final String expectedXml = "<StructuredData>\n"
                 + "<type>t&gt;yp&lt;e&amp;" + XmlFixture.ENCODED_TEXT
                 + "</type>\n"
@@ -134,8 +133,7 @@ class StructuredDataMessageTest {
         final String type = "t>yp<e&" + XmlFixture.TEXT;
         final StructuredDataId id =
                 new StructuredDataId(idName, idEnterpriseNumber, idRequired, idOptional, Integer.MAX_VALUE);
-        final String actualXml =
-                new StructuredDataMessage(id, null, type).getFormattedMessage(new String[] {"XML"});
+        final String actualXml = new StructuredDataMessage(id, null, type).getFormattedMessage(new String[] {"XML"});
         final String expectedXml = "<StructuredData>\n"
                 + "<type>t&gt;yp&lt;e&amp;" + XmlFixture.ENCODED_TEXT
                 + "</type>\n"

--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/message/StructuredDataMessageTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/message/StructuredDataMessageTest.java
@@ -64,6 +64,7 @@ class StructuredDataMessageTest {
         final String expected = "<StructuredData>\n"
                 + "<type>Alert</type>\n"
                 + "<id>MsgId@12345</id>\n"
+                + "<message>Test message {}</message>\n"
                 + "<Map>\n"
                 + "  <Entry key=\"memo\">This is a very long test memo to prevent regression of LOG4J2-114</Entry>\n"
                 + "  <Entry key=\"message\">Test message {}</Entry>\n"
@@ -74,11 +75,44 @@ class StructuredDataMessageTest {
     }
 
     @Test
+    void testMsgXmlIncludesConstructorMessage() {
+        // #4141: constructor message must appear (and be escaped) even when not put into the map
+        final StructuredDataMessage msg = new StructuredDataMessage("an id", "a <msg> & more", "a type");
+        final String result = msg.getFormattedMessage(new String[] {"XML"});
+        final String expected = "<StructuredData>\n"
+                + "<type>a type</type>\n"
+                + "<id>an id</id>\n"
+                + "<message>a &lt;msg&gt; &amp; more</message>\n"
+                + "<Map>\n"
+                + "</Map>\n"
+                + "</StructuredData>\n";
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void testMsgXmlDistinguishesConstructorMessageFromMapEntry() {
+        // #4141: free-form message and a map entry keyed "message" are independent
+        final StructuredDataMessage msg = new StructuredDataMessage("an id", "a message", "a type");
+        msg.put("message", "foo");
+        final String result = msg.getFormattedMessage(new String[] {"XML"});
+        final String expected = "<StructuredData>\n"
+                + "<type>a type</type>\n"
+                + "<id>an id</id>\n"
+                + "<message>a message</message>\n"
+                + "<Map>\n"
+                + "  <Entry key=\"message\">foo</Entry>\n"
+                + "</Map>\n"
+                + "</StructuredData>\n";
+        assertEquals(expected, result);
+    }
+
+    @Test
     void testXmlEncodingOfIdAndType1() {
         final String id = "i<&d>" + XmlFixture.TEXT;
         final String type = "t>yp<e&" + XmlFixture.TEXT;
+        // null message: keep this test focused on id/type escaping (and covers omission of <message>)
         final String actualXml =
-                new StructuredDataMessage(id, "discarded message", type).getFormattedMessage(new String[] {"XML"});
+                new StructuredDataMessage(id, null, type).getFormattedMessage(new String[] {"XML"});
         final String expectedXml = "<StructuredData>\n"
                 + "<type>t&gt;yp&lt;e&amp;" + XmlFixture.ENCODED_TEXT
                 + "</type>\n"
@@ -101,7 +135,7 @@ class StructuredDataMessageTest {
         final StructuredDataId id =
                 new StructuredDataId(idName, idEnterpriseNumber, idRequired, idOptional, Integer.MAX_VALUE);
         final String actualXml =
-                new StructuredDataMessage(id, "discarded message", type).getFormattedMessage(new String[] {"XML"});
+                new StructuredDataMessage(id, null, type).getFormattedMessage(new String[] {"XML"});
         final String expectedXml = "<StructuredData>\n"
                 + "<type>t&gt;yp&lt;e&amp;" + XmlFixture.ENCODED_TEXT
                 + "</type>\n"

--- a/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/message/StructuredDataMessage.java
@@ -373,6 +373,15 @@ public class StructuredDataMessage extends MapMessage<StructuredDataMessage, Str
         StringBuilders.escapeXml(sb, start);
         sb.append("</id>\n");
 
+        // Encode message as its own element (distinct from a map entry keyed "message")
+        if (message != null) {
+            sb.append("<message>");
+            start = sb.length();
+            sb.append(message);
+            StringBuilders.escapeXml(sb, start);
+            sb.append("</message>\n");
+        }
+
         // Encode the rest
         super.asXml(sb);
 

--- a/src/changelog/.2.x.x/fix-StructuredDataMessage-XML-message.xml
+++ b/src/changelog/.2.x.x/fix-StructuredDataMessage-XML-message.xml
@@ -6,6 +6,7 @@
            https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <issue id="4141" link="https://github.com/apache/logging-log4j2/issues/4141"/>
+  <issue id="4180" link="https://github.com/apache/logging-log4j2/pull/4180"/>
   <description format="asciidoc">
     Include the free-form `message` field when encoding `StructuredDataMessage` to XML
   </description>

--- a/src/changelog/.2.x.x/fix-StructuredDataMessage-XML-message.xml
+++ b/src/changelog/.2.x.x/fix-StructuredDataMessage-XML-message.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="4141" link="https://github.com/apache/logging-log4j2/issues/4141"/>
+  <description format="asciidoc">
+    Include the free-form `message` field when encoding `StructuredDataMessage` to XML
+  </description>
+</entry>


### PR DESCRIPTION
## What

Fixes #4141: `StructuredDataMessage` XML encoding omitted the free-form message supplied at construction.

## Changes

- Encode the constructor `message` field as a distinct `<message>` element in `asXml`, with the same XML escaping used for `type` and `id`
- Keep it separate from map entries so a user-supplied `put("message", ...)` remains an independent SD-PARAM
- Omit the element when the constructor message is `null`
- Add regression tests for inclusion, escaping, and the map-key conflict case

### Example

```java
new StructuredDataMessage("an id", "a message", "a type");
```

now encodes as:

```xml
<StructuredData>
<type>a type</type>
<id>an id</id>
<message>a message</message>
<Map>
</Map>
</StructuredData>
```

When both the constructor message and a map entry keyed `"message"` are set, both appear:

```xml
<message>a message</message>
...
  <Entry key="message">foo</Entry>
```

## Testing

```bash
mvn -pl log4j-api-test -am test -Dtest=StructuredDataMessageTest -Dsurefire.failIfNoSpecifiedTests=false
```

All `StructuredDataMessageTest` cases pass.