### PR TITLE
Clear the database appender buffer when committing fails

### DIFF
--- a/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/AbstractDatabaseManagerTest.java
+++ b/log4j-core-test/src/test/java/org/apache/logging/log4j/core/appender/db/AbstractDatabaseManagerTest.java
@@ -18,10 +18,13 @@ package org.apache.logging.log4j.core.appender.db;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -225,6 +228,34 @@ class AbstractDatabaseManagerTest {
         then(manager).should().commitAndClose();
         then(manager).should().shutdownInternal();
         then(manager).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    void testBufferedEventsAreDiscardedWhenCommitFails() throws Exception {
+        setUp("name", 10);
+
+        final LogEvent event1 = mock(LogEvent.class);
+        final LogEvent event2 = mock(LogEvent.class);
+
+        when(event1.toImmutable()).thenReturn(mock(LogEvent.class));
+        when(event2.toImmutable()).thenReturn(mock(LogEvent.class));
+
+        manager.startup();
+        manager.write(event1, null);
+        manager.write(event2, null);
+
+        // The first flush fails while committing the transaction, the next one succeeds.
+        doThrow(new DbAppenderLoggingException("Failed to commit the transaction"))
+                .doReturn(true)
+                .when(manager)
+                .commitAndClose();
+
+        assertThrows(DbAppenderLoggingException.class, manager::flush);
+
+        manager.flush();
+
+        // Events of a transaction that failed to commit must not be sent again.
+        verify(manager, times(2)).writeInternal(any(LogEvent.class), isNull());
     }
 
     @Test

--- a/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/AbstractDatabaseManager.java
+++ b/log4j-core/src/main/java/org/apache/logging/log4j/core/appender/db/AbstractDatabaseManager.java
@@ -192,9 +192,14 @@ public abstract class AbstractDatabaseManager extends AbstractManager implements
                     this.writeInternal(event, layout != null ? layout.toSerializable(event) : null);
                 }
             } finally {
-                this.commitAndClose();
-                // not sure if this should be done when writing the events failed
-                this.buffer.clear();
+                try {
+                    this.commitAndClose();
+                } finally {
+                    // The events were already handed to the database layer, so they must not be kept
+                    // when committing fails: the next flush would send them again and the buffer
+                    // would grow without bound while the failure persists.
+                    this.buffer.clear();
+                }
             }
         }
     }

--- a/src/changelog/.2.x.x/4318_fix_database_appender_buffer_on_failed_commit.xml
+++ b/src/changelog/.2.x.x/4318_fix_database_appender_buffer_on_failed_commit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="fixed">
+    <issue id="4318" link="https://github.com/apache/logging-log4j2/issues/4318"/>
+    <description format="asciidoc">
+        Clear the buffer of a buffered database appender when committing a transaction fails.
+        Previously the events were kept, so the next flush sent them again and the buffer grew
+        without bound while the database failure persisted.
+    </description>
+</entry>


### PR DESCRIPTION
Fixes #4318.

`AbstractDatabaseManager#flush()` handed the buffered events to
`writeInternal()` and then ran `commitAndClose()` and `buffer.clear()` in
the same `finally` block:

```java
} finally {
    this.commitAndClose();
    // not sure if this should be done when writing the events failed
    this.buffer.clear();
}
```

When `commitAndClose()` throws (a database failure during the commit/close
phase), the `clear()` was skipped. The events therefore stayed in the
buffer and were written a second time by the following flush, and, because
the buffer keeps accumulating new events while the failure persists, it
grew without bound. `flush()` is also called from `shutdown()`, so a
failing commit at shutdown could also mask the original exception with a
secondary one from re-sending the same events.

The fix moves `buffer.clear()` into an inner `finally` block, so the events
are discarded no matter how `commitAndClose()` returns or throws. The
events were already passed to the database layer, so keeping them cannot
recover the transaction.

`testBufferedEventsAreDiscardedWhenCommitFails` makes `commitAndClose()`
fail once and then succeed, and asserts that `writeInternal()` is invoked
exactly twice in total (once per event), i.e. that the failed transaction
is not re-sent.

Note on scope: `connectAndStart()` is deliberately left outside the `try`,
so events are still retried when the *connection* cannot be established.
Only the commit/close phase changes behaviour here.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds ([the build instructions](https://logging.apache.org/log4j/2.x/development.html#building))
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests are provided
