### PR TITLE
Fix the log4j-spring-cloud-config-client test harness 

### DIFF
--- a/log4j-spring-cloud-config-client/pom.xml
+++ b/log4j-spring-cloud-config-client/pom.xml
@@ -113,6 +113,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/log4j-spring-cloud-config-client/pom.xml
+++ b/log4j-spring-cloud-config-client/pom.xml
@@ -120,4 +120,26 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <!-- Uses a different id than `default-test` to ignore the `java8-tests` profile -->
+          <execution>
+            <id>run-tests</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-test</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/log4j-spring-cloud-config-client/src/test/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2EventListenerTest.java
+++ b/log4j-spring-cloud-config-client/src/test/java/org/apache/logging/log4j/spring/cloud/config/client/Log4j2EventListenerTest.java
@@ -22,14 +22,14 @@ import java.io.File;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.ConfigurationListener;
 import org.apache.logging.log4j.core.config.Reconfigurable;
-import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.apache.logging.log4j.core.util.Source;
+import org.apache.logging.log4j.core.util.WatchManager;
 import org.apache.logging.log4j.core.util.Watcher;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -41,30 +41,23 @@ import org.springframework.test.context.junit4.SpringRunner;
  * Class Description goes here.
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = {SpringConfiguration.class})
+@SpringBootTest(
+        classes = {SpringConfiguration.class},
+        properties = {"logging.config=classpath:log4j2-console.xml"})
 public class Log4j2EventListenerTest {
-
-    private static final String CONFIG = "log4j-console.xml";
-    private static final String DIR = "target/logs";
-
-    public static LoggerContextRule loggerContextRule =
-            LoggerContextRule.createShutdownTimeoutLoggerContextRule(CONFIG);
-
-    @Rule
-    public RuleChain chain = loggerContextRule.withCleanFilesRule(DIR);
 
     @Autowired
     private ApplicationEventPublisher publisher;
+
+    private static WatchManager watchManager() {
+        return ((LoggerContext) LogManager.getContext(false)).getConfiguration().getWatchManager();
+    }
 
     @Test
     public void test() {
         final AtomicInteger count = new AtomicInteger(0);
         final Source source = new Source(new File("test.java"));
-        loggerContextRule
-                .getLoggerContext()
-                .getConfiguration()
-                .getWatchManager()
-                .watch(source, new TestWatcher(count));
+        watchManager().watch(source, new TestWatcher(count));
         publisher.publishEvent(new EnvironmentChangeEvent(new HashSet<>()));
         assertTrue(count.get() > 0);
     }

--- a/log4j-spring-cloud-config-client/src/test/resources/log4j2-console.xml
+++ b/log4j-spring-cloud-config-client/src/test/resources/log4j2-console.xml
@@ -15,7 +15,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<Configuration status="OFF">
+<Configuration status="OFF" monitorInterval="300">
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d [%t] %-5level: %msg%n%throwable" />

--- a/src/changelog/.2.x.x/4317_fix_spring_cloud_config_client_test_harness.xml
+++ b/src/changelog/.2.x.x/4317_fix_spring_cloud_config_client_test_harness.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+  <issue id="4317" link="https://github.com/apache/logging-log4j2/pull/4317"/>
+  <description format="asciidoc">
+    Fix the `junit-vintage-engine` dependency and fixes the `log4j-spring-cloud-config-client` test harness.
+  </description>
+</entry>


### PR DESCRIPTION
Follow-up to @vy's request on #4252. The module has run no tests since removed `junit-vintage-engine` while `Log4j2EventListenerTest` stayed on JUnit 4.         
                                                                                                                                                                                
 After Restoring jave some issues: `CONFIG` names a file that does not exist, Boot's bundled `log4j2.xml` claims the `LoggerContext` first, and no configuration declares `monitorInterval`, so `WatchManager.start()` never subscribes to `WatchEventManager`.