### PR TITLE
Forward mail attributes in deprecated `SmtpAppender.createAppender`

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SmtpAppenderTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/SmtpAppenderTest.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.DefaultConfiguration;
 import org.apache.logging.log4j.core.net.MimeMessageBuilder;
 import org.apache.logging.log4j.core.net.SmtpManager;
 import org.apache.logging.log4j.core.test.AvailablePortFinder;
@@ -106,6 +107,52 @@ class SmtpAppenderTest {
 
         builder.setSubject(subject);
         assertEquals(subject, builder.build().getSubject());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void testCreateAppenderForwardsMailAttributes() {
+        final SmtpAppender appender = SmtpAppender.createAppender(
+                new DefaultConfiguration(),
+                "Test",
+                "to@example.com",
+                "cc@example.com",
+                "bcc@example.com",
+                "from@example.com",
+                "replyTo@example.com",
+                "Subject Pattern %m",
+                "smtp",
+                HOST,
+                "4711",
+                "username",
+                "password",
+                "false",
+                "3",
+                null,
+                null,
+                null);
+        assertNotNull(appender);
+        assertEquals("Test", appender.getName());
+
+        // `MailManager` names encode the mail attributes, so an equal name means every attribute was forwarded.
+        final SmtpAppender expected = SmtpAppender.newBuilder()
+                .setName("Test")
+                .setTo("to@example.com")
+                .setCc("cc@example.com")
+                .setBcc("bcc@example.com")
+                .setFrom("from@example.com")
+                .setReplyTo("replyTo@example.com")
+                .setSubject("Subject Pattern %m")
+                .setSmtpProtocol("smtp")
+                .setSmtpHost(HOST)
+                .setSmtpPort(4711)
+                .setSmtpUsername("username")
+                .setSmtpPassword("password")
+                .setSmtpDebug(false)
+                .setBufferSize(3)
+                .build();
+        assertNotNull(expected);
+        assertEquals(expected.getManager().getName(), appender.getManager().getName());
     }
 
     @Test

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/SmtpAppender.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/SmtpAppender.java
@@ -357,6 +357,17 @@ public final class SmtpAppender extends AbstractAppender {
             return null;
         }
         return SmtpAppender.newBuilder()
+                .setName(name)
+                .setTo(to)
+                .setCc(cc)
+                .setBcc(bcc)
+                .setFrom(from)
+                .setReplyTo(replyTo)
+                .setSubject(subject)
+                .setSmtpProtocol(smtpProtocol)
+                .setSmtpHost(smtpHost)
+                .setSmtpUsername(smtpUsername)
+                .setSmtpPassword(smtpPassword)
                 .setIgnoreExceptions(Booleans.parseBoolean(ignore, true))
                 .setSmtpPort(AbstractAppender.parseInt(smtpPortStr, 0))
                 .setSmtpDebug(Boolean.parseBoolean(smtpDebug))

--- a/src/changelog/.2.x.x/4304_fix_smtp_appender_create_appender.xml
+++ b/src/changelog/.2.x.x/4304_fix_smtp_appender_create_appender.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <issue id="4304" link="https://github.com/apache/logging-log4j2/pull/4304"/>
+    <description format="asciidoc">
+        Fix the deprecated `SmtpAppender.createAppender()` factory method, which threw a `NullPointerException` instead of returning an appender, because it forwarded neither the appender name nor the mail attributes to the builder.
+    </description>
+</entry>


### PR DESCRIPTION
## What breaks

`SmtpAppender.createAppender` never returns an appender. It throws `NullPointerException: name` out of the `AbstractAppender` constructor, and none of the mail settings passed to it reach the `MailManager`. The deprecated factory is still public API, so anything that calls it programmatically fails at configuration time.

## Cause

Commit 30e9563f (`[LOG4J2-3362] Adds a SmtpManager compatible with Jakarta EE 9`, first released in 2.18.0) rewrote the body of `createAppender` to delegate to `SmtpAppender.newBuilder()`. The delegation forwards seven of the eighteen parameters and drops the rest, at `log4j-core/src/main/java/org/apache/logging/log4j/core/appender/SmtpAppender.java:358`:

```java
return SmtpAppender.newBuilder()
        .setIgnoreExceptions(Booleans.parseBoolean(ignore, true))
        .setSmtpPort(AbstractAppender.parseInt(smtpPortStr, 0))
        .setSmtpDebug(Boolean.parseBoolean(smtpDebug))
        .setBufferSize(bufferSizeStr == null ? DEFAULT_BUFFER_SIZE : Integers.parseInt(bufferSizeStr))
        .setLayout(layout)
        .setFilter(filter)
        .setConfiguration(config != null ? config : new DefaultConfiguration())
        .build();
```

`name`, `to`, `cc`, `bcc`, `from`, `replyTo`, `subject`, `smtpProtocol`, `smtpHost`, `smtpUsername` and `smtpPassword` are never passed on. `Builder.build()` therefore reaches `new SmtpAppender(getName(), ...)` with a null name, and `AbstractAppender` does `this.name = Objects.requireNonNull(name, "name")` at `log4j-core/src/main/java/org/apache/logging/log4j/core/appender/AbstractAppender.java:231`. The `if (name == null)` guard at the top of `createAppender` passes, because the caller did supply a name; it just goes nowhere.

The body before that commit built the `SmtpManager` directly from all of those arguments, so this is a regression in the refactor and not a limitation of the deprecated entry point. The plugin system is unaffected: `createAppender` carries no `@PluginFactory`, so XML and properties configurations go through `newBuilder()`.

## Fix

Forward the eleven missing attributes to the builder. Passing `smtpProtocol` straight through is safe because `Builder.build()` already resets a null or empty protocol to `smtp`, which is what the builder field defaults to.

## Testing

`SmtpAppenderTest#testCreateAppenderForwardsMailAttributes` calls the deprecated factory with every attribute set, asserts the appender name, then compares the resulting `MailManager` name against the manager name of an equivalent `newBuilder()` chain. `MailManager.createManagerName` encodes to, cc, bcc, from, replyTo, subject, protocol, host, port, username and debug into that name, so equal names mean every attribute arrived.

Run on macOS with Temurin 17:

```
./mvnw -pl log4j-api-java9,log4j-core-java9,log4j-core-test -am install -DskipTests
./mvnw -pl log4j-core-test test -Dtest=SmtpAppenderTest,SmtpAppenderAsyncTest,SmtpManagerTest,MimeMessageBuilderTest -Dsurefire.failIfNoSpecifiedTests=false
```

On `2.x` at ded9666 with the test but without the `SmtpAppender` change: `Tests run: 6, Failures: 0, Errors: 1` in `SmtpAppenderTest`, reported as `testCreateAppenderForwardsMailAttributes ... NullPointerException: name`. With the change: `Tests run: 12, Failures: 0, Errors: 0, Skipped: 0` across the four classes.

`./mvnw -pl log4j-core,log4j-core-test verify -DskipTests` is green, so spotless, apache-rat, spotbugs and the bnd baseline check all pass, and `./mvnw -N verify` runs `validate-changelog` over the new entry file without complaint.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds ([the build instructions](https://logging.apache.org/log4j/2.x/development.html#building))
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests are provided
