### PR TITLE
Enforce milestone requirement for PRs targeting the 2.x branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -52,7 +52,6 @@ github:
     - log4j2
     - logging
     - logger
-    - api
     - syslog
 
   # Pull Request settings:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -75,6 +75,8 @@ github:
   # Enforce Review-then-Commit
   protected_branches:
     2.x:
+      # Enforce rules for Committers and PMC members too
+      enforce_admins: true
       # All reviews must be addressed before merging
       required_conversation_resolution: true
       # Require checks to pass before merging
@@ -86,6 +88,9 @@ github:
           # The GitHub Advanced Security app: 57789
           - app_id: 57789
             context: "CodeQL"
+          # Require Milestone (GitHub Actions app: 15368)
+          - app_id: 15368
+            context: "Require Milestone"
       # At least one positive review must be present
       required_pull_request_reviews:
         required_approving_review_count: 1

--- a/.github/workflows/require-milestone.yml
+++ b/.github/workflows/require-milestone.yml
@@ -23,7 +23,7 @@ on:
     types: [opened, synchronize, reopened, milestoned, demilestoned]
 
 jobs:
-  validate-milestone:
+  Require Milestone:
     name: Require Milestone
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/require-milestone.yml
+++ b/.github/workflows/require-milestone.yml
@@ -1,0 +1,63 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: "Enforce PR Milestone"
+
+on:
+  pull_request_target:
+    branches:
+      - '2.x'
+    types: [opened, synchronize, reopened, milestoned, demilestoned]
+
+jobs:
+  validate-milestone:
+    name: Require Milestone
+    runs-on: ubuntu-latest
+    steps:
+      - name: Strictly Enforce Open 2.x Milestone
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_MILESTONE="${{ github.event.pull_request.milestone.title }}"
+
+          # 1. VIOLENTLY BLOCK if no milestone is attached to the PR
+          if [ -z "$PR_MILESTONE" ]; then
+            echo "❌ ERROR: No milestone is attached to this PR!"
+            echo "You cannot merge until a milestone is assigned."
+            exit 1
+          fi
+
+          # 2. VIOLENTLY BLOCK if they attached a 3.x or 1.x milestone on the 2.x branch
+          if [[ ! "$PR_MILESTONE" =~ ^2\. ]]; then
+            echo "❌ ERROR: You are merging into the '2.x' branch, but using milestone '$PR_MILESTONE'."
+            echo "Please use a 2.x milestone (e.g., 2.25.0)."
+            exit 1
+          fi
+
+          # 3. Fetch all currently OPEN milestones in the repository
+          OPEN_MILESTONES=$(gh api repos/${{ github.repository }}/milestones -f state=open -q '.[].title')
+
+          # 4. VIOLENTLY BLOCK if the milestone hasn't been created yet by a PMC member (or is closed)
+          if echo "$OPEN_MILESTONES" | grep -Fxq "$PR_MILESTONE"; then
+            echo "✅ SUCCESS: Milestone '$PR_MILESTONE' is attached and currently open."
+            exit 0
+          else
+            echo "❌ ERROR: The milestone '$PR_MILESTONE' DOES NOT EXIST or is CLOSED."
+            echo "Merge is blocked. A PMC member must create this milestone in GitHub before you can merge."
+            echo "Currently open milestones are:"
+            echo "$OPEN_MILESTONES"
+            exit 1
+          fi


### PR DESCRIPTION
This PR blocks Pull Requests from being merged into the `2.x` branch unless they have a valid milestone assigned. This ensures proper release tracking.

**What this does:**
* **Adds a GitHub Action:** Checks that a milestone is attached, it starts with `2.`, and it is currently open in the repository.
* **Updates `.asf.yaml`:** Makes this check mandatory and locks the merge button for everyone (including Committers and PMC members) if it fails.

**How to merge after this PR:**
The merge button will be disabled by default. A Committer just needs to attach an open 2.x milestone (like `2.25.5` or `2.x`) to the PR. The check will instantly turn green and unlock the merge button.