### PR TITLE
Update Log4j API to 2.25.5

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/AbstractActionTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/rolling/action/AbstractActionTest.java
@@ -47,8 +47,9 @@ class AbstractActionTest {
         assertThat(
                 formattedMessage,
                 containsString("Exception reported by action 'class org.apache."
-                        + "logging.log4j.core.appender.rolling.action.AbstractActionTest$TestAction' java.io.IOException: "
-                        + "failed" + System.lineSeparator()
+                        + "logging.log4j.core.appender.rolling.action.AbstractActionTest$TestAction'"
+                        + System.lineSeparator()
+                        + "java.io.IOException: failed" + System.lineSeparator()
                         + "\tat org.apache.logging.log4j.core.appender.rolling.action.AbstractActionTest"
                         + "$TestAction.execute(AbstractActionTest.java:"));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
     <project.build.outputTimestamp>2024-11-09T05:50:28Z</project.build.outputTimestamp>
 
     <!-- Version of Log4j API required -->
-    <log4j-api.version>2.24.3</log4j-api.version>
+    <log4j-api.version>2.25.5</log4j-api.version>
 
     <!-- ========================
          Site-specific properties

--- a/src/changelog/.3.x.x/update_org_apache_logging_log4j_log4j_api.xml
+++ b/src/changelog/.3.x.x/update_org_apache_logging_log4j_log4j_api.xml
@@ -2,7 +2,6 @@
 <entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns="https://logging.apache.org/xml/ns"
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
-       type="updated">
-  <issue id="3292" link="https://github.com/apache/logging-log4j2/pull/3292"/>
-  <description format="asciidoc">Update `org.apache.logging.log4j:log4j-api` to version `2.24.3`</description>
+       type="changed">
+  <description format="asciidoc">Use Log4j API 2.25.x as baseline.</description>
 </entry>


### PR DESCRIPTION
Upgrade the released Log4j API baseline from 2.24.3 to the 2.25.5 LTS release. The public API has been frozen since 2.24.x.

Adapt AbstractActionTest to the StatusData formatting introduced on the 2.x line, where throwable stack traces are prefixed with a newline instead of a space. This isolates the Log4j update and its behavior change from #4292.

Verification:
- ./mvnw -Drat.skip=true clean verify
- All 31 reactor modules passed. RAT was skipped only because this local worktree contains unrelated .apache-magpie integration files without license headers.