### PR TITLE
Default `protocol` to UDP in the Log4j 1 `SyslogAppender` builder

### DIFF
--- a/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/SyslogAppenderBuilder.java
+++ b/log4j-1.2-api/src/main/java/org/apache/log4j/builders/appender/SyslogAppenderBuilder.java
@@ -77,7 +77,7 @@ public class SyslogAppenderBuilder extends AbstractBuilder implements AppenderBu
         final AtomicReference<String> facility = new AtomicReference<>();
         final AtomicReference<String> level = new AtomicReference<>();
         final AtomicReference<String> host = new AtomicReference<>();
-        final AtomicReference<Protocol> protocol = new AtomicReference<>(Protocol.TCP);
+        final AtomicReference<Protocol> protocol = new AtomicReference<>(Protocol.UDP);
         final AtomicBoolean header = new AtomicBoolean(false);
         final AtomicBoolean facilityPrinting = new AtomicBoolean(false);
         forEachElement(appenderElement.getChildNodes(), currentElement -> {
@@ -100,7 +100,7 @@ public class SyslogAppenderBuilder extends AbstractBuilder implements AppenderBu
                             set(HEADER_PARAM, currentElement, header);
                             break;
                         case PROTOCOL_PARAM:
-                            protocol.set(Protocol.valueOf(getValueAttribute(currentElement, Protocol.TCP.name())));
+                            protocol.set(Protocol.valueOf(getValueAttribute(currentElement, Protocol.UDP.name())));
                             break;
                         case SYSLOG_HOST_PARAM:
                             set(SYSLOG_HOST_PARAM, currentElement, host);
@@ -140,7 +140,7 @@ public class SyslogAppenderBuilder extends AbstractBuilder implements AppenderBu
         final String facility = getProperty(FACILITY_PARAM, DEFAULT_FACILITY);
         final boolean facilityPrinting = getBooleanProperty(FACILITY_PRINTING_PARAM, false);
         final boolean header = getBooleanProperty(HEADER_PARAM, false);
-        final String protocol = getProperty(PROTOCOL_PARAM, Protocol.TCP.name());
+        final String protocol = getProperty(PROTOCOL_PARAM, Protocol.UDP.name());
         final String syslogHost = getProperty(SYSLOG_HOST_PARAM, DEFAULT_HOST + ":" + DEFAULT_PORT);
 
         return createAppender(

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderConfigurationTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderConfigurationTest.java
@@ -90,7 +90,7 @@ class SyslogAppenderConfigurationTest {
 
     @Test
     void testPropertiesProtocolDefault() throws Exception {
-        checkProtocolPropertiesConfig(Protocol.TCP, "target/test-classes/log4j1-syslog-protocol-default.properties");
+        checkProtocolPropertiesConfig(Protocol.UDP, "target/test-classes/log4j1-syslog-protocol-default.properties");
     }
 
     @Test
@@ -105,7 +105,7 @@ class SyslogAppenderConfigurationTest {
 
     @Test
     void testXmlProtocolDefault() throws Exception {
-        checkProtocolXmlConfig(Protocol.TCP, "target/test-classes/log4j1-syslog.xml");
+        checkProtocolXmlConfig(Protocol.UDP, "target/test-classes/log4j1-syslog.xml");
     }
 
     @Test

--- a/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderTest.java
+++ b/log4j-1.2-api/src/test/java/org/apache/log4j/config/SyslogAppenderTest.java
@@ -36,7 +36,8 @@ class SyslogAppenderTest {
 
     @BeforeAll
     static void beforeAll() throws IOException {
-        initTCPTestEnvironment(null);
+        syslogServer = MockSyslogServerFactory.createUDPSyslogServer();
+        syslogServer.start();
         System.setProperty("syslog.port", Integer.toString(syslogServer.getLocalPort()));
         System.setProperty(
                 ConfigurationFactory.LOG4J1_CONFIGURATION_FILE_PROPERTY, "target/test-classes/log4j1-syslog.xml");
@@ -61,10 +62,5 @@ class SyslogAppenderTest {
             }
         }
         assertThat(messages, hasSize(1));
-    }
-
-    protected static void initTCPTestEnvironment(final String messageFormat) throws IOException {
-        syslogServer = MockSyslogServerFactory.createTCPSyslogServer();
-        syslogServer.start();
     }
 }

--- a/src/changelog/.2.x.x/4238_default_log4j1_syslog_protocol_to_udp.xml
+++ b/src/changelog/.2.x.x/4238_default_log4j1_syslog_protocol_to_udp.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <issue id="4238" link="https://github.com/apache/logging-log4j2/issues/4238"/>
+    <description format="asciidoc">
+        Default the Log4j 1 `SyslogAppender` bridge to UDP, matching Log4j 1 behavior.
+    </description>
+</entry>

--- a/src/site/antora/modules/ROOT/pages/migrate-from-log4j1.adoc
+++ b/src/site/antora/modules/ROOT/pages/migrate-from-log4j1.adoc
@@ -386,6 +386,8 @@ Log4j 2 contains an equivalent for most Log4j 1 appenders:
 | {log4j1-url}/apidocs/org/apache/log4j/net/SyslogAppender.html[org.apache.log4j.net.SyslogAppender]
 | xref:manual/appenders/network.adoc#SyslogAppender[Syslog]
 | Does not support custom layouts.
+The `protocol` parameter is a `log4j-1.2-api` extension and defaults to `UDP`, matching Log4j 1 behavior.
+Other values are not recommended because `Log4j1SyslogLayout` does not escape newline characters for stream framing.
 
 | {log4j1-url}/apidocs/org/apache/log4j/rewrite/RewriteAppender.html[org.apache.log4j.rewrite.RewriteAppender]
 | xref:manual/appenders/delegating.adoc#RewriteAppender[Rewrite]


### PR DESCRIPTION
Fixes #4238.

Defaults the Log4j 1 `SyslogAppender` bridge protocol to UDP for XML and properties configurations, matching Log4j 1 behavior. Explicit protocol values remain unchanged.

Also documents `protocol` as a `log4j-1.2-api` extension and why stream transports are not recommended with `Log4j1SyslogLayout`.

Verification:
- `./mvnw verify`