### PR TITLE
Honor spring.cloud.config.watch.enabled on Log4j2EventListener

### DIFF
--- a/log4j-spring-cloud-config-client/src/main/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2EventListener.java
+++ b/log4j-spring-cloud-config-client/src/main/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2EventListener.java
@@ -20,17 +20,48 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
 
 @Component
 @ConditionalOnProperty(value = "spring.cloud.config.watch.enabled")
-public class Log4j2EventListener implements ApplicationListener<EnvironmentChangeEvent> {
+public class Log4j2EventListener implements ApplicationListener<EnvironmentChangeEvent>, EnvironmentAware {
     private static Logger LOGGER = LogManager.getLogger(Log4j2EventListener.class);
+    private Environment environment;
+
+    @Override
+    public void setEnvironment(final Environment environment) {
+        this.environment = environment;
+    }
 
     @Override
     public void onApplicationEvent(final EnvironmentChangeEvent environmentChangeEvent) {
+        if (!isWatchEnabled(environmentChangeEvent)) {
+            LOGGER.debug("Ignoring environment change event; spring.cloud.config.watch.enabled is false");
+            return;
+        }
         LOGGER.debug("Application change event triggered");
         WatchEventManager.publishEvent();
+    }
+
+    /**
+     * {@code spring.factories} constructs this listener outside the bean factory, so
+     * {@code @ConditionalOnProperty} never applies. Honor the same property here.
+     */
+    private boolean isWatchEnabled(final EnvironmentChangeEvent event) {
+        Environment env = this.environment;
+        if (env == null) {
+            final Object source = event.getSource();
+            if (source instanceof ApplicationContext) {
+                env = ((ApplicationContext) source).getEnvironment();
+            }
+        }
+        if (env == null) {
+            return true;
+        }
+        return !Boolean.FALSE.equals(env.getProperty("spring.cloud.config.watch.enabled", Boolean.class));
     }
 }

--- a/log4j-spring-cloud-config-client/src/test/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2EventListenerTest.java
+++ b/log4j-spring-cloud-config-client/src/test/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2EventListenerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.logging.log4j.spring.cloud.config.client;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -35,6 +36,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.context.environment.EnvironmentChangeEvent;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**
@@ -67,6 +70,26 @@ public class Log4j2EventListenerTest {
                 .watch(source, new TestWatcher(count));
         publisher.publishEvent(new EnvironmentChangeEvent(new HashSet<>()));
         assertTrue(count.get() > 0);
+    }
+
+    @Test
+    public void doesNotReloadWhenWatchDisabled() {
+        final MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("spring.cloud.config.watch.enabled", "false");
+        try (GenericApplicationContext context = new GenericApplicationContext()) {
+            context.setEnvironment(environment);
+            context.refresh();
+            final AtomicInteger count = new AtomicInteger(0);
+            final Source source = new Source(new File("test.java"));
+            loggerContextRule
+                    .getLoggerContext()
+                    .getConfiguration()
+                    .getWatchManager()
+                    .watch(source, new TestWatcher(count));
+            new Log4j2EventListener()
+                    .onApplicationEvent(new EnvironmentChangeEvent(context, new HashSet<>()));
+            assertEquals(0, count.get());
+        }
     }
 
     private static class TestWatcher implements Watcher {

--- a/src/changelog/.2.x.x/4244_honor_watch_enabled_on_event_listener.xml
+++ b/src/changelog/.2.x.x/4244_honor_watch_enabled_on_event_listener.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="4244" link="https://github.com/apache/logging-log4j2/issues/4244"/>
+  <description format="asciidoc">
+    Honor `spring.cloud.config.watch.enabled` in `Log4j2EventListener` when it is created from `spring.factories`.
+  </description>
+</entry>


### PR DESCRIPTION
`Log4j2EventListener` is also created from `spring.factories`, so `@ConditionalOnProperty` never applies and `spring.cloud.config.watch.enabled=false` does nothing.

I check that property in `onApplicationEvent` (via `EnvironmentAware` or the event source context). Explicit `false` skips the reload. Missing or true keeps the old behavior.

Fixes #4244

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds ([the build instructions](https://logging.apache.org/log4j/2.x/development.html#building))
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests are provided
