### PR TITLE
Document the JdbcAppender truncateStrings attribute

### DIFF
--- a/src/site/antora/modules/ROOT/pages/manual/appenders/database.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/appenders/database.adoc
@@ -452,6 +452,13 @@ If set to a value greater than 0, after an error, the `JdbcDatabaseManager` will
 If the reconnecting fails then an exception will be thrown and can be caught by the application if
 <<JdbcAppender-attr-ignoreExceptions,`ignoreExceptions`>>
 is set to `false`.
+
+| [[JdbcAppender-attr-truncateStrings]]truncateStrings
+| `boolean`
+| `true`
+|
+If `true`, values written to columns of a string type are truncated to the size reported by the database metadata.
+This avoids errors caused by values that are longer than the target column.
 |===
 
 [#JdbcAppender-elements]


### PR DESCRIPTION
`JdbcAppender.Builder#truncateStrings` is a `@PluginBuilderAttribute` with a default of `true`, so
it can be configured on the `<Jdbc>` element. It was the only optional attribute of the appender
that the manual did not document, which makes the attribute undiscoverable even though it changes
what is written to the database: when it is `true`, values written to string columns are truncated
to the size reported by the database metadata.

This adds the missing row to the attribute table in
`src/site/antora/modules/ROOT/pages/manual/appenders/database.adoc`, in the same format as the
neighbouring `reconnectIntervalMillis` row.

Validation: rendered the page with Asciidoctor and confirmed the table still has four columns per
row and that the new row is emitted with the `JdbcAppender-attr-truncateStrings` anchor, the type
`boolean` and the default `true`. The full Antora build was not run locally; it is driven by the
shared `apache/logging-parent` deploy-site workflow.

## Checklist

* Base your changes on `2.x` branch if you are targeting Log4j 2; use `main` otherwise
* `./mvnw verify` succeeds ([the build instructions](https://logging.apache.org/log4j/2.x/development.html#building))
* Non-trivial changes contain an entry file in the `src/changelog/.2.x.x` directory
* Tests are provided
