### PR TITLE
Update Dependabot ignore rules for Logback, Cassandra, Groovy, Elastic and Kroki

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -160,6 +160,9 @@ updates:
       # Groovy 5 breaks the JSR-223 script filters on 2.x
       - dependency-name: "org.apache.groovy:*"
         versions: [ "[5,)" ]
+      # spring-cloud 5.x is the Spring Boot 4 / Framework 7 generation
+      - dependency-name: "org.springframework.cloud:spring-cloud-context"
+        versions: [ "[5,)" ]
 
   - package-ecosystem: maven
     directories:
@@ -283,6 +286,9 @@ updates:
         versions: [ "[3,)" ]
       # 0.18 is a 2.x-era plugin jar kept as a test fixture, not a dependency
       - dependency-name: "com.vlkan.log4j2:*"
+      # spring-cloud 5.x is the Spring Boot 4 / Framework 7 generation
+      - dependency-name: "org.springframework.cloud:spring-cloud-context"
+        versions: [ "[5,)" ]
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -217,7 +217,9 @@ updates:
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
-      # elastic.version doubles as the Docker image tag; elasticsearch:8.17.11 does not exist
+      # `co.elastic.clients:elasticsearch-java` shares the `elastic.version` property of
+      # `log4j-layout-template-json-test` with the `elasticsearch` and `logstash` Docker image tags.
+      # The Java client gets patch releases the Docker images don't have, e.g. `8.17.11`.
       - dependency-name: "co.elastic.clients:*"
 
   # The `2.26.x` maintenance branch only receives patch-level Maven updates.
@@ -284,7 +286,8 @@ updates:
       # We must also ignore the old Group ID so Dependabot doesn't try to auto-migrate it.
       - dependency-name: "com.github.tomakehurst:wiremock*"
         versions: [ "[3,)" ]
-      # 0.18 is a 2.x-era plugin jar kept as a test fixture, not a dependency
+      # `com.vlkan.log4j2:log4j2-logstash-layout:0.18` is pinned on the `log4j-core-test` classpath
+      # as a legacy Log4j 2.x plugin JAR; the version is part of the fixture, not something to bump.
       - dependency-name: "com.vlkan.log4j2:*"
       # spring-cloud 5.x is the Spring Boot 4 / Framework 7 generation
       - dependency-name: "org.springframework.cloud:spring-cloud-context"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -315,4 +315,4 @@ updates:
     ignore:
       # kroki 1.0 is incompatible with the pinned Antora 3.2 alpha
       - dependency-name: "asciidoctor-kroki"
-        versions: [ "[1,)" ]
+        versions: [ ">=1.0.0" ]

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -50,6 +50,8 @@ updates:
       # from the remaining artifacts
       - "log4j-mongodb4/**"
       - "log4j-slf4j-impl/**"
+      # Cassandra pins Guava, JNR and Snappy for reproducibility
+      - "log4j-cassandra/**"
     schedule:
       interval: "monthly"
     cooldown:
@@ -82,9 +84,9 @@ updates:
       # Tomcat Juli 10.1.x requires Java 11
       - dependency-name: "org.apache.tomcat:*"
         versions: [ "[10.1,)" ]
-      # Keep Logback version 1.2.x
+      # Logback 1.4+ binds SLF4J 2.0; 2.x stays on the 1.3.x line
       - dependency-name: "ch.qos.logback:*"
-        versions: [ "[1.3,)" ]
+        versions: [ "[1.4,)" ]
       # Mockito 5.x requires Java 11
       - dependency-name: "org.mockito:*"
         versions: [ "[5,)" ]
@@ -152,6 +154,12 @@ updates:
       # We must also ignore the old Group ID so Dependabot doesn't try to auto-migrate it.
       - dependency-name: "com.github.tomakehurst:wiremock*"
         versions: [ "[3,)" ]
+      # cassandra-driver-core v4 relocated to com.datastax.oss:java-driver-core
+      - dependency-name: "com.datastax.cassandra:*"
+        versions: [ "[4,)" ]
+      # Groovy 5 breaks the JSR-223 script filters on 2.x
+      - dependency-name: "org.apache.groovy:*"
+        versions: [ "[5,)" ]
 
   - package-ecosystem: maven
     directories:
@@ -206,6 +214,8 @@ updates:
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
+      # elastic.version doubles as the Docker image tag; elasticsearch:8.17.11 does not exist
+      - dependency-name: "co.elastic.clients:*"
 
   # The `2.26.x` maintenance branch only receives patch-level Maven updates.
   - package-ecosystem: maven
@@ -271,6 +281,8 @@ updates:
       # We must also ignore the old Group ID so Dependabot doesn't try to auto-migrate it.
       - dependency-name: "com.github.tomakehurst:wiremock*"
         versions: [ "[3,)" ]
+      # 0.18 is a 2.x-era plugin jar kept as a test fixture, not a dependency
+      - dependency-name: "com.vlkan.log4j2:*"
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -291,3 +303,7 @@ updates:
       npm-all-main:
         patterns: [ "*" ]
     target-branch: "main"
+    ignore:
+      # kroki 1.0 is incompatible with the pinned Antora 3.2 alpha
+      - dependency-name: "asciidoctor-kroki"
+        versions: [ "[1,)" ]


### PR DESCRIPTION
Six bullets, each naming the PR it settles: #4301/#4253 (logback range corrected from the inert [1.3,)), #4285 (exclude-paths), #4210 (DataStax group ID differs from the     
  existing org.apache.cassandra:* rule), #4208/#4295 (Groovy 5 on 2.x only), #4302 (elastic doubles as the Docker tag), #4290 (kroki).