### PR TITLE
Update Guava to 33.7.1 on 2.26.x

### DIFF
--- a/log4j-parent/pom.xml
+++ b/log4j-parent/pom.xml
@@ -83,7 +83,7 @@
     <error-prone-annotations.version>2.38.0</error-prone-annotations.version>
     <felix.version>7.0.5</felix.version>
     <groovy.version>4.0.27</groovy.version>
-    <guava.version>33.4.8-jre</guava.version>
+    <guava.version>33.7.1-jre</guava.version>
     <h2.version>2.2.224</h2.version>
     <hamcrest.version>3.0</hamcrest.version>
     <HdrHistogram.version>2.2.2</HdrHistogram.version>
@@ -109,7 +109,7 @@
     <jeromq.version>0.6.0</jeromq.version>
     <jmdns.version>3.6.1</jmdns.version>
     <jmh.version>1.37</jmh.version>
-    <jspecify.version>1.0.0</jspecify.version>
+    <jspecify.version>1.0.1</jspecify.version>
     <junit.version>4.13.2</junit.version>
     <junit-jupiter.version>5.13.4</junit-jupiter.version>
     <junit-pioneer.version>1.9.1</junit-pioneer.version>


### PR DESCRIPTION
## Summary

Update the managed Guava version on `2.26.x` to `33.7.1-jre`, as requested in the member review. Align JSpecify to `1.0.1`, the version required by Guava 33.7.1, so Maven Enforcer's `RequireUpperBoundDeps` rule remains satisfied.

## Change

- Update `guava.version` from `33.4.8-jre` to `33.7.1-jre`.
- Update `jspecify.version` from `1.0.0` to `1.0.1` to match Guava's transitive dependency requirement.
- Leave Maven and all production code unchanged.

## Verification

- Java 17: `./mvnw -B -ntp -pl :log4j-api-test -am validate` — passed all four modules and all Enforcer rules.
- Java 17: `./mvnw -B -ntp verify` — passed all 41 modules; Surefire reports 10,933 tests, 0 failures, 0 errors, and 40 skipped tests. This also covered Enforcer, SpotBugs, RAT, Spotless, OSGi/module checks, API baselines, and SBOM generation.
- Java 17: `./mvnw -B -ntp site` — passed all 41 modules. The external Kroki service returned HTTP 525 for one pre-existing diagram, which Antora reported as a skipped-diagram warning without failing the site build.
- `git diff --check` — passed.

## Checklist

- [x] Based on the current `2.26.x` head.
- [x] Uses the exact Guava version requested by the reviewer.
- [x] `./mvnw verify` and the separate site build succeed.
- [x] No changelog entry is needed for this dependency-management correction.
- [x] No production code or test behavior changed.

## AI assistance

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):

- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Host model: `gpt-5.6-sol`
- Reasoning effort: `xhigh`
- Service mode: `fast`
- Execution mode: local
