### PR TITLE
fix: `InstantPatternLegacyFormatter` precision for legacy `n` patterns

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/NamedInstantPatternTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/NamedInstantPatternTest.java
@@ -55,5 +55,6 @@ class NamedInstantPatternTest {
         String legacy = legacyFormatter.format(instant);
         String modern = formatter.format(instant);
         assertThat(legacy).isEqualTo(modern);
+        assertThat(legacyFormatter.getPrecision()).isEqualTo(formatter.getPrecision());
     }
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternLegacyFormatterPrecisionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternLegacyFormatterPrecisionTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.core.util.internal.instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Locale;
+import java.util.TimeZone;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression for issue #3816: legacy fractional-second letter {@code n} must not be
+ * treated as always-nanosecond when computing cache precision.
+ */
+class InstantPatternLegacyFormatterPrecisionTest {
+
+    @Test
+    void microsPatternUsingLegacyNUsesMicroPrecision() {
+        final InstantPatternFormatter legacy = InstantPatternFormatter.newBuilder()
+                .setLegacyFormattersEnabled(true)
+                .setPattern("yyyy-MM-dd HH:mm:ss,nnnnnn")
+                .setLocale(Locale.US)
+                .setTimeZone(TimeZone.getTimeZone("UTC"))
+                .build();
+        final InstantPatternFormatter modern = InstantPatternFormatter.newBuilder()
+                .setLegacyFormattersEnabled(false)
+                .setPattern("yyyy-MM-dd HH:mm:ss,SSSSSS")
+                .setLocale(Locale.US)
+                .setTimeZone(TimeZone.getTimeZone("UTC"))
+                .build();
+        assertThat(legacy.getPrecision()).isEqualTo(ChronoUnit.MICROS);
+        assertThat(legacy.getPrecision()).isEqualTo(modern.getPrecision());
+    }
+
+    @Test
+    void millisPatternUsingLegacySssUsesMilliPrecision() {
+        final InstantPatternFormatter legacy = InstantPatternFormatter.newBuilder()
+                .setLegacyFormattersEnabled(true)
+                .setPattern("yyyy-MM-dd HH:mm:ss,SSS")
+                .setLocale(Locale.US)
+                .setTimeZone(TimeZone.getTimeZone("UTC"))
+                .build();
+        assertThat(legacy.getPrecision()).isEqualTo(ChronoUnit.MILLIS);
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternLegacyFormatter.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/util/internal/instant/InstantPatternLegacyFormatter.java
@@ -46,7 +46,10 @@ final class InstantPatternLegacyFormatter implements InstantPatternFormatter {
     private final BiConsumer<StringBuilder, Instant> formatter;
 
     InstantPatternLegacyFormatter(final String pattern, final Locale locale, final TimeZone timeZone) {
-        this.precision = new InstantPatternDynamicFormatter(pattern, locale, timeZone).getPrecision();
+        // Replaces 'n' used in legacy patterns with 'S' to obtain the right precision.
+        // In legacy patterns, the precision of 'n' depends on the pattern length, but
+        // in `DateTimeFormatter`, it is always nanoseconds.
+        this.precision = new InstantPatternDynamicFormatter(pattern.replace('n', 'S'), locale, timeZone).getPrecision();
         this.pattern = pattern;
         this.locale = locale;
         this.timeZone = timeZone;

--- a/src/changelog/.2.x.x/3816_legacy_instant_pattern_precision.xml
+++ b/src/changelog/.2.x.x/3816_legacy_instant_pattern_precision.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="3816" link="https://github.com/apache/logging-log4j2/issues/3816"/>
+  <description format="asciidoc">Fix precision detection in `InstantPatternLegacyFormatter` for legacy fractional-second patterns using `n`</description>
+</entry>

--- a/src/changelog/.2.x.x/3816_legacy_instant_pattern_precision.xml
+++ b/src/changelog/.2.x.x/3816_legacy_instant_pattern_precision.xml
@@ -4,5 +4,8 @@
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <issue id="3816" link="https://github.com/apache/logging-log4j2/issues/3816"/>
-  <description format="asciidoc">Fix precision detection in `InstantPatternLegacyFormatter` for legacy fractional-second patterns using `n`</description>
+  <issue id="4220" link="https://github.com/apache/logging-log4j2/pull/4220"/>
+  <description format="asciidoc">
+    Fix precision detection in legacy date &amp; time pattern formatting
+  </description>
 </entry>


### PR DESCRIPTION
## What Problem This Solves

`InstantPatternLegacyFormatter` computed precision by constructing `InstantPatternDynamicFormatter` with the **legacy** pattern string. Legacy FixedDateFormat patterns use `n` for variable-length fractional seconds. DateTimeFormatter treats `n` as always nano-of-second, so patterns such as `yyyy-MM-dd HH:mm:ss,nnnnnn` were classified as `NANOS` instead of `MICROS`, breaking cache invalidation for legacy formatters.

## Evidence

Issue #3816. Approach matches ppkarwasz's fix on main (`n` → `S` before precision detection), which was not present on `2.x`.

### Red-green

Without the fix:

```
expected: Micros
 but was: Nanos
```

With the fix:

```bash
export JAVA_HOME=$(/usr/libexec/java_home -v 17)
./mvnw -pl log4j-core,log4j-core-test -am test \
  -Dtest=InstantPatternLegacyFormatterPrecisionTest,NamedInstantPatternTest \
  -Dsurefire.failIfNoSpecifiedTests=false
```

`InstantPatternLegacyFormatterPrecisionTest`: 2 passed  
`NamedInstantPatternTest`: 21 passed (also asserts legacy/modern precision parity)

## Summary

- Map legacy `n` to `S` only for precision detection
- Dedicated precision unit tests + NamedInstantPattern precision assertion
- Changelog; Fixes #3816