### PR TITLE
Change `build` and `codeql-analysis` triggers

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,18 +19,12 @@ name: build
 
 on:
   push:
+    # These filters apply only to the current branch (`2.x`) and new branches cut from it:
+    # only `release/2*` branches automatically inherit this workflow.
     branches:
       - "2.x"
-      - "2.25.x"
       - "release/2*"
   pull_request:
-    types:
-      # Standard types
-      - opened
-      - synchronize
-      - reopened
-      # Used in Dependabot PRs to retrigger required workflows
-      - ready_for_review
 
 # Cancel in-progress runs when a newer commit lands on the same PR; pushes to 2.x run to completion.
 concurrency:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -19,16 +19,12 @@ name: codeql-analysis
 
 on:
   push:
-    branches: [ "2.x", "main" ]
+    # These filters apply only to the current branch (`2.x`) and new branches cut from it:
+    # only `release/2*` branches automatically inherit this workflow.
+    branches:
+      - "2.x"
+      - "release/2*"
   pull_request:
-    branches: [ "2.x", "main" ]
-    types:
-      # Standard types
-      - opened
-      - synchronize
-      - reopened
-      # Used in Dependabot PRs to retrigger required workflows
-      - ready_for_review
   schedule:
     - cron: '32 12 * * 5'
 


### PR DESCRIPTION
Since apache/logging-parent#500 has been merged, workflow runs no longer need to be triggered by PR events of type `ready_for_review`. We therefore remove the `pull_request.types` filter entirely, which restores the default event types.

We also simplify the `branches` filters on the `push` and `pull_request` triggers. Since this workflow file lives on `2.x`, these filters only affect `2.x` itself and branches created from it:

- For `push`: only `release/2*` branches automatically inherit these workflows. We drop `2.25.x` (in `build`) and `main` (in `codeql-analysis`), since those entries would only be useful if we were to branch `2.25.x` or `main` anew from `2.x`. Keeping them would confuse readers of the workflow file.
- For `pull_request`: all branches will run these workflows if a PR is opened against them (e.g. "stacked" PRs opened against the branch of another PR).

