### PR TITLE
Port `MessageFactory`-namespaced logger registry from `2.x`

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/LoggerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/LoggerTest.java
@@ -52,6 +52,7 @@ import org.apache.logging.log4j.message.ReusableMessageFactory;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.message.StringFormatterMessageFactory;
 import org.apache.logging.log4j.message.StructuredDataMessage;
+import org.apache.logging.log4j.status.StatusLogger;
 import org.awaitility.Awaitility;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.Tag;
@@ -121,7 +122,7 @@ public class LoggerTest {
 
     @Test
     public void builder() {
-        final int currentLine = 124;
+        final int currentLine = 125;
         logger.atDebug().withLocation().log("Hello");
         final Marker marker = MarkerManager.getMarker("test");
         logger.atError().withMarker(marker).log("Hello {}", "John");
@@ -417,6 +418,17 @@ public class LoggerTest {
         assertEquals(
                 String.format("%,d", Integer.MAX_VALUE),
                 events.get(0).getMessage().getFormattedMessage());
+    }
+
+    @Test
+    public void getLogger_String_MessageFactoryMismatchProducesNoWarning(final TestInfo testInfo) {
+        final String name = testInfo.getTestMethod().map(Method::getName).orElseThrow(AssertionError::new);
+        testMessageFactoryMismatch(name, StringFormatterMessageFactory.INSTANCE, new ReusableMessageFactory());
+        testMessageFactoryMismatch(name + "Null", StringFormatterMessageFactory.INSTANCE, null);
+        final boolean mismatchWarning = StatusLogger.getLogger().getStatusData().stream()
+                .map(data -> data.getMessage().getFormattedMessage())
+                .anyMatch(message -> message.contains("created with the message factory"));
+        assertFalse(mismatchWarning, "The message factory mismatch warning should not be emitted");
     }
 
     @Test

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/LoggerContext.java
@@ -63,13 +63,11 @@ import org.apache.logging.log4j.plugins.di.InstanceFactory;
 import org.apache.logging.log4j.plugins.di.Key;
 import org.apache.logging.log4j.plugins.di.spi.ConfigurableInstanceFactoryPostProcessor;
 import org.apache.logging.log4j.plugins.util.OrderedComparator;
-import org.apache.logging.log4j.spi.ExtendedLogger;
 import org.apache.logging.log4j.spi.LoggerContextFactory;
 import org.apache.logging.log4j.spi.LoggerContextShutdownAware;
 import org.apache.logging.log4j.spi.LoggerContextShutdownEnabled;
 import org.apache.logging.log4j.spi.LoggerRegistry;
 import org.apache.logging.log4j.spi.Terminable;
-import org.apache.logging.log4j.status.StatusLogger;
 import org.apache.logging.log4j.util.Lazy;
 import org.apache.logging.log4j.util.ServiceLoaderUtil;
 import org.jspecify.annotations.Nullable;
@@ -180,38 +178,6 @@ public class LoggerContext extends AbstractLifeCycle
             final String configLocation,
             final ConfigurableInstanceFactory instanceFactory) {
         this(contextName, externalContext, fileToUri(configLocation), instanceFactory);
-    }
-
-    /**
-     * Checks that the message factory a logger was created with is the same as the given messageFactory. If they are
-     * different log a warning to the {@linkplain StatusLogger}. A null MessageFactory translates to the default
-     * MessageFactory.
-     *
-     * @param logger The logger to check
-     * @param messageFactory The message factory to check.
-     */
-    private void checkMessageFactory(final ExtendedLogger logger, final MessageFactory messageFactory) {
-        final String name = logger.getName();
-        final MessageFactory loggerMessageFactory = logger.getMessageFactory();
-        final MessageFactory currentMessageFactory = defaultMessageFactory;
-        if (messageFactory != null && !loggerMessageFactory.equals(messageFactory)) {
-            StatusLogger.getLogger()
-                    .warn(
-                            "The Logger {} was created with the message factory {} and is now requested with the "
-                                    + "message factory {}, which may create log events with unexpected formatting.",
-                            name,
-                            loggerMessageFactory,
-                            messageFactory);
-        } else if (messageFactory == null && loggerMessageFactory != currentMessageFactory) {
-            StatusLogger.getLogger()
-                    .warn(
-                            "The Logger {} was created with the message factory {} and is now requested with a null "
-                                    + "message factory (defaults to {}), which may create log events with unexpected "
-                                    + "formatting.",
-                            name,
-                            loggerMessageFactory,
-                            currentMessageFactory.getClass().getName());
-        }
     }
 
     public PropertyEnvironment getEnvironment() {
@@ -563,19 +529,16 @@ public class LoggerContext extends AbstractLifeCycle
     }
 
     /**
-     * Obtains a Logger from the Context.
+     * Obtains a logger from the context.
      *
-     * @param name The name of the Logger to return.
-     * @param messageFactory The message factory is used only when creating a logger, subsequent use does not change the
-     *            logger but will log a warning if mismatched.
-     * @return The Logger.
+     * @param name a logger name
+     * @param messageFactory a message factory to associate the logger with
+     * @return a logger matching the given name and message factory
      */
     @Override
-    public Logger getLogger(final String name, final MessageFactory messageFactory) {
+    public Logger getLogger(final String name, final @Nullable MessageFactory messageFactory) {
         final MessageFactory actualMessageFactory = messageFactory != null ? messageFactory : defaultMessageFactory;
-        final Logger logger = loggerRegistry.computeIfAbsent(name, actualMessageFactory, this::newLogger);
-        checkMessageFactory(logger, actualMessageFactory);
-        return logger;
+        return loggerRegistry.computeIfAbsent(name, actualMessageFactory, this::newLogger);
     }
 
     /**
@@ -617,7 +580,7 @@ public class LoggerContext extends AbstractLifeCycle
      * @return True if the Logger exists, false otherwise.
      */
     @Override
-    public boolean hasLogger(final String name, final MessageFactory messageFactory) {
+    public boolean hasLogger(final String name, final @Nullable MessageFactory messageFactory) {
         return loggerRegistry.hasLogger(name, messageFactory);
     }
 


### PR DESCRIPTION
## Summary

Completes the port of #2962 by removing the now-dead `checkMessageFactory` machinery from `LoggerContext`.
The MessageFactory-namespaced `InternalLoggerRegistry` itself was already ported in #4157. This PR removes the leftover core code that only existed to warn about message-factory mismatches under the old name-keyed registry.

## Why `checkMessageFactory` was dead code

The `LoggerRegistry` now keys loggers by **(name, message factory)**. As a result:

- `computeIfAbsent(name, mf, newLogger)` always returns a logger whose message factory matches the requested one, so the warning branch `!loggerMessageFactory.equals(messageFactory)` could never fire.
- `getLogger` normalizes a `null` message factory to the default *before* reaching the registry, so the null-mismatch branch was unreachable as well.

The behavior this method guarded against — returning an existing logger created with a *different* message factory — no longer exists: a request with a different factory now returns a distinct, correctly-bound logger instead of the old logger plus a warning. `2.x` removed this dead method in PR #2936, the same change that introduced the namespaced registry there; this PR mirrors that change in the `3.x`, keeping it a faithful port.

**Note on registry placement:** as suggested in https://github.com/apache/logging-log4j2/issues/2962#issuecomment-2469688771, the namespaced registry was kept out of `log4j-api`; it lives in `log4j-core` (mirroring `2.x`) rather than `log4j-kit`, since kit sits below core and can't reference the core `Logger` type.

## Changes

1. **`log4j-core` — `LoggerContext`**
   - Removed private `checkMessageFactory(ExtendedLogger, MessageFactory)` and its call site in `getLogger(String, MessageFactory)`.
   - Removed the now-unused `ExtendedLogger` and `StatusLogger` imports.
   - Added `@Nullable` to the message-factory parameter of `getLogger(String, MessageFactory)` and `hasLogger(String, MessageFactory)`; refreshed the `getLogger` Javadoc to describe the message-factory-matching semantics.
2. **`log4j-core-test` — `LoggerTest`**
   - Added regression test `getLogger_String_MessageFactoryMismatchProducesNoWarning`: re-requests a logger with a different and with a `null` message factory, and asserts no "created with the message factory" status warning is emitted.
   - Kept the `builder` hardcoded source-line constant in sync with the file layout.

Closes #2962