### PR TITLE
Add Dependabot configuration for `2.25.x` and rename update groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -57,7 +57,8 @@ updates:
     groups:
       # Groups all non-major updates in a single PR.
       # No group matches major updates, so each one gets a separate PR.
-      maven-minor-updates:
+      # "Bump the maven-minor-2.x group across N directories with M updates"
+      maven-minor-2.x:
         update-types: [ "minor", "patch" ]
     target-branch: "2.x"
     registries:
@@ -162,7 +163,8 @@ updates:
     groups:
       # Groups all non-major updates in a single PR.
       # No group matches major updates, so each one gets a separate PR.
-      maven-minor-updates:
+      # "Bump the maven-minor-2.x group in /log4j-mongodb4 with M updates"
+      maven-minor-2.x:
         update-types: [ "minor", "patch" ]
     target-branch: "2.x"
     registries:
@@ -177,9 +179,33 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      dependencies:
+      # "Bump the actions-all-2.x group with M updates"
+      actions-all-2.x:
         patterns: [ "*" ]
     target-branch: "2.x"
+
+  # The `2.25.x` LTS branch only receives patch-level Maven updates.
+  # Dependabot is not expected to run on its own here: the `yearly` schedule is a placeholder
+  # and updates are triggered manually from the "Dependabot" tab of the "Insights" page.
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: "yearly"
+    cooldown:
+      default-days: 7
+    groups:
+      # "Bump the maven-patch-2.25.x group across N directories with M updates"
+      maven-patch-2.25.x:
+        patterns: [ "*" ]
+    target-branch: "2.25.x"
+    registries:
+      - maven-central
+    ignore:
+      # Only allow patch-level upgrades on this maintenance branch
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   # The `2.26.x` maintenance branch only receives patch-level Maven updates.
   - package-ecosystem: maven
@@ -189,8 +215,8 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      # "Bump the Maven patch updates group across N directories with M updates"
-      Maven patch updates:
+      # "Bump the maven-patch-2.26.x group across N directories with M updates"
+      maven-patch-2.26.x:
         patterns: [ "*" ]
     target-branch: "2.26.x"
     registries:
@@ -211,7 +237,8 @@ updates:
     groups:
       # Groups all non-major updates in a single PR.
       # No group matches major updates, so each one gets a separate PR.
-      maven-minor-updates:
+      # "Bump the maven-minor-main group across N directories with M updates"
+      maven-minor-main:
         update-types: [ "minor", "patch" ]
     target-branch: "main"
     registries:
@@ -250,7 +277,8 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      dependencies:
+      # "Bump the actions-all-main group with M updates"
+      actions-all-main:
         patterns: [ "*" ]
     target-branch: "main"
 
@@ -259,6 +287,7 @@ updates:
     schedule:
       interval: "monthly"
     groups:
-      dependencies:
+      # "Bump the npm-all-main group with M updates"
+      npm-all-main:
         patterns: [ "*" ]
     target-branch: "main"

--- a/.github/workflows/process-dependabot.yaml
+++ b/.github/workflows/process-dependabot.yaml
@@ -44,5 +44,11 @@ jobs:
       # Convert the PR into draft
       pull-requests: write
     with:
-      # The path to the changelog directory for the current development branch.
-      changelog-path: src/changelog/.2.x.x
+      # The path to the changelog directory of the branch targeted by the PR.
+      # This workflow runs from the default branch for PRs against *every* branch,
+      # so the path is derived from the base branch of the PR that triggered it.
+      changelog-path: ${{
+          github.event.workflow_run.pull_requests[0].base.ref == 'main'
+          && 'src/changelog/.3.x.x'
+          || 'src/changelog/.2.x.x'
+        }}


### PR DESCRIPTION
This PR makes two changes to `.github/dependabot.yaml`:

- Adds a patch-only Maven entry for the `2.25.x` LTS branch, modeled on the existing `2.26.x` entry. It uses a `yearly` schedule as a placeholder: since `2.25.x` is an LTS branch, Dependabot updates will be triggered manually from the "Dependabot" tab of the "Insights" page.
- Renames all update groups to `<ecosystem>-<level>-<branch>`, so that the target branch is visible in the title of Dependabot PRs (which otherwise only mention the group name and directories):

  | Entry | Group |
  |---|---|
  | Maven, `2.x` (root and `log4j-mongodb4`) | `maven-minor-2.x` |
  | GitHub Actions, `2.x` | `actions-all-2.x` |
  | Maven, `2.25.x` | `maven-patch-2.25.x` |
  | Maven, `2.26.x` | `maven-patch-2.26.x` |
  | Maven, `main` | `maven-minor-main` |
  | GitHub Actions, `main` | `actions-all-main` |
  | npm, `main` | `npm-all-main` |

  The `<level>` segment states what the group admits: `patch` on maintenance branches, `minor` where minor and patch updates are grouped and major updates get separate PRs, `all` where everything is grouped.

It also updates `.github/workflows/process-dependabot.yaml`, which runs from the default branch for PRs against every branch, to derive the changelog directory from the base branch of the triggering PR: `src/changelog/.3.x.x` for `main` and `src/changelog/.2.x.x` otherwise.

> [!NOTE]
> Renaming a group changes its Dependabot branch name, so any currently open grouped PR will be closed and recreated under the new name on the next Dependabot run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

