### PR TITLE
Fix date format from `mm` to `MM` in Pattern Layout docs

### DIFF
--- a/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/pattern-layout.adoc
@@ -464,7 +464,7 @@ You can also define custom date formats, see following examples:
 |%d{HH:mm:ss,SSS}
 |14:34:02,123
 
-|%d{yyyy-mm-dd'T'HH:mm:ss.SSS'Z'}\{UTC}
+|%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}\{UTC}
 |2012-11-02T14:34:02.123Z
 
 |%d\{dd-MMMM-yyyy}\{UTC}\{de-DE}


### PR DESCRIPTION
In Pattern Layout docs there is a typo: 'mm' is used for month and it should be 'MM', since lower case stands for minutes.

https://logging.apache.org/log4j/2.x/manual/pattern-layout.html

<img width="1423" height="550" alt="image" src="https://github.com/user-attachments/assets/3e90e88a-7bca-4fed-8d72-bd980c9b617c" />
