### PR TITLE
fix: treat null parameters as empty in CsvParameterLayout

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/CsvParameterLayoutTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/layout/CsvParameterLayoutTest.java
@@ -29,11 +29,14 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.categories.Layouts;
 import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.message.ObjectArrayMessage;
+import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.test.junit.ThreadContextRule;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -168,6 +171,19 @@ public class CsvParameterLayoutTest {
     public void testLayoutTab() throws Exception {
         final Logger root = this.init.getRootLogger();
         testLayoutNormalApi(root, CsvParameterLayout.createLayout(CSVFormat.TDF), true);
+    }
+
+    @Test
+    public void testNullParametersProduceEmptyRecord() {
+        // SimpleMessage#getParameters() returns null; must not NPE (GH-4243)
+        final AbstractCsvLayout layout = CsvParameterLayout.createDefaultLayout();
+        final LogEvent event = Log4jLogEvent.newBuilder()
+                .setLoggerName("test")
+                .setLevel(Level.INFO)
+                .setMessage(new SimpleMessage("plain text without parameters"))
+                .build();
+        final String result = layout.toSerializable(event);
+        Assert.assertEquals(layout.getFormat().getRecordSeparator(), result);
     }
 
     @Test

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/CsvParameterLayout.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/layout/CsvParameterLayout.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginConfiguration;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.status.StatusLogger;
+import org.apache.logging.log4j.util.Constants;
 
 /**
  * A Comma-Separated Value (CSV) layout to log event parameters.
@@ -95,7 +96,7 @@ public class CsvParameterLayout extends AbstractCsvLayout {
         final Object[] parameters = message.getParameters();
         final StringBuilder buffer = getStringBuilder();
         try {
-            getFormat().printRecord(buffer, parameters);
+            getFormat().printRecord(buffer, parameters == null ? Constants.EMPTY_OBJECT_ARRAY : parameters);
             return buffer.toString();
         } catch (final IOException e) {
             StatusLogger.getLogger().error(message, e);

--- a/src/changelog/.2.x.x/4243_fix_CsvParameterLayout_null_parameters.xml
+++ b/src/changelog/.2.x.x/4243_fix_CsvParameterLayout_null_parameters.xml
@@ -6,6 +6,7 @@
            https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
   <issue id="4243" link="https://github.com/apache/logging-log4j2/issues/4243"/>
+  <issue id="4245" link="https://github.com/apache/logging-log4j2/pull/4245"/>
   <description format="asciidoc">
     Fix `NullPointerException` in `CsvParameterLayout` when a log event has no parameters (for example `SimpleMessage`).
   </description>

--- a/src/changelog/.2.x.x/4243_fix_CsvParameterLayout_null_parameters.xml
+++ b/src/changelog/.2.x.x/4243_fix_CsvParameterLayout_null_parameters.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="4243" link="https://github.com/apache/logging-log4j2/issues/4243"/>
+  <description format="asciidoc">
+    Fix `NullPointerException` in `CsvParameterLayout` when a log event has no parameters (for example `SimpleMessage`).
+  </description>
+</entry>


### PR DESCRIPTION
Fixes #4243

## Description

`CsvParameterLayout.toSerializable` passes `Message.getParameters()` to `CSVFormat.printRecord` without a null check. Parameter-less messages such as `SimpleMessage` return `null` from `getParameters()`, and Commons CSV throws `NullPointerException` when the values array is null. Only `IOException` is caught, so the NPE escapes to the appender and the event is lost.

This change treats a null parameter array as `Constants.EMPTY_OBJECT_ARRAY`, which produces a well-formed empty CSV record (record separator only) and matches the zero-length parameters case.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds ([the build instructions](https://logging.apache.org/log4j/2.x/development.html#building))
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests are provided

## Testing

- JDK 17 (branch enforcer requires `[17,18)`)
- `./mvnw test -pl :log4j-core-test -am -Dtest=CsvParameterLayoutTest#testNullParametersProduceEmptyRecord -Dsurefire.failIfNoSpecifiedTests=false` — **2/2 pass**
- Related existing layout tests in the same class (`testLayoutDefaultNormal`, `testLayoutDefaultObjectArrayMessage`, `testLayoutTab`, charset/content-type tests) also pass
- Spotless check clean on `:log4j-core` and `:log4j-core-test`