### PR TITLE
Fix predefined ANSI styles in JAnsiTextRenderer

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/JAnsiTextRendererTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/pattern/JAnsiTextRendererTest.java
@@ -41,7 +41,13 @@ class JAnsiTextRendererTest {
                         "\u001b[37mkey\u001b[m = \u001b[36;1msome value\u001b[m"),
                 // Return broken escapes as is
                 Arguments.of("", "Hello @|crazy|@ world!", "Hello @|crazy|@ world!"),
-                Arguments.of("", "Hello @|world!", "Hello @|world!"));
+                Arguments.of("", "Hello @|world!", "Hello @|world!"),
+                // Predefined Style=Spock: Name is BG_RED + WHITE
+                Arguments.of("Style=Spock", "@|Name XYZ|@", "\u001b[41;37mXYZ\u001b[m"),
+                // Predefined Style=Kirk: Name is BG_RED + YELLOW + BOLD
+                Arguments.of("Style=Kirk", "@|Name XYZ|@", "\u001b[41;33;1mXYZ\u001b[m"),
+                // User-supplied ANSI names still work when a predefined style is selected
+                Arguments.of("Style=Spock", "@|bg_red,white XYZ|@", "\u001b[41;37mXYZ\u001b[m"));
     }
 
     @ParameterizedTest

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/AnsiEscape.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/AnsiEscape.java
@@ -427,6 +427,9 @@ public enum AnsiEscape {
     static Map<String, String> createMap(
             final String[] values, final String[] dontEscapeKeys, final String separatorRegex) {
         final String[] sortedIgnoreKeys = dontEscapeKeys != null ? dontEscapeKeys.clone() : Strings.EMPTY_ARRAY;
+        for (int i = 0; i < sortedIgnoreKeys.length; i++) {
+            sortedIgnoreKeys[i] = toRootUpperCase(sortedIgnoreKeys[i]);
+        }
         Arrays.sort(sortedIgnoreKeys);
         final Map<String, String> map = new HashMap<>();
         for (final String string : values) {

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/JAnsiTextRenderer.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/pattern/JAnsiTextRenderer.java
@@ -95,11 +95,11 @@ public final class JAnsiTextRenderer implements TextRenderer {
     private static final int CSI_LENGTH = 2;
 
     private static Map.Entry<String, String> entry(final String name, final AnsiEscape... codes) {
-        final StringBuilder sb = new StringBuilder(AnsiEscape.CSI.getCode());
-        for (final AnsiEscape code : codes) {
-            sb.append(code.getCode());
+        final String[] names = new String[codes.length];
+        for (int i = 0; i < codes.length; i++) {
+            names[i] = codes[i].name();
         }
-        return new AbstractMap.SimpleImmutableEntry<>(name, sb.toString());
+        return new AbstractMap.SimpleImmutableEntry<>(name, AnsiEscape.createSequence(names));
     }
 
     @SafeVarargs
@@ -201,12 +201,12 @@ public final class JAnsiTextRenderer implements TextRenderer {
         if (formats.length > 1) {
             final String stylesStr = formats[1];
             final Map<String, String> map = AnsiEscape.createMap(
-                    stylesStr.split("\\s", -1), new String[] {"BeginToken", "EndToken", "Style"}, ",");
+                    stylesStr.split("\\s", -1), new String[] {"BEGINTOKEN", "ENDTOKEN", "STYLE"}, ",");
 
-            // Handle the special tokens
-            beginToken = Objects.toString(map.remove("BeginToken"), BEGIN_TOKEN);
-            endToken = Objects.toString(map.remove("EndToken"), END_TOKEN);
-            final String predefinedStyle = map.remove("Style");
+            // Handle the special tokens. createMap stores keys in root upper-case.
+            beginToken = Objects.toString(map.remove("BEGINTOKEN"), BEGIN_TOKEN);
+            endToken = Objects.toString(map.remove("ENDTOKEN"), END_TOKEN);
+            final String predefinedStyle = map.remove("STYLE");
 
             // Create style map
             final Map<String, String> styleMap = new HashMap<>(map.size() + defaultStyleMap.size());
@@ -214,7 +214,7 @@ public final class JAnsiTextRenderer implements TextRenderer {
             if (predefinedStyle != null) {
                 final Map<String, String> predefinedMap = PREFEDINED_STYLE_MAPS.get(predefinedStyle);
                 if (predefinedMap != null) {
-                    map.putAll(predefinedMap);
+                    predefinedMap.forEach((k, v) -> map.put(toRootUpperCase(k), v));
                 } else {
                     LOGGER.warn(
                             "Unknown predefined map name {}, pick one of {}",

--- a/src/changelog/.2.x.x/4254_fix_predefined_ansi_styles.xml
+++ b/src/changelog/.2.x.x/4254_fix_predefined_ansi_styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="4254" link="https://github.com/apache/logging-log4j2/issues/4254"/>
+  <description format="asciidoc">
+    Apply predefined ANSI styles (`Style=Spock`, `Style=Kirk`) in `JAnsiTextRenderer` and emit valid SGR sequences for those styles.
+  </description>
+</entry>


### PR DESCRIPTION
Fixes #4254.

`Style=Spock` and `Style=Kirk` never applied: `AnsiEscape.createMap` stores keys in root upper-case, but `JAnsiTextRenderer` looked up mixed-case special tokens (`Style`, `BeginToken`, `EndToken`) and merged predefined maps with mixed-case names such as `Name`. Lookups then fell through to `createSequence("Name")` and rendered an empty SGR. Predefined `entry()` values were also concatenated without `;` separators or a trailing `m`.

This change:

- treats ignore-keys in `createMap` as case-insensitive
- reads the upper-case special tokens and merges predefined style names in root upper-case
- builds predefined style sequences with `AnsiEscape.createSequence`

## Test

Executed:

```
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./mvnw -pl log4j-core-test -am test -Dtest=JAnsiTextRendererTest -Dsurefire.failIfNoSpecifiedTests=false
```

`JAnsiTextRendererTest`: 7 tests, 0 failures (RED then GREEN for the Spock/Kirk cases).

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* Focused `JAnsiTextRendererTest` passed as above
* Changelog entry in `src/changelog/.2.x.x`
* Tests are provided