### PR TITLE
Improve missing logging provider diagnostic

### DIFF
--- a/log4j-api-test/src/test/java/org/apache/logging/log4j/util/ProviderUtilTest.java
+++ b/log4j-api-test/src/test/java/org/apache/logging/log4j/util/ProviderUtilTest.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.TestProvider;
+import org.apache.logging.log4j.simple.internal.SimpleProvider;
 import org.apache.logging.log4j.spi.Provider;
 import org.apache.logging.log4j.test.TestLogger;
 import org.apache.logging.log4j.test.TestLoggerContextFactory;
@@ -56,13 +57,16 @@ class ProviderUtilTest {
     }
 
     @Test
-    void should_have_a_fallback_provider() {
+    void should_log_diagnostic_and_use_simple_provider_when_no_provider_is_available() {
         final PropertiesUtil properties = new PropertiesUtil(new Properties());
         assertThat(ProviderUtil.selectProvider(properties, NO_PROVIDERS, statusLogger))
                 .as("check selected provider")
-                .isNotNull();
-        // An error for the absence of providers
-        assertHasErrorOrWarning(statusLogger);
+                .isInstanceOf(SimpleProvider.class);
+        assertThat(statusLogger.getEntries())
+                .contains(" ERROR Log4j API could not find a logging provider.\n"
+                        + "Log4j API will use Simple Logger by default.\n"
+                        + "See https://logging.apache.org/log4j/2.x/manual/installation.html "
+                        + "for instructions on how to configure Log4j API.");
     }
 
     @Test

--- a/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderUtil.java
+++ b/log4j-api/src/main/java/org/apache/logging/log4j/util/ProviderUtil.java
@@ -245,7 +245,10 @@ public final class ProviderUtil {
             final Comparator<Provider> comparator = Comparator.comparing(Provider::getPriority);
             switch (providers.size()) {
                 case 0:
-                    statusLogger.error("Log4j API could not find a logging provider.");
+                    statusLogger.error("Log4j API could not find a logging provider.\n"
+                            + "Log4j API will use Simple Logger by default.\n"
+                            + "See https://logging.apache.org/log4j/2.x/manual/installation.html "
+                            + "for instructions on how to configure Log4j API.");
                     break;
                 case 1:
                     break;

--- a/src/changelog/.2.x.x/3415_improve_missing_provider_diagnostic.xml
+++ b/src/changelog/.2.x.x/3415_improve_missing_provider_diagnostic.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="https://logging.apache.org/xml/ns"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+           https://logging.apache.org/xml/ns
+           https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="changed">
+  <issue id="3415" link="https://github.com/apache/logging-log4j2/issues/3415"/>
+  <description format="asciidoc">
+    Improve the diagnostic shown when no Log4j API provider is available
+  </description>
+</entry>

--- a/src/site/antora/modules/ROOT/pages/manual/installation.adoc
+++ b/src/site/antora/modules/ROOT/pages/manual/installation.adoc
@@ -186,6 +186,8 @@ xref:manual/status-logger.adoc[Status Logger] to avoid its unintentional usages:
 
 ----
 2024-10-03T11:53:34.281462230Z main ERROR Log4j API could not find a logging provider.
+Log4j API will use Simple Logger by default.
+See https://logging.apache.org/log4j/2.x/manual/installation.html for instructions on how to configure Log4j API.
 ----
 
 To remove the warning and confirm that you want to use Simple Logger, add a


### PR DESCRIPTION
Fixes #3415.

Clarifies the diagnostic emitted when Log4j API cannot find a provider. The message now explains that Simple Logger is the fallback and links directly to the installation guidance. The installation manual and the provider fallback test use the same text.

## Validation

- Focused ProviderUtilTest suite: 11 tests passed.
- Scoped Spotless check for the API and API test modules passed.
- Manual packaged-JAR process with only Log4j API on the classpath confirmed the Simple Logger fallback and all diagnostic lines.
- Full Maven verification compiled and validated the changed API work and ran 8,766 core tests. It stopped on a timing-only rollover wait in RollingAppenderDirectCronTest from log4j-core-test; the exact isolated test then passed.

## Checklist

* [x] Changes are based on the 2.x branch.
* [ ] Full Maven verification completed without an unrelated test-environment timing error; details are included above.
* [x] Changelog entry is included.
* [x] Tests are included.
