### PR TITLE
escape scope attribute names and values in DumpTag

### DIFF
--- a/log4j-taglib/src/main/java/org/apache/logging/log4j/taglib/DumpTag.java
+++ b/log4j-taglib/src/main/java/org/apache/logging/log4j/taglib/DumpTag.java
@@ -22,6 +22,7 @@ import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.Tag;
 import javax.servlet.jsp.tagext.TagSupport;
+import org.apache.logging.log4j.util.StringBuilders;
 
 /**
  * This class implements the {@code <log:dump>} tag.
@@ -60,8 +61,8 @@ public class DumpTag extends TagSupport {
                 final String name = names.nextElement();
                 final Object value = this.pageContext.getAttribute(name, this.scope);
 
-                this.pageContext.getOut().write("<dt><code>" + name + "</code></dt>");
-                this.pageContext.getOut().write("<dd><code>" + value + "</code></dd>");
+                this.pageContext.getOut().write("<dt><code>" + escapeHtml(name) + "</code></dt>");
+                this.pageContext.getOut().write("<dd><code>" + escapeHtml(String.valueOf(value)) + "</code></dd>");
             }
             this.pageContext.getOut().write("</dl>");
         } catch (final IOException e) {
@@ -69,5 +70,11 @@ public class DumpTag extends TagSupport {
         }
 
         return Tag.EVAL_PAGE;
+    }
+
+    private static String escapeHtml(final String value) {
+        final StringBuilder builder = new StringBuilder(value);
+        StringBuilders.escapeXml(builder, 0);
+        return builder.toString();
     }
 }

--- a/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/DumpTagTest.java
+++ b/log4j-taglib/src/test/java/org/apache/logging/log4j/taglib/DumpTagTest.java
@@ -89,6 +89,23 @@ class DumpTagTest {
     }
 
     @Test
+    void testDoEndTagEscapesHtml() throws Exception {
+        this.context.setAttribute("<name>", "<script>alert('xss')</script>", PageContext.PAGE_SCOPE);
+
+        final int returnValue = this.tag.doEndTag();
+        assertEquals(Tag.EVAL_PAGE, returnValue, "The return value is not correct.");
+
+        this.writer.flush();
+        final String output = new String(this.output.toByteArray(), UTF8);
+        assertEquals(
+                "<dl>" + "<dt><code>&lt;name&gt;</code></dt>"
+                        + "<dd><code>&lt;script&gt;alert(&apos;xss&apos;)&lt;/script&gt;</code></dd>"
+                        + "</dl>",
+                output,
+                "Attribute names and values must be HTML-escaped.");
+    }
+
+    @Test
     void testDoEndTagSessionScopeNoAttributes() throws Exception {
         this.context.setAttribute("badAttribute01", "skippedValue01", PageContext.PAGE_SCOPE);
 

--- a/src/changelog/.2.x.x/fix_taglib_dump_tag_xss.xml
+++ b/src/changelog/.2.x.x/fix_taglib_dump_tag_xss.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="4316" link="https://github.com/apache/logging-log4j2/pull/4316"/>
+  <description format="asciidoc">
+    HTML-escape scope attribute names and values rendered by the `log:dump` JSP tag (`DumpTag`) to prevent cross-site scripting
+  </description>
+</entry>


### PR DESCRIPTION
`DumpTag` (`log:dump`) writes the names and values of every attribute in the selected scope straight into the page:

- request- and session-scope attributes are routinely attacker-influenced (a request parameter copied into a request attribute, a form bean, etc.), so any page using `log:dump` with those scopes emits reflected/stored XSS
- `doEndTag` concatenated the attribute `name` and `value` into the HTML output with no escaping
- both are now escaped with `StringBuilders.escapeXml` before writing, the same escaping `HtmlLayout` and `Log4j1XmlLayout` already apply to event data

## Checklist

- [x] Base your changes on the `2.x` branch
- [x] `./mvnw verify` succeeds for the affected module
- [x] Changelog entry added under `src/changelog/.2.x.x`
- [x] Tests are provided
