### PR TITLE
Fix NPE in PluginElementVisitor when handling unresolved child elements

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/config/properties/PropertiesConfigurationTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,7 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LifeCycle;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.config.Property;
@@ -39,6 +41,9 @@ import org.apache.logging.log4j.core.filter.ThresholdFilter;
 import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.logging.log4j.core.test.junit.Named;
+import org.apache.logging.log4j.status.StatusData;
+import org.apache.logging.log4j.test.ListStatusListener;
+import org.apache.logging.log4j.test.junit.UsingStatusListener;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
@@ -167,5 +172,26 @@ class PropertiesConfigurationTest {
         assertEquals(2, firstEvents.size());
         final List<LogEvent> thirdEvents = third.getEvents();
         assertEquals(1, thirdEvents.size());
+    }
+
+    @Test
+    @UsingStatusListener
+    @LoggerContextSource("log4j2-unresolved-layout.properties")
+    void testUnresolvedLayoutDoesNotFailConfiguration(final Configuration config, final ListStatusListener listener) {
+        assertEquals(LifeCycle.State.STARTED, config.getState());
+        assertTrue(
+                listener.findStatusData(Level.ERROR).anyMatch(data -> data.getMessage()
+                        .getFormattedMessage()
+                        .contains("Unable to locate plugin for ThisLayoutDoesNotExist")),
+                "Unresolved layout was not reported");
+        assertTrue(
+                listener.getStatusData()
+                        .map(StatusData::getThrowable)
+                        .noneMatch(NullPointerException.class::isInstance),
+                "Unresolved layout caused a NullPointerException");
+        final Appender appender = config.getAppender("StdOut");
+        assertNotNull(appender, "Appender was not created");
+        assertInstanceOf(ConsoleAppender.class, appender);
+        assertNotNull(appender.getLayout(), "No default layout");
     }
 }

--- a/log4j-core-test/src/test/resources/log4j2-unresolved-layout.properties
+++ b/log4j-core-test/src/test/resources/log4j2-unresolved-layout.properties
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+status = OFF
+
+appender.Stdout.type = Console
+appender.Stdout.name = StdOut
+appender.Stdout.target = SYSTEM_OUT
+appender.Stdout.layout.type = ThisLayoutDoesNotExist
+
+rootLogger.appenderRef.console.ref = StdOut
+rootLogger.level = ERROR

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginElementVisitor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginElementVisitor.java
@@ -47,6 +47,10 @@ public class PluginElementVisitor extends AbstractPluginVisitor<PluginElement> {
             boolean first = true;
             for (final Node child : node.getChildren()) {
                 final PluginType<?> childType = child.getType();
+                if (childType == null) {
+                    LOGGER.debug("Ignoring unresolved element {} in {}.", child.getName(), node.getName());
+                    continue;
+                }
                 if (name.equalsIgnoreCase(childType.getElementName())
                         || this.conversionType.isAssignableFrom(childType.getPluginClass())) {
                     if (!first) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginElementVisitor.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/config/plugins/visitors/PluginElementVisitor.java
@@ -48,7 +48,7 @@ public class PluginElementVisitor extends AbstractPluginVisitor<PluginElement> {
             for (final Node child : node.getChildren()) {
                 final PluginType<?> childType = child.getType();
                 if (childType == null) {
-                    LOGGER.debug("Ignoring unresolved element {} in {}.", child.getName(), node.getName());
+                    LOGGER.error("Ignoring unresolved element {} in {}.", child.getName(), node.getName());
                     continue;
                 }
                 if (name.equalsIgnoreCase(childType.getElementName())

--- a/src/changelog/.2.x.x/4248_fix_plugin_element_visitor_array_npe.xml
+++ b/src/changelog/.2.x.x/4248_fix_plugin_element_visitor_array_npe.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="4248" link="https://github.com/apache/logging-log4j2/issues/4248"/>
+  <issue id="4250" link="https://github.com/apache/logging-log4j2/pull/4250"/>
+  <description format="asciidoc">
+    Fix `NPE` while injecting array elements of a plugin that has an unresolved child element.
+  </description>
+</entry>


### PR DESCRIPTION
Fixes #4248  `NPE` while injecting array elements of a plugin that has an unresolved child element.
