### PR TITLE
Name direct write cron files after the rollover period they cover

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/CronTriggeringPolicyTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/CronTriggeringPolicyTest.java
@@ -16,13 +16,17 @@
  */
 package org.apache.logging.log4j.core.appender.rolling;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.apache.logging.log4j.core.appender.RollingRandomAccessFileAppender;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.NullConfiguration;
 import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.core.util.CronExpression;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -70,6 +74,30 @@ class CronTriggeringPolicyTest {
     @Test
     void testBuilderOnce() {
         testBuilder();
+    }
+
+    /**
+     * Without a {@code fileName} the appender writes directly to the file its pattern resolves to.
+     * That file covers the whole rollover period, so it must be named after the period's start
+     * rather than after the moment the appender happened to start. Otherwise a restart later in
+     * the period opens a second file for a period that is supposed to have only one.
+     */
+    @Test
+    void testDirectWriteFileNameUsesPeriodStart() throws Exception {
+        final String schedule = "0 0 0 ? * SUN";
+        // @formatter:off
+        final RollingFileAppender raf = RollingFileAppender.newBuilder()
+                .setName("test5")
+                .setFilePattern("target/testcmd5.log-%d{yyyyMMdd}")
+                .setPolicy(CronTriggeringPolicy.createPolicy(configuration, Boolean.FALSE.toString(), schedule))
+                .setConfiguration(configuration)
+                .build();
+        // @formatter:on
+        assertNotNull(raf);
+
+        final Date periodStart = new CronExpression(schedule).getPrevFireTime(new Date());
+        final String expected = "target/testcmd5.log-" + new SimpleDateFormat("yyyyMMdd").format(periodStart);
+        assertEquals(expected, raf.getManager().getFileName());
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/CronTriggeringPolicy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/CronTriggeringPolicy.java
@@ -150,7 +150,9 @@ public final class CronTriggeringPolicy extends AbstractTriggeringPolicy {
     private void rollover() {
         // If possible, use the time rollover was supposed to occur, not the actual time.
         final Date rollTime = future != null ? future.getFireTime() : new Date();
-        manager.rollover(cronExpression.getPrevFireTime(rollTime), lastRollDate);
+        // The file being rolled covers the period that ends at `rollTime`, so it is named after
+        // that period's start. The file replacing it opens the period beginning at `rollTime`.
+        manager.rollover(cronExpression.getPrevFireTime(rollTime), rollTime);
         if (future != null) {
             lastRollDate = future.getFireTime();
         }

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DirectWriteRolloverStrategy.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/rolling/DirectWriteRolloverStrategy.java
@@ -390,8 +390,10 @@ public class DirectWriteRolloverStrategy extends AbstractRolloverStrategy implem
             final SortedMap<Integer, Path> eligibleFiles = getEligibleFiles(manager);
             final int fileIndex = eligibleFiles.size() > 0 ? (nextIndex > 0 ? nextIndex : eligibleFiles.lastKey()) : 1;
             final StringBuilder buf = new StringBuilder(255);
-            // LOG4J2-3339 - Always use the current time for new direct write files.
-            manager.getPatternProcessor().setCurrentFileTime(System.currentTimeMillis());
+            // Name the file after the start of the rollover period it belongs to, which the
+            // triggering policy records as the pattern processor's current file time. Policies
+            // that do not track a period leave that value at 0, and `formatFileName()` then
+            // falls back to the current time on its own.
             manager.getPatternProcessor().formatFileName(strSubstitutor, buf, true, fileIndex);
             final int suffixLength = suffixLength(buf.toString());
             final String name = suffixLength > 0 ? buf.substring(0, buf.length() - suffixLength) : buf.toString();

--- a/src/changelog/.2.x.x/fix_direct_write_cron_current_file_name.xml
+++ b/src/changelog/.2.x.x/fix_direct_write_cron_current_file_name.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <description format="asciidoc">
+        Fix the file a `CronTriggeringPolicy` appender without a `fileName` writes to. The file is now named after
+        the start of the rollover period it covers, instead of after the moment the appender started, so restarting
+        within a period reopens that period's file rather than creating another one. Note that this changes the
+        names of direct write files for such appenders.
+    </description>
+</entry>

--- a/src/changelog/.2.x.x/fix_direct_write_cron_current_file_name.xml
+++ b/src/changelog/.2.x.x/fix_direct_write_cron_current_file_name.xml
@@ -5,6 +5,7 @@
            https://logging.apache.org/xml/ns
            https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
+    <issue id="4227" link="https://github.com/apache/logging-log4j2/pull/4227"/>
     <description format="asciidoc">
         Fix the file a `CronTriggeringPolicy` appender without a `fileName` writes to. The file is now named after
         the start of the rollover period it covers, instead of after the moment the appender started, so restarting


### PR DESCRIPTION
**This changes the names of direct write files for cron based appenders.** That is the point of the change, but it is user visible on upgrade, so it deserves a decision rather than a rubber stamp. Details below.

An appender configured without a `fileName` writes directly to the file its pattern resolves to. That file covers a whole rollover period, but it is currently named after the moment the appender started rather than after the period it covers.

With a weekly schedule and a day-granularity pattern:

```xml
<RollingFile name="errorLogAppender" filePattern="${LOG_DIR}/error.log-%d{yyyyMMdd}">
    <PatternLayout pattern="%m%n"/>
    <CronTriggeringPolicy schedule="0 0 0 ? * SUN" evaluateOnStartup="true"/>
</RollingFile>
```

starting on Tuesday 2026-07-28 writes to `error.log-20260728`. The period began on Sunday 2026-07-26, so a restart on Wednesday opens `error.log-20260729` instead of continuing the same file. A week with daily restarts leaves seven files where the schedule implies one, and rollover only ever closes out whichever fragment happens to be current.

## Cause

`CronTriggeringPolicy.initialize()` computes the period start and records it correctly:

```java
final Date lastRegularRoll = cronExpression.getPrevFireTime(new Date());
aManager.getPatternProcessor().setCurrentFileTime(lastRegularRoll.getTime());
```

`DirectWriteRolloverStrategy.getCurrentFileName()` then discards it:

```java
// LOG4J2-3339 - Always use the current time for new direct write files.
manager.getPatternProcessor().setCurrentFileTime(System.currentTimeMillis());
```

That override compensates for a different problem. `CronTriggeringPolicy.rollover()` passes `lastRollDate`, the *previous* period's start, as the new file's time:

```java
manager.rollover(cronExpression.getPrevFireTime(rollTime), lastRollDate);
```

and `RollingFileManager.rollover(prevFileTime, prevRollTime)` assigns that to the current file time, so each replacement file was named after the file just rolled. Substituting the current time hid this, and works only because at the instant of a rollover "now" is approximately the new period's start. At startup "now" is an arbitrary point inside the period, which is where it breaks.

## Fix

Pass the roll time rather than the previous roll date, so the replacement file is named after the period it opens, and let `getCurrentFileName()` use the period start the policy already recorded.

Blast radius is limited to policies that track a period. `PatternProcessor.formatFileName()` already falls back to the current time when the current file time is 0:

```java
final long time = useCurrentTime
        ? currentFileTime != 0 ? currentFileTime : System.currentTimeMillis()
        : prevFileTime != 0 ? prevFileTime : System.currentTimeMillis();
```

and `PatternProcessor.updateTime()` resets it to 0, so `TimeBasedTriggeringPolicy`, which never sets it, keeps its existing behaviour unchanged. Only cron, which knows its period start, behaves differently.

## Compatibility

Direct write files for cron based appenders change name, from the start time of the process to the start of the rollover period. For the example above that is `error.log-20260726` rather than `error.log-20260728`. Existing files are untouched and are neither read nor renamed; a restart after upgrading simply begins writing to the period's file. The changelog entry calls this out.

Appenders configured *with* a `fileName` are unaffected, since `getCurrentFileName()` is only consulted on the direct write path.

## Testing

`CronTriggeringPolicyTest#testDirectWriteFileNameUsesPeriodStart` asserts the manager's file name matches the period start computed independently from the same cron expression. Against `2.x` without the fix it fails with:

```
expected: <target/testcmd5.log-20260726> but was: <target/testcmd5.log-20260728>
```

`RollingAppenderDirectCronTest`, the regression test added with LOG4J2-3339, still passes; it asserts that a rolled file's name matches the timestamp of its first line, which this change preserves.

`./mvnw verify` passes across all 41 modules: 11088 tests, 0 failures, 0 errors, 40 pre-existing environment-conditional skips.

## Relationship to the other PR

Independent of the startup-delay fix in the companion PR; the two touch different code paths and can merge in either order. They surfaced from the same investigation, which is why both concern `CronTriggeringPolicy`.

## Checklist

* [x] Based on `2.x`
* [x] `./mvnw verify` succeeds
* [x] Changelog entry in `src/changelog/.2.x.x`
* [x] Tests are provided
