### PR TITLE
Fix properties config parsing for MarkerFilter onMismatch/onMatch attribute casing (Fixes #2791)

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/properties/MarkerFilterPropertiesCaseTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/properties/MarkerFilterPropertiesCaseTest.java
@@ -3,7 +3,7 @@ package org.apache.logging.log4j.core.config.properties;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import org.apache.logging.log4j.core.Configuration;
+import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.junit.jupiter.api.Test;

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/properties/MarkerFilterPropertiesCaseTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/properties/MarkerFilterPropertiesCaseTest.java
@@ -1,0 +1,19 @@
+package org.apache.logging.log4j.core.config.properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.apache.logging.log4j.core.Configuration;
+import org.apache.logging.log4j.core.LifeCycle;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.junit.jupiter.api.Test;
+
+class MarkerFilterPropertiesCaseTest {
+
+    @Test
+    @LoggerContextSource("log4j2-properties-markerfilter-miscase.properties")
+    void testMarkerFilterPropertyCase(final Configuration config) {
+        assertNotNull(config);
+        assertEquals(LifeCycle.State.STARTED, config.getState(), "Configuration did not start");
+    }
+}

--- a/log4j-core-test/src/test/resources/log4j2-properties-markerfilter-miscase.properties
+++ b/log4j-core-test/src/test/resources/log4j2-properties-markerfilter-miscase.properties
@@ -1,0 +1,16 @@
+status = ERROR
+dest = err
+
+appender.Stdout.type = Console
+appender.Stdout.name = StdOut
+appender.Stdout.target = SYSTEM_OUT
+appender.Stdout.layout.type = PatternLayout
+appender.Stdout.layout.pattern = %d [%t] %-5level: %msg%n%throwable
+
+appender.Stdout.filter.marker.type = MarkerFilter
+appender.Stdout.filter.marker.onMatch = DENY
+appender.Stdout.filter.marker.onMisMatch = NEUTRAL
+appender.Stdout.filter.marker.marker = FLOW
+
+rootLogger.appenderRef.console.ref = StdOut
+rootLogger.level = ERROR

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationBuilder.java
@@ -257,8 +257,8 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
         if (Strings.isEmpty(type)) {
             throw new ConfigurationException("No type attribute provided for Filter " + key);
         }
-        final String onMatch = (String) properties.remove(AbstractFilterBuilder.ATTR_ON_MATCH);
-        final String onMismatch = (String) properties.remove(AbstractFilterBuilder.ATTR_ON_MISMATCH);
+        final String onMatch = removeIgnoreCase(properties, AbstractFilterBuilder.ATTR_ON_MATCH);
+        final String onMismatch = removeIgnoreCase(properties, AbstractFilterBuilder.ATTR_ON_MISMATCH);
         final FilterComponentBuilder filterBuilder = builder.newFilter(type, onMatch, onMismatch);
         return processRemainingProperties(filterBuilder, properties);
     }
@@ -417,5 +417,16 @@ public class PropertiesConfigurationBuilder extends ConfigurationBuilderFactory
 
     public LoggerContext getLoggerContext() {
         return loggerContext;
+    }
+
+    private static String removeIgnoreCase(final Properties properties, final String key) {
+        for (final String k : properties.stringPropertyNames()) {
+            if (k.equalsIgnoreCase(key)) {
+                final String value = properties.getProperty(k);
+                properties.remove(k);
+                return value;
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
This PR fixes a properties-configuration parsing compatibility issue reported in #2791.

In `.properties` configs, `MarkerFilter` attributes `onMatch` / `onMismatch` were treated with strict key matching in `PropertiesConfigurationBuilder`, which could leave mis-cased keys (for example `onMisMatch`) unconsumed and produce invalid attribute errors at runtime.

### What changed

1. `log4j-core`  
   - Updated `PropertiesConfigurationBuilder#createFilter(...)` to resolve `onMatch` and `onMismatch` in a case-insensitive way before building the filter.

2. `log4j-core-test`  
   - Added regression config:  
     `log4j2-properties-markerfilter-miscase.properties`
   - Added regression test:  
     `MarkerFilterPropertiesCaseTest`
   - Test validates that configuration starts successfully with a mis-cased `onMisMatch` property, preventing regression.

### Why

This restores expected compatibility for properties-based `MarkerFilter` configuration and avoids startup/runtime errors caused by minor attribute casing differences.

Fixes #2791.

How to verify this change (add to PR description or comment)

### How to verify

1. Use Java 17.
2. From repository root:
   ```bash ./mvnw -pl log4j-core-test -am -Dtest=MarkerFilterPropertiesCaseTest test

3. Expected result:
•  MarkerFilterPropertiesCaseTest  passes.
• Configuration file with  onMisMatch  is accepted and configuration starts.
4. (Optional full validation)

