### PR TITLE
Revert `spring-cloud-context` to 4.3.0 on `2.x`

### DIFF
--- a/log4j-spring-cloud-config-client/pom.xml
+++ b/log4j-spring-cloud-config-client/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <!-- Dependency versions -->
-    <spring-cloud.version>5.0.2</spring-cloud.version>
+    <spring-cloud.version>4.3.0</spring-cloud.version>
 
     <!--
       ~ OSGi and JPMS options

--- a/src/changelog/.2.x.x/update_org.springframework.cloud_spring-cloud-context.xml
+++ b/src/changelog/.2.x.x/update_org.springframework.cloud_spring-cloud-context.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns="https://logging.apache.org/xml/ns"
-       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
-       type="updated">
-  <issue id="4211" link="https://github.com/apache/logging-log4j2/pull/4211"/>
-  <description format="asciidoc">Update `org.springframework.cloud:spring-cloud-context` to version `5.0.2`</description>
-</entry>


### PR DESCRIPTION
#4211 raised `spring-cloud.version` from 4.3.0 to 5.0.2. Spring Cloud 5.0 is the                                                                                              
  Spring Boot 4 generation: `spring-cloud-context:5.0.2` resolves `spring-boot-*:4.0.7`                                                                                         
  and `spring-security-crypto:7.0.6`, against a module that sits on Spring Boot 3.                                                                                              
                                                                                                                                                                                
  The module still compiles, so the PR's required checks passed, but the push build on                                                                                          
  `2.x` fails `enforce-upper-bound-deps` in `log4j-spring-cloud-config-sample-application`:                                                                                     
                                                                                                                                                                                
      Require upper bound dependencies error for                                                                                                                                
      org.springframework.cloud:spring-cloud-context:4.3.0                                                                                                                      
      +-log4j-spring-cloud-config-client:2.27.0-SNAPSHOT                                                                                                                        
        +-spring-cloud-context:4.3.0 (managed) <-- spring-cloud-context:5.0.2                                                                                                   
                                                                                                                                                                                
  The Dependabot rule meant to prevent this, `org.springframework.cloud:*` at `[2021,)`,                                                                                        
  was written for the `spring-cloud-dependencies` release-train numbering and cannot match                                                                                      
  a 5.0.2. A matching rule is added in #4305.                                        