### PR TITLE
Reject dynamic proxies in `FilteredObjectInputStream`

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/FilteredObjectInputStreamTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/FilteredObjectInputStreamTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.logging.log4j.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InvalidObjectException;
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.logging.log4j.test.junit.SerialUtil;
+import org.junit.jupiter.api.Test;
+
+class FilteredObjectInputStreamTest {
+
+    private static FilteredObjectInputStream filteredStream(final byte[] data) throws Exception {
+        return new FilteredObjectInputStream(new ByteArrayInputStream(data));
+    }
+
+    @Test
+    void allow_listed_object_graph_round_trips() throws Exception {
+        final Map<String, Object> original = new HashMap<>();
+        original.put("string", "value");
+        original.put("integer", 17);
+        original.put("array", new int[] {1, 2, 3});
+        final Object restored =
+                filteredStream(SerialUtil.serialize((Serializable) original)).readObject();
+        assertEquals(original.keySet(), ((Map<?, ?>) restored).keySet());
+    }
+
+    @Test
+    void class_outside_allow_list_is_rejected() throws Exception {
+        final byte[] data = SerialUtil.serialize(new File("rejected"));
+        assertThrows(InvalidObjectException.class, () -> filteredStream(data).readObject());
+    }
+
+    @Test
+    void dynamic_proxy_is_rejected() throws Exception {
+        final byte[] data = SerialUtil.serialize((Serializable) serializableProxy());
+        assertThrows(InvalidObjectException.class, () -> filteredStream(data).readObject());
+    }
+
+    @Test
+    void allowed_extra_classes_do_not_re_enable_proxies() throws Exception {
+        final Object proxy = serializableProxy();
+        final byte[] data = SerialUtil.serialize((Serializable) proxy);
+        final FilteredObjectInputStream stream = new FilteredObjectInputStream(
+                new ByteArrayInputStream(data),
+                Collections.singleton(proxy.getClass().getName()));
+        assertThrows(InvalidObjectException.class, stream::readObject);
+    }
+
+    private static Object serializableProxy() {
+        return Proxy.newProxyInstance(
+                FilteredObjectInputStreamTest.class.getClassLoader(),
+                new Class<?>[] {Comparator.class},
+                new SerializableInvocationHandler());
+    }
+
+    private static class SerializableInvocationHandler implements InvocationHandler, Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Object invoke(final Object proxy, final Method method, final Object[] args) {
+            return null;
+        }
+    }
+}

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/FilteredObjectInputStream.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/FilteredObjectInputStream.java
@@ -71,6 +71,20 @@ public class FilteredObjectInputStream extends ObjectInputStream {
         return super.resolveClass(desc);
     }
 
+    /**
+     * Unconditionally rejects dynamic proxy classes.
+     * <p>
+     *     Proxy class descriptors do not pass through {@link #resolveClass(ObjectStreamClass)}, so they would
+     *     otherwise bypass the allowlist entirely. No supported Log4j serialized form contains a dynamic proxy, and
+     *     the JEP 290 filter used on Java 9 and later rejects proxy classes as well, since their synthetic class names
+     *     never match the allowlist.
+     * </p>
+     */
+    @Override
+    protected Class<?> resolveProxyClass(final String[] interfaces) throws IOException, ClassNotFoundException {
+        throw new InvalidObjectException("Proxy classes are not allowed for deserialization");
+    }
+
     private static boolean isAllowedByDefault(final String name) {
         return isRequiredPackage(name) || REQUIRED_JAVA_CLASSES.contains(name);
     }

--- a/src/changelog/.2.x.x/4269_reject_proxy_deserialization.xml
+++ b/src/changelog/.2.x.x/4269_reject_proxy_deserialization.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="4269" link="https://github.com/apache/logging-log4j2/pull/4269"/>
+  <description format="asciidoc">
+    `FilteredObjectInputStream` now rejects dynamic proxy classes.
+  </description>
+</entry>


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is part of the deserialization hardening work tracked in #4168. The Logging Services PMC does **not** use nor recommend Java serialization/deserialization, and [our security FAQ](https://logging.apache.org/security/faq.html#deserialization) has long documented this position. This work is submitted solely to reduce the false-positive "vulnerability" reports that keep being filed regardless of that FAQ. Its utility for end users is close to zero.

On Java 8, `FilteredObjectInputStream` is the only deserialization protection available, but dynamic proxy class descriptors are resolved through `ObjectInputStream#resolveProxyClass`, not `resolveClass`, so they bypassed the allowlist entirely. A stream could thus instantiate a proxy of arbitrary interfaces on the Java 8 code path.

On Java 9 and later, the JEP 290 filter already rejects proxies, because their synthetic class names (`com.sun.proxy.$ProxyN`, `jdk.proxy1.$ProxyN`, …) never match the allowlist. This PR aligns the Java 8 path by overriding `resolveProxyClass` to reject proxies outright — no supported Log4j serialized form contains one.

The rejection also applies when extra allowed classes are supplied to the constructor; proxies are never legitimate in a Log4j stream, so there is no opt-out.
