### PR TITLE
Strip CR/LF from SMTP subjects derived from event data

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/net/MimeMessageBuilderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/net/MimeMessageBuilderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.net;
+
+import java.util.Properties;
+
+import javax.mail.Session;
+import javax.mail.internet.MimeMessage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests {@link MimeMessageBuilder} header sanitization.
+ */
+class MimeMessageBuilderTest {
+
+    @Test
+    void testSubjectWithoutLineBreaksIsUnchanged() throws Exception {
+        MimeMessageBuilder builder = new MimeMessageBuilder(Session.getInstance(new Properties()));
+        MimeMessage message = builder.setSubject("Error in app").build();
+        assertThat(message.getSubject()).isEqualTo("Error in app");
+    }
+
+    @Test
+    void testSubjectLineBreaksAreStripped() throws Exception {
+        MimeMessageBuilder builder = new MimeMessageBuilder(Session.getInstance(new Properties()));
+        MimeMessage message = builder.setSubject("Error\r\nBcc: victim@example.com").build();
+        // CR and LF are stripped, so the remainder is inert text within the single
+        // subject value and cannot start a new header.
+        assertThat(message.getSubject())
+                .doesNotContain("\r")
+                .doesNotContain("\n");
+    }
+}

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/MimeMessageBuilder.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/MimeMessageBuilder.java
@@ -71,9 +71,17 @@ public class MimeMessageBuilder implements Builder<MimeMessage> {
 
     public MimeMessageBuilder setSubject(final String subject) throws MessagingException {
         if (subject != null) {
-            message.setSubject(subject, StandardCharsets.UTF_8.name());
+            message.setSubject(sanitizeHeader(subject), StandardCharsets.UTF_8.name());
         }
         return this;
+    }
+
+    /**
+     * Removes CR and LF characters from the value of a header set from (possibly
+     * attacker-controlled) event data, to prevent header injection.
+     */
+    private static String sanitizeHeader(final String value) {
+        return value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0 ? value.replaceAll("[\\r\\n]", " ") : value;
     }
 
     /**

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SmtpManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/net/SmtpManager.java
@@ -259,9 +259,17 @@ public class SmtpManager extends MailManager {
         synchronized (msg) {
             msg.setContent(mp);
             msg.setSentDate(new Date());
-            msg.setSubject(subject);
+            msg.setSubject(sanitizeHeader(subject));
             Transport.send(msg);
         }
+    }
+
+    /**
+     * Removes CR and LF characters from the value of a header set from (possibly
+     * attacker-controlled) event data, to prevent header injection.
+     */
+    private static String sanitizeHeader(final String value) {
+        return value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0 ? value.replaceAll("[\\r\\n]", " ") : value;
     }
 
     private synchronized void connect(final LogEvent appendEvent) {

--- a/log4j-jakarta-smtp/src/main/java/org/apache/logging/log4j/smtp/MimeMessageBuilder.java
+++ b/log4j-jakarta-smtp/src/main/java/org/apache/logging/log4j/smtp/MimeMessageBuilder.java
@@ -71,9 +71,17 @@ public class MimeMessageBuilder implements Builder<MimeMessage> {
 
     public MimeMessageBuilder setSubject(final String subject) throws MessagingException {
         if (subject != null) {
-            message.setSubject(subject, StandardCharsets.UTF_8.name());
+            message.setSubject(sanitizeHeader(subject), StandardCharsets.UTF_8.name());
         }
         return this;
+    }
+
+    /**
+     * Removes CR and LF characters from the value of a header set from (possibly
+     * attacker-controlled) event data, to prevent header injection.
+     */
+    private static String sanitizeHeader(final String value) {
+        return value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0 ? value.replaceAll("[\\r\\n]", " ") : value;
     }
 
     @Override

--- a/log4j-jakarta-smtp/src/main/java/org/apache/logging/log4j/smtp/SmtpManager.java
+++ b/log4j-jakarta-smtp/src/main/java/org/apache/logging/log4j/smtp/SmtpManager.java
@@ -212,9 +212,17 @@ public class SmtpManager extends MailManager {
         synchronized (msg) {
             msg.setContent(mp);
             msg.setSentDate(new Date());
-            msg.setSubject(subject);
+            msg.setSubject(sanitizeHeader(subject));
             Transport.send(msg);
         }
+    }
+
+    /**
+     * Removes CR and LF characters from the value of a header set from (possibly
+     * attacker-controlled) event data, to prevent header injection.
+     */
+    private static String sanitizeHeader(final String value) {
+        return value.indexOf('\r') >= 0 || value.indexOf('\n') >= 0 ? value.replaceAll("[\\r\\n]", " ") : value;
     }
 
     private synchronized void connect(final LogEvent appendEvent) {


### PR DESCRIPTION
## Description
The `SmtpAppender` subject is produced by a PatternLayout serializer and commonly embeds event data (message, MDC, throwable). CR/LF sequences in that data currently flow into `MimeMessage.setSubject` unsanitized, allowing mail header injection when an attacker can influence logged content — for example a logged username or error message containing `\r\nBcc: attacker@example.com` results in an injected `Bcc` header relayed through the application's SMTP credentials.

This strips CR and LF from the subject in:
- `MimeMessageBuilder.setSubject` (`log4j-core` and `log4j-jakarta-smtp`)
- the multipart send paths of both `SmtpManager` variants

## Testing
`MimeMessageBuilderTest` (new): asserts a plain subject round-trips unchanged, and a subject containing CRLF has all CR/LF removed (making the remainder inert text within the single subject value). Both pass; no other behavior changes.