### PR TITLE
Fix `Log4j1SyslogLayout` builder javadoc attributes

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/layout/Log4j1SyslogLayout.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/layout/Log4j1SyslogLayout.java
@@ -49,14 +49,19 @@ import org.apache.logging.log4j.util.Chars;
 public final class Log4j1SyslogLayout extends AbstractStringLayout {
 
     /**
-     * Builds a SyslogLayout.
+     * Builds a {@link Log4j1SyslogLayout}.
      * <p>The main arguments are</p>
      * <ul>
      * <li>facility: The Facility is used to try to classify the message.</li>
-     * <li>includeNewLine: If true a newline will be appended to the result.</li>
-     * <li>escapeNL: Pattern to use for replacing newlines.</li>
+     * <li>facilityPrinting: If true the facility name is included in the message.</li>
+     * <li>header: If true a header with local host name and timestamp is included.</li>
+     * <li>messageLayout: Optional layout used to render the message body.</li>
      * <li>charset: The character set.</li>
      * </ul>
+     * <p>
+     * Unlike {@link org.apache.logging.log4j.core.layout.SyslogLayout}, this layout does not support
+     * {@code includeNewLine} or {@code escapeNL} options.
+     * </p>
      * @param <B> the builder type
      */
     public static class Builder<B extends Builder<B>> extends AbstractStringLayout.Builder<B>


### PR DESCRIPTION
## What

`Log4j1SyslogLayout.Builder` javadoc listed `includeNewLine` and `escapeNL`, which were copy-pasted from `org.apache.logging.log4j.core.layout.SyslogLayout` and are not implemented on this layout.

## Changes

- Document the builder attributes that actually exist: `facility`, `facilityPrinting`, `header`, `messageLayout`, and `charset`
- Note that `includeNewLine` / `escapeNL` are not supported on this layout

## Test

- Source review against builder fields and `toSerializable()`
- Module previously compiled `Log4j1SyslogLayout` after the edit (javadoc-only change)

Fixes #4237