### PR TITLE
Add missing RootLogger.Builder withFilter alias

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/LoggerConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/LoggerConfigTest.java
@@ -175,6 +175,4 @@ class LoggerConfigTest {
         assertSame(filter, viaTypo.getFilter());
         assertSame(filter, viaAlias.getFilter());
     }
-
-
 }

--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/LoggerConfigTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/LoggerConfigTest.java
@@ -159,4 +159,22 @@ class LoggerConfigTest {
         assertNotNull(loggerConfig.getAppenderRefs());
         assertTrue(loggerConfig.getAppenderRefs().isEmpty());
     }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void testRootLoggerBuilderWithFilterAlias() {
+        final Filter filter = mock(Filter.class);
+        final LoggerConfig viaTypo = LoggerConfig.RootLogger.newRootBuilder()
+                .setConfig(new NullConfiguration())
+                .withtFilter(filter)
+                .build();
+        final LoggerConfig viaAlias = LoggerConfig.RootLogger.newRootBuilder()
+                .setConfig(new NullConfiguration())
+                .withFilter(filter)
+                .build();
+        assertSame(filter, viaTypo.getFilter());
+        assertSame(filter, viaAlias.getFilter());
+    }
+
+
 }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -1136,7 +1136,9 @@ public class LoggerConfig extends AbstractFilterable implements LocationAware {
                 return setFilter(filter);
             }
 
-            /** @deprecated since 2.25.0. Use {@link #setFilter(Filter)} instead. */
+            /**
+             * @deprecated since 2.25.0. Use {@link #setFilter(Filter)} instead.
+             */
             @Deprecated
             public B withFilter(final Filter filter) {
                 return setFilter(filter);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/LoggerConfig.java
@@ -1136,6 +1136,12 @@ public class LoggerConfig extends AbstractFilterable implements LocationAware {
                 return setFilter(filter);
             }
 
+            /** @deprecated since 2.25.0. Use {@link #setFilter(Filter)} instead. */
+            @Deprecated
+            public B withFilter(final Filter filter) {
+                return setFilter(filter);
+            }
+
             @Override
             public LoggerConfig build() {
                 final LevelAndRefs container = LoggerConfig.getLevelAndRefs(level, refs, levelAndRefs, config);

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/package-info.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/package-info.java
@@ -18,7 +18,7 @@
  * Configuration of Log4j 2.
  */
 @Export
-@Version("2.26.0")
+@Version("2.27.0")
 package org.apache.logging.log4j.core.config;
 
 import org.osgi.annotation.bundle.Export;

--- a/src/changelog/.2.x.x/3369_add_missing_RootLogger_withFilter_alias.xml
+++ b/src/changelog/.2.x.x/3369_add_missing_RootLogger_withFilter_alias.xml
@@ -6,8 +6,8 @@
            https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="added">
     <issue id="3369" link="https://github.com/apache/logging-log4j2/issues/3369"/>
+    <issue id="4224" link="https://github.com/apache/logging-log4j2/pull/4224"/>
     <description format="asciidoc">
-        Add the missing `LoggerConfig.RootLogger.Builder#withFilter(Filter)` alias so it matches
-        `LoggerConfig.Builder`, and keep the misspelled `withtFilter` method as a deprecated wrapper.
+        Add missing `withFilter()` method to `LoggerConfig.RootLogger.Builder` to fix `withtFilter` typo.
     </description>
 </entry>

--- a/src/changelog/.2.x.x/3369_add_missing_RootLogger_withFilter_alias.xml
+++ b/src/changelog/.2.x.x/3369_add_missing_RootLogger_withFilter_alias.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="added">
+    <issue id="3369" link="https://github.com/apache/logging-log4j2/issues/3369"/>
+    <description format="asciidoc">
+        Add the missing `LoggerConfig.RootLogger.Builder#withFilter(Filter)` alias so it matches
+        `LoggerConfig.Builder`, and keep the misspelled `withtFilter` method as a deprecated wrapper.
+    </description>
+</entry>


### PR DESCRIPTION
## Summary
`LoggerConfig.Builder` already exposes a deprecated `withFilter(Filter)` alias next to the misspelled `withtFilter(Filter)`, but `LoggerConfig.RootLogger.Builder` only had `withtFilter`. This adds the matching `withFilter` alias so both builders behave the same way, keeps `withtFilter` as a deprecated wrapper around `setFilter`, and adds a small unit test for both call paths.

Fixes #3369

## Test plan
- [x] Added `LoggerConfigTest.testRootLoggerBuilderWithFilterAlias`
- [ ] CI `LoggerConfigTest` on this PR