### PR TITLE
Add `Dependabot Analyze PR` workflow to `main`

### DIFF
--- a/.github/workflows/analyze-dependabot.yaml
+++ b/.github/workflows/analyze-dependabot.yaml
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: "Dependabot Analyze PR"
+
+on:
+  # `pull_request` runs the workflow file from the PR merge commit, so this copy applies to PRs against `main`.
+  # The follow-up "Dependabot Process PR" workflow is triggered by `workflow_run`, which GitHub only evaluates
+  # on the default branch (`2.x`), so it does not need a copy here. The copy on `2.x` selects the changelog
+  # directory based on the base branch of the PR.
+  pull_request:
+
+# Default permissions for each job.
+# Additional permissions should be assigned on a per-job basis.
+permissions: { }
+
+jobs:
+
+  analyze-dependabot:
+    # `github.actor` prevents recursive calls when `github-actions[bot]` pushes to the PR;
+    # `github.event.pull_request.user.login` skips PRs not opened by Dependabot.
+    if: ${{
+      github.repository == 'apache/logging-log4j2'
+      && github.actor == 'dependabot[bot]'
+      && github.event.pull_request.user.login == 'dependabot[bot]'
+      }}
+    uses: apache/logging-parent/.github/workflows/analyze-dependabot-reusable.yaml@gha/v0


### PR DESCRIPTION
Adds `.github/workflows/analyze-dependabot.yaml` to `main`, so that Dependabot PRs against `main` get the same analysis as those against `2.x`.

The `pull_request` trigger runs the workflow file from the PR merge commit, so each branch that Dependabot targets needs its own copy. The follow-up `Dependabot Process PR` workflow is triggered by `workflow_run`, which GitHub only evaluates on the default branch, so no copy of it is needed here: the one on `2.x` handles PRs against every branch.

The file is identical to the `2.x` version apart from a comment explaining the above. The reusable workflow in `logging-parent` takes no inputs, so nothing is branch-specific.

> [!NOTE]
> Depends on #4284, which teaches the `2.x` copy of `Dependabot Process PR` to use `src/changelog/.3.x.x` for PRs against `main`. Until it is merged, a Dependabot PR against `main` would get its changelog entry written to `src/changelog/.2.x.x`, which does not exist on `main`.

No changelog entry, since this only touches CI configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QXFCr2hQv3zoVf7wo5Lab
