### PR TITLE
Add log4j-api-kotlin dependency to BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,6 +380,8 @@
     <log4j.docgen.pluginDescriptorsDir.phase1>${maven.multiModuleProjectDirectory}/target/plugin-descriptors/phase1</log4j.docgen.pluginDescriptorsDir.phase1>
     <log4j.docgen.pluginDescriptorsDir.phase2>${maven.multiModuleProjectDirectory}/target/plugin-descriptors/phase2</log4j.docgen.pluginDescriptorsDir.phase2>
 
+    <!-- log4j-api-kotlin> -->
+    <log4j-api-kotlin.version>1.5.0</log4j-api-kotlin.version>
   </properties>
 
   <dependencyManagement>
@@ -495,6 +497,12 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-jul</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api-kotlin</artifactId>
+        <version>${log4j-api-kotlin.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -380,8 +380,6 @@
     <log4j.docgen.pluginDescriptorsDir.phase1>${maven.multiModuleProjectDirectory}/target/plugin-descriptors/phase1</log4j.docgen.pluginDescriptorsDir.phase1>
     <log4j.docgen.pluginDescriptorsDir.phase2>${maven.multiModuleProjectDirectory}/target/plugin-descriptors/phase2</log4j.docgen.pluginDescriptorsDir.phase2>
 
-    <!-- log4j-api-kotlin> -->
-    <log4j-api-kotlin.version>1.5.0</log4j-api-kotlin.version>
   </properties>
 
   <dependencyManagement>
@@ -401,6 +399,12 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api-kotlin</artifactId>
+        <version>1.5.0</version>
       </dependency>
 
       <dependency>
@@ -497,12 +501,6 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-jul</artifactId>
         <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api-kotlin</artifactId>
-        <version>${log4j-api-kotlin.version}</version>
       </dependency>
 
       <dependency>

--- a/src/changelog/.2.x.x/4145_add_log4j_api_kotlin_to_bom.xml
+++ b/src/changelog/.2.x.x/4145_add_log4j_api_kotlin_to_bom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+    <issue id="4145" link="https://github.com/apache/logging-log4j2/issues/4145"/>
+    <issue id="4222" link="https://github.com/apache/logging-log4j2/pull/4222"/>
+    <description format="asciidoc">
+        Add `log4j-api-kotlin` to the Log4j Bill of Materials (`log4j-bom`).
+    </description>
+</entry>


### PR DESCRIPTION
This PR adds `log4j-api-kotlin` to the Log4j Bill of Materials (`log4j-bom` / root `pom.xml`). 

Fixes #4145.