### PR TITLE
Bound array allocation in `SortedArrayStringMap` deserialization

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/SortedArrayStringMapTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/SortedArrayStringMapTest.java
@@ -32,14 +32,18 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStreamReader;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.logging.log4j.test.junit.SerialUtil;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -117,6 +121,78 @@ class SortedArrayStringMapTest {
         expected.putValue("B", "Bvalue");
         expected.putValue("unserializable", null);
         assertEquals(expected, copy);
+    }
+
+    /**
+     * Returns a copy of the serialized form with the declared capacity replaced.
+     * <p>
+     *     The capacity and mappings count follow the default field data as a block-data record
+     *     ({@code 0x77}, length {@code 0x08}), so the pair can be located by its original values.
+     * </p>
+     */
+    private static byte[] patchCapacity(
+            final byte[] binary, final int capacity, final int mappings, final int newCapacity) {
+        final ByteBuffer buffer = ByteBuffer.wrap(binary.clone());
+        for (int i = 0; i + 10 <= binary.length; i++) {
+            if (buffer.get(i) == 0x77
+                    && buffer.get(i + 1) == 0x08
+                    && buffer.getInt(i + 2) == capacity
+                    && buffer.getInt(i + 6) == mappings) {
+                buffer.putInt(i + 2, newCapacity);
+                return buffer.array();
+            }
+        }
+        throw new AssertionError("Unable to locate the capacity field in the serialized form");
+    }
+
+    @Test
+    void testDeserializationDoesNotPreallocateDeclaredCapacity() {
+        final SortedArrayStringMap original = new SortedArrayStringMap();
+        original.putValue("a", "avalue");
+        original.putValue("B", null);
+        original.putValue("3", "3value");
+
+        // A forged stream declaring a huge capacity must not force a huge allocation.
+        final byte[] forged = patchCapacity(serialize(original), 4, 3, Integer.MAX_VALUE);
+        final SortedArrayStringMap copy = deserialize(forged);
+        assertEquals(original, copy);
+    }
+
+    @Test
+    void testDeserializationDoesNotKeepDeclaredCapacityOfEmptyMap() {
+        final SortedArrayStringMap original = new SortedArrayStringMap();
+
+        // A forged threshold must not force a huge allocation on the first `putValue` call.
+        final byte[] forged = patchCapacity(serialize(original), 4, 0, Integer.MAX_VALUE);
+        final SortedArrayStringMap copy = deserialize(forged);
+        assertEquals(original, copy);
+        copy.putValue("a", "avalue");
+        assertEquals("avalue", copy.getValue("a"));
+    }
+
+    @Test
+    void testDeserializationRejectsMoreMappingsThanCapacity() throws Exception {
+        final SortedArrayStringMap original = new SortedArrayStringMap();
+        original.putValue("a", "avalue");
+        original.putValue("B", null);
+        original.putValue("3", "3value");
+
+        final byte[] forged = patchCapacity(serialize(original), 4, 3, 2);
+        final ObjectInputStream ois = SerialUtil.getObjectInputStream(forged);
+        assertThrows(InvalidObjectException.class, ois::readObject);
+    }
+
+    @Test
+    void testDeserializationResizesBeyondInitialAllocation() {
+        final SortedArrayStringMap original = new SortedArrayStringMap();
+        // One entry more than the bounded initial allocation of the deserialized arrays
+        final int count = (1 << 17) + 1;
+        for (int i = 0; i < count; i++) {
+            original.putValue(String.format("%08x", i), null);
+        }
+
+        final SortedArrayStringMap copy = deserialize(serialize(original));
+        assertEquals(original, copy);
     }
 
     @Test

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/SortedArrayStringMap.java
@@ -57,6 +57,14 @@ public class SortedArrayStringMap implements IndexedStringMap {
      */
     private static final int DEFAULT_INITIAL_CAPACITY = 4;
 
+    /**
+     * The maximum number of entries pre-allocated during deserialization: each array of this size occupies
+     * 1 MiB on a typical 64-bit JVM.
+     * Streams declaring a larger capacity grow the arrays on demand as entries are actually read, so a forged
+     * capacity cannot force a large allocation.
+     */
+    private static final int MAX_DESERIALIZATION_CAPACITY = 1 << 17;
+
     private static final long serialVersionUID = -5748905872274478116L;
     private static final int HASHVAL = 31;
 
@@ -513,18 +521,30 @@ public class SortedArrayStringMap implements IndexedStringMap {
         if (mappings < 0) {
             throw new InvalidObjectException("Illegal mappings count: " + mappings);
         }
-
-        // allocate the bucket array;
-        if (mappings > 0) {
-            inflateTable(capacity);
-        } else {
-            threshold = capacity;
+        if (mappings > capacity) {
+            throw new InvalidObjectException("Illegal mappings count: " + mappings + " for capacity: " + capacity);
         }
 
-        // Read the keys and values, and put the mappings in the arrays
-        for (int i = 0; i < mappings; i++) {
-            keys[i] = (String) s.readObject();
-            values[i] = SerializationUtil.readWrappedObject(s);
+        if (mappings > 0) {
+            // Do not trust the declared capacity: allocate a bounded amount up front
+            // and resize as entries are actually read.
+            int allocated = Math.min(capacity, MAX_DESERIALIZATION_CAPACITY);
+            String[] newKeys = new String[allocated];
+            Object[] newValues = new Object[allocated];
+            for (int i = 0; i < mappings; i++) {
+                if (i == allocated) {
+                    allocated = (int) Math.min(capacity, 2L * allocated);
+                    newKeys = Arrays.copyOf(newKeys, allocated);
+                    newValues = Arrays.copyOf(newValues, allocated);
+                }
+                newKeys[i] = (String) s.readObject();
+                newValues[i] = SerializationUtil.readWrappedObject(s);
+            }
+            keys = newKeys;
+            values = newValues;
+            threshold = allocated;
+        } else {
+            threshold = Math.min(capacity, MAX_DESERIALIZATION_CAPACITY);
         }
         size = mappings;
     }

--- a/src/changelog/.2.x.x/4272_bound_string_map_deserialization_allocation.xml
+++ b/src/changelog/.2.x.x/4272_bound_string_map_deserialization_allocation.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="4272" link="https://github.com/apache/logging-log4j2/pull/4272"/>
+  <description format="asciidoc">
+    `SortedArrayStringMap` no longer trusts the capacity declared in a serialized stream.
+  </description>
+</entry>


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is part of the deserialization hardening work tracked in #4168. The Logging Services PMC does **not** use nor recommend Java serialization/deserialization, and [our security FAQ](https://logging.apache.org/security/faq.html#deserialization) has long documented this position. This work is submitted solely to reduce the false-positive "vulnerability" reports that keep being filed regardless of that FAQ. Its utility for end users is close to zero.

`SortedArrayStringMap.readObject` allocated its key and value arrays at the capacity declared in the stream before reading a single entry, so a forged capacity field caused an arbitrarily large allocation (`OutOfMemoryError`) — the classic serialization memory-amplification shape, where a few bytes of input commit the reader to megabytes of allocation.

The declared capacity is no longer trusted: deserialization pre-allocates at most 128 Ki entries (1 MiB per array on a typical 64-bit JVM) and grows the arrays as entries are actually read, so allocation is proportional to the data present in the stream. A `mappings` count exceeding the declared capacity is now rejected as an inconsistent stream.

The serialized form is unchanged — this only affects how a stream is read — so there is no compatibility impact in either direction.

Stacked on #4271.
